### PR TITLE
ci(release): drop run-essentials mirror sync now that source is public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,39 +72,6 @@ jobs:
           ignore-unfixed: true
           exit-code: '0'
 
-      - name: Prepare image-pinned compose
-        env:
-          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
-        run: |
-          mkdir release-assets
-
-          # Pin the docker-compose files to the released image (the public mirror
-          # has no source to build from). The sync step copies these to the mirror.
-          # No bundle zip is produced — GitHub's auto "Source code" archive of the
-          # (run-essentials-only) mirror serves that purpose.
-          python3 - <<'PYEOF'
-          import re, os, sys
-
-          image = os.environ['IMAGE']
-          build_re = re.compile(r'(?m)(    )build:\n(?:[ ]{6,}[^\n]*\n)+')
-
-          for src, dst in [
-              ('docker-compose.yml',    'release-assets/docker-compose.yml'),
-              ('docker-compose.ha.yml', 'release-assets/docker-compose.ha.yml'),
-          ]:
-              with open(src) as f:
-                  content = f.read()
-              patched, n = build_re.subn(
-                  lambda m: m.group(1) + f'image: {image}\n',
-                  content,
-              )
-              if n == 0:
-                  print(f'WARNING: build block not found in {src}', file=sys.stderr)
-              with open(dst, 'w') as f:
-                  f.write(patched)
-              print(f'Generated {dst} with image={image}')
-          PYEOF
-
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
@@ -124,46 +91,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
-
-      - name: Sync run-essentials to nexspence repo
-        run: |
-          git clone https://x-access-token:${{ secrets.RELEASE_PAT }}@github.com/nexspence/nexspence.git /tmp/nexspence-pub
-          cd /tmp/nexspence-pub
-
-          # The public mirror carries what is needed to RUN Nexspence:
-          #   - config sample + docker-compose files (image-pinned to this release)
-          #   - the Helm chart (deploy/helm/nexspence)
-          #   - the HA load-balancer config (deploy/nginx-ha.conf) for docker-compose.ha.yml
-          #   - the monitoring profile files (deploy/monitoring) for --profile monitoring
-          #   - the Keycloak realm import (keycloak/) for the OIDC SSO profile
-          #   - the seed scripts (scripts/) — seed-all.sh + its deps + seed-cleanup.sh
-          # Documentation lives on the website and is intentionally NOT mirrored here.
-          git rm -rq --ignore-unmatch docs deploy keycloak scripts config.yaml.example \
-            docker-compose.yml docker-compose.ha.yml
-
-          cp "$GITHUB_WORKSPACE/config.yaml.example" config.yaml.example
-          cp "$GITHUB_WORKSPACE/release-assets/docker-compose.yml" docker-compose.yml
-          cp "$GITHUB_WORKSPACE/release-assets/docker-compose.ha.yml" docker-compose.ha.yml
-          mkdir -p deploy/helm
-          cp -r "$GITHUB_WORKSPACE/deploy/helm/nexspence" deploy/helm/nexspence
-          cp "$GITHUB_WORKSPACE/deploy/nginx-ha.conf" deploy/nginx-ha.conf
-          cp -r "$GITHUB_WORKSPACE/deploy/monitoring" deploy/monitoring
-          rm -rf deploy/monitoring/prometheus-token   # strip any local bind-mount artifact
-          cp -r "$GITHUB_WORKSPACE/keycloak" keycloak
-          mkdir -p scripts
-          cp "$GITHUB_WORKSPACE/scripts/seed-all.sh" \
-             "$GITHUB_WORKSPACE/scripts/seed-repos.sh" \
-             "$GITHUB_WORKSPACE/scripts/seed-packages.sh" \
-             "$GITHUB_WORKSPACE/scripts/seed-rbac.sh" \
-             "$GITHUB_WORKSPACE/scripts/seed-cleanup.sh" \
-             scripts/
-          cp "$GITHUB_WORKSPACE"/scripts/create-*.sh scripts/
-          cp "$GITHUB_WORKSPACE/README.md" README.md
-
-          git config user.name  "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --staged --quiet || \
-            git commit -m "dist: sync run-essentials from nexspence-core ${{ github.ref_name }}"
-          git push origin main
 


### PR DESCRIPTION
## Phase 6 — release rewiring after open-sourcing

Now that `nexspence` holds the **full source** (no longer a curated mirror), the release workflow's mirror behaviour is actively harmful.

### What changed
- **Removed** the `Sync run-essentials to nexspence repo` step. It cloned this repo and force-curated `main` down to run-essentials — correct for a mirror, **destructive** now (a release would strip the open-source tree back to run-essentials and push over `main`).
- **Removed** the `Prepare image-pinned compose` step that only produced `release-assets/` for that sync (`.goreleaser.yaml` does not reference it).
- Kept Docker build/push + GoReleaser. Releases now build from this repo's own tree.

### Follow-ups (separate, owner action)
- Add `RELEASE_PAT` (and any deploy-website secrets) to this repo's Actions secrets — currently **none** are set, so `tag.yml`/`release.yml`/`deploy-website.yml` won't run until added.
- Do **not** cut a release from this repo until this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)