### PR TITLE
ci(release): ship run-essentials bundle as a release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,3 +92,47 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
 
+      - name: Build & upload run-essentials bundle
+        # The auto "Source code" archive now ships the full dev tree (the repo is the
+        # full source). This curated bundle restores the prior run-essentials download
+        # — config + image-pinned compose + Helm chart + nginx-ha + monitoring +
+        # keycloak realm + seed scripts + README/LICENSE — for users who just want to
+        # RUN Nexspence. Uploaded as a release asset (NOT a separate mirror repo).
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          STAGE="release-bundle"
+          DIR="${STAGE}/nexspence-${VERSION}"
+          rm -rf "$STAGE"
+          mkdir -p "$DIR/deploy/helm" "$DIR/scripts"
+
+          cp config.yaml.example README.md LICENSE "$DIR/"
+          cp -r deploy/helm/nexspence "$DIR/deploy/helm/nexspence"
+          cp deploy/nginx-ha.conf "$DIR/deploy/"
+          cp -r deploy/monitoring "$DIR/deploy/monitoring"
+          rm -f "$DIR/deploy/monitoring/prometheus-token"   # strip local bind-mount artifact
+          cp -r keycloak "$DIR/keycloak"
+          cp scripts/seed-all.sh scripts/seed-repos.sh scripts/seed-packages.sh \
+             scripts/seed-rbac.sh scripts/seed-cleanup.sh "$DIR/scripts/"
+          cp scripts/create-*.sh "$DIR/scripts/"
+
+          # Pin the compose files to the released image (no source to build in the bundle).
+          DIR="$DIR" python3 - <<'PYEOF'
+          import re, os
+          image = os.environ['IMAGE']
+          dst = os.environ['DIR']
+          build_re = re.compile(r'(?m)(    )build:\n(?:[ ]{6,}[^\n]*\n)+')
+          for f in ('docker-compose.yml', 'docker-compose.ha.yml'):
+              with open(f) as fh:
+                  content = fh.read()
+              patched, _ = build_re.subn(lambda m: m.group(1) + f'image: {image}\n', content)
+              with open(os.path.join(dst, f), 'w') as fh:
+                  fh.write(patched)
+          PYEOF
+
+          ASSET="nexspence-run-essentials-${VERSION}.zip"
+          ( cd "$STAGE" && zip -rq "../$ASSET" "nexspence-${VERSION}" )
+          gh release upload "$GITHUB_REF_NAME" "$ASSET" --repo "$GITHUB_REPOSITORY" --clobber
+

--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,6 @@ dist/
 
 # Release-workflow scratch (written before GoReleaser runs; must not dirty the tree)
 release-assets/
+release-bundle/
 .cache/
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -101,9 +101,8 @@ release:
     owner: nexspence
     name: nexspence
   mode: replace
-  # Cross-repo release: the tag exists on nexspence-core (where we build), not on
-  # nexspence/nexspence. Pin the tag/release to the public repo's main branch so
-  # GitHub creates the tag there — mirroring the prior `gh release create` flow.
+  # The release runs from this repo (full source); pin to main so the tag/release
+  # resolve to the default branch.
   target_commitish: main
   footer: |
     ### 🐳 Docker
@@ -119,8 +118,10 @@ release:
 
     #### Quick start
 
-    Download the **Source code (zip)** below, extract it, rename
-    `config.yaml.example` → `config.yaml`, and set the admin password and JWT secret.
+    Download **`nexspence-run-essentials-{{ .Version }}.zip`** below (config +
+    image-pinned compose + Helm chart + monitoring + Keycloak realm + seed scripts),
+    extract it, rename `config.yaml.example` → `config.yaml`, and set the admin
+    password and JWT secret. (The full source is the **Source code** archive / `git clone`.)
 
     | Mode | Command |
     |------|---------|


### PR DESCRIPTION
## Why
After open-sourcing, GitHub's auto **Source code** archive now contains the entire dev tree (cmd, internal, frontend, docs, website…). Previously — when `nexspence` was a run-essentials mirror — that archive was the easy "download & run" bundle. This restores that bundle as a dedicated release asset.

## What
- New `release.yml` step **Build & upload run-essentials bundle**: assembles `config.yaml.example`, image-pinned `docker-compose*.yml`, `deploy/helm/nexspence` + `nginx-ha.conf` + `monitoring`, `keycloak/`, the seed `scripts/`, `README.md`, `LICENSE` into `nexspence-run-essentials-<version>.zip` and `gh release upload`s it.
- `.goreleaser.yaml` footer quick-start now points at the bundle (full source = Source code archive / `git clone`).
- `.gitignore`: `release-bundle/` scratch dir.

The v1.19.1 release already has this asset (uploaded manually); this makes it automatic for every future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)