### PR TITLE
fix(security): eliminate world-known JWT default + blob-store path traversal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ WORKDIR /app
 
 COPY --from=builder /nexspence /app/nexspence
 COPY --from=builder /src/config.yaml.example /app/config.yaml
+COPY --from=builder /src/deploy/docker-entrypoint.sh /app/entrypoint.sh
 COPY --from=frontend-builder /frontend/dist /app/frontend/dist
 
 # Run as a non-root user (uid/gid 1000). Pre-create the dirs the app and the
@@ -65,7 +66,8 @@ COPY --from=frontend-builder /frontend/dist /app/frontend/dist
 # under a writable path; TRIVY_CACHE_DIR pins it explicitly (correct env var
 # for modern trivy ≥0.x).
 RUN addgroup -g 1000 nexspence && adduser -D -u 1000 -G nexspence nexspence \
-    && mkdir -p /app/data/blobs /app/.cache \
+    && mkdir -p /app/data/blobs /app/.cache /app/secrets \
+    && chmod +x /app/entrypoint.sh \
     && chown -R nexspence:nexspence /app
 ENV HOME=/app
 ENV TRIVY_CACHE_DIR=/app/.cache/trivy
@@ -73,5 +75,5 @@ USER 1000
 
 EXPOSE 8081 5000
 
-ENTRYPOINT ["/app/nexspence"]
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["serve", "--config", "/app/config.yaml"]

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Auto-provision a unique JWT secret for zero-config deployments (docker compose).
+#
+# If NEXSPENCE_AUTH_JWT_SECRET is unset or still the shipped development default,
+# generate a random 64-char secret once and persist it to a writable volume so it
+# stays stable across restarts and is shared by every replica that mounts the same
+# volume. When the operator supplies a real secret (Helm Secret, explicit env),
+# this is a no-op and the provided value is used as-is.
+set -eu
+
+DEV_DEFAULT="nexspence-dev-default-secret-change-me-in-production"
+SECRET_FILE="${NEXSPENCE_JWT_SECRET_FILE:-/app/secrets/jwt_secret}"
+
+current="${NEXSPENCE_AUTH_JWT_SECRET:-}"
+if [ -z "$current" ] || [ "$current" = "$DEV_DEFAULT" ]; then
+    if [ -s "$SECRET_FILE" ]; then
+        NEXSPENCE_AUTH_JWT_SECRET="$(cat "$SECRET_FILE")"
+    else
+        gen="$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 64)"
+        # Atomic create (noclobber): if a peer replica wrote first, this fails
+        # and we fall through to reading the winner's value below.
+        if mkdir -p "$(dirname "$SECRET_FILE")" 2>/dev/null &&
+            (set -C; printf '%s' "$gen" >"$SECRET_FILE") 2>/dev/null; then
+            chmod 600 "$SECRET_FILE" 2>/dev/null || true
+            echo "nexspence: generated a unique JWT secret -> $SECRET_FILE"
+        fi
+        if [ -s "$SECRET_FILE" ]; then
+            NEXSPENCE_AUTH_JWT_SECRET="$(cat "$SECRET_FILE")"
+        else
+            NEXSPENCE_AUTH_JWT_SECRET="$gen"
+            echo "nexspence: using an ephemeral JWT secret (could not persist to $SECRET_FILE; sessions reset on restart)"
+        fi
+    fi
+    export NEXSPENCE_AUTH_JWT_SECRET
+fi
+
+exec /app/nexspence "$@"

--- a/deploy/helm/nexspence/templates/secret.yaml
+++ b/deploy/helm/nexspence/templates/secret.yaml
@@ -8,7 +8,24 @@ metadata:
 type: Opaque
 stringData:
   NEXSPENCE_DATABASE_DSN: {{ include "nexspence.databaseDSN" . | quote }}
-  NEXSPENCE_AUTH_JWT_SECRET: {{ .Values.config.jwtSecret | quote }}
+  {{- /*
+    JWT secret resolution:
+      1. explicit .Values.config.jwtSecret wins;
+      2. otherwise reuse the value already persisted in this release's Secret
+         (so upgrades keep existing sessions valid);
+      3. otherwise generate a fresh random 64-char secret.
+    This avoids shipping a world-known default signing key.
+  */ -}}
+  {{- $jwt := .Values.config.jwtSecret }}
+  {{- if not $jwt }}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "nexspence.fullname" .) }}
+  {{- if and $existing $existing.data (index $existing.data "NEXSPENCE_AUTH_JWT_SECRET") }}
+  {{- $jwt = index $existing.data "NEXSPENCE_AUTH_JWT_SECRET" | b64dec }}
+  {{- else }}
+  {{- $jwt = randAlphaNum 64 }}
+  {{- end }}
+  {{- end }}
+  NEXSPENCE_AUTH_JWT_SECRET: {{ $jwt | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.config.adminPassword | quote }}
   {{- if eq .Values.storage.type "s3" }}
   NEXSPENCE_STORAGE_S3_ACCESS_KEY: {{ .Values.storage.s3.accessKey | quote }}

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -44,11 +44,14 @@ config:
   logLevel: "info"
   logFormat: "json"
   httpListen: ":8081"
-  # -- JWT secret — development default: server boots but WARNS; override with a unique secret (min 32 chars) for production
-  jwtSecret: "nexspence-dev-default-secret-change-me-in-production"
-  # -- Permit the shipped default JWT secret / admin password ("admin123") at startup.
-  # Defaults to true so the chart's quick-start boots out of the box; set to false in
-  # production once you have set a unique jwtSecret and adminPassword.
+  # -- JWT secret (min 32 chars). Leave empty to auto-generate a unique random
+  # secret on first install and persist it across upgrades (recommended). Set an
+  # explicit value only if you need to share the secret across clusters.
+  jwtSecret: ""
+  # -- Permit the shipped default admin password ("admin123") at startup.
+  # Defaults to true so the chart's quick-start boots out of the box; set to false
+  # in production once you have set a unique adminPassword. The JWT secret is no
+  # longer a shipped default (it is auto-generated when jwtSecret is empty).
   allowInsecureDefaults: true
   jwtExpiryHours: 8
   # -- Bootstrap admin credentials

--- a/docker-compose.ha.yml
+++ b/docker-compose.ha.yml
@@ -132,8 +132,11 @@ services:
       NEXSPENCE_STORAGE_S3_REGION: "us-east-1"
       NEXSPENCE_REDIS_ENABLED: "true"
       NEXSPENCE_REDIS_ADDR: "redis:6379"
-      NEXSPENCE_AUTH_JWT_SECRET: "${NEXSPENCE_JWT_SECRET:-nexspence-dev-default-secret-change-me-in-production}"  # development default — server boots but WARNS; set NEXSPENCE_JWT_SECRET to a unique secret for production
-      NEXSPENCE_AUTH_ALLOW_INSECURE_DEFAULTS: "true"  # dev quick-start: permit shipped default secrets; production must leave this false
+      # Auto-generated (unique per deployment) by the image entrypoint and
+      # persisted to the shared nexspence_secrets volume so both replicas use the
+      # same key. Set NEXSPENCE_JWT_SECRET to pin your own (min 32 chars).
+      NEXSPENCE_AUTH_JWT_SECRET: "${NEXSPENCE_JWT_SECRET:-}"
+      NEXSPENCE_AUTH_ALLOW_INSECURE_DEFAULTS: "true"  # dev quick-start: permit shipped default admin password; production must leave this false
       # ── OIDC (Keycloak dev IdP, active when OIDC_ENABLED=true) ──────
       # In HA mode the load balancer (nginx :8080) fronts both nodes,
       # so redirect_url and frontend_base_url point to nginx, not to a node.
@@ -152,6 +155,7 @@ services:
       NEXSPENCE_OIDC_PROVISIONING: "jit"
       NEXSPENCE_OIDC_SCOPES: "openid,profile,email"
     volumes:
+      - nexspence_secrets:/app/secrets
       - ${CONFIG_FILE:-./config.yaml}:/app/config.yaml:ro
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8081/healthz"]
@@ -226,6 +230,7 @@ services:
 volumes:
   postgres_data:
   redis_data:
+  nexspence_secrets:
   minio_data:
   prometheus_data:
   grafana_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,10 @@ services:
         required: false
     environment:
       NEXSPENCE_DATABASE_DSN: "postgres://nexspence:nexspence@postgres:5432/nexspence?sslmode=disable"
-      NEXSPENCE_AUTH_JWT_SECRET: "nexspence-dev-default-secret-change-me-in-production"  # development default — server boots but WARNS; override for production
-      NEXSPENCE_AUTH_ALLOW_INSECURE_DEFAULTS: "true"  # dev quick-start: permit shipped default secrets; production must leave this false
+      # JWT secret is auto-generated (unique per deployment) by the image
+      # entrypoint and persisted to the nexspence_secrets volume. To pin your own,
+      # set NEXSPENCE_AUTH_JWT_SECRET here (min 32 chars).
+      NEXSPENCE_AUTH_ALLOW_INSECURE_DEFAULTS: "true"  # dev quick-start: permit shipped default admin password; production must leave this false
       NEXSPENCE_HTTP_ADDR: ":8081"
       NEXSPENCE_HTTP_BASE_URL: "http://localhost:8081"
       NEXSPENCE_STORAGE_DEFAULT_TYPE: "local"
@@ -137,6 +139,7 @@ services:
       #   docker compose run --rm --user 0 nexspence chown -R 1000:1000 /app/data/blobs
       # (or recreate the volume) so the non-root process can write to it.
       - nexspence_blobs:/app/data/blobs
+      - nexspence_secrets:/app/secrets
       - ${CONFIG_FILE:-./config.yaml}:/app/config.yaml:ro
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8081/service/rest/v1/status/check"]
@@ -258,6 +261,7 @@ services:
 volumes:
   postgres_data:
   nexspence_blobs:
+  nexspence_secrets:
   minio_data:
   frontend_node_modules:
   prometheus_data:

--- a/internal/api/handlers/oidc.go
+++ b/internal/api/handlers/oidc.go
@@ -51,9 +51,14 @@ func NewOIDCHandler(
 // Login starts the OIDC authorization code + PKCE flow.
 // GET /api/v1/auth/oidc/login[?return_to=/path]
 func (h *OIDCHandler) Login(c *gin.Context) {
-	state := randBase64URL(32)
-	nonce := randBase64URL(32)
-	codeVerifier := randBase64URL(64)
+	state, err1 := randBase64URL(32)
+	nonce, err2 := randBase64URL(32)
+	codeVerifier, err3 := randBase64URL(64)
+	if err := errors.Join(err1, err2, err3); err != nil {
+		h.log.Errorw("oidc generate random state failed", "err", err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
 	sum := sha256.Sum256([]byte(codeVerifier))
 	codeChallenge := base64.RawURLEncoding.EncodeToString(sum[:])
 
@@ -220,8 +225,10 @@ func IsSafeReturnPath(p string) bool {
 	return true
 }
 
-func randBase64URL(n int) string {
+func randBase64URL(n int) (string, error) {
 	b := make([]byte, n)
-	_, _ = rand.Read(b)
-	return base64.RawURLEncoding.EncodeToString(b)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -24,23 +24,37 @@ func NewLocalBlobStore(basePath string) (*LocalBlobStore, error) {
 	return &LocalBlobStore{basePath: basePath}, nil
 }
 
-func (s *LocalBlobStore) keyPath(key string) string {
+func (s *LocalBlobStore) keyPath(key string) (string, error) {
+	var p string
 	// Shard by first 4 chars to avoid huge flat directories
 	if len(key) >= 4 {
-		return filepath.Join(s.basePath, key[:2], key[2:4], key)
+		p = filepath.Join(s.basePath, key[:2], key[2:4], key)
+	} else {
+		p = filepath.Join(s.basePath, key)
 	}
-	return filepath.Join(s.basePath, key)
+	// Containment guard: filepath.Join cleans the result, so a key carrying
+	// "../" segments (e.g. from an attacker-crafted backup/import archive)
+	// would resolve outside basePath. Reject any key whose final path escapes
+	// the blob store root.
+	base := filepath.Clean(s.basePath)
+	if p != base && !strings.HasPrefix(p, base+string(os.PathSeparator)) {
+		return "", fmt.Errorf("invalid blob key %q: resolves outside blob store", key)
+	}
+	return p, nil
 }
 
 // Put writes the blob for key, staging to a temp file and renaming for atomicity.
 func (s *LocalBlobStore) Put(_ context.Context, key string, r io.Reader, _ int64) error {
-	dst := s.keyPath(key)
+	dst, err := s.keyPath(key)
+	if err != nil {
+		return err
+	}
 	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 		return err
 	}
 	// Write to a temp file first, then rename (atomic on same filesystem)
 	tmp := dst + ".tmp"
-	f, err := os.Create(tmp) //nolint:gosec // path is an internal content-addressed blob key, not user-controlled
+	f, err := os.Create(tmp) //nolint:gosec // dst is validated by keyPath to stay within the blob store base dir
 	if err != nil {
 		return err
 	}
@@ -58,7 +72,11 @@ func (s *LocalBlobStore) Put(_ context.Context, key string, r io.Reader, _ int64
 
 // Get opens the blob for key and returns its reader and size.
 func (s *LocalBlobStore) Get(_ context.Context, key string) (io.ReadCloser, int64, error) {
-	f, err := os.Open(s.keyPath(key))
+	p, err := s.keyPath(key)
+	if err != nil {
+		return nil, 0, err
+	}
+	f, err := os.Open(p)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -72,7 +90,11 @@ func (s *LocalBlobStore) Get(_ context.Context, key string) (io.ReadCloser, int6
 
 // Delete removes the blob for key; a missing blob is not an error.
 func (s *LocalBlobStore) Delete(_ context.Context, key string) error {
-	err := os.Remove(s.keyPath(key))
+	p, err := s.keyPath(key)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(p)
 	if os.IsNotExist(err) {
 		return nil
 	}
@@ -81,7 +103,11 @@ func (s *LocalBlobStore) Delete(_ context.Context, key string) error {
 
 // Exists reports whether a blob is stored for key.
 func (s *LocalBlobStore) Exists(_ context.Context, key string) (bool, error) {
-	_, err := os.Stat(s.keyPath(key))
+	p, err := s.keyPath(key)
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(p)
 	if err == nil {
 		return true, nil
 	}
@@ -93,7 +119,11 @@ func (s *LocalBlobStore) Exists(_ context.Context, key string) (bool, error) {
 
 // Size returns the byte size of the blob for key.
 func (s *LocalBlobStore) Size(_ context.Context, key string) (int64, error) {
-	info, err := os.Stat(s.keyPath(key))
+	p, err := s.keyPath(key)
+	if err != nil {
+		return 0, err
+	}
+	info, err := os.Stat(p)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -76,7 +76,7 @@ func (s *LocalBlobStore) Get(_ context.Context, key string) (io.ReadCloser, int6
 	if err != nil {
 		return nil, 0, err
 	}
-	f, err := os.Open(p)
+	f, err := os.Open(p) //nolint:gosec // p is validated by keyPath to stay within the blob store base dir
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -61,6 +61,35 @@ func TestLocalBlobStore_Get_NotFound(t *testing.T) {
 	require.Error(t, err)
 }
 
+// A blob key carrying "../" segments (e.g. from a crafted backup/import
+// archive) must be rejected and must not write outside the blob store root.
+func TestLocalBlobStore_Put_PathTraversal_Rejected(t *testing.T) {
+	base := t.TempDir() + "/blobs"
+	store, err := storage.NewLocalBlobStore(base)
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	escaped := base + "/../pwned"
+	defer os.Remove(escaped)
+
+	traversalKey := "../../pwned"
+	err = store.Put(ctx, traversalKey, bytes.NewReader([]byte("malicious")), 9)
+	require.Error(t, err, "Put must reject a key that escapes the blob store root")
+	assert.Contains(t, err.Error(), "outside blob store")
+
+	_, statErr := os.Stat(escaped)
+	assert.True(t, os.IsNotExist(statErr), "no file should be written outside the blob store root")
+
+	// Get/Delete/Exists/Size must reject the traversal key too.
+	_, _, err = store.Get(ctx, traversalKey)
+	require.Error(t, err)
+	require.Error(t, store.Delete(ctx, traversalKey))
+	_, err = store.Exists(ctx, traversalKey)
+	require.Error(t, err)
+	_, err = store.Size(ctx, traversalKey)
+	require.Error(t, err)
+}
+
 func TestLocalBlobStore_Delete_Existing(t *testing.T) {
 	store := newLocal(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes from a full backend security audit. Each finding was confirmed by an independent adversarial verification pass (confidence ≥9/10 for the two top findings).

### 1. HIGH — World-known default JWT signing key shipped in deploy manifests
The committed dev-default JWT secret (`nexspence-dev-default-secret-change-me-in-production`) was the **actual default** in `docker-compose.yml`, `docker-compose.ha.yml`, and the Helm chart, all with `allow_insecure_defaults=true`. Since roles are embedded in HS256 JWTs and trusted for admin gating, a quick-start deploy let **any authenticated user forge an `nx-admin` token** off the public key (CWE-798).

**Fix:**
- **Helm**: `secret.yaml` auto-generates a random 64-char `jwtSecret` when unset, persisted across upgrades via `lookup`; `values.yaml` default is now `""`.
- **Docker image**: new `deploy/docker-entrypoint.sh` generates a unique secret on first start and persists it to `/app/secrets` (shared across HA replicas; atomic create handles the race). Compose files drop the hardcoded secret and mount the `nexspence_secrets` volume. `docker compose up` stays zero-config with a unique key per deployment.

### 2. MEDIUM — Zip-slip / arbitrary file write via crafted backup/import archive
`LocalBlobStore.keyPath` joined an attacker-supplied `BlobKey` (from an uploaded `import`/`restore` archive) to the base dir with no containment check, so a `../`-laden key escaped the blob root → arbitrary file write as the server OS user (admin-gated, but crosses the app-admin → host boundary).

**Fix:** `keyPath` validates the resolved path stays within `basePath`; all callers propagate the rejection. New test `TestLocalBlobStore_Put_PathTraversal_Rejected`.

### 3. LOW — `randBase64URL` ignored `crypto/rand` errors (OIDC login)
Now returns the error; `OIDCHandler.Login` fails closed (500) on entropy failure.

## Deferred
- **SAML assertion replay** (`internal/auth/saml.go`): below the high-confidence bar; a proper fix needs request-ID tracking / one-time-use assertion cache and risks breaking IdP-initiated SSO. Recommend a dedicated change.
- **LDAP implicit group→role mapping**: excluded per request.

## Verification
`go build ./...` ✅ · `go vet ./...` ✅ · `gofmt` clean ✅ · new traversal test passes · `docker compose config -q` ✅ both files · entrypoint validated (`sh -n` + persistence/reuse dry-run) · Helm renders a random secret.
Only red test is the pre-existing `TestWebhookHandler_Test_200` (netguard blocks loopback in this env; fails identically on clean `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
