### PR TITLE
docs: reflect auto-generated JWT secret (Helm + Docker entrypoint)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ helm install nexspence \
   --create-namespace
 ```
 
+> `config.jwtSecret` is optional — the chart auto-generates a unique secret (persisted across upgrades) when it is omitted. Set it only to pin a known value.
+
 Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium Gateway API), external PostgreSQL, S3 storage, and HPA — see **[deploy/helm/nexspence/README.md](deploy/helm/nexspence/README.md)**.
 
 ---

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -29,7 +29,7 @@ storage:
   #   force_path_style: true
 
 auth:
-  jwt_secret: "CHANGE_ME_AT_LEAST_32_CHARACTERS_LONG"   # set via NEXSPENCE_AUTH_JWT_SECRET env in production; server refuses to start with this placeholder unless allow_insecure_defaults=true
+  jwt_secret: "CHANGE_ME_AT_LEAST_32_CHARACTERS_LONG"   # from source / native install: set this (or NEXSPENCE_AUTH_JWT_SECRET) — server refuses to start with this placeholder unless allow_insecure_defaults=true. The Docker image and Helm chart auto-generate a unique secret when it is unset, so you don't set it there.
   # Optional dedicated key for encrypting replication credentials (recommended).
   # Without it the key is derived from jwt_secret, so rotating jwt_secret would
   # invalidate stored replication passwords. Generate: openssl rand -base64 32

--- a/deploy/helm/nexspence/README.md
+++ b/deploy/helm/nexspence/README.md
@@ -25,6 +25,8 @@ helm dependency update
 
 Then install with exactly one of the networking options below.
 
+> **JWT secret:** `config.jwtSecret` is optional. When omitted, the chart auto-generates a unique random secret on first install and reuses it across upgrades (via a `lookup` of the existing Secret). The `--set config.jwtSecret=...` in the examples below is only needed to pin a known value or share the secret across clusters.
+
 ### nginx ingress-controller
 
 ```bash

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -123,6 +123,8 @@ helm install nexspence \
   --create-namespace
 ```
 
+> `config.jwtSecret` is optional — when omitted, the chart auto-generates a unique random secret on first install and persists it across upgrades. Set it explicitly only to pin a known value or share it across clusters.
+
 Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium Gateway API), external PostgreSQL, S3 storage, and HPA — see [deploy/helm/nexspence/README.md](../deploy/helm/nexspence/README.md).
 
 ---
@@ -141,7 +143,7 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `storage.s3.bucket` | — | S3 bucket name (required when type=s3) |
 | `storage.s3.endpoint` | — | S3 endpoint URL (e.g. `http://minio:9000`) |
 | `storage.s3.force_path_style` | `true` | Required for MinIO / non-AWS S3 |
-| `auth.jwt_secret` | — | JWT signing key — **change before production** |
+| `auth.jwt_secret` | — | JWT signing key. **From source / native install: set this (min 32 chars) before production.** The Docker image and Helm chart auto-generate a unique secret when it is unset. |
 | `auth.encryption_key` | — | Optional base64 32-byte key for replication credentials (decouples them from `jwt_secret`; existing rows are re-encrypted automatically at startup). Generate: `openssl rand -base64 32` |
 | `auth.jwt_expiry_hours` | `24` | JWT token lifetime |
 | `auth.anonymous_enabled` | `true` | Allow unauthenticated read on public repos |


### PR DESCRIPTION
## Summary

Doc sync for the v1.19.2 security change: the Docker image entrypoint and the Helm chart now **auto-generate a unique JWT secret** when none is provided. The docs previously implied you must always set one.

## Changes
- **`config.yaml.example`**: clarify the `jwt_secret` placeholder applies to **source / native installs only** — Docker & Helm auto-generate it.
- **`docs/deployment.md`**: note `config.jwtSecret` is optional for Helm (auto-generated, persisted across upgrades); update the config-reference table row.
- **`README.md`** + **`deploy/helm/nexspence/README.md`**: note `jwtSecret` auto-generates when omitted; `--set config.jwtSecret=...` is only for pinning/sharing.

## Not included (flagged for follow-up)
- **`website/`** has the same JWT guidance, but it's i18n-driven (text comes from EN/RU dictionaries, not inline HTML) and the site doesn't auto-deploy on this repo yet (missing `DROPLET_*` secrets). Worth a separate i18n-aware pass. The live changelog (fetched via GitHub API) is unaffected and already renders v1.19.2 correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
