### PR TITLE
feat(release): publish Helm chart as OCI artifact to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,3 +136,17 @@ jobs:
           ( cd "$STAGE" && zip -rq "../$ASSET" "nexspence-${VERSION}" )
           gh release upload "$GITHUB_REF_NAME" "$ASSET" --repo "$GITHUB_REPOSITORY" --clobber
 
+      - name: Publish Helm chart to GHCR (OCI)
+        # helm is pre-installed on ubuntu-latest runners. Packages the chart at the
+        # release version and pushes it to oci://ghcr.io/<owner>/charts so users can
+        # `helm install oci://ghcr.io/nexspence/charts/nexspence --version X.Y.Z`.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "${{ secrets.RELEASE_PAT }}" | helm registry login "${REGISTRY}" -u "${{ github.actor }}" --password-stdin
+          cd deploy/helm/nexspence
+          # The postgresql sub-chart is vendored under charts/ (Chart.lock pinned),
+          # so packaging needs no network and no extra dependency step.
+          helm package . --version "$VERSION" --app-version "$VERSION"
+          helm push "nexspence-${VERSION}.tgz" "oci://${REGISTRY}/${{ github.repository_owner }}/charts"
+          echo "Pushed chart: oci://${REGISTRY}/${{ github.repository_owner }}/charts/nexspence:${VERSION}"
+

--- a/deploy/helm/nexspence/Chart.yaml
+++ b/deploy/helm/nexspence/Chart.yaml
@@ -4,9 +4,9 @@ description: Nexspence — open-source universal artifact repository manager
 type: application
 version: 0.1.0
 appVersion: "latest"
-home: https://github.com/nexspence-oss/nexspence
+home: https://github.com/nexspence/nexspence
 sources:
-  - https://github.com/nexspence-oss/nexspence
+  - https://github.com/nexspence/nexspence
 keywords:
   - artifact-repository
   - nexus-alternative
@@ -15,9 +15,12 @@ keywords:
   - docker
   - helm
 maintainers:
-  - name: nexspence-oss
+  - name: nexspence
 dependencies:
   - name: postgresql
     version: "15.5.38"
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled
+# Links the OCI package (ghcr.io/nexspence/charts/nexspence) back to the repo on GitHub.
+annotations:
+  org.opencontainers.image.source: https://github.com/nexspence/nexspence

--- a/deploy/helm/nexspence/README.md
+++ b/deploy/helm/nexspence/README.md
@@ -10,9 +10,27 @@ Nexspence — open-source universal artifact repository manager (Nexus OSS alter
 
 ---
 
-## Installation
+## Install from GHCR (OCI) — recommended
 
-Download `nexspence-vX.Y.Z.zip` from the latest release and extract it:
+Each release publishes the chart as an OCI artifact to GitHub Packages, so you can
+install it directly without downloading anything:
+
+```bash
+helm install nexspence oci://ghcr.io/nexspence/charts/nexspence \
+  --version 1.19.2 \
+  -f https://raw.githubusercontent.com/nexspence/nexspence/main/deploy/helm/nexspence/values-examples/nginx.yaml \
+  --namespace nexspence --create-namespace
+```
+
+`config.jwtSecret` is auto-generated when omitted (see the JWT note below). Pin a
+specific chart version with `--version` (omit it to pull the latest). Browse versions:
+**[ghcr.io/nexspence/charts/nexspence](https://github.com/nexspence/nexspence/pkgs/container/charts%2Fnexspence)**.
+
+---
+
+## Install from a release bundle
+
+Download the `nexspence-run-essentials-vX.Y.Z.zip` from the latest release and extract it:
 **[github.com/nexspence/nexspence/releases](https://github.com/nexspence/nexspence/releases)**
 
 The Helm chart is at `deploy/helm/nexspence/` inside the extracted directory.


### PR DESCRIPTION
## Summary

Publishes the Helm chart as an **OCI artifact to GHCR** on every release, so it shows up under the repo's **Packages** and users can install it directly:

```bash
helm install nexspence oci://ghcr.io/nexspence/charts/nexspence \
  --version 1.19.2 \
  -f https://raw.githubusercontent.com/nexspence/nexspence/main/deploy/helm/nexspence/values-examples/nginx.yaml \
  --namespace nexspence --create-namespace
```

## Changes
- **`.github/workflows/release.yml`** — new *Publish Helm chart to GHCR (OCI)* step: `helm registry login` → `helm package` (chart + appVersion pinned to the release tag) → `helm push oci://ghcr.io/nexspence/charts`. `helm` is pre-installed on the runner; the postgresql sub-chart is vendored under `charts/` so packaging is fully offline (no `helm dependency` network step).
- **`Chart.yaml`** — fix `home`/`sources` to `nexspence/nexspence` (were the old `nexspence-oss` org) and add `annotations.org.opencontainers.image.source` so GitHub **auto-links the chart package to this repo** (this is what makes it appear on the Packages tab).
- **Helm chart README** — document the OCI install path (recommended) next to the release-bundle path.

## Verification
- `helm show chart` parses; annotation present in the packaged chart.
- `helm lint` passes (only the cosmetic "icon recommended" info).
- `helm package` builds **offline** from the vendored `charts/postgresql-15.5.38.tgz` (verified locally).
- `release.yml` YAML validated.

## Notes
- Maven/NuGet/RubyGems/npm registries are intentionally **not** used — Nexspence is a Go server app, not a library for those ecosystems; nothing to publish there.
- The **container image** already publishes to `ghcr.io/nexspence/nexspence` with the source label. If it isn't showing on the Packages tab, that's a one-time package **visibility/link** toggle in the package settings (needs `admin:packages`/owner — the current automation token lacks that scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
