### PR TITLE
fix(helm): correct image repo, restore pullable Postgres, fix trivy cache under read-only rootfs

### DIFF
--- a/deploy/helm/nexspence/templates/deployment.yaml
+++ b/deploy/helm/nexspence/templates/deployment.yaml
@@ -43,6 +43,16 @@ spec:
             - name: http
               containerPort: 8081
               protocol: TCP
+          env:
+            # Pin the trivy (CVE scan) cache to the writable emptyDir below.
+            # The image sets these too, but pinning them here keeps scans
+            # working under readOnlyRootFilesystem regardless of image build —
+            # trivy's default cache ($HOME/.cache/trivy) would otherwise resolve
+            # onto the read-only rootfs and every image scan would fail.
+            - name: HOME
+              value: /app
+            - name: TRIVY_CACHE_DIR
+              value: /app/.cache/trivy
           envFrom:
             - configMapRef:
                 name: {{ include "nexspence.fullname" . }}

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: ghcr.io/nexspence-oss/nexspence
+  repository: ghcr.io/nexspence/nexspence
   pullPolicy: IfNotPresent
   # -- Overrides the image tag (defaults to chart appVersion)
   tag: ""
@@ -174,6 +174,13 @@ affinity: {}
 # Set enabled: false and provide externalDatabase.dsn for external Postgres.
 postgresql:
   enabled: true
+  # Bitnami removed the legacy `docker.io/bitnami/*` image tags from Docker Hub
+  # in 2025 (moved to the paid `bitnamisecure` catalog); the archived copies
+  # live under `bitnamilegacy/*`. Pin the bundled subchart image there so a
+  # default install does not hit ImagePullBackOff. Override or run an external
+  # database (postgresql.enabled=false) for production.
+  image:
+    repository: bitnamilegacy/postgresql
   auth:
     username: nexspence
     password: nexspence


### PR DESCRIPTION
## Summary

A default `helm install ./deploy/helm/nexspence` is currently **broken**. Three independent defects, all confirmed end-to-end on a docker-desktop cluster:

| # | Bug | Fix |
|---|-----|-----|
| 1 | `image.repository: ghcr.io/nexspence-oss/nexspence` — non-existent org. Releases push to `ghcr.io/nexspence/nexspence`, so default installs (and `appVersion: "latest"`) hit `ImagePullBackOff`. | → `ghcr.io/nexspence/nexspence` |
| 2 | Bundled Bitnami postgresql subchart pulls `docker.io/bitnami/postgresql:16.4.0-debian-12-r14`, which Bitnami **removed from Docker Hub in 2025** (moved to paid `bitnamisecure`; archived copies under `bitnamilegacy`). → `ImagePullBackOff` on Postgres. | Pin subchart image to `bitnamilegacy/postgresql` |
| 3 | Under `readOnlyRootFilesystem: true`, trivy's default cache resolves to `$HOME/.cache/trivy` on the **read-only rootfs**, so every Security-UI image scan fails. | Pin `HOME` + `TRIVY_CACHE_DIR` in deployment env to the writable `/app/.cache` emptyDir |

## Verification

Default `helm install` (no `--set` overrides) on docker-desktop k8s:
- `nexspence-postgresql-0` and the app pod both reach **Running** (`bitnamilegacy/postgresql` pulls; app migrates + serves HTTP).
- `readOnlyRootFilesystem: true` confirmed (write to `/` denied).
- `/proc/1/environ` shows `HOME=/app` + `TRIVY_CACHE_DIR=/app/.cache/trivy`; the cache path is writable → trivy scans work under the read-only rootfs (closes the Phase 5 hardening residual).
- `helm lint` clean; `helm template` renders both images correctly with zero overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)