### PR TITLE
fix(bootstrap): apply configured admin password over the seed placeholder hash

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/metrics"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/repository/postgres"
 )
 
@@ -275,18 +276,38 @@ func syncBlobStorePaths(ctx context.Context, pool *pgxpool.Pool, cfg *config.Con
 	return nil
 }
 
-// bootstrapAdmin ensures the admin user exists with the configured password.
-// It only owns initial creation: if the admin user already exists its password
-// is left untouched (rotate it via the API, not config + restart).
-func bootstrapAdmin(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, log logger.Logger) error {
-	b := cfg.Bootstrap
-	if b.AdminUsername == "" || b.AdminPassword == "" {
-		return nil
-	}
+// seedPlaceholderAdminHash is the bcrypt hash the initial migration (001) seeds
+// for the admin user. Despite the migration comment it is NOT a hash of the
+// documented admin123 password — it is a well-known placeholder. While it is
+// still in place the operator's configured bootstrap password has never taken
+// effect, so bootstrap treats it as "not yet set" and applies the configured
+// password. Once the admin password has been changed (API rotation or a prior
+// bootstrap correction) this no longer matches and the password is left alone.
+const seedPlaceholderAdminHash = "$2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPj/VcSAg/ROS"
 
+// bootstrapAdmin ensures the admin user exists with the configured password.
+func bootstrapAdmin(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, log logger.Logger) error {
 	authSvc := auth.NewService(cfg.Auth.JWTSecret, cfg.Auth.JWTExpiryHours, cfg.Auth.BcryptCost)
 	userRepo := postgres.NewUserRepo(pool)
 	roleRepo := postgres.NewRoleRepo(pool)
+	return ensureBootstrapAdmin(ctx, userRepo, roleRepo, authSvc, cfg.Bootstrap, log)
+}
+
+// ensureBootstrapAdmin creates the admin user on first boot (with the configured
+// password and the nx-admin role) and, on subsequent boots, applies the
+// configured password only if the stored hash is still the seed placeholder.
+// An admin whose password has genuinely been changed is never touched.
+func ensureBootstrapAdmin(
+	ctx context.Context,
+	userRepo repository.UserRepo,
+	roleRepo repository.RoleRepo,
+	authSvc *auth.Service,
+	b config.BootstrapConfig,
+	log logger.Logger,
+) error {
+	if b.AdminUsername == "" || b.AdminPassword == "" {
+		return nil
+	}
 
 	hash, err := authSvc.HashPassword(b.AdminPassword)
 	if err != nil {
@@ -294,7 +315,7 @@ func bootstrapAdmin(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config,
 	}
 
 	existing, err := userRepo.Get(ctx, b.AdminUsername)
-	if err != nil {
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		return err
 	}
 
@@ -319,11 +340,21 @@ func bootstrapAdmin(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config,
 			_ = roleRepo.SetUserRoles(ctx, u.ID, []string{adminRole.ID})
 		}
 		log.Info("bootstrap: admin user created", "username", b.AdminUsername)
-	} else {
-		// Bootstrap only owns initial creation — do not touch an existing
-		// admin's password (operators rotate it via the API, not config).
-		log.Info("bootstrap: admin user already exists — password not modified", "username", b.AdminUsername)
+		return nil
 	}
+
+	// Admin already exists. The seed migration pre-creates it with a placeholder
+	// hash; while that placeholder is in place the configured password has never
+	// applied, so set it now (first-boot correction). Otherwise leave it alone —
+	// operators rotate the password via the API, not config + restart.
+	if existing.PasswordHash == seedPlaceholderAdminHash {
+		if err := userRepo.UpdatePassword(ctx, b.AdminUsername, hash); err != nil {
+			return err
+		}
+		log.Info("bootstrap: admin had the seed placeholder password — applied configured admin_password", "username", b.AdminUsername)
+		return nil
+	}
+	log.Info("bootstrap: admin user already exists — password not modified", "username", b.AdminUsername)
 	return nil
 }
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/auth"
+	"github.com/nexspence-oss/nexspence/internal/config"
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/logger"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func testBootstrapCfg() config.BootstrapConfig {
+	return config.BootstrapConfig{
+		AdminUsername:  "admin",
+		AdminPassword:  "admin123",
+		AdminEmail:     "admin@example.com",
+		AdminFirstName: "Admin",
+	}
+}
+
+func testAuthSvc() *auth.Service {
+	// bcrypt cost 4 (MinCost) keeps these tests fast.
+	return auth.NewService("test-secret-test-secret-test-1234", 8, 4)
+}
+
+// Regression: a fresh deploy seeds the admin row with a placeholder hash (NOT
+// admin123). Bootstrap must apply the configured password so admin/admin123 can
+// log in. Previously bootstrap saw "admin already exists" and left the broken
+// placeholder in place.
+func TestEnsureBootstrapAdmin_SeedPlaceholder_PasswordApplied(t *testing.T) {
+	authSvc := testAuthSvc()
+	users := testutil.NewUserRepo(&domain.User{
+		ID:           "u-admin",
+		Username:     "admin",
+		PasswordHash: seedPlaceholderAdminHash,
+		Status:       domain.UserStatusActive,
+		Source:       domain.UserSourceLocal,
+	})
+	log := logger.New("error", "json")
+
+	if err := ensureBootstrapAdmin(context.Background(), users, testutil.NewRoleRepo(), authSvc, testBootstrapCfg(), log); err != nil {
+		t.Fatalf("ensureBootstrapAdmin: %v", err)
+	}
+
+	got, _ := users.Get(context.Background(), "admin")
+	if got.PasswordHash == seedPlaceholderAdminHash {
+		t.Fatal("password hash still the seed placeholder; configured password was not applied")
+	}
+	if err := authSvc.CheckPassword(got.PasswordHash, "admin123"); err != nil {
+		t.Fatalf("admin123 does not verify against the stored hash: %v", err)
+	}
+}
+
+// A genuinely changed admin password must never be clobbered by bootstrap
+// (preserves the #36 hardening intent: rotate via API, not config+restart).
+func TestEnsureBootstrapAdmin_ChangedPassword_NotModified(t *testing.T) {
+	authSvc := testAuthSvc()
+	custom, err := authSvc.HashPassword("operator-secret")
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	users := testutil.NewUserRepo(&domain.User{
+		ID:           "u-admin",
+		Username:     "admin",
+		PasswordHash: custom,
+		Status:       domain.UserStatusActive,
+	})
+	log := logger.New("error", "json")
+
+	if err := ensureBootstrapAdmin(context.Background(), users, testutil.NewRoleRepo(), authSvc, testBootstrapCfg(), log); err != nil {
+		t.Fatalf("ensureBootstrapAdmin: %v", err)
+	}
+
+	got, _ := users.Get(context.Background(), "admin")
+	if got.PasswordHash != custom {
+		t.Fatal("changed admin password was overwritten by bootstrap")
+	}
+	if err := authSvc.CheckPassword(got.PasswordHash, "admin123"); err == nil {
+		t.Fatal("admin123 must NOT verify against a changed password")
+	}
+}
+
+// No admin row at all: bootstrap creates one with the configured password and
+// the nx-admin role. (mock Get returns ErrNotFound, which must be treated as
+// "not found", not a hard error.)
+func TestEnsureBootstrapAdmin_Missing_Created(t *testing.T) {
+	authSvc := testAuthSvc()
+	users := testutil.NewUserRepo()
+	roles := testutil.NewRoleRepo(&domain.Role{ID: "r-admin", Name: "nx-admin"})
+	log := logger.New("error", "json")
+
+	if err := ensureBootstrapAdmin(context.Background(), users, roles, authSvc, testBootstrapCfg(), log); err != nil {
+		t.Fatalf("ensureBootstrapAdmin: %v", err)
+	}
+
+	got, err := users.Get(context.Background(), "admin")
+	if err != nil || got == nil {
+		t.Fatalf("admin not created: err=%v", err)
+	}
+	if err := authSvc.CheckPassword(got.PasswordHash, "admin123"); err != nil {
+		t.Fatalf("created admin password does not verify: %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

A **fresh deploy cannot log in as `admin` / `admin123`** (confirmed on a clean v1.20.1 k8s install → `{"error":"invalid credentials"}`).

**Root cause:** migration `001_initial.sql` seeds the admin user with `$2a$12$LQv3c1yqBWVHxkd0LHAkCO...` — the well-known tutorial placeholder hash, **not** a hash of `admin123` (despite the migration comment). Historically the startup bootstrap overwrote it every boot, so login worked. The #36 hardening ("bootstrap no longer overwrites admin pw") removed that overwrite, so the broken placeholder now stands and **neither `admin123` nor a custom `NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD` ever takes effect** on a new database.

## Fix

`bootstrapAdmin` now delegates to a testable `ensureBootstrapAdmin(userRepo, roleRepo, authSvc, cfg, log)`:

- **missing admin** → create with configured password + `nx-admin` role (also fixes a latent bug: the repo returns `ErrNotFound`, which the old code treated as a hard error rather than "create");
- **admin exists with the seed placeholder hash** → apply the configured password (first-boot correction);
- **admin password genuinely changed** → left untouched (preserves the #36 intent: rotate via API, not config+restart).

## Tests

`cmd/server/main_test.go` (testutil mocks, no DB) covers all three paths:
- `SeedPlaceholder_PasswordApplied` — the regression
- `ChangedPassword_NotModified` — #36 guarantee
- `Missing_Created` — fresh create + ErrNotFound handling

`go build ./...`, `go vet`, `gofmt` clean; tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)