### PR TITLE
fix(test): ensure current audit_events partition exists in integration tests

### DIFF
--- a/internal/testutil/pgtest/pgtest.go
+++ b/internal/testutil/pgtest/pgtest.go
@@ -16,7 +16,10 @@ import (
 	"github.com/ory/dockertest/v3"
 	"github.com/ory/dockertest/v3/docker"
 
+	"github.com/nexspence-oss/nexspence/internal/audit"
+	"github.com/nexspence-oss/nexspence/internal/config"
 	appdb "github.com/nexspence-oss/nexspence/internal/db"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 )
 
 var (
@@ -103,6 +106,15 @@ func start() {
 		startErr = fmt.Errorf("connect pool: %w", err)
 		return
 	}
+
+	// Migrations only ship the partitions that existed for audit_events at
+	// authoring time. Production guarantees the current partition via
+	// Rotator.RunOnce() at server startup (cmd/server/main.go) — mirror that
+	// here so tests don't rot once the calendar rolls past the last
+	// hand-written partition.
+	auditCfg := config.AuditConfig{LookaheadMonths: 2}
+	rotator := audit.NewRotator(audit.NewPgPartitionStore(p), auditCfg, logger.New("error", "json"))
+	rotator.RunOnce(context.Background())
 
 	pool = p
 	purge = func() {


### PR DESCRIPTION
## Summary
- All 15 open dependabot PRs (and any fresh PR) currently fail `integration tests (postgres + storage)` with `no partition of relation "audit_events" found for row` — unrelated to any of those dependency bumps.
- Root cause: `internal/db/migrations/001_initial.sql` only ships static `audit_events` partitions through 2026-06. Production creates the current + lookahead partitions via `Rotator.RunOnce()` at server startup (`cmd/server/main.go:135-136`), but the integration test fixture (`internal/testutil/pgtest/pgtest.go`) only ran migrations and never invoked that rotation logic — so tests broke the moment the calendar rolled past June.
- Fix: `pgtest.go` now runs the same rotator logic after migrating, mirroring the production startup path.

## Test plan
- [x] `go test -tags=integration ./internal/repository/postgres/...` — 396/396 passing (was previously failing `TestAuditRepo_*`)
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)