### PR TITLE
feat: blob garbage collection (age-gated, scheduler, UI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,10 +314,10 @@ The Helm chart reference ships with the chart itself: [`deploy/helm/nexspence/RE
 | 60–63 | LDAP role mapping, Conda, Terraform, Helm chart | ✓ complete |
 | 64–67 | Landing page, in-app docs, security hardening | ✓ complete |
 | 68 | Extended monitoring — Prometheus endpoint, Grafana dashboard, UI Charts tab | ✓ complete |
+| 69 | Blob GC — age-gated orphan collection, global cron scheduler, UI panel | ✓ complete |
 | CLI | [`nxs` CLI](https://github.com/nexspence/nxs) — terminal & CI/CD client, v0.1.0 | ✓ complete |
 | next | SBOM generation, cosign image signing | planned |
 | next | OpenTelemetry traces | planned |
-| next | blob GC | planned |
 
 ---
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -66,6 +66,12 @@ search:
 cleanup:
   default_schedule: "0 */6 * * *"   # cron schedule used for policies without schedule_cron
 
+# Blob garbage collection: remove blobs no longer referenced by any asset.
+gc:
+  enabled: true              # run scheduled blob garbage collection
+  schedule: "0 3 * * 0"      # cron: weekly, Sunday 03:00
+  min_age: "24h"             # only collect orphans older than this (grace period)
+
 # Audit log retention.
 # Events live in monthly PostgreSQL partitions.
 # Rotator pre-creates partitions for the next `lookahead_months` ahead and

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -735,6 +735,45 @@ paths:
       responses:
         '200': { description: OK }
 
+  /api/v1/blobstores/{name}/compact:
+    post:
+      tags: [BlobStores]
+      summary: Garbage-collect unreferenced blobs
+      description: >
+        Scans the named blob store and removes blobs no longer referenced by any
+        asset (orphans) that are older than the grace period. Admin only.
+      operationId: compactBlobStore
+      parameters:
+        - { name: name, in: path, required: true, schema: { type: string } }
+        - name: dry_run
+          in: query
+          required: false
+          description: Report orphans without deleting them.
+          schema: { type: boolean }
+        - name: min_age
+          in: query
+          required: false
+          description: >
+            Only collect orphans older than this Go duration (e.g. "24h").
+            Absent or 0 uses the server's configured gc.min_age default.
+          schema: { type: string }
+      responses:
+        '200':
+          description: Compaction result
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  store: { type: string }
+                  scannedBlobs: { type: integer }
+                  orphans: { type: integer }
+                  freedBytes: { type: integer, format: int64 }
+                  dryRun: { type: boolean }
+                  errors: { type: array, items: { type: string } }
+        '400': { description: Invalid min_age }
+        '503': { description: GC service not configured }
+
   /service/rest/v1/blobstores/file:
     post:
       tags: [BlobStores]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -282,6 +282,13 @@ export const nexusApi = {
     apiClient.delete(`/service/rest/v1/blobstores/${name}`),
   getBlobStoreUsage: (name: string) =>
     apiClient.get(`/api/v1/blob-stores/${name}/usage`),
+  compactBlobStore: (name: string, opts?: { dryRun?: boolean; minAge?: string }) =>
+    apiClient.post(`/api/v1/blobstores/${name}/compact`, null, {
+      params: {
+        dry_run: opts?.dryRun ? 'true' : undefined,
+        min_age: opts?.minAge || undefined,
+      },
+    }),
   testBlobStore: (type: string, config: Record<string, unknown>) =>
     apiClient.post<{ ok: boolean; error?: string }>('/api/v1/blobstores/test', { type, config }),
 

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -131,6 +131,26 @@ describe('AdminPage — Blob Stores tab', () => {
     expect(screen.getByText('maven-hosted')).toBeInTheDocument()
   })
 
+  it('detail modal: runs a dry-run garbage collection', async () => {
+    let compactUrl = ''
+    server.use(
+      http.get('/service/rest/v1/blobstores', () => HttpResponse.json([blobStore])),
+      http.get('/api/v1/blob-stores/:name/usage', () =>
+        HttpResponse.json({ store: blobStore, linkedRepositories: [], totalAssetBytes: 0 }),
+      ),
+      http.post('/api/v1/blobstores/:name/compact', ({ request }) => {
+        compactUrl = request.url
+        return HttpResponse.json({ store: 'default', scannedBlobs: 5, orphans: 2, freedBytes: 2048, dryRun: true })
+      }),
+    )
+    renderAdmin('blobs')
+    fireEvent.click(await screen.findByText('default'))
+    await screen.findByText('Blob Store: default')
+    fireEvent.click(await screen.findByRole('button', { name: /Dry run/i }))
+    await waitFor(() => expect(compactUrl).toContain('dry_run=true'))
+    expect(await screen.findByText(/2 orphans/i)).toBeInTheDocument()
+  })
+
   it('detail modal: edit local path config and save', async () => {
     let put: { config?: { path?: string } } | null = null
     server.use(

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1631,6 +1631,29 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
     },
   })
 
+  const [gcResult, setGcResult] = useState<null | {
+    scannedBlobs: number; orphans: number; freedBytes: number; dryRun: boolean
+  }>(null)
+  const [gcError, setGcError] = useState('')
+  const gcMut = useMutation({
+    mutationFn: (dryRun: boolean) =>
+      nexusApi.compactBlobStore(name, { dryRun }).then(r => r.data as {
+        scannedBlobs: number; orphans: number; freedBytes: number; dryRun: boolean
+      }),
+    onSuccess: (res) => {
+      setGcResult(res)
+      setGcError('')
+      if (!res.dryRun) {
+        qc.invalidateQueries({ queryKey: ['blobstore-usage', name] })
+        qc.invalidateQueries({ queryKey: ['blobstores'] })
+      }
+    },
+    onError: (e: unknown) => {
+      const msg = (e as { response?: { data?: { error?: string } } })?.response?.data?.error ?? 'GC failed'
+      setGcError(msg)
+    },
+  })
+
   const startEdit = () => {
     const cfg = bs?.config ?? {}
     setEditBucket((cfg.bucket as string) ?? '')
@@ -1769,6 +1792,38 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
                 </HoloButton>
                 <HoloButton onClick={() => { setEditing(false); setEditErr('') }}>Cancel</HoloButton>
               </div>
+            </div>
+          )}
+
+          {bs.type !== 'group' && (
+            <div style={{ marginBottom: 16, padding: '12px 14px', background: 'rgba(255,255,255,0.03)', borderRadius: 10, border: '1px solid var(--holo-border)' }}>
+              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-faint)', textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: 8 }}>
+                Garbage collection
+              </div>
+              <p style={{ fontSize: 12, color: 'var(--holo-text-dim)', margin: '0 0 10px' }}>
+                Remove blobs no longer referenced by any asset (older than the grace period).
+              </p>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <HoloButton disabled={gcMut.isPending} onClick={() => gcMut.mutate(true)}>
+                  {gcMut.isPending ? 'Scanning…' : 'Dry run'}
+                </HoloButton>
+                <HoloButton
+                  variant="danger"
+                  disabled={gcMut.isPending}
+                  onClick={() => { if (confirm(`Run garbage collection on "${name}"? Orphaned blobs will be deleted.`)) gcMut.mutate(false) }}
+                >
+                  Compact
+                </HoloButton>
+              </div>
+              {gcResult && (
+                <div role="status" style={{ marginTop: 10, fontSize: 12, color: 'var(--holo-text)' }}>
+                  {gcResult.dryRun ? 'Dry run: ' : 'Collected: '}
+                  {gcResult.orphans} orphans ({fmtBytes(gcResult.freedBytes)}) of {gcResult.scannedBlobs} scanned.
+                </div>
+              )}
+              {gcError && (
+                <div role="alert" style={{ marginTop: 8, color: 'var(--holo-red)', fontSize: 12 }}>{gcError}</div>
+              )}
             </div>
           )}
 

--- a/internal/api/handlers/blobstores.go
+++ b/internal/api/handlers/blobstores.go
@@ -495,14 +495,24 @@ func (h *BlobStoreHandler) TestConnection(c *gin.Context) {
 }
 
 // Compact handles POST /api/v1/blobstores/:name/compact
-// Query param ?dry_run=true reports orphans without deleting them.
+// Query params: ?dry_run=true reports orphans without deleting;
+// ?min_age=24h overrides the configured grace period (0/absent → server default).
 func (h *BlobStoreHandler) Compact(c *gin.Context) {
 	if h.gcSvc == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "GC service not configured"})
 		return
 	}
-	dryRun := c.Query("dry_run") == "true"
-	result, err := h.gcSvc.Compact(c.Request.Context(), dryRun)
+	name := c.Param("name")
+	opts := service.GCOptions{DryRun: c.Query("dry_run") == "true"}
+	if raw := c.Query("min_age"); raw != "" {
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid min_age: " + err.Error()})
+			return
+		}
+		opts.MinAge = d
+	}
+	result, err := h.gcSvc.CompactStore(c.Request.Context(), name, opts)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/api/handlers/blobstores_test.go
+++ b/internal/api/handlers/blobstores_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
@@ -26,7 +27,12 @@ func mountBlobStores(t *testing.T, stores ...*domain.BlobStore) (*gin.Engine, *t
 	repoRepo := testutil.NewRepoRepo()
 	assetRepo := testutil.NewAssetRepo()
 	blobStore := testutil.NewBlobStore()
-	gc := &service.BlobGCService{Assets: assetRepo, BlobStore: blobStore}
+	gc := &service.BlobGCService{
+		Assets:   assetRepo,
+		Stores:   blobRepo,
+		Resolver: testutil.NewFakeResolver(blobStore),
+		Log:      slog.Default(),
+	}
 
 	h := handlers.NewBlobStoreHandler(blobRepo).
 		WithBlobStore(blobStore).
@@ -313,7 +319,7 @@ func TestBlobStore_Compact_DryRun_Success(t *testing.T) {
 	// Put an orphan blob (no asset references it) so Compact reports an orphan.
 	require.NoError(t, blobStore.Put(testContext(), "orphan-key", strings.NewReader("data"), 4))
 
-	rec := do(t, r, http.MethodPost, "/api/v1/blobstores/store-a/compact?dry_run=true", nil)
+	rec := do(t, r, http.MethodPost, "/api/v1/blobstores/default/compact?dry_run=true", nil)
 	require.Equal(t, http.StatusOK, rec.Code)
 	var res service.GCResult
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
@@ -327,7 +333,7 @@ func TestBlobStore_Compact_Delete_Success(t *testing.T) {
 	r, _, _, _, blobStore := mountBlobStores(t)
 	require.NoError(t, blobStore.Put(testContext(), "orphan-key", strings.NewReader("data"), 4))
 
-	rec := do(t, r, http.MethodPost, "/api/v1/blobstores/store-a/compact", nil)
+	rec := do(t, r, http.MethodPost, "/api/v1/blobstores/default/compact", nil)
 	require.Equal(t, http.StatusOK, rec.Code)
 	var res service.GCResult
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))

--- a/internal/api/handlers/blobstores_test.go
+++ b/internal/api/handlers/blobstores_test.go
@@ -2,7 +2,6 @@ package handlers_test
 
 import (
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"strings"
 	"testing"
@@ -31,7 +30,6 @@ func mountBlobStores(t *testing.T, stores ...*domain.BlobStore) (*gin.Engine, *t
 		Assets:   assetRepo,
 		Stores:   blobRepo,
 		Resolver: testutil.NewFakeResolver(blobStore),
-		Log:      slog.Default(),
 	}
 
 	h := handlers.NewBlobStoreHandler(blobRepo).

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -161,6 +161,18 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	// Start per-policy cron scheduler in background (default: cfg.Cleanup.DefaultSchedule).
 	go cleanupSvc.StartCronScheduler(context.Background(), cfg.Cleanup.DefaultSchedule)
 
+	gcSvc := &service.BlobGCService{
+		Assets:        assetRepo,
+		Stores:        blobRepo,
+		Resolver:      blobRegistry,
+		Locker:        locker,
+		Log:           log,
+		DefaultMinAge: cfg.GC.MinAge,
+	}
+	if cfg.GC.Enabled {
+		go gcSvc.StartCronScheduler(context.Background(), cfg.GC.Schedule, cfg.GC.MinAge)
+	}
+
 	replSvc := service.NewReplicationService(replRepo, assetRepo, localBlob, cfg.Auth.JWTSecret, cfg.Auth.EncryptionKeyBytes(), log)
 	go replSvc.StartCronScheduler(context.Background())
 
@@ -213,7 +225,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, log)
 	repoH := handlers.NewRepositoryHandler(repoSvc, rbacSvc)
 	userH := handlers.NewUserHandler(userSvc)
-	blobH := handlers.NewBlobStoreHandler(blobRepo).WithUsageDeps(repoRepo, assetRepo).WithRegistry(blobRegistry)
+	blobH := handlers.NewBlobStoreHandler(blobRepo).WithUsageDeps(repoRepo, assetRepo).WithRegistry(blobRegistry).WithGC(gcSvc)
 	componentH := handlers.NewComponentHandler(componentRepo, assetRepo, repoRepo, cfg.HTTP.BaseURL).WithRBAC(rbacSvc)
 	browseH := handlers.NewBrowseHandler(repoRepo, componentRepo, assetRepo, blobRepo, localBlob, rbacSvc)
 	cleanupH := handlers.NewCleanupHandler(cleanupRepo, repoRepo, cleanupSvc)
@@ -434,6 +446,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		admin.POST("/service/rest/v1/blobstores/:type", blobH.Create)
 		admin.PUT("/service/rest/v1/blobstores/:type/:name", blobH.Update)
 		admin.DELETE("/service/rest/v1/blobstores/:name", blobH.Delete)
+		admin.POST("/api/v1/blobstores/:name/compact", blobH.Compact)
 
 		// ── Users ─────────────────────────────────────────────
 		admin.GET("/service/rest/v1/security/users", userH.List)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Log       LogConfig       `mapstructure:"log"`
 	Search    SearchConfig    `mapstructure:"search"`
 	Cleanup   CleanupConfig   `mapstructure:"cleanup"`
+	GC        GCConfig        `mapstructure:"gc"`
 	Audit     AuditConfig     `mapstructure:"audit"`
 	Docker    DockerConfig    `mapstructure:"docker"`
 	Redis     RedisConfig     `mapstructure:"redis"`
@@ -323,6 +324,13 @@ type CleanupConfig struct {
 	DefaultSchedule string `mapstructure:"default_schedule"`
 }
 
+// GCConfig configures scheduled blob garbage collection.
+type GCConfig struct {
+	Enabled  bool          `mapstructure:"enabled"`
+	Schedule string        `mapstructure:"schedule"`
+	MinAge   time.Duration `mapstructure:"min_age"`
+}
+
 // AuditConfig controls audit-log retention, soft cap, and partition rotation.
 type AuditConfig struct {
 	RetentionDays    int           `mapstructure:"retention_days"`
@@ -392,6 +400,9 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("log.format", "json")
 	v.SetDefault("search.min_query_len", 2)
 	v.SetDefault("cleanup.default_schedule", "0 */6 * * *")
+	v.SetDefault("gc.enabled", true)
+	v.SetDefault("gc.schedule", "0 3 * * 0")
+	v.SetDefault("gc.min_age", "24h")
 	v.SetDefault("audit.retention_days", 90)
 	v.SetDefault("audit.soft_cap", int64(1_000_000))
 	v.SetDefault("audit.rotation_interval", "24h")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -175,6 +176,21 @@ func TestLoad_AllowInsecureDefaults_DefaultsFalse(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cfg.Auth.AllowInsecureDefaults,
 		"auth.allow_insecure_defaults must default to false (fail-closed)")
+}
+
+func TestLoad_GCDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.GC.Enabled, "gc.enabled default should be true")
+	assert.Equal(t, "0 3 * * 0", cfg.GC.Schedule)
+	assert.Equal(t, 24*time.Hour, cfg.GC.MinAge)
 }
 
 func TestLoad_AllowInsecureDefaults_EnvOverride(t *testing.T) {

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -2,14 +2,34 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"time"
 
+	"github.com/robfig/cron/v3"
+
+	"github.com/nexspence-oss/nexspence/internal/distlock"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 )
 
-// GCResult reports what was found and removed during a compaction run.
+// StoreResolver resolves a physical BlobStore from a descriptor.
+// *storage.Registry satisfies this interface.
+type StoreResolver interface {
+	Get(ctx context.Context, desc storage.BlobStoreDescriptor) (storage.BlobStore, error)
+}
+
+// GCOptions controls a compaction run.
+// MinAge <= 0 means "use the service's DefaultMinAge".
+type GCOptions struct {
+	DryRun bool
+	MinAge time.Duration
+}
+
+// GCResult reports what a single store's compaction found and removed.
 type GCResult struct {
+	Store        string   `json:"store"`
 	ScannedBlobs int      `json:"scannedBlobs"`
 	Orphans      int      `json:"orphans"`
 	FreedBytes   int64    `json:"freedBytes"`
@@ -17,51 +37,159 @@ type GCResult struct {
 	Errors       []string `json:"errors,omitempty"`
 }
 
-// BlobGCService finds and removes blobs in a blob store that are not
-// referenced by any asset record (orphaned blobs).
+// BlobGCService finds and removes blobs not referenced by any asset (orphans),
+// age-gated by a grace period, across one or all blob stores.
 type BlobGCService struct {
-	Assets    repository.AssetRepo
-	BlobStore storage.BlobStore
+	Assets        repository.AssetRepo
+	Stores        repository.BlobStoreRepo
+	Resolver      StoreResolver
+	Locker        distlock.Locker
+	Log           *slog.Logger
+	DefaultMinAge time.Duration
 }
 
-// Compact scans all keys in the blob store, checks each against the asset DB,
-// and deletes any key that has no corresponding asset.
-// If dryRun is true, orphans are reported but not deleted.
-func (s *BlobGCService) Compact(ctx context.Context, dryRun bool) (*GCResult, error) {
-	// Build set of all referenced blob keys from the DB.
-	dbKeys, err := s.Assets.ListAllBlobKeys(ctx)
+const gcLockKey = "nexspence:lock:gc:run"
+const gcLockTTL = 30 * time.Minute
+
+func (s *BlobGCService) log() *slog.Logger {
+	if s.Log != nil {
+		return s.Log
+	}
+	return slog.Default()
+}
+
+// referencedSet returns the set of all blob keys referenced by any asset.
+func (s *BlobGCService) referencedSet(ctx context.Context) (map[string]struct{}, error) {
+	keys, err := s.Assets.ListAllBlobKeys(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list db blob keys: %w", err)
 	}
-	referenced := make(map[string]struct{}, len(dbKeys))
-	for _, k := range dbKeys {
-		referenced[k] = struct{}{}
+	set := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		set[k] = struct{}{}
 	}
+	return set, nil
+}
 
-	// List all keys present in the physical store.
-	storeKeys, err := s.BlobStore.ListKeys(ctx)
+// CompactStore compacts a single blob store by name.
+func (s *BlobGCService) CompactStore(ctx context.Context, name string, opts GCOptions) (*GCResult, error) {
+	referenced, err := s.referencedSet(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list store keys: %w", err)
+		return nil, err
+	}
+	row, err := s.Stores.Get(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("get blob store %q: %w", name, err)
+	}
+	store, err := s.Resolver.Get(ctx, storage.BlobStoreDescriptor{
+		ID: row.ID, Type: row.Type, Config: row.Config,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolve blob store %q: %w", name, err)
+	}
+	return s.compact(ctx, name, store, referenced, opts), nil
+}
+
+// CompactAll compacts every blob store. It holds a distributed lock so only one
+// node runs at a time; if another node holds it, CompactAll returns (nil, nil).
+func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCResult, error) {
+	if s.Locker != nil {
+		lock, err := s.Locker.Acquire(ctx, gcLockKey, gcLockTTL)
+		if errors.Is(err, distlock.ErrLockHeld) {
+			s.log().Info("blob gc skipped: another node is running gc")
+			return nil, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("blob gc: acquire lock: %w", err)
+		}
+		defer func() { _ = lock.Release(ctx) }()
 	}
 
-	result := &GCResult{ScannedBlobs: len(storeKeys), DryRun: dryRun}
+	referenced, err := s.referencedSet(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := s.Stores.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("blob gc: list stores: %w", err)
+	}
 
-	for _, key := range storeKeys {
-		if _, ok := referenced[key]; ok {
-			continue // still used
+	results := make([]*GCResult, 0, len(rows))
+	for i := range rows {
+		row := rows[i]
+		store, rerr := s.Resolver.Get(ctx, storage.BlobStoreDescriptor{
+			ID: row.ID, Type: row.Type, Config: row.Config,
+		})
+		if rerr != nil {
+			s.log().Error("blob gc: resolve store failed", "store", row.Name, "err", rerr)
+			results = append(results, &GCResult{
+				Store:  row.Name,
+				DryRun: opts.DryRun,
+				Errors: []string{fmt.Sprintf("resolve store: %v", rerr)},
+			})
+			continue
 		}
-		// Orphan found.
-		size, _ := s.BlobStore.Size(ctx, key)
-		result.Orphans++
-		result.FreedBytes += size
+		results = append(results, s.compact(ctx, row.Name, store, referenced, opts))
+	}
+	return results, nil
+}
 
-		if !dryRun {
-			if err := s.BlobStore.Delete(ctx, key); err != nil {
-				result.Errors = append(result.Errors,
-					fmt.Sprintf("delete %s: %v", key, err))
+// compact runs the core scan/delete for a single resolved store.
+func (s *BlobGCService) compact(ctx context.Context, name string, store storage.BlobStore,
+	referenced map[string]struct{}, opts GCOptions) *GCResult {
+
+	minAge := opts.MinAge
+	if minAge <= 0 {
+		minAge = s.DefaultMinAge
+	}
+
+	result := &GCResult{Store: name, DryRun: opts.DryRun}
+
+	entries, err := store.ListEntries(ctx)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("list entries: %v", err))
+		return result
+	}
+	result.ScannedBlobs = len(entries)
+
+	for _, e := range entries {
+		if _, ok := referenced[e.Key]; ok {
+			continue // still referenced
+		}
+		// Age gate: skip blobs younger than the grace period (may be an
+		// in-flight upload whose asset row is not committed yet).
+		if minAge > 0 && !e.ModTime.IsZero() && time.Since(e.ModTime) < minAge {
+			continue
+		}
+		result.Orphans++
+		result.FreedBytes += e.Size
+		if !opts.DryRun {
+			if derr := store.Delete(ctx, e.Key); derr != nil {
+				result.Errors = append(result.Errors, fmt.Sprintf("delete %s: %v", e.Key, derr))
 			}
 		}
 	}
+	return result
+}
 
-	return result, nil
+// StartCronScheduler runs CompactAll on the given cron schedule until ctx is
+// done. Run as a goroutine. A blank or invalid schedule disables scheduling.
+func (s *BlobGCService) StartCronScheduler(ctx context.Context, schedule string, minAge time.Duration) {
+	if schedule == "" {
+		s.log().Info("blob gc scheduler disabled: empty schedule")
+		return
+	}
+	c := cron.New()
+	_, err := c.AddFunc(schedule, func() {
+		if _, err := s.CompactAll(context.Background(), GCOptions{MinAge: minAge}); err != nil {
+			s.log().Error("blob gc cron error", "err", err)
+		}
+	})
+	if err != nil {
+		s.log().Error("blob gc: invalid schedule, scheduler disabled", "schedule", schedule, "err", err)
+		return
+	}
+	c.Start()
+	<-ctx.Done()
+	c.Stop()
 }

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"time"
 
 	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
 
 	"github.com/nexspence-oss/nexspence/internal/distlock"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 )
@@ -44,18 +45,18 @@ type BlobGCService struct {
 	Stores        repository.BlobStoreRepo
 	Resolver      StoreResolver
 	Locker        distlock.Locker
-	Log           *slog.Logger
+	Log           logger.Logger
 	DefaultMinAge time.Duration
 }
 
 const gcLockKey = "nexspence:lock:gc:run"
 const gcLockTTL = 30 * time.Minute
 
-func (s *BlobGCService) log() *slog.Logger {
+func (s *BlobGCService) log() logger.Logger {
 	if s.Log != nil {
 		return s.Log
 	}
-	return slog.Default()
+	return zap.NewNop().Sugar()
 }
 
 // referencedSet returns the set of all blob keys referenced by any asset.

--- a/internal/service/gc_service_test.go
+++ b/internal/service/gc_service_test.go
@@ -121,6 +121,30 @@ func TestGC_CompactAllIteratesStores(t *testing.T) {
 	assert.False(t, bs.Has("junk"))
 }
 
+func TestGC_CompactStoreUnknownName(t *testing.T) {
+	svc := buildGC(testutil.NewAssetRepo(), testutil.NewBlobStore())
+	_, err := svc.CompactStore(context.Background(), "does-not-exist", service.GCOptions{})
+	require.Error(t, err)
+}
+
+func TestGC_StartCronScheduler_EmptyScheduleReturns(t *testing.T) {
+	svc := buildGC(testutil.NewAssetRepo(), testutil.NewBlobStore())
+	// Empty schedule must return immediately (no goroutine left blocking).
+	svc.StartCronScheduler(context.Background(), "", 0)
+}
+
+func TestGC_StartCronScheduler_InvalidScheduleReturns(t *testing.T) {
+	svc := buildGC(testutil.NewAssetRepo(), testutil.NewBlobStore())
+	svc.StartCronScheduler(context.Background(), "not-a-valid-cron", 0)
+}
+
+func TestGC_StartCronScheduler_ValidScheduleStopsOnCancel(t *testing.T) {
+	svc := buildGC(testutil.NewAssetRepo(), testutil.NewBlobStore())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel so StartCronScheduler starts then returns at <-ctx.Done()
+	svc.StartCronScheduler(ctx, "0 0 * * *", time.Hour)
+}
+
 func TestGC_CompactAllSkipsWhenLockHeld(t *testing.T) {
 	assets := testutil.NewAssetRepo()
 	bs := testutil.NewBlobStore()

--- a/internal/service/gc_service_test.go
+++ b/internal/service/gc_service_test.go
@@ -3,7 +3,9 @@ package service_test
 import (
 	"bytes"
 	"context"
+	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,17 +15,23 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
-func buildGC(assetRepo *testutil.AssetRepo, bs *testutil.BlobStore) *service.BlobGCService {
-	return &service.BlobGCService{Assets: assetRepo, BlobStore: bs}
+func buildGC(assets *testutil.AssetRepo, bs *testutil.BlobStore) *service.BlobGCService {
+	return &service.BlobGCService{
+		Assets:   assets,
+		Stores:   testutil.NewBlobStoreRepo(), // provides a "default" store
+		Resolver: testutil.NewFakeResolver(bs),
+		Log:      slog.Default(),
+	}
 }
 
 func TestGC_NoBlobs(t *testing.T) {
 	svc := buildGC(testutil.NewAssetRepo(), testutil.NewBlobStore())
-	result, err := svc.Compact(context.Background(), false)
+	result, err := svc.CompactStore(context.Background(), "default", service.GCOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.ScannedBlobs)
 	assert.Equal(t, 0, result.Orphans)
 	assert.Equal(t, int64(0), result.FreedBytes)
+	assert.Equal(t, "default", result.Store)
 }
 
 func TestGC_AllReferenced(t *testing.T) {
@@ -31,75 +39,101 @@ func TestGC_AllReferenced(t *testing.T) {
 	bs := testutil.NewBlobStore()
 	ctx := context.Background()
 
-	// Put a blob and a matching asset.
 	require.NoError(t, bs.Put(ctx, "key1", bytes.NewReader([]byte("data")), 4))
-	asset := &domain.Asset{
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
 		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
 		Path: "/file.txt", BlobKey: "key1", BlobStoreID: "bs1",
-	}
-	require.NoError(t, assets.Create(ctx, asset))
+	}))
 
 	svc := buildGC(assets, bs)
-	result, err := svc.Compact(ctx, false)
+	result, err := svc.CompactStore(ctx, "default", service.GCOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.ScannedBlobs)
 	assert.Equal(t, 0, result.Orphans)
-	assert.True(t, bs.Has("key1"), "referenced blob must not be deleted")
+	assert.True(t, bs.Has("key1"))
 }
 
 func TestGC_OrphanDeleted(t *testing.T) {
 	assets := testutil.NewAssetRepo()
 	bs := testutil.NewBlobStore()
 	ctx := context.Background()
-
-	// Blob exists in store but has no asset.
 	require.NoError(t, bs.Put(ctx, "orphan1", bytes.NewReader([]byte("garbage")), 7))
 
 	svc := buildGC(assets, bs)
-	result, err := svc.Compact(ctx, false)
+	result, err := svc.CompactStore(ctx, "default", service.GCOptions{})
 	require.NoError(t, err)
-	assert.Equal(t, 1, result.ScannedBlobs)
 	assert.Equal(t, 1, result.Orphans)
 	assert.Equal(t, int64(7), result.FreedBytes)
-	assert.False(t, bs.Has("orphan1"), "orphaned blob must be deleted")
+	assert.False(t, bs.Has("orphan1"))
 }
 
 func TestGC_DryRunKeepsBlob(t *testing.T) {
 	assets := testutil.NewAssetRepo()
 	bs := testutil.NewBlobStore()
 	ctx := context.Background()
-
 	require.NoError(t, bs.Put(ctx, "orphan2", bytes.NewReader([]byte("dry")), 3))
 
 	svc := buildGC(assets, bs)
-	result, err := svc.Compact(ctx, true) // dry_run=true
+	result, err := svc.CompactStore(ctx, "default", service.GCOptions{DryRun: true})
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Orphans)
 	assert.True(t, result.DryRun)
-	assert.True(t, bs.Has("orphan2"), "dry run must not delete anything")
+	assert.True(t, bs.Has("orphan2"))
 }
 
-func TestGC_MixedReferencedAndOrphans(t *testing.T) {
+func TestGC_FreshOrphanRetainedByMinAge(t *testing.T) {
 	assets := testutil.NewAssetRepo()
 	bs := testutil.NewBlobStore()
 	ctx := context.Background()
-
-	// Two blobs: one referenced, one orphaned.
-	require.NoError(t, bs.Put(ctx, "good", bytes.NewReader([]byte("ok")), 2))
-	require.NoError(t, bs.Put(ctx, "bad", bytes.NewReader([]byte("junk")), 4))
-
-	asset := &domain.Asset{
-		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
-		Path: "/ok", BlobKey: "good", BlobStoreID: "bs1",
-	}
-	require.NoError(t, assets.Create(ctx, asset))
+	require.NoError(t, bs.Put(ctx, "fresh", bytes.NewReader([]byte("new")), 3))
+	// Put sets mtime = now, so a 24h grace period must retain it.
 
 	svc := buildGC(assets, bs)
-	result, err := svc.Compact(ctx, false)
+	result, err := svc.CompactStore(ctx, "default", service.GCOptions{MinAge: 24 * time.Hour})
 	require.NoError(t, err)
-	assert.Equal(t, 2, result.ScannedBlobs)
+	assert.Equal(t, 0, result.Orphans, "fresh orphan must be retained")
+	assert.True(t, bs.Has("fresh"))
+}
+
+func TestGC_OldOrphanCollectedByMinAge(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	bs := testutil.NewBlobStore()
+	ctx := context.Background()
+	require.NoError(t, bs.Put(ctx, "old", bytes.NewReader([]byte("old")), 3))
+	bs.SetMTime("old", time.Now().Add(-48*time.Hour))
+
+	svc := buildGC(assets, bs)
+	result, err := svc.CompactStore(ctx, "default", service.GCOptions{MinAge: 24 * time.Hour})
+	require.NoError(t, err)
 	assert.Equal(t, 1, result.Orphans)
-	assert.Equal(t, int64(4), result.FreedBytes)
-	assert.True(t, bs.Has("good"))
-	assert.False(t, bs.Has("bad"))
+	assert.False(t, bs.Has("old"))
+}
+
+func TestGC_CompactAllIteratesStores(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	bs := testutil.NewBlobStore()
+	ctx := context.Background()
+	require.NoError(t, bs.Put(ctx, "junk", bytes.NewReader([]byte("x")), 1))
+
+	svc := buildGC(assets, bs) // testutil repo yields exactly one store: "default"
+	results, err := svc.CompactAll(ctx, service.GCOptions{})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, 1, results[0].Orphans)
+	assert.False(t, bs.Has("junk"))
+}
+
+func TestGC_CompactAllSkipsWhenLockHeld(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	bs := testutil.NewBlobStore()
+	ctx := context.Background()
+	require.NoError(t, bs.Put(ctx, "junk", bytes.NewReader([]byte("x")), 1))
+
+	svc := buildGC(assets, bs)
+	svc.Locker = testutil.NewHeldLocker() // Acquire always returns distlock.ErrLockHeld
+
+	results, err := svc.CompactAll(ctx, service.GCOptions{})
+	require.NoError(t, err)
+	assert.Nil(t, results, "must skip when another node holds the lock")
+	assert.True(t, bs.Has("junk"), "nothing collected when skipped")
 }

--- a/internal/service/gc_service_test.go
+++ b/internal/service/gc_service_test.go
@@ -3,7 +3,6 @@ package service_test
 import (
 	"bytes"
 	"context"
-	"log/slog"
 	"testing"
 	"time"
 
@@ -20,7 +19,6 @@ func buildGC(assets *testutil.AssetRepo, bs *testutil.BlobStore) *service.BlobGC
 		Assets:   assets,
 		Stores:   testutil.NewBlobStoreRepo(), // provides a "default" store
 		Resolver: testutil.NewFakeResolver(bs),
-		Log:      slog.Default(),
 	}
 }
 

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -151,6 +151,29 @@ func (s *LocalBlobStore) ListKeys(_ context.Context) ([]string, error) {
 	return keys, err
 }
 
+// ListEntries walks the store and returns each blob's key, size and mtime.
+func (s *LocalBlobStore) ListEntries(_ context.Context) ([]BlobEntry, error) {
+	var entries []BlobEntry
+	err := filepath.WalkDir(s.basePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			return ierr
+		}
+		rel, _ := filepath.Rel(s.basePath, path)
+		parts := strings.SplitN(filepath.ToSlash(rel), "/", 3)
+		key := rel
+		if len(parts) == 3 {
+			key = parts[2]
+		}
+		entries = append(entries, BlobEntry{Key: key, Size: info.Size(), ModTime: info.ModTime()})
+		return nil
+	})
+	return entries, err
+}
+
 // UsedBytes returns the total size of all blobs under the base directory.
 func (s *LocalBlobStore) UsedBytes(_ context.Context) (int64, error) {
 	var total int64

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -158,6 +159,21 @@ func TestLocalBlobStore_ListKeys_Multiple(t *testing.T) {
 	for _, k := range put {
 		assert.Contains(t, keys, k)
 	}
+}
+
+func TestLocalBlobStore_ListEntries(t *testing.T) {
+	store := newLocal(t)
+	ctx := context.Background()
+	require.NoError(t, store.Put(ctx, "abcdef01", bytes.NewReader([]byte("hello")), 5))
+
+	entries, err := store.ListEntries(ctx)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	e := entries[0]
+	assert.Equal(t, "abcdef01", e.Key)
+	assert.EqualValues(t, 5, e.Size)
+	assert.False(t, e.ModTime.IsZero(), "mod time must not be zero")
+	assert.LessOrEqual(t, time.Since(e.ModTime), time.Minute, "mod time must be recent")
 }
 
 func TestLocalBlobStore_UsedBytes_Empty(t *testing.T) {

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -197,6 +197,40 @@ func (s *S3BlobStore) ListKeys(ctx context.Context) ([]string, error) {
 	return keys, nil
 }
 
+// ListEntries returns every object's blob key, size and last-modified time.
+func (s *S3BlobStore) ListEntries(ctx context.Context) ([]BlobEntry, error) {
+	var entries []BlobEntry
+	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return entries, fmt.Errorf("s3 list entries: %w", err)
+		}
+		for _, obj := range page.Contents {
+			if obj.Key == nil {
+				continue
+			}
+			parts := strings.SplitN(*obj.Key, "/", 3)
+			key := *obj.Key
+			if len(parts) == 3 {
+				key = parts[2]
+			}
+			var size int64
+			if obj.Size != nil {
+				size = *obj.Size
+			}
+			var mt time.Time
+			if obj.LastModified != nil {
+				mt = *obj.LastModified
+			}
+			entries = append(entries, BlobEntry{Key: key, Size: size, ModTime: mt})
+		}
+	}
+	return entries, nil
+}
+
 // UsedBytes sums the size of all objects in the bucket.
 // This iterates all objects and may be slow on large buckets.
 // For production, prefer S3 Storage Lens metrics or a cached counter.

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -30,6 +30,17 @@ type BlobStore interface {
 	// ListKeys returns all blob keys present in the store.
 	// Used by GC to find orphaned blobs not referenced by any asset.
 	ListKeys(ctx context.Context) ([]string, error)
+
+	// ListEntries returns every blob in the store with its size and last-modified
+	// time. Used by GC to age-gate orphan deletion.
+	ListEntries(ctx context.Context) ([]BlobEntry, error)
+}
+
+// BlobEntry describes one stored blob for GC listing.
+type BlobEntry struct {
+	Key     string
+	Size    int64
+	ModTime time.Time
 }
 
 // PresignableStore is an optional extension of BlobStore for S3-backed stores.

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nexspence-oss/nexspence/internal/distlock"
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/storage"
@@ -784,11 +785,12 @@ func (r *CleanupPolicyRepo) Delete(_ context.Context, id string) error {
 type BlobStore struct {
 	mu      sync.Mutex
 	blobs   map[string][]byte
+	mtimes  map[string]time.Time
 	Deleted []string // records Delete calls
 }
 
 func NewBlobStore() *BlobStore {
-	return &BlobStore{blobs: make(map[string][]byte)}
+	return &BlobStore{blobs: make(map[string][]byte), mtimes: make(map[string]time.Time)}
 }
 
 func (b *BlobStore) Put(_ context.Context, key string, r io.Reader, _ int64) error {
@@ -799,6 +801,7 @@ func (b *BlobStore) Put(_ context.Context, key string, r io.Reader, _ int64) err
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.blobs[key] = data
+	b.mtimes[key] = time.Now()
 	return nil
 }
 func (b *BlobStore) Get(_ context.Context, key string) (io.ReadCloser, int64, error) {
@@ -850,6 +853,26 @@ func (b *BlobStore) ListKeys(_ context.Context) ([]string, error) {
 	}
 	return keys, nil
 }
+// SetMTime overrides the recorded modification time for a key (test helper).
+func (b *BlobStore) SetMTime(key string, t time.Time) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.mtimes[key] = t
+}
+
+func (b *BlobStore) ListEntries(_ context.Context) ([]storage.BlobEntry, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entries := make([]storage.BlobEntry, 0, len(b.blobs))
+	for k, data := range b.blobs {
+		entries = append(entries, storage.BlobEntry{
+			Key:     k,
+			Size:    int64(len(data)),
+			ModTime: b.mtimes[k],
+		})
+	}
+	return entries, nil
+}
 func (b *BlobStore) Has(key string) bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -864,6 +887,29 @@ func (b *BlobStore) Read(key string) (string, error) {
 		return "", fmt.Errorf("not found")
 	}
 	return string(data), nil
+}
+
+// ── FakeResolver ──────────────────────────────────────────────
+
+// FakeResolver returns a fixed BlobStore for any descriptor. Implements
+// service.StoreResolver for GC tests.
+type FakeResolver struct{ Store storage.BlobStore }
+
+func NewFakeResolver(s storage.BlobStore) FakeResolver { return FakeResolver{Store: s} }
+
+func (f FakeResolver) Get(_ context.Context, _ storage.BlobStoreDescriptor) (storage.BlobStore, error) {
+	return f.Store, nil
+}
+
+// ── HeldLocker ────────────────────────────────────────────────
+
+// HeldLocker always reports the lock as held by another caller.
+type HeldLocker struct{}
+
+func NewHeldLocker() HeldLocker { return HeldLocker{} }
+
+func (HeldLocker) Acquire(_ context.Context, _ string, _ time.Duration) (distlock.Lock, error) {
+	return nil, distlock.ErrLockHeld
 }
 
 // ── Helpers ───────────────────────────────────────────────────

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -1193,6 +1193,9 @@ helm install nexspence deploy/helm/nexspence \
       <tr><td><code>redis.enabled</code></td><td><code>false</code></td><td>Enable Redis (required for HA)</td></tr>
       <tr><td><code>redis.addr</code></td><td><code>localhost:6379</code></td><td>Redis address</td></tr>
       <tr><td><code>cleanup.default_schedule</code></td><td><code>0 2 * * *</code></td><td>Default cron for cleanup policies</td></tr>
+      <tr><td><code>gc.enabled</code></td><td><code>true</code></td><td>Run scheduled blob garbage collection</td></tr>
+      <tr><td><code>gc.schedule</code></td><td><code>0 3 * * 0</code></td><td>Cron for blob GC (weekly by default)</td></tr>
+      <tr><td><code>gc.min_age</code></td><td><code>24h</code></td><td>Grace period — only collect orphans older than this</td></tr>
       <tr><td><code>audit.retention_days</code></td><td><code>90</code></td><td>Audit log partition retention</td></tr>
       <tr><td><code>http.cors_origins</code></td><td><code>[]</code></td><td>Allowed CORS origins; empty = same-origin / wildcard dev default</td></tr>
       <tr><td><code>http.max_body_mb</code></td><td><code>1024</code></td><td>Max request body in MB; bodies above it get <code>413</code> (artifact/upload routes exempt)</td></tr>


### PR DESCRIPTION
## Blob GC — completion

Finishes the roadmap `next → blob GC` item: safe (age-gated) orphan collection across all blob stores, a registered API route, a global cron scheduler, and an admin UI panel.

### What changed
- **Storage**: `ListEntries()` (key + size + mtime) on the `BlobStore` interface for local and S3 — enables the grace-period gate.
- **Service**: `BlobGCService` refactored to resolve stores via `storage.Registry` (`StoreResolver`); `CompactStore(name)` / `CompactAll()`; age-gate via `min_age`; HA distributed lock `nexspence:lock:gc:run`.
- **Config**: `gc.enabled` / `gc.schedule` (weekly default) / `gc.min_age` (24h default).
- **API**: `POST /api/v1/blobstores/:name/compact?dry_run&min_age` registered (admin only).
- **Scheduler**: global cron runs `CompactAll` (mirrors `CleanupService`).
- **UI**: "Garbage collection" panel (Dry run / Compact) in the blob store detail modal.
- **Docs**: OpenAPI spec + website config reference; README roadmap marked complete.

### Testing
- Backend: 1398 tests pass (1 pre-existing environment-only webhook-loopback failure, unrelated).
- Frontend: 458 tests pass, tsc + eslint clean.
- E2E on a live `docker compose` stack: referenced blob retained, old orphan collected, dry-run non-destructive, default 24h grace period protects fresh orphans.

Companion CLI change (`nxs blobstore compact`) ships in the `nxs` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
