### PR TITLE
style(gc): fix gofmt and whitespace lint issues

### DIFF
--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -138,7 +138,6 @@ func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCRe
 // compact runs the core scan/delete for a single resolved store.
 func (s *BlobGCService) compact(ctx context.Context, name string, store storage.BlobStore,
 	referenced map[string]struct{}, opts GCOptions) *GCResult {
-
 	minAge := opts.MinAge
 	if minAge <= 0 {
 		minAge = s.DefaultMinAge

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -853,6 +853,7 @@ func (b *BlobStore) ListKeys(_ context.Context) ([]string, error) {
 	}
 	return keys, nil
 }
+
 // SetMTime overrides the recorded modification time for a key (test helper).
 func (b *BlobStore) SetMTime(key string, t time.Time) {
 	b.mu.Lock()


### PR DESCRIPTION
Follow-up to #43. The blob GC merge landed at a commit where `golangci-lint` was failing on two formatting issues (gofmt in `internal/testutil/mocks.go`, an unnecessary leading newline in `internal/service/gc_service.go`). This restores a green `main`.

Verified locally: `golangci-lint run ./...` → no issues; `gofmt -l` clean; build + GC tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)