### PR TITLE
ci: bump Go to 1.26.5 to fix GO-2026-5856 (crypto/tls)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
       - name: Install golangci-lint (pinned, via Go proxy)
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
       - name: Enforce per-package ≥80% floor
         run: |
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
       - name: Run postgres integration tests with coverage
         run: |

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
           cache: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nexspence-oss/nexspence
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1


### PR DESCRIPTION
## Problem
`govulncheck` was failing on **every open PR** (#48–#58), leaving them all `UNSTABLE` and unmergeable. Root cause is not the dependency bumps — it's **GO-2026-5856** in the `crypto/tls` standard library (reachable via LDAP StartTLS, HTTPS server, replication TestConnection, SSE stream). Fixed in **go1.26.5**.

## Fix
Bump the pinned Go version `1.26.4 → 1.26.5` in `go.mod`, `.github/workflows/ci.yml` (3 jobs) and `.github/workflows/govulncheck.yml`. `release.yml`/`tag.yml` inherit via `go-version-file: go.mod`.

## Verification
```
$ go build ./...        # Success (auto-fetches go1.26.5 toolchain)
$ govulncheck ./...
No vulnerabilities found.
```
After merge, Dependabot PRs need `@dependabot rebase` to pick up the new base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)