### PR TITLE
fix(apt): accept root-level .deb uploads (405 on hosted deb repo)

### DIFF
--- a/internal/formats/apt/handler.go
+++ b/internal/formats/apt/handler.go
@@ -76,8 +76,10 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	case (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) && strings.HasPrefix(p, "/pool/"):
 		h.serveFile(c, repoName, p)
 
-	// Upload .deb: PUT /pool/:component/:file.deb
-	case c.Request.Method == http.MethodPut && strings.HasPrefix(p, "/pool/"):
+	// Upload .deb: PUT /pool/:component/:file.deb, or a root-level PUT of a .deb
+	// (apt clients and `curl --upload-file foo.deb .../repository/<repo>/` upload
+	// to the repository root rather than an explicit pool path).
+	case c.Request.Method == http.MethodPut && (strings.HasPrefix(p, "/pool/") || strings.HasSuffix(p, ".deb")):
 		h.handleUpload(c, repoName, p)
 
 	// Delete .deb
@@ -193,9 +195,16 @@ func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
 		version = parts[1]
 	}
 
+	// Normalize root-level uploads into the canonical pool layout so the
+	// Packages index (which lists /pool/ assets) still finds them.
+	storePath := p
+	if !strings.HasPrefix(storePath, "/pool/") {
+		storePath = poolPath(pkgName, filename)
+	}
+
 	coords := base.Coords{Name: pkgName, Version: version}
 	if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
-		repoName, p, "application/vnd.debian.binary-package",
+		repoName, storePath, "application/vnd.debian.binary-package",
 		coords, c.Request.Body, c.Request.ContentLength); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -220,4 +229,19 @@ func (h *Handler) serveFile(c *gin.Context, repoName, p string) {
 
 func normPath(p string) string {
 	return path.Clean("/" + strings.TrimPrefix(p, "/"))
+}
+
+// poolPath builds the canonical Debian pool location for a root-level upload:
+// /pool/main/<prefix>/<pkg>/<file>.deb, where <prefix> follows Debian's
+// convention (the first letter, or "lib<x>" for lib* packages).
+func poolPath(pkgName, filename string) string {
+	prefix := "_"
+	if pkgName != "" {
+		if strings.HasPrefix(pkgName, "lib") && len(pkgName) > 3 {
+			prefix = pkgName[:4]
+		} else {
+			prefix = pkgName[:1]
+		}
+	}
+	return "/pool/main/" + prefix + "/" + pkgName + "/" + filename
 }

--- a/internal/formats/apt/handler_test.go
+++ b/internal/formats/apt/handler_test.go
@@ -57,6 +57,31 @@ func TestApt_UploadAndDownload(t *testing.T) {
 	assert.Equal(t, "deb-bytes", w.Body.String())
 }
 
+func TestApt_RootUpload_NormalizesToPool(t *testing.T) {
+	// Regression for #46: `curl --upload-file foo.deb .../repository/<repo>/`
+	// PUTs a .deb to the repository root, which previously returned 405.
+	repo := testutil.SimpleRepo("debs-root", "apt")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putDeb(r, "debs-root", "/docker-ce_5.0_amd64.deb", "docker-bytes"))
+
+	// Stored under the canonical pool layout, so it downloads and indexes.
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/debs-root/pool/main/d/docker-ce/docker-ce_5.0_amd64.deb", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "docker-bytes", w.Body.String())
+
+	req = httptest.NewRequest(http.MethodGet,
+		"/repository/debs-root/dists/focal/main/binary-amd64/Packages", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "docker-ce")
+}
+
 func TestApt_Release(t *testing.T) {
 	repo := testutil.SimpleRepo("debs2", "apt")
 	r := setup(repo)


### PR DESCRIPTION
## Problem — Issue #46
Uploading a `.deb` to an **apt hosted** repository returned `405 Method Not Allowed`, while `raw/hosted` upload and `apt/proxy` worked fine.

```
curl -i -H "Authorization: Bearer nxs_..." --upload-file ./docker-ce_noble_amd64.deb \
     "http://HOST:8081/repository/deb/"
→ HTTP/1.1 405 Method Not Allowed
```

## Root cause
`internal/formats/apt/handler.go` only matched the upload (PUT) case when the path started with `/pool/`. `curl --upload-file` (and apt clients) upload to the **repository root** — the path becomes `/docker-ce_noble_amd64.deb`, which fell through to `default → 405`. `raw/hosted` accepts PUT at any path, which is why it worked.

## Fix
- Accept a root-level PUT of a `.deb` (path ends in `.deb`) in addition to `/pool/...`.
- Normalize root uploads into the canonical `/pool/main/<prefix>/<pkg>/<file>` layout so the `Packages` index (which lists `/pool/` assets) still finds them.

## Verification
```
$ go test ./internal/formats/apt/...
ok  (18 passed)
```
New regression test `TestApt_RootUpload_NormalizesToPool`: root PUT → 201, downloadable at its pool path, and listed in the `Packages` index.

Fixes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)