### PR TITLE
fix(docker): keep blob-upload Location under /v2/ (push 401 at 100%)

### DIFF
--- a/internal/formats/docker/handler.go
+++ b/internal/formats/docker/handler.go
@@ -344,7 +344,7 @@ func (h *Handler) handleBlobUploads(c *gin.Context, repoName, imageName, uuid st
 	}
 }
 
-func (h *Handler) initiateUpload(c *gin.Context, repoName, imageName string) {
+func (h *Handler) initiateUpload(c *gin.Context, repoName, _ string) {
 	if !requireDockerAuth(c) {
 		return
 	}
@@ -355,14 +355,19 @@ func (h *Handler) initiateUpload(c *gin.Context, repoName, imageName string) {
 		repoName: repoName,
 		created:  time.Now(),
 	})
-	uploadURL := fmt.Sprintf("/repository/%s/v2/%s/blobs/uploads/%s", repoName, imageName, uuid)
+	// The Location must stay under the same /v2/ prefix (and short/long path
+	// form) the client authenticated against. Deriving it from the request's
+	// own URL keeps the blob PATCH/PUT on the authenticated /v2/ surface; a
+	// hardcoded /repository/... URL routed the finalize PUT to a different
+	// auth surface and returned 401 at 100% (issue #47).
+	uploadURL := strings.TrimRight(c.Request.URL.Path, "/") + "/" + uuid
 	c.Header("Location", uploadURL)
 	c.Header("Docker-Upload-UUID", uuid)
 	c.Header("Range", "0-0")
 	c.Status(http.StatusAccepted)
 }
 
-func (h *Handler) patchUpload(c *gin.Context, repoName, imageName, uuid string) {
+func (h *Handler) patchUpload(c *gin.Context, _, _, uuid string) {
 	raw, ok := h.uploads.Load(uuid)
 	if !ok {
 		dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
@@ -377,8 +382,9 @@ func (h *Handler) patchUpload(c *gin.Context, repoName, imageName, uuid string) 
 		return
 	}
 	offset := int64(sess.buf.Len())
-	uploadURL := fmt.Sprintf("/repository/%s/v2/%s/blobs/uploads/%s", repoName, imageName, uuid)
-	c.Header("Location", uploadURL)
+	// The request URL already is the upload location — echo it verbatim so the
+	// finalizing PUT stays on the same authenticated /v2/ path (see #47).
+	c.Header("Location", c.Request.URL.Path)
 	c.Header("Range", fmt.Sprintf("0-%d", offset-1))
 	c.Header("Docker-Upload-UUID", uuid)
 	c.Status(http.StatusAccepted)
@@ -419,7 +425,12 @@ func (h *Handler) finalizeUpload(c *gin.Context, repoName, imageName, uuid strin
 	h.uploads.Delete(uuid)
 
 	c.Header("Docker-Content-Digest", digest)
-	c.Header("Location", "/v2/"+imageName+"/blobs/"+digest)
+	// Point at the stored blob under the same /v2/ prefix the client used.
+	blobLoc := "/v2/" + imageName + "/blobs/" + digest
+	if i := strings.Index(c.Request.URL.Path, "/blobs/"); i >= 0 {
+		blobLoc = c.Request.URL.Path[:i] + "/blobs/" + digest
+	}
+	c.Header("Location", blobLoc)
 	c.Header("Content-Range", fmt.Sprintf("0-%d", len(data)-1))
 	c.Status(http.StatusCreated)
 }

--- a/internal/formats/docker/handler_test.go
+++ b/internal/formats/docker/handler_test.go
@@ -78,6 +78,69 @@ func pushBlob(t *testing.T, r *gin.Engine, repoName, imageName, content string) 
 	return dgst
 }
 
+// setupV2Scoped mimics production routing (short-path /v2/:repoName/*) where the
+// Docker client only sends its credentials to requests under /v2/. It reproduces
+// issue #47: if the blob-upload Location escapes the /v2/ prefix, the finalize
+// PUT arrives anonymous and gets 401.
+func setupV2Scoped(repo *domain.Repository) *gin.Engine {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := docker.New(d)
+	r := gin.New()
+	// Credentials are only attached to /v2/ requests (as a real Docker client does).
+	r.Use(func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.URL.Path, "/v2/") {
+			ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+			c.Request = c.Request.WithContext(ctx)
+		}
+		c.Next()
+	})
+	dispatch := func(c *gin.Context) {
+		c.Params = gin.Params{
+			{Key: "repoName", Value: c.Param("repoName")},
+			{Key: "path", Value: "/v2" + c.Param("dockerpath")},
+		}
+		h.ServeHTTP(c)
+	}
+	r.Any("/v2/:repoName/*dockerpath", dispatch)
+	return r
+}
+
+func TestDocker_ShortPathPush_StaysAuthenticated(t *testing.T) {
+	repo := testutil.SimpleRepo("da", "docker")
+	r := setupV2Scoped(repo)
+	content := "layer-bytes"
+	dgst := digest(content)
+
+	// POST initiate — the client authenticated against /v2/.
+	req := httptest.NewRequest(http.MethodPost, "/v2/da/devops/alpine/blobs/uploads/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	loc := w.Header().Get("Location")
+	require.True(t, strings.HasPrefix(loc, "/v2/"),
+		"Location must stay under /v2/ so the client keeps sending credentials, got %q", loc)
+
+	// PATCH the blob body — must not 401.
+	req2 := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader(content))
+	req2.ContentLength = int64(len(content))
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusAccepted, w2.Code, "PATCH must stay authenticated")
+
+	// PUT finalize — this is where #47 returned 401 at 100%.
+	req3 := httptest.NewRequest(http.MethodPut, loc+"?digest="+dgst, nil)
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, req3)
+	require.Equal(t, http.StatusCreated, w3.Code, "finalize PUT must stay authenticated (issue #47)")
+}
+
 // ── Version check ─────────────────────────────────────────────
 
 func TestDocker_VersionCheck(t *testing.T) {


### PR DESCRIPTION
## Problem — Issue #47
`docker push` to a docker hosted repo: `docker login` succeeds, a layer uploads to **100%** ("Pushing [===>] 8.698MB"), then the push fails with `unauthorized: authentication required`.

## Root cause
`internal/formats/docker/handler.go` returned the blob-upload `Location` as a hardcoded
`/repository/<repo>/v2/<image>/blobs/uploads/<uuid>` — **outside** the `/v2/` API prefix.

A Docker client scopes the credentials it cached during the `/v2/` login challenge to requests **under `/v2/`**. It followed the `/repository/...` Location *anonymously*; the blob `PATCH`/finalize `PUT` then landed on the generic `/repository/:repoName/*` auth surface, was rejected by RBAC as an anonymous write, and returned **401 after the layer body was already streamed** — hence the failure exactly at 100%.

## Fix
Derive the `Location` from the request's own URL so the whole upload sequence stays on the same `/v2/` path (and short-/long-path form) the client authenticated against:
- `initiateUpload`: `Location = <request path>/<uuid>`
- `patchUpload`: echo the request path verbatim
- `finalizeUpload`: build the blob location from the request's `/v2/...` prefix

## Verification
```
$ go build ./...            # Success
$ golangci-lint run ./internal/formats/docker/...   # No issues
$ go test ./internal/formats/docker/...             # 34 passed
```
New regression test `TestDocker_ShortPathPush_StaysAuthenticated` reproduces the real
short-path push with credentials scoped to `/v2/` (as a real client does). **Verified it fails on the old code** (`Location "/repository/da/v2/devops/alpine/blobs/uploads/…"`) and passes with the fix.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)