### PR TITLE
fix: bundle fixes for #62 #75 #76 #77 #79 #80 #81 (v1.22.0)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/metrics"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/repository/postgres"
+	"github.com/nexspence-oss/nexspence/internal/storage"
 )
 
 func main() {
@@ -153,6 +154,11 @@ func cmdServe() *cobra.Command {
 				// Non-fatal — server still starts
 			}
 
+			if err := syncS3BlobStores(cmd.Context(), pool, cfg, log); err != nil {
+				log.Warn("s3 blob store sync failed", "err", err)
+				// Non-fatal — server still starts
+			}
+
 			// Seed Prometheus gauges from DB on startup.
 			{
 				var artifacts, bytes, downloads int64
@@ -274,6 +280,90 @@ func syncBlobStorePaths(ctx context.Context, pool *pgxpool.Pool, cfg *config.Con
 		}
 	}
 	return nil
+}
+
+// s3SeedStores are the blob stores the initial migration seeds as local
+// ("default", "docker"). "default" is the fallback store resolveBlobStoreRef
+// uses for every repository without an explicit blobStoreId; "docker" is the
+// store docker repositories may be assigned. Both are reconciled to s3 when
+// storage.default_type=s3 so no local store silently captures writes.
+var s3SeedStores = []string{"default", "docker"}
+
+// desiredS3Config maps the config-file S3 settings onto the config-key names the
+// storage registry expects when instantiating an s3 BlobStore. Note the key
+// rename: the registry reads access_key/secret_key (see newFromDescriptor in
+// internal/storage/registry.go), NOT the config file's access_key_id/secret_access_key.
+func desiredS3Config(s3 config.S3Config) map[string]any {
+	return map[string]any{
+		"bucket":           s3.Bucket,
+		"region":           s3.Region,
+		"endpoint":         s3.Endpoint,
+		"access_key":       s3.AccessKeyID,
+		"secret_key":       s3.SecretAccessKey,
+		"force_path_style": s3.ForcePathStyle,
+	}
+}
+
+// syncS3BlobStores reconciles the configured S3 settings into the seed blob
+// stores when storage.default_type=s3. Without it (issue #81) the seed migration
+// leaves "default"/"docker" as local stores, so repositories with no explicit
+// blobStoreId resolve to local disk even though the operator configured S3 —
+// only the health display and the d.BlobStore fallback reflect S3. Mirrors
+// syncBlobStorePaths: runs on every startup so the DB always reflects the
+// configured storage backend.
+func syncS3BlobStores(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, log logger.Logger) error {
+	if cfg.Storage.DefaultType != "s3" {
+		return nil
+	}
+	return reconcileS3BlobStores(ctx, postgres.NewBlobStoreRepo(pool), cfg.Storage.S3, nil, log)
+}
+
+// reconcileS3BlobStores upserts the s3SeedStores to type=s3 with s3, creating
+// any that are missing. Idempotent: stores already matching the desired s3
+// config are left untouched. When reg is non-nil, updated stores are
+// invalidated so a cached local instance isn't reused (reg is nil on startup —
+// the Registry is built after this runs, so it reads the reconciled rows fresh).
+func reconcileS3BlobStores(ctx context.Context, blobRepo repository.BlobStoreRepo, s3 config.S3Config, reg *storage.Registry, log logger.Logger) error {
+	desired := desiredS3Config(s3)
+	for _, name := range s3SeedStores {
+		bs, err := blobRepo.Get(ctx, name)
+		if err != nil && !errors.Is(err, repository.ErrNotFound) {
+			return err
+		}
+		if bs == nil {
+			if createErr := blobRepo.Create(ctx, &domain.BlobStore{Name: name, Type: "s3", Config: desired}); createErr != nil {
+				return createErr
+			}
+			log.Info("s3 blob store created", "name", name, "bucket", s3.Bucket, "endpoint", s3.Endpoint)
+			continue
+		}
+		if bs.Type == "s3" && s3ConfigEqual(bs.Config, desired) {
+			continue // already reconciled
+		}
+		bs.Type = "s3"
+		bs.Config = desired
+		if updateErr := blobRepo.Update(ctx, bs); updateErr != nil {
+			return updateErr
+		}
+		if reg != nil && bs.ID != "" {
+			reg.Invalidate(bs.ID)
+		}
+		log.Info("s3 blob store reconciled", "name", name, "bucket", s3.Bucket, "endpoint", s3.Endpoint)
+	}
+	return nil
+}
+
+// s3ConfigEqual reports whether cur already holds exactly the desired s3 config.
+func s3ConfigEqual(cur, desired map[string]any) bool {
+	if len(cur) != len(desired) {
+		return false
+	}
+	for k, dv := range desired {
+		if cur[k] != dv {
+			return false
+		}
+	}
+	return true
 }
 
 // seedPlaceholderAdminHash is the bcrypt hash the initial migration (001) seeds

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/db"
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
 	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/metrics"
 	"github.com/nexspence-oss/nexspence/internal/repository"
@@ -55,6 +56,15 @@ func cmdServe() *cobra.Command {
 
 			log := logger.New(cfg.Log.Level, cfg.Log.Format)
 			log.Info("starting nexspence", "version", Version, "addr", cfg.HTTP.Addr)
+
+			// Install any server-wide outbound proxy default for upstream fetches.
+			// Per-repository proxy_config overrides these; when unset, env
+			// HTTP_PROXY/HTTPS_PROXY/NO_PROXY are honored by the guarded client.
+			if p := cfg.Proxy; p.HTTPProxy != "" || p.HTTPSProxy != "" || p.SOCKS5Proxy != "" || p.NoProxy != "" {
+				repoproxy.SetGlobalProxy(p.HTTPProxy, p.HTTPSProxy, p.SOCKS5Proxy, p.NoProxy, p.Username, p.Password)
+				log.Info("outbound proxy configured for upstream fetches",
+					"http", p.HTTPProxy != "", "https", p.HTTPSProxy != "", "socks5", p.SOCKS5Proxy != "")
+			}
 			if cfg.Auth.AnonymousEnabled {
 				log.Warn("auth.anonymous_enabled is true — unauthenticated artifact access is allowed; set false to require authentication")
 			}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -25,6 +25,103 @@ func testAuthSvc() *auth.Service {
 	return auth.NewService("test-secret-test-secret-test-1234", 8, 4)
 }
 
+func testS3Config() config.S3Config {
+	return config.S3Config{
+		Bucket:          "artifacts",
+		Region:          "us-east-1",
+		Endpoint:        "http://minio:9000",
+		AccessKeyID:     "minioadmin",
+		SecretAccessKey: "miniosecret",
+		ForcePathStyle:  true,
+	}
+}
+
+// assertS3Store fails unless bs is an s3 store whose config uses the registry's
+// expected key names (access_key/secret_key, NOT access_key_id) matching s3.
+func assertS3Store(t *testing.T, bs *domain.BlobStore, s3 config.S3Config) {
+	t.Helper()
+	if bs == nil {
+		t.Fatal("blob store is nil")
+	}
+	if bs.Type != "s3" {
+		t.Fatalf("type = %q, want s3", bs.Type)
+	}
+	want := map[string]any{
+		"bucket":           s3.Bucket,
+		"region":           s3.Region,
+		"endpoint":         s3.Endpoint,
+		"access_key":       s3.AccessKeyID,
+		"secret_key":       s3.SecretAccessKey,
+		"force_path_style": s3.ForcePathStyle,
+	}
+	for k, v := range want {
+		if bs.Config[k] != v {
+			t.Fatalf("config[%q] = %v, want %v", k, bs.Config[k], v)
+		}
+	}
+	if _, ok := bs.Config["access_key_id"]; ok {
+		t.Fatal("config must use registry key access_key, not access_key_id")
+	}
+}
+
+// Regression #81: with storage.default_type=s3 the seed migration still leaves
+// the "default"/"docker" blob stores as local, so repositories with no explicit
+// blobStoreId write to local disk. Reconcile must convert the seed stores to s3.
+func TestReconcileS3BlobStores_ConvertsSeedLocalToS3(t *testing.T) {
+	s3 := testS3Config()
+	blobs := testutil.NewBlobStoreRepo(
+		&domain.BlobStore{ID: "bs-default", Name: "default", Type: "local", Config: map[string]any{"path": "./data/blobs/default"}},
+		&domain.BlobStore{ID: "bs-docker", Name: "docker", Type: "local", Config: map[string]any{"path": "./data/blobs/docker"}},
+	)
+	log := logger.New("error", "json")
+
+	if err := reconcileS3BlobStores(context.Background(), blobs, s3, nil, log); err != nil {
+		t.Fatalf("reconcileS3BlobStores: %v", err)
+	}
+
+	def, _ := blobs.Get(context.Background(), "default")
+	assertS3Store(t, def, s3)
+	dock, _ := blobs.Get(context.Background(), "docker")
+	assertS3Store(t, dock, s3)
+}
+
+// Reconcile creates a seed store that is missing entirely.
+func TestReconcileS3BlobStores_CreatesMissing(t *testing.T) {
+	s3 := testS3Config()
+	blobs := testutil.NewBlobStoreRepo(
+		&domain.BlobStore{ID: "bs-default", Name: "default", Type: "local", Config: map[string]any{"path": "./data/blobs/default"}},
+	)
+	log := logger.New("error", "json")
+
+	if err := reconcileS3BlobStores(context.Background(), blobs, s3, nil, log); err != nil {
+		t.Fatalf("reconcileS3BlobStores: %v", err)
+	}
+
+	dock, err := blobs.Get(context.Background(), "docker")
+	if err != nil {
+		t.Fatalf("docker store not created: %v", err)
+	}
+	assertS3Store(t, dock, s3)
+}
+
+// Reconcile is idempotent: a second run leaves the already-reconciled stores
+// unchanged and returns no error.
+func TestReconcileS3BlobStores_Idempotent(t *testing.T) {
+	s3 := testS3Config()
+	blobs := testutil.NewBlobStoreRepo(
+		&domain.BlobStore{ID: "bs-default", Name: "default", Type: "local", Config: map[string]any{"path": "./data/blobs/default"}},
+	)
+	log := logger.New("error", "json")
+
+	for i := 0; i < 2; i++ {
+		if err := reconcileS3BlobStores(context.Background(), blobs, s3, nil, log); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+	def, _ := blobs.Get(context.Background(), "default")
+	assertS3Store(t, def, s3)
+}
+
 // Regression: a fresh deploy seeds the admin row with a placeholder hash (NOT
 // admin123). Bootstrap must apply the configured password so admin/admin123 can
 // log in. Previously bootstrap saw "admin already exists" and left the broken

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -124,6 +124,98 @@ describe('BrowsePage — repo selector & empty states', () => {
     await user.click(delBtns[delBtns.length - 1])
     await waitFor(() => expect(deleted).toBe(true))
   })
+
+  // Regression for #75/#76: the row delete must target the asset path. When the
+  // component name was used instead, the prefix matched nothing (npm: silent
+  // no-op) or was empty (apt proxy: 400 with no server-side error).
+  it('deletes using the asset path, not the component name', async () => {
+    const user = userEvent.setup()
+    const deletedPaths: string[] = []
+    server.use(
+      http.get('/service/rest/v1/components', () =>
+        HttpResponse.json({
+          items: [{
+            id: 'c1', name: 'lodash', group: '', version: '4.17.21', format: 'npm',
+            assets: [{ id: 'a1', path: '/lodash/-/lodash-4.17.21.tgz', fileSize: 1, contentType: 't' }],
+          }],
+          continuationToken: null,
+        }),
+      ),
+      http.delete('/api/v1/browse/repositories/:name/path', ({ request }) => {
+        deletedPaths.push(new URL(request.url).searchParams.get('path') ?? '')
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    renderBrowse('?repo=maven-hosted')
+    await screen.findByText('lodash')
+    await user.click(screen.getByTitle('Delete'))
+    await screen.findByText('Delete file?')
+    const delBtns = screen.getAllByRole('button', { name: /^Delete/ })
+    await user.click(delBtns[delBtns.length - 1])
+    await waitFor(() => expect(deletedPaths).toEqual(['/lodash/-/lodash-4.17.21.tgz']))
+  })
+
+  // An apt proxy stores every cached file under one component, so deleting the
+  // row must remove all of its assets — not just the first one.
+  it('deletes every asset of a multi-asset component', async () => {
+    const user = userEvent.setup()
+    const deletedPaths: string[] = []
+    server.use(
+      http.get('/service/rest/v1/components', () =>
+        HttpResponse.json({
+          items: [{
+            id: 'c1', name: 'nginx', group: '', version: '1.24', format: 'apt',
+            assets: [
+              { id: 'a1', path: '/pool/main/n/nginx/nginx_1.24_amd64.deb', fileSize: 1, contentType: 't' },
+              { id: 'a2', path: '/dists/trixie/InRelease', fileSize: 1, contentType: 't' },
+            ],
+          }],
+          continuationToken: null,
+        }),
+      ),
+      http.delete('/api/v1/browse/repositories/:name/path', ({ request }) => {
+        deletedPaths.push(new URL(request.url).searchParams.get('path') ?? '')
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    renderBrowse('?repo=maven-hosted')
+    await screen.findByText('nginx')
+    await user.click(screen.getByTitle('Delete'))
+    await screen.findByText('Delete component?')
+    const delBtns = screen.getAllByRole('button', { name: /^Delete/ })
+    await user.click(delBtns[delBtns.length - 1])
+    await waitFor(() => expect(deletedPaths.sort()).toEqual([
+      '/dists/trixie/InRelease',
+      '/pool/main/n/nginx/nginx_1.24_amd64.deb',
+    ]))
+  })
+
+  // A component with no assets has nothing to delete: report it instead of
+  // firing a request that the server rejects with an unexplained 400.
+  it('reports an error instead of deleting a component that has no assets', async () => {
+    const user = userEvent.setup()
+    let called = false
+    server.use(
+      http.get('/service/rest/v1/components', () =>
+        HttpResponse.json({
+          items: [{ id: 'c1', name: 'ghost', group: '', version: '1', format: 'npm', assets: [] }],
+          continuationToken: null,
+        }),
+      ),
+      http.delete('/api/v1/browse/repositories/:name/path', () => {
+        called = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    renderBrowse('?repo=maven-hosted')
+    await screen.findByText('ghost')
+    await user.click(screen.getByTitle('Delete'))
+    await screen.findByText('Delete file?')
+    const delBtns = screen.getAllByRole('button', { name: /^Delete/ })
+    await user.click(delBtns[delBtns.length - 1])
+    expect(await screen.findByText(/no assets to delete/i)).toBeInTheDocument()
+    expect(called).toBe(false)
+  })
 })
 
 describe('BrowsePage — Raw tree', () => {

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -1020,7 +1020,11 @@ export default function BrowsePage() {
     path: string; repo: string;
     dockerImage?: string; dockerRef?: string;
     label?: string;
+    // affectedPaths is display-only (listed in the modal); paths is what actually
+    // gets deleted. A component row deletes every asset it owns, so both are set.
     affectedPaths?: string[];
+    paths?: string[];
+    heading?: string;
   } | null>(null)
   const [deleting, setDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<string | null>(null)
@@ -1054,7 +1058,15 @@ export default function BrowsePage() {
       } else if (deleteTarget.dockerImage) {
         await nexspenceApi.deleteDockerImage(deleteTarget.repo, deleteTarget.dockerImage)
       } else {
-        await nexspenceApi.deleteByPath(deleteTarget.repo, deleteTarget.path)
+        // Deleting by an empty path would hit the server as a 400 with nothing to
+        // act on, so surface the real reason instead of firing the request.
+        const targets = (deleteTarget.paths ?? [deleteTarget.path]).filter(Boolean)
+        if (targets.length === 0) {
+          throw new Error('This component has no assets to delete.')
+        }
+        for (const p of targets) {
+          await nexspenceApi.deleteByPath(deleteTarget.repo, p)
+        }
       }
       const repo = deleteTarget.repo
       setDeleteTarget(null)
@@ -1062,7 +1074,9 @@ export default function BrowsePage() {
       void queryClient.invalidateQueries({ queryKey: ['dockerBrowseTree', repo] })
       void queryClient.invalidateQueries({ queryKey: ['rawBrowseTree', repo] })
     } catch (err: unknown) {
-      const msg = axios.isAxiosError(err) ? err.response?.data?.message ?? err.message : String(err)
+      const msg = axios.isAxiosError(err)
+        ? err.response?.data?.message ?? err.response?.data?.error ?? err.message
+        : err instanceof Error ? err.message : String(err)
       setDeleteError(msg)
     } finally {
       setDeleting(false)
@@ -1525,7 +1539,10 @@ export default function BrowsePage() {
             {items.map((c) => {
               const color = FORMAT_COLORS[c.format] ?? '#6b7280'
               const firstAsset = c.assets?.[0]
-              const assetPath = firstAsset?.path ?? c.name
+              // Delete targets asset paths only. Falling back to the component
+              // name produced a prefix that matched nothing (npm) or an empty
+              // path the server rejected (apt proxy) — see #75/#76.
+              const assetPaths = (c.assets ?? []).map((a) => a.path).filter(Boolean)
               const isHighlighted = (!!highlightComponentId && c.id === highlightComponentId) ||
                 (!!highlightAssetPath && !!c.assets?.some((a) => a.path === highlightAssetPath))
               return (
@@ -1565,7 +1582,15 @@ export default function BrowsePage() {
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     {canDeleteRepo && (
-                      <GhostBtn danger onClick={() => setDeleteTarget({ path: assetPath, repo: repoName })} title="Delete">
+                      <GhostBtn danger onClick={() => setDeleteTarget({
+                        path: assetPaths[0] ?? '',
+                        paths: assetPaths,
+                        repo: repoName,
+                        label: `${c.name}${c.version ? ` ${c.version}` : ''}`,
+                        ...(assetPaths.length > 1
+                          ? { affectedPaths: assetPaths, heading: 'Delete component?' }
+                          : {}),
+                      })} title="Delete">
                         <Trash2 size={13} />
                       </GhostBtn>
                     )}
@@ -1622,13 +1647,15 @@ export default function BrowsePage() {
           {deleteTarget && <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: 'var(--holo-text)', display: 'flex', alignItems: 'center', gap: 8 }}>
               <Trash2 size={17} style={{ color: '#ef4444' }} />
-              {deleteTarget.affectedPaths ? 'Delete folder?' : 'Delete file?'}
+              {deleteTarget.heading ?? (deleteTarget.affectedPaths ? 'Delete folder?' : 'Delete file?')}
             </h3>
             <div style={{ fontSize: 13, color: 'var(--holo-text-dim)' }}>
               <span style={{ fontFamily: 'monospace', color: '#fca5a5', fontSize: 12 }}>{deleteTarget.label ?? deleteTarget.path}</span>
               {deleteTarget.affectedPaths && (
                 <p style={{ margin: '8px 0 0', fontSize: 12, color: 'var(--holo-text-faint)' }}>
-                  All files in this folder will be permanently deleted:
+                  {deleteTarget.heading
+                    ? 'All assets of this component will be permanently deleted:'
+                    : 'All files in this folder will be permanently deleted:'}
                 </p>
               )}
             </div>

--- a/frontend/src/pages/CleanupPage.test.tsx
+++ b/frontend/src/pages/CleanupPage.test.tsx
@@ -80,7 +80,7 @@ describe('CleanupPage', () => {
     server.use(
       http.post('/service/rest/v1/cleanup-policies/:id/run', () => {
         ran = true
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json({ deleted: 0, freedBytes: 0 })
       }),
     )
     renderWithProviders(<CleanupPage />)
@@ -88,6 +88,34 @@ describe('CleanupPage', () => {
     const runBtns = screen.getAllByTitle('Run now')
     fireEvent.click(runBtns[0])
     await waitFor(() => expect(ran).toBe(true))
+  })
+
+  // #62: a manual run now reports how many assets were deleted, instead of the
+  // old fire-and-forget acknowledgement that showed nothing.
+  it('shows deleted count after a manual run', async () => {
+    server.use(
+      http.post('/service/rest/v1/cleanup-policies/:id/run', () =>
+        HttpResponse.json({ deleted: 3, freedBytes: 2048, dryRun: false }),
+      ),
+    )
+    renderWithProviders(<CleanupPage />)
+    await screen.findByText('delete-old-snapshots')
+    fireEvent.click(screen.getAllByTitle('Run now')[0])
+    expect(await screen.findByText(/Deleted 3 asset\(s\)/)).toBeInTheDocument()
+  })
+
+  // A policy attached to nothing reports the skip reason so the user knows why
+  // nothing happened (issue #62: "manual execution produces no results").
+  it('shows the skip reason for an unattached policy', async () => {
+    server.use(
+      http.post('/service/rest/v1/cleanup-policies/:id/run', () =>
+        HttpResponse.json({ deleted: 0, skipped: true, skippedReason: 'policy is not attached to any repository' }),
+      ),
+    )
+    renderWithProviders(<CleanupPage />)
+    await screen.findByText('delete-old-snapshots')
+    fireEvent.click(screen.getAllByTitle('Run now')[0])
+    expect(await screen.findByText(/not attached to any repository/)).toBeInTheDocument()
   })
 
   it('deletes a policy after confirm', async () => {

--- a/frontend/src/pages/CleanupPage.tsx
+++ b/frontend/src/pages/CleanupPage.tsx
@@ -301,13 +301,15 @@ function PolicyModal({
   const [wizardLoading, setWizardLoading] = useState(false)
   const [showBrowser, setShowBrowser] = useState(false)
 
-  // Fetch repos for scope picker (only when format is not '*')
+  // Fetch repos for the scope picker. Available for every format, including '*'
+  // (a clear-all policy still needs to target a specific repository).
   const { data: reposData } = useQuery<{ name: string; format: string }[]>({
     queryKey: ['repositories'],
     queryFn: () => nexusApi.listRepositories().then(r => r.data),
-    enabled: form.format !== '*',
   })
-  const filteredRepos = (reposData ?? []).filter(r => r.format === form.format)
+  const filteredRepos = form.format === '*'
+    ? (reposData ?? [])
+    : (reposData ?? []).filter(r => r.format === form.format)
 
   const payload = () => ({
     name: form.name.trim(),
@@ -349,8 +351,9 @@ function PolicyModal({
 
   const LABEL = { fontSize: 12, fontWeight: 600 as const, color: 'var(--holo-text-dim)', textTransform: 'uppercase' as const, letterSpacing: '0.04em' }
 
-  // Scope section — shared between wizard and edit modal
-  const scopeSection = form.format !== '*' ? (
+  // Scope section — shared between wizard and edit modal. Shown for all formats
+  // (including '*') so a clear-all policy can be pinned to a repository.
+  const scopeSection = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       {/* Divider */}
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginTop: 4 }}>
@@ -441,7 +444,7 @@ function PolicyModal({
         </div>
       )}
     </div>
-  ) : null
+  )
 
   // ── Create mode: stepped wizard ───────────────────────────────────────
   if (!initial) {
@@ -683,6 +686,7 @@ export default function CleanupPage() {
   const [modal, setModal] = useState<'create' | CleanupPolicy | null>(null)
   const [running, setRunning] = useState<string | null>(null)
   const [previewId, setPreviewId] = useState<string | null>(null)
+  const [runResult, setRunResult] = useState<{ tone: 'ok' | 'warn' | 'err'; text: string } | null>(null)
 
   const { data: policies = [], isLoading, refetch } = useQuery<CleanupPolicy[]>({
     queryKey: ['cleanupPolicies'],
@@ -696,10 +700,26 @@ export default function CleanupPage() {
 
   const handleRun = async (id: string) => {
     setRunning(id)
+    setRunResult(null)
     try {
-      await nexusApi.runCleanupPolicy(id)
-      setTimeout(() => { refetch(); setRunning(null) }, 1500)
-    } catch { setRunning(null) }
+      // A single-policy run is synchronous and returns its outcome.
+      const res = await nexusApi.runCleanupPolicy(id)
+      const r = res.data as { deleted?: number; freedBytes?: number; dryRun?: boolean; skipped?: boolean; skippedReason?: string } | undefined
+      if (r?.skipped) {
+        setRunResult({ tone: 'warn', text: `Skipped: ${r.skippedReason ?? 'nothing to do'}` })
+      } else if (r) {
+        const freedKb = Math.round((r.freedBytes ?? 0) / 1024)
+        const verb = r.dryRun ? 'Would delete' : 'Deleted'
+        setRunResult({ tone: 'ok', text: `${verb} ${r.deleted ?? 0} asset(s), ${freedKb} KB${r.dryRun ? ' (dry run)' : ''}` })
+      } else {
+        setRunResult({ tone: 'ok', text: 'Cleanup started' })
+      }
+      refetch()
+    } catch (e) {
+      setRunResult({ tone: 'err', text: apiErrorMessage(e, 'Run failed') })
+    } finally {
+      setRunning(null)
+    }
   }
 
   const previewPolicy = previewId ? policies.find(p => p.id === previewId) : null
@@ -737,6 +757,24 @@ export default function CleanupPage() {
           <HoloButton variant="primary" icon={<Plus size={15} />} onClick={() => setModal('create')}>New Policy</HoloButton>
         </div>
       </div>
+
+      {runResult && (
+        <div
+          role="status"
+          onClick={() => setRunResult(null)}
+          style={{
+            cursor: 'pointer',
+            padding: '10px 14px',
+            borderRadius: 8,
+            fontSize: 13,
+            border: `1px solid ${runResult.tone === 'err' ? 'rgba(239,68,68,0.4)' : runResult.tone === 'warn' ? 'rgba(234,179,8,0.4)' : 'rgba(34,211,153,0.4)'}`,
+            background: runResult.tone === 'err' ? 'rgba(239,68,68,0.1)' : runResult.tone === 'warn' ? 'rgba(234,179,8,0.1)' : 'rgba(34,211,153,0.1)',
+            color: runResult.tone === 'err' ? '#fca5a5' : runResult.tone === 'warn' ? '#fde68a' : '#6ee7b7',
+          }}
+        >
+          {runResult.text}
+        </div>
+      )}
 
       {isLoading ? (
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 12, color: 'var(--holo-text-faint)', fontSize: 14, paddingTop: 48 }}>Loading…</div>

--- a/frontend/src/pages/RepositoriesPage.test.tsx
+++ b/frontend/src/pages/RepositoriesPage.test.tsx
@@ -313,6 +313,39 @@ describe('RepositoriesPage', () => {
     expect((posted! as { proxyConfig?: { remote_url: string } }).proxyConfig?.remote_url).toContain('maven.org')
   })
 
+  it('includes per-repo outbound proxy settings in proxyConfig', async () => {
+    const user = userEvent.setup()
+    let posted: Record<string, unknown> | null = null
+    server.use(
+      http.post('/service/rest/v1/repositories/:format/:type', async ({ request }) => {
+        posted = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(fixtures.repository(), { status: 201 })
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await screen.findByText('maven-hosted')
+    await user.click(screen.getByRole('button', { name: /Create Repository/ }))
+    await screen.findByText('Step 1 of 3')
+
+    await user.click(screen.getByRole('button', { name: /Hosted — store/ }))
+    await user.click(await screen.findByText(/Proxy — cache/))
+    await user.click(screen.getByRole('button', { name: /Next/ }))
+
+    await screen.findByText('Step 2 of 3')
+    await user.type(screen.getByPlaceholderText('my-repo'), 'maven-proxy')
+    await user.type(screen.getByPlaceholderText('http://proxy.internal:3128'), 'http://proxy.internal:3128')
+    await user.type(screen.getByPlaceholderText('socks5://proxy.internal:1080'), 'socks5://socks.internal:1080')
+    await user.click(screen.getByRole('button', { name: /Next/ }))
+    await screen.findByText('Step 3 of 3')
+    await user.click(screen.getByRole('button', { name: /^Create$/ }))
+
+    await waitFor(() => expect(posted).toBeTruthy())
+    const pc = (posted! as { proxyConfig?: Record<string, string> }).proxyConfig
+    expect(pc?.http_proxy).toBe('http://proxy.internal:3128')
+    expect(pc?.socks5_proxy).toBe('socks5://socks.internal:1080')
+    expect(pc?.remote_url).toContain('maven.org')
+  })
+
   it('errors when a group has no members selected', async () => {
     const user = userEvent.setup()
     renderWithProviders(<RepositoriesPage />)

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -403,6 +403,8 @@ function CreateRepoModal({ onClose, onCreated }: {
   const [form, setForm] = useState({
     name: '', format: 'maven2', type: 'hosted', description: '',
     remoteUrl: PROXY_DEFAULTS['maven2'],
+    httpProxy: '', httpsProxy: '', socks5Proxy: '', noProxy: '',
+    proxyUsername: '', proxyPassword: '',
     memberNames: [] as string[],
     cleanupPolicyIds: [] as string[],
     quotaGB: '',
@@ -465,7 +467,16 @@ function CreateRepoModal({ onClose, onCreated }: {
         description: form.description,
       }
       if (effectiveStoreId) body.blobStoreId = effectiveStoreId
-      if (form.type === 'proxy') body.proxyConfig = { remote_url: form.remoteUrl.trim() }
+      if (form.type === 'proxy') {
+        const proxyConfig: Record<string, string> = { remote_url: form.remoteUrl.trim() }
+        if (form.httpProxy.trim()) proxyConfig.http_proxy = form.httpProxy.trim()
+        if (form.httpsProxy.trim()) proxyConfig.https_proxy = form.httpsProxy.trim()
+        if (form.socks5Proxy.trim()) proxyConfig.socks5_proxy = form.socks5Proxy.trim()
+        if (form.noProxy.trim()) proxyConfig.no_proxy = form.noProxy.trim()
+        if (form.proxyUsername.trim()) proxyConfig.proxy_username = form.proxyUsername.trim()
+        if (form.proxyPassword) proxyConfig.proxy_password = form.proxyPassword
+        body.proxyConfig = proxyConfig
+      }
       if (form.type === 'group') body.formatConfig = { member_names: form.memberNames }
       if (form.type === 'group' && form.routingRuleId) {
         body.routingRuleId = form.routingRuleId
@@ -544,6 +555,64 @@ function CreateRepoModal({ onClose, onCreated }: {
           />
           <span className={styles.hint}>URL of the upstream registry to proxy and cache</span>
         </div>
+      )}
+      {form.type === 'proxy' && (
+        <details className={styles.formRow}>
+          <summary style={{ cursor: 'pointer', ...LABEL_STYLE }}>Outbound proxy (optional)</summary>
+          <span className={styles.hint}>
+            Route upstream fetches through an HTTP or SOCKS5 proxy. Leave blank to use the
+            server default (HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment).
+          </span>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>HTTP proxy</label>
+            <HoloInput
+              value={form.httpProxy}
+              onChange={e => setField('httpProxy', e.target.value)}
+              placeholder="http://proxy.internal:3128"
+            />
+          </div>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>HTTPS proxy</label>
+            <HoloInput
+              value={form.httpsProxy}
+              onChange={e => setField('httpsProxy', e.target.value)}
+              placeholder="http://secure-proxy.internal:3128"
+            />
+          </div>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>SOCKS5 proxy</label>
+            <HoloInput
+              value={form.socks5Proxy}
+              onChange={e => setField('socks5Proxy', e.target.value)}
+              placeholder="socks5://proxy.internal:1080"
+            />
+          </div>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>No proxy</label>
+            <HoloInput
+              value={form.noProxy}
+              onChange={e => setField('noProxy', e.target.value)}
+              placeholder="localhost,.internal.example.com"
+            />
+          </div>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>Proxy username</label>
+            <HoloInput
+              value={form.proxyUsername}
+              onChange={e => setField('proxyUsername', e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>Proxy password</label>
+            <HoloInput
+              type="password"
+              value={form.proxyPassword}
+              onChange={e => setField('proxyPassword', e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+        </details>
       )}
       {form.type === 'group' && (
         <div className={styles.formRow}>

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.53.0
+	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.46.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -139,7 +140,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/arch v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20260528193900-50dc527dd6c7 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	golang.org/x/arch v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20260528193900-50dc527dd6c7 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
+	golang.org/x/text v0.39.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -351,8 +351,8 @@ golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
-golang.org/x/text v0.38.0 h1:sXmwo9DwP3OK9EZ7PqAdaooSGozfl/3a6/xJcbzPRhE=
-golang.org/x/text v0.38.0/go.mod h1:YXZt3QhHUKYT53r2lLKFIVi6Ao1jdzrTR/KQ09qyxF4=
+golang.org/x/text v0.39.0 h1:UbZz4pLOvn600D6Oh6GGEI6VAmndrEBLv8/6BEXzyus=
+golang.org/x/text v0.39.0/go.mod h1:3UwRclnC2g0TU9x8PZiyfOajCd1zaUNHF9cvqcQZ+ZM=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:Kjn0N0tCrDgiAFW+lGO4JZ3ck44CehvJQMAwj9QF0G8=
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=

--- a/internal/api/handlers/cleanup.go
+++ b/internal/api/handlers/cleanup.go
@@ -13,6 +13,7 @@ import (
 // cleanupRunner is the minimal interface CleanupHandler needs from CleanupService.
 type cleanupRunner interface {
 	RunPolicy(ctx context.Context, id string) error
+	RunPolicyResult(ctx context.Context, id string) (*domain.CleanupRunResult, error)
 	RunAll(ctx context.Context) error
 	ReloadPolicy(ctx context.Context, id string)
 	PreviewPolicy(ctx context.Context, id string) (*domain.CleanupPreviewResult, error)
@@ -118,7 +119,10 @@ func (h *CleanupHandler) Delete(c *gin.Context) {
 	c.Status(http.StatusNoContent)
 }
 
-// Run POST /service/rest/v1/cleanup-policies/:id/run — trigger policy immediately
+// Run POST /service/rest/v1/cleanup-policies/:id/run — trigger policy immediately.
+// A single policy runs synchronously and returns its outcome (deleted count,
+// freed bytes, or a skip reason) so the UI can report a result instead of a bare
+// acknowledgement. Running all policies stays asynchronous.
 func (h *CleanupHandler) Run(c *gin.Context) {
 	id := c.Param("id")
 	if id == "_all" {
@@ -126,8 +130,12 @@ func (h *CleanupHandler) Run(c *gin.Context) {
 		c.JSON(http.StatusAccepted, gin.H{"status": "running all policies"})
 		return
 	}
-	go func() { _ = h.runner.RunPolicy(context.Background(), id) }()
-	c.JSON(http.StatusAccepted, gin.H{"status": "running", "id": id})
+	res, err := h.runner.RunPolicyResult(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, res)
 }
 
 // Preview POST /api/v1/cleanup-policies/:id/preview — dry-run preview (no deletes)

--- a/internal/api/handlers/cleanup_test.go
+++ b/internal/api/handlers/cleanup_test.go
@@ -182,7 +182,10 @@ func TestCleanupHandler_Delete_DeleteError_500(t *testing.T) {
 
 // ── Run ───────────────────────────────────────────────────────────────────────
 
-func TestCleanupHandler_Run_Single_202(t *testing.T) {
+// A single-policy run is synchronous and returns the run summary. A policy not
+// attached to any repository reports a skip with a reason (issue #62: "manual
+// execution produces no results" — now the reason is surfaced).
+func TestCleanupHandler_Run_Single_Unattached_ReportsSkip(t *testing.T) {
 	r, policies, _, _ := mountCleanup(t)
 	p := &domain.CleanupPolicy{
 		Name: "run-me", Format: "*", Enabled: true,
@@ -190,11 +193,32 @@ func TestCleanupHandler_Run_Single_202(t *testing.T) {
 	}
 	require.NoError(t, policies.Create(testContext(), p))
 	rec := do(t, r, http.MethodPost, "/service/rest/v1/cleanup-policies/"+p.ID+"/run", nil)
-	require.Equal(t, http.StatusAccepted, rec.Code)
-	var body map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-	assert.Equal(t, "running", body["status"])
-	assert.Equal(t, p.ID, body["id"])
+	require.Equal(t, http.StatusOK, rec.Code)
+	var res domain.CleanupRunResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	assert.True(t, res.Skipped)
+	assert.Contains(t, res.SkippedReason, "not attached")
+}
+
+// A single-policy run that deletes assets returns counts.
+func TestCleanupHandler_Run_Single_ReportsCounts(t *testing.T) {
+	r, policies, repos, assets := mountCleanup(t)
+	p := &domain.CleanupPolicy{
+		Name: "clear", Format: "*", Enabled: true, Criteria: map[string]any{},
+	}
+	require.NoError(t, policies.Create(testContext(), p))
+	require.NoError(t, repos.Create(testContext(), &domain.Repository{
+		Name: "debian", ID: "r1", Format: domain.FormatApt, CleanupPolicyIDs: []string{p.ID},
+	}))
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 42, Path: "/x"}}
+
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/cleanup-policies/"+p.ID+"/run", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var res domain.CleanupRunResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	assert.False(t, res.Skipped)
+	assert.Equal(t, 1, res.Deleted)
+	assert.Equal(t, int64(42), res.FreedBytes)
 }
 
 func TestCleanupHandler_Run_All_202(t *testing.T) {

--- a/internal/api/handlers/components.go
+++ b/internal/api/handlers/components.go
@@ -65,6 +65,13 @@ func (h *ComponentHandler) List(c *gin.Context) {
 			limit = v
 		}
 	}
+	// The browse UI pages with ?offset=; the Nexus-compatible clients use
+	// ?continuationToken=. Accept both — continuationToken wins when both are sent.
+	if off := c.Query("offset"); off != "" {
+		if v, err := strconv.Atoi(off); err == nil && v >= 0 {
+			offset = v
+		}
+	}
 	if tok := c.Query("continuationToken"); tok != "" {
 		if v, err := strconv.Atoi(tok); err == nil {
 			offset = v
@@ -101,6 +108,10 @@ func (h *ComponentHandler) List(c *gin.Context) {
 		items = h.rbacSvc.FilterComponents(c.Request.Context(),
 			stringVal(userID), stringSliceVal(roles), items, anonMap)
 	}
+	if err := h.attachAssets(c.Request.Context(), items); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	for i := range items {
 		h.enrichComponent(c, &items[i])
 	}
@@ -109,6 +120,35 @@ func (h *ComponentHandler) List(c *gin.Context) {
 		"items":             items,
 		"continuationToken": page.ContinuationToken,
 	})
+}
+
+// attachAssets fills in Assets for every component that doesn't have them yet,
+// using a single batched query instead of one per component. Callers that already
+// populated Assets (e.g. Get) pay nothing.
+//
+// The browse UI keys its per-row actions (download, delete) off asset paths, so a
+// component listing without assets makes those actions target the component name
+// and silently do nothing.
+func (h *ComponentHandler) attachAssets(ctx context.Context, items []domain.Component) error {
+	var needsAssets []string
+	for i := range items {
+		if len(items[i].Assets) == 0 {
+			needsAssets = append(needsAssets, items[i].ID)
+		}
+	}
+	if len(needsAssets) == 0 {
+		return nil
+	}
+	byID, err := h.assets.ListByComponentIDs(ctx, needsAssets)
+	if err != nil {
+		return err
+	}
+	for i := range items {
+		if len(items[i].Assets) == 0 {
+			items[i].Assets = byID[items[i].ID]
+		}
+	}
+	return nil
 }
 
 // Get handles GET /service/rest/v1/components/:id
@@ -237,25 +277,11 @@ func (h *ComponentHandler) Search(c *gin.Context) {
 			stringVal(userID), stringSliceVal(roles), items, anonMap)
 	}
 	// Preload assets in a single batched query instead of one query per component.
-	var needsAssets []string
-	for i := range items {
-		if len(items[i].Assets) == 0 {
-			needsAssets = append(needsAssets, items[i].ID)
-		}
-	}
-	var byID map[string][]domain.Asset
-	if len(needsAssets) > 0 {
-		var err error
-		byID, err = h.assets.ListByComponentIDs(c.Request.Context(), needsAssets)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
+	if err := h.attachAssets(c.Request.Context(), items); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
 	for i := range items {
-		if len(items[i].Assets) == 0 {
-			items[i].Assets = byID[items[i].ID]
-		}
 		h.enrichComponent(c, &items[i])
 	}
 

--- a/internal/api/handlers/components_test.go
+++ b/internal/api/handlers/components_test.go
@@ -145,6 +145,102 @@ func TestComponentHandler_List_Pagination_Params(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 }
 
+// TestComponentHandler_List_IncludesAssets: the browse UI deletes a row by the
+// path of its first asset, so the list envelope must carry assets — not just
+// component metadata. Without them the UI falls back to the component *name*
+// and the delete silently matches nothing (issues #75/#76).
+func TestComponentHandler_List_IncludesAssets(t *testing.T) {
+	r, comps, assets, repos := mountComponents(t)
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "npm-proxy", Format: domain.FormatNPM, Type: domain.TypeProxy})
+	require.NoError(t, comps.Create(testContext(), &domain.Component{Name: "lodash", Version: "4.17.21", Repository: "npm-proxy"}))
+	require.NoError(t, assets.Create(testContext(), &domain.Asset{
+		ComponentID: "comp-1", Repository: "npm-proxy", Path: "/lodash/-/lodash-4.17.21.tgz", SizeBytes: 10,
+	}))
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components?repository=npm-proxy", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got componentsResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Items, 1)
+	require.Len(t, got.Items[0].Assets, 1, "list must include the component's assets")
+	assert.Equal(t, "/lodash/-/lodash-4.17.21.tgz", got.Items[0].Assets[0].Path)
+	assert.Equal(t, "http://localhost/repository/npm-proxy/lodash/-/lodash-4.17.21.tgz",
+		got.Items[0].Assets[0].DownloadURL)
+}
+
+// Assets are fetched for every listed component in a single batched query.
+func TestComponentHandler_List_BatchesAssetLookup(t *testing.T) {
+	r, comps, assets, repos := mountComponents(t)
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "raw-host", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	for i := 0; i < 3; i++ {
+		require.NoError(t, comps.Create(testContext(), &domain.Component{
+			Name: fmt.Sprintf("pkg-%d", i), Repository: "raw-host",
+		}))
+	}
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components?repository=raw-host", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, assets.ListByComponentIDsCalls, "one batched query, not one per component")
+	assert.Zero(t, assets.ListByComponentIDCalls)
+}
+
+// An asset-repo failure while enriching the list must surface as a 500 rather
+// than silently returning components without assets.
+func TestComponentHandler_List_AssetRepoError_500(t *testing.T) {
+	r, comps, assets, repos := mountComponents(t)
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "raw-host", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	require.NoError(t, comps.Create(testContext(), &domain.Component{Name: "a", Repository: "raw-host"}))
+	assets.Err = errors.New("asset query failed")
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components?repository=raw-host", nil)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// TestComponentHandler_List_OffsetParam: the browse UI pages with ?offset=,
+// which the handler ignored — every "Next" page re-rendered page 1 (issue #80).
+func TestComponentHandler_List_OffsetParam(t *testing.T) {
+	r, comps, _, repos := mountComponents(t)
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "raw-host", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	for _, n := range []string{"a", "b", "c", "d"} {
+		require.NoError(t, comps.Create(testContext(), &domain.Component{Name: n, Repository: "raw-host"}))
+	}
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components?repository=raw-host&limit=2&offset=2", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 2, comps.LastListOffset, "offset query param must reach the repo layer")
+	var got componentsResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Items, 2)
+	assert.Equal(t, "c", got.Items[0].Name)
+	assert.Equal(t, "d", got.Items[1].Name)
+}
+
+// continuationToken keeps working and wins over offset when both are supplied.
+func TestComponentHandler_List_ContinuationTokenWinsOverOffset(t *testing.T) {
+	r, comps, _, repos := mountComponents(t)
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "raw-host", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	for _, n := range []string{"a", "b", "c", "d"} {
+		require.NoError(t, comps.Create(testContext(), &domain.Component{Name: n, Repository: "raw-host"}))
+	}
+	rec := do(t, r, http.MethodGet,
+		"/service/rest/v1/components?repository=raw-host&limit=1&offset=2&continuationToken=3", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 3, comps.LastListOffset)
+}
+
+// A first page that has more rows behind it advertises the next token.
+func TestComponentHandler_List_ContinuationTokenEmitted(t *testing.T) {
+	r, comps, _, repos := mountComponents(t)
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "raw-host", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	for _, n := range []string{"a", "b", "c"} {
+		require.NoError(t, comps.Create(testContext(), &domain.Component{Name: n, Repository: "raw-host"}))
+	}
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components?repository=raw-host&limit=2", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got componentsResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.NotNil(t, got.ContinuationToken)
+	assert.Equal(t, "2", *got.ContinuationToken)
+}
+
 func TestComponentHandler_List_ExpandRepoError_500(t *testing.T) {
 	r, _, _, repos := mountComponents(t)
 	repos.Err = errors.New("db down")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -157,6 +157,11 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	repoSvc.WithWebhooks(webhookSvc)
 	cleanupSvc := service.NewCleanupService(cleanupRepo, repoRepo, assetRepo, blobRepo, localBlob, log)
 	cleanupSvc.WithLocker(locker)
+	// Resolve each asset's physical store so cleanup deletes blobs from S3 /
+	// group members, not just the global default store.
+	cleanupSvc.WithResolver(blobRegistry)
+	// Prune components left empty after a run so the repo doesn't keep showing rows.
+	cleanupSvc.WithComponents(componentRepo)
 
 	// Start per-policy cron scheduler in background (default: cfg.Cleanup.DefaultSchedule).
 	go cleanupSvc.StartCronScheduler(context.Background(), cfg.Cleanup.DefaultSchedule)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,20 @@ type Config struct {
 	Audit     AuditConfig     `mapstructure:"audit"`
 	Docker    DockerConfig    `mapstructure:"docker"`
 	Redis     RedisConfig     `mapstructure:"redis"`
+	Proxy     ProxyConfig     `mapstructure:"proxy"`
+}
+
+// ProxyConfig configures the server-wide outbound proxy used when fetching from
+// upstream registries for proxy repositories. All fields are optional; when
+// empty, the standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables are
+// honored instead. Per-repository proxy_config overrides these defaults.
+type ProxyConfig struct {
+	HTTPProxy   string `mapstructure:"http_proxy"`
+	HTTPSProxy  string `mapstructure:"https_proxy"`
+	SOCKS5Proxy string `mapstructure:"socks5_proxy"`
+	NoProxy     string `mapstructure:"no_proxy"`
+	Username    string `mapstructure:"username"`
+	Password    string `mapstructure:"password"`
 }
 
 // BootstrapConfig holds the admin account that is created/synced on every startup.

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -477,6 +477,18 @@ type CleanupPreviewResult struct {
 	TotalBytes int64                 `json:"totalBytes"`
 }
 
+// CleanupRunResult summarizes a single cleanup-policy execution. It is returned
+// to the manual-run endpoint so the UI can report what happened instead of a
+// fire-and-forget acknowledgement.
+type CleanupRunResult struct {
+	PolicyID      string `json:"policyId"`
+	Deleted       int    `json:"deleted"`
+	FreedBytes    int64  `json:"freedBytes"`
+	DryRun        bool   `json:"dryRun"`
+	Skipped       bool   `json:"skipped"`
+	SkippedReason string `json:"skippedReason,omitempty"`
+}
+
 // ── Audit Event ──────────────────────────────────────────────
 
 // AuditEvent is a single recorded action (who, what, when, result) in the audit log.

--- a/internal/formats/apt/apt_proxy_test.go
+++ b/internal/formats/apt/apt_proxy_test.go
@@ -1,0 +1,129 @@
+package apt_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/apt"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// useUnguardedUpstream swaps the SSRF-guarded upstream client for a plain one so
+// cache-miss fetches can reach the loopback httptest server used as a fake mirror.
+func useUnguardedUpstream(t *testing.T) {
+	t.Helper()
+	orig := repoproxy.UpstreamClient
+	repoproxy.UpstreamClient = &http.Client{}
+	t.Cleanup(func() { repoproxy.UpstreamClient = orig })
+}
+
+// setupProxy wires an apt proxy repo pointed at upstream and returns the engine
+// plus the component/asset mocks so tests can inspect what was cached.
+func setupProxy(t *testing.T, name, upstream string) (*gin.Engine, *testutil.ComponentRepo, *testutil.AssetRepo) {
+	t.Helper()
+	repo := testutil.SimpleRepo(name, "apt")
+	repo.Type = domain.TypeProxy
+	repo.ProxyConfig = map[string]any{"remote_url": upstream}
+
+	comps := testutil.NewComponentRepo()
+	assets := testutil.NewAssetRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     assets,
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := apt.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps, assets
+}
+
+func get(t *testing.T, r *gin.Engine, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+	return w
+}
+
+// A cached .deb must land on a component named after the package, with the
+// version parsed out of the filename — same coordinates a hosted upload gets.
+// Before this, apt's proxy branch passed empty coords and every cached file
+// shared one nameless component (#76).
+func TestAptProxy_CachedDeb_HasPackageCoordinates(t *testing.T) {
+	useUnguardedUpstream(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("deb-bytes"))
+	}))
+	defer upstream.Close()
+
+	r, comps, _ := setupProxy(t, "apt-proxy", upstream.URL)
+
+	w := get(t, r, "/repository/apt-proxy/pool/main/n/nginx/nginx_1.24.0-1_amd64.deb")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	page, err := comps.List(t.Context(), "apt-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "nginx", page.Items[0].Name)
+	assert.Equal(t, "1.24.0-1", page.Items[0].Version)
+}
+
+// Metadata files are not packages: they get their own component keyed by path,
+// so they stay individually browsable and deletable.
+func TestAptProxy_CachedMetadata_IsPerPathComponent(t *testing.T) {
+	useUnguardedUpstream(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("Suite: trixie\n"))
+	}))
+	defer upstream.Close()
+
+	r, comps, _ := setupProxy(t, "apt-proxy", upstream.URL)
+
+	require.Equal(t, http.StatusOK, get(t, r, "/repository/apt-proxy/dists/trixie/InRelease").Code)
+	require.Equal(t, http.StatusOK, get(t, r, "/repository/apt-proxy/dists/trixie/Release").Code)
+
+	page, err := comps.List(t.Context(), "apt-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 2, "each metadata file is its own component")
+	names := map[string]bool{}
+	for _, c := range page.Items {
+		names[c.Name] = true
+		assert.NotEmpty(t, c.Name, "component name must never be empty")
+	}
+	assert.True(t, names["dists/trixie/InRelease"])
+	assert.True(t, names["dists/trixie/Release"])
+}
+
+// Every cached asset must be reachable from the component that owns it —
+// this is what the browse row needs in order to delete it.
+func TestAptProxy_CachedAsset_LinkedToComponent(t *testing.T) {
+	useUnguardedUpstream(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("deb-bytes"))
+	}))
+	defer upstream.Close()
+
+	r, comps, assets := setupProxy(t, "apt-proxy", upstream.URL)
+	require.Equal(t, http.StatusOK,
+		get(t, r, "/repository/apt-proxy/pool/main/v/vim/vim_9.1_amd64.deb").Code)
+
+	page, err := comps.List(t.Context(), "apt-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+
+	owned, err := assets.ListByComponentID(t.Context(), page.Items[0].ID)
+	require.NoError(t, err)
+	require.Len(t, owned, 1)
+	assert.Equal(t, "/pool/main/v/vim/vim_9.1_amd64.deb", owned[0].Path)
+}

--- a/internal/formats/apt/handler.go
+++ b/internal/formats/apt/handler.go
@@ -52,8 +52,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		} else if strings.Contains(p, "/Packages") {
 			ct = "text/plain"
 		}
-		coords := base.Coords{}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, ct); err != nil {
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", proxyCoords(p), ct); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return
@@ -185,15 +184,31 @@ Description: Nexspence APT Repository
 	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(release))
 }
 
+// debCoords parses the Debian "name_version_arch.deb" filename convention.
+// Non-conforming names keep the whole filename as the package name.
+func debCoords(filename string) (pkgName, version string) {
+	pkgName, version = filename, "0.0.0"
+	if parts := strings.Split(strings.TrimSuffix(filename, ".deb"), "_"); len(parts) >= 2 {
+		pkgName, version = parts[0], parts[1]
+	}
+	return pkgName, version
+}
+
+// proxyCoords derives component coordinates for a file cached from upstream.
+// Packages get real package/version coordinates so they browse like hosted ones;
+// index files (Release, InRelease, Packages) are keyed by their path, since each
+// is a distinct document rather than a version of a package.
+func proxyCoords(p string) base.Coords {
+	if strings.HasSuffix(p, ".deb") {
+		name, version := debCoords(path.Base(p))
+		return base.Coords{Name: name, Version: version}
+	}
+	return base.Coords{Name: strings.TrimPrefix(p, "/"), Version: "metadata"}
+}
+
 func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
 	filename := path.Base(p)
-	// Parse: name_version_arch.deb
-	parts := strings.Split(strings.TrimSuffix(filename, ".deb"), "_")
-	pkgName, version := filename, "0.0.0"
-	if len(parts) >= 2 {
-		pkgName = parts[0]
-		version = parts[1]
-	}
+	pkgName, version := debCoords(filename)
 
 	// Normalize root-level uploads into the canonical pool layout so the
 	// Packages index (which lists /pool/ assets) still finds them.

--- a/internal/formats/apt/handler.go
+++ b/internal/formats/apt/handler.go
@@ -52,8 +52,15 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		} else if strings.Contains(p, "/Packages") {
 			ct = "text/plain"
 		}
+		// /pool/ holds immutable .deb artifacts; everything under /dists/
+		// (Release/InRelease/Packages and other indexes) is mutable metadata that
+		// upstreams re-sign with an expiry, so it must be revalidated on a TTL.
+		var maxAge time.Duration
+		if !strings.HasPrefix(p, "/pool/") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
 		coords := base.Coords{}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, ct); err != nil {
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, ct, maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -171,12 +171,20 @@ func RegisterStoredBlob(ctx context.Context, d formats.Deps, repo *domain.Reposi
 	if version == "" {
 		version = "1"
 	}
+	name := coords.Name
+	if name == "" {
+		// Formats that cache proxied files verbatim (apt, yum, nuget, conan, ...)
+		// have no coordinates to parse. Components are upserted on
+		// (repo, format, group, name, version), so an empty name would fold every
+		// cached file into one nameless component that the browse UI can't act on.
+		name = strings.TrimPrefix(filePath, "/")
+	}
 	comp := &domain.Component{
 		RepositoryID: repo.ID,
 		Repository:   repo.Name,
 		Format:       string(repo.Format),
 		Group:        coords.Group,
-		Name:         coords.Name,
+		Name:         name,
 		Version:      version,
 	}
 	if err := d.Components.Create(ctx, comp); err != nil {

--- a/internal/formats/base/store_test.go
+++ b/internal/formats/base/store_test.go
@@ -103,6 +103,60 @@ func TestStoreArtifact_HappyPath(t *testing.T) {
 	assert.Len(t, assetList.Items, 1)
 }
 
+// Formats that cache proxied files without parsing coordinates (apt, yum, nuget,
+// conan, cargo, gomod) pass empty Coords. Those must not collapse into one
+// nameless component: the browse UI keys rows off the component name, and an
+// empty name made every cached file share a single unusable row (#76).
+func TestRegisterStoredBlob_EmptyCoords_DerivesNameFromPath(t *testing.T) {
+	repo := testutil.SimpleRepo("apt-proxy", "apt")
+	d, _, comps, _ := deps(repo)
+
+	_, err := base.RegisterStoredBlob(context.Background(), d, repo,
+		"/dists/trixie/InRelease", "text/plain", base.Coords{},
+		"blobkey-1", "sha256", "sha1", "md5", 10, "", "")
+	require.NoError(t, err)
+
+	compList, err := comps.List(context.Background(), "apt-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, compList.Items, 1)
+	assert.Equal(t, "dists/trixie/InRelease", compList.Items[0].Name)
+}
+
+// Two different cached paths must produce two distinct components.
+func TestRegisterStoredBlob_EmptyCoords_DistinctPathsDistinctComponents(t *testing.T) {
+	repo := testutil.SimpleRepo("apt-proxy", "apt")
+	d, _, comps, _ := deps(repo)
+
+	for _, p := range []string{"/dists/trixie/InRelease", "/dists/trixie/Release"} {
+		_, err := base.RegisterStoredBlob(context.Background(), d, repo,
+			p, "text/plain", base.Coords{},
+			"key"+p, "sha256", "sha1", "md5", 10, "", "")
+		require.NoError(t, err)
+	}
+
+	compList, err := comps.List(context.Background(), "apt-proxy", 100, 0)
+	require.NoError(t, err)
+	assert.Len(t, compList.Items, 2, "each cached path is its own component")
+}
+
+// An explicit name still wins — the fallback only fills a gap.
+func TestRegisterStoredBlob_ExplicitCoordsWin(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-proxy", "npm")
+	d, _, comps, _ := deps(repo)
+
+	_, err := base.RegisterStoredBlob(context.Background(), d, repo,
+		"/lodash/-/lodash-4.17.21.tgz", "application/octet-stream",
+		base.Coords{Name: "lodash", Version: "4.17.21"},
+		"blobkey-2", "sha256", "sha1", "md5", 10, "", "")
+	require.NoError(t, err)
+
+	compList, err := comps.List(context.Background(), "npm-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, compList.Items, 1)
+	assert.Equal(t, "lodash", compList.Items[0].Name)
+	assert.Equal(t, "4.17.21", compList.Items[0].Version)
+}
+
 func TestStoreArtifact_RepoNotFound(t *testing.T) {
 	repo := testutil.SimpleRepo("exists", "raw")
 	d, _, _, _ := deps(repo)

--- a/internal/formats/cargo/handler.go
+++ b/internal/formats/cargo/handler.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -55,8 +56,14 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			h.serveIndexConfig(c, repoName)
 			return
 		}
+		// Sparse-index entries under /index/ are mutable metadata (they list a
+		// crate's versions); /api/v1/crates/.../download .crate files are immutable.
+		var maxAge time.Duration
+		if strings.HasPrefix(p, "/index/") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
 		coords := base.Coords{}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream"); err != nil {
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/conan/handler.go
+++ b/internal/formats/conan/handler.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -53,8 +54,14 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"ok": true})
 			return
 		}
+		// Conan revision files are content-addressed (immutable); the "/latest"
+		// endpoints resolve to a moving recipe/package revision, so revalidate those.
+		var maxAge time.Duration
+		if strings.HasSuffix(p, "/latest") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
 		coords := base.Coords{}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream"); err != nil {
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/conda/handler.go
+++ b/internal/formats/conda/handler.go
@@ -223,7 +223,7 @@ func (h *Handler) proxyRepodata(c *gin.Context, repo *domain.Repository, repoNam
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	resp, err := repoproxy.UpstreamClient.Do(req)
+	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch: " + err.Error()})
 		return

--- a/internal/formats/conda/handler.go
+++ b/internal/formats/conda/handler.go
@@ -203,9 +203,10 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 		return
 	}
 
-	// Package binary: cache via repoproxy
+	// Package binary: cache via repoproxy. Conda packages are immutable
+	// (repodata.json — the mutable index — is handled by proxyRepodata above).
 	coords := base.Coords{Name: filename, Group: platform}
-	if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar"); err != nil {
+	if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar", 0); err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 	}
 }

--- a/internal/formats/docker/handler.go
+++ b/internal/formats/docker/handler.go
@@ -146,7 +146,13 @@ func (h *Handler) handleManifests(c *gin.Context, repoName, imageName, reference
 			upPath := "/v2/" + imageName + "/manifests/" + reference
 			coords := base.Coords{Name: imageName, Version: reference}
 			ct := "application/vnd.docker.distribution.manifest.v2+json"
-			if err := repoproxy.ServeGET(c, h.deps, repo, cachePath, upPath, coords, ct); err != nil {
+			// A manifest referenced by digest is immutable; a tag (e.g. :latest)
+			// is a moving pointer, so revalidate it on a TTL.
+			var maxAge time.Duration
+			if !strings.HasPrefix(reference, "sha256:") {
+				maxAge = repoproxy.MetadataMaxAge(repo)
+			}
+			if err := repoproxy.ServeGET(c, h.deps, repo, cachePath, upPath, coords, ct, maxAge); err != nil {
 				dockerError(c, http.StatusBadGateway, "UNKNOWN", err.Error())
 			}
 			return
@@ -253,7 +259,8 @@ func (h *Handler) handleBlobs(c *gin.Context, repoName, imageName, digest string
 			// Upstream OCI path: /v2/{image}/blobs/{digest}
 			upPath := "/v2/" + imageName + "/blobs/" + digest
 			coords := base.Coords{Name: imageName, Version: digest}
-			if err := repoproxy.ServeGET(c, h.deps, repo, cachePath, upPath, coords, "application/octet-stream"); err != nil {
+			// Blobs are content-addressed by digest — immutable, never revalidate.
+			if err := repoproxy.ServeGET(c, h.deps, repo, cachePath, upPath, coords, "application/octet-stream", 0); err != nil {
 				dockerError(c, http.StatusBadGateway, "UNKNOWN", err.Error())
 			}
 			return

--- a/internal/formats/gomod/handler.go
+++ b/internal/formats/gomod/handler.go
@@ -63,7 +63,13 @@ func (h *Handler) handleGet(c *gin.Context, repoName, p string) {
 		return
 	}
 	if repo != nil && repo.Type == domain.TypeProxy {
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", goProxyCoords(p), goContentType(p)); err != nil {
+		// @latest and @v/list resolve to a moving target (newest version / the full
+		// version list); @v/<ver>.{info,mod,zip} are immutable per version.
+		var maxAge time.Duration
+		if strings.HasSuffix(p, "/@latest") || strings.HasSuffix(p, "/@v/list") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", goProxyCoords(p), goContentType(p), maxAge); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/helm/handler.go
+++ b/internal/formats/helm/handler.go
@@ -49,7 +49,9 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			return
 		}
 		coords := base.Coords{Name: strings.TrimSuffix(strings.TrimPrefix(p, "/"), ".tgz")}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar"); err != nil {
+		// Chart tarballs are immutable (index.yaml — the mutable index — is
+		// fetched-and-rewritten above, not cached through here).
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar", 0); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/helm/handler.go
+++ b/internal/formats/helm/handler.go
@@ -230,7 +230,7 @@ func (h *Handler) fetchAndRewriteHelmIndex(c *gin.Context, repo *domain.Reposito
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid upstream URL: " + err.Error()})
 		return
 	}
-	resp, err := repoproxy.UpstreamClient.Do(req)
+	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch failed: " + err.Error()})
 		return

--- a/internal/formats/maven/handler.go
+++ b/internal/formats/maven/handler.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -41,12 +42,19 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		}
 		if repo != nil && repo.Type == domain.TypeProxy {
 			coords := parsePath(filePath)
+			main := filePath
 			if isChecksum(filePath) {
-				main := strings.TrimSuffix(filePath, path.Ext(filePath))
+				main = strings.TrimSuffix(filePath, path.Ext(filePath))
 				coords = parsePath(main)
 			}
 			ct := mavenContentType(filePath)
-			if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, ct); err != nil {
+			// maven-metadata.xml (and its .md5/.sha1 siblings) is the mutable index
+			// that lists released/snapshot versions; jars/poms are immutable.
+			var maxAge time.Duration
+			if path.Base(main) == "maven-metadata.xml" {
+				maxAge = repoproxy.MetadataMaxAge(repo)
+			}
+			if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, ct, maxAge); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			}
 			return

--- a/internal/formats/npm/handler.go
+++ b/internal/formats/npm/handler.go
@@ -102,7 +102,8 @@ func (h *Handler) serveTarball(c *gin.Context, repoName, filePath string) {
 		if coords.Version == "" {
 			coords.Version = "1"
 		}
-		if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, "application/octet-stream"); err != nil {
+		// npm tarballs are immutable (name+version) — never revalidate.
+		if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, "application/octet-stream", 0); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
 		return
@@ -137,7 +138,8 @@ func (h *Handler) serveMetadata(c *gin.Context, repoName, pkgPath string) {
 		trim := strings.Trim(strings.TrimPrefix(pkgPath, "/"), "/")
 		up := "/" + repoproxy.NPMMetadataPath(trim)
 		coords := base.Coords{Name: pkgName, Version: "metadata"}
-		if err := repoproxy.ServeGET(c, h.deps, repo, pkgPath, up, coords, "application/json"); err != nil {
+		// The packument is mutable metadata (new versions appear over time).
+		if err := repoproxy.ServeGET(c, h.deps, repo, pkgPath, up, coords, "application/json", repoproxy.MetadataMaxAge(repo)); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/nuget/handler.go
+++ b/internal/formats/nuget/handler.go
@@ -57,8 +57,14 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			h.fetchAndRewriteNuGetIndex(c, repo)
 			return
 		}
+		// .nupkg package content is immutable; registration/flat-container index
+		// pages are mutable metadata (new versions appear) and revalidate on a TTL.
+		var maxAge time.Duration
+		if !strings.HasSuffix(p, ".nupkg") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
 		coords := base.Coords{}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream"); err != nil {
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/nuget/handler.go
+++ b/internal/formats/nuget/handler.go
@@ -304,7 +304,7 @@ func (h *Handler) fetchAndRewriteNuGetIndex(c *gin.Context, repo *domain.Reposit
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := repoproxy.UpstreamClient.Do(req)
+	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch failed: " + err.Error()})
 		return

--- a/internal/formats/pypi/handler.go
+++ b/internal/formats/pypi/handler.go
@@ -52,7 +52,8 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	case c.Request.Method == http.MethodGet && (p == "/simple" || p == "/simple/"):
 		if repo != nil && repo.Type == domain.TypeProxy {
 			coords := base.Coords{Name: "_simple", Version: "index"}
-			if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8"); err != nil {
+			// The simple index is mutable metadata — revalidate on a TTL.
+			if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8", repoproxy.MetadataMaxAge(repo)); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			}
 			return
@@ -65,7 +66,8 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		if repo != nil && repo.Type == domain.TypeProxy {
 			normalized := normalizePackageName(pkgName)
 			coords := base.Coords{Name: normalized, Version: "simple-page"}
-			if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8"); err != nil {
+			// A per-package simple page is mutable metadata (new releases appear).
+			if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8", repoproxy.MetadataMaxAge(repo)); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			}
 			return
@@ -201,7 +203,8 @@ func (h *Handler) serveFile(c *gin.Context, repoName, filePath string) {
 		pkgGuess := path.Base(path.Dir(filePath))
 		coords := base.Coords{Name: normalizePackageName(pkgGuess), Version: "wheel"}
 		ct := pypiContentType(path.Base(filePath))
-		if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, ct); err != nil {
+		// Wheels/sdists are immutable release files — never revalidate.
+		if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, ct, 0); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/raw/handler.go
+++ b/internal/formats/raw/handler.go
@@ -43,7 +43,9 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			if ct == "" {
 				ct = "application/octet-stream"
 			}
-			if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, ct); err != nil {
+			// Raw repositories have no metadata/index concept — treat all paths as
+			// immutable cached content (maxAge 0), preserving prior behavior.
+			if err := repoproxy.ServeGET(c, h.deps, repo, filePath, "", coords, ct, 0); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			}
 			return

--- a/internal/formats/repoproxy/coverage_extra_test.go
+++ b/internal/formats/repoproxy/coverage_extra_test.go
@@ -1,0 +1,102 @@
+package repoproxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+func proxyRepoWith(cfg map[string]any) *domain.Repository {
+	return &domain.Repository{Name: "p", Type: domain.TypeProxy, Online: true, ProxyConfig: cfg}
+}
+
+// MetadataMaxAge parses every supported numeric encoding and falls back to the
+// default for missing/invalid/non-positive values.
+func TestMetadataMaxAge_Parsing(t *testing.T) {
+	cases := []struct {
+		name string
+		repo *domain.Repository
+		want time.Duration
+	}{
+		{"nil repo", nil, DefaultMetadataMaxAge},
+		{"nil config", &domain.Repository{}, DefaultMetadataMaxAge},
+		{"missing key", proxyRepoWith(map[string]any{"remote_url": "x"}), DefaultMetadataMaxAge},
+		{"float64", proxyRepoWith(map[string]any{"metadata_max_age": float64(30)}), 30 * time.Second},
+		{"int", proxyRepoWith(map[string]any{"metadata_max_age": 45}), 45 * time.Second},
+		{"int64", proxyRepoWith(map[string]any{"metadata_max_age": int64(60)}), 60 * time.Second},
+		{"json.Number", proxyRepoWith(map[string]any{"metadata_max_age": json.Number("90")}), 90 * time.Second},
+		{"string", proxyRepoWith(map[string]any{"metadata_max_age": "120"}), 120 * time.Second},
+		{"bad json.Number", proxyRepoWith(map[string]any{"metadata_max_age": json.Number("nope")}), DefaultMetadataMaxAge},
+		{"bad string", proxyRepoWith(map[string]any{"metadata_max_age": "abc"}), DefaultMetadataMaxAge},
+		{"zero", proxyRepoWith(map[string]any{"metadata_max_age": 0}), DefaultMetadataMaxAge},
+		{"negative", proxyRepoWith(map[string]any{"metadata_max_age": -5}), DefaultMetadataMaxAge},
+		{"wrong type", proxyRepoWith(map[string]any{"metadata_max_age": true}), DefaultMetadataMaxAge},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MetadataMaxAge(tc.repo); got != tc.want {
+				t.Fatalf("MetadataMaxAge = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// redirectPolicy allows redirects up to the cap and rejects beyond it.
+func TestRedirectPolicy(t *testing.T) {
+	if err := redirectPolicy(nil, make([]*http.Request, proxyMaxRedirects-1)); err != nil {
+		t.Fatalf("under cap should be allowed: %v", err)
+	}
+	if err := redirectPolicy(nil, make([]*http.Request, proxyMaxRedirects)); err == nil {
+		t.Fatal("at/over cap should be rejected")
+	}
+}
+
+// hostPort accepts host:port and URL forms and rejects malformed input.
+func TestHostPort(t *testing.T) {
+	ok := []struct{ in, want string }{
+		{"127.0.0.1:8899", "127.0.0.1:8899"},
+		{"http://proxy.local:3128", "proxy.local:3128"},
+		{"socks5://10.0.0.1:1080", "10.0.0.1:1080"},
+		{" 127.0.0.1:1 ", "127.0.0.1:1"},
+	}
+	for _, tc := range ok {
+		got, err := hostPort(tc.in)
+		if err != nil || got != tc.want {
+			t.Fatalf("hostPort(%q) = %q,%v want %q", tc.in, got, err, tc.want)
+		}
+	}
+	bad := []string{"", "no-port", "http://", "://bad"}
+	for _, in := range bad {
+		if _, err := hostPort(in); err == nil {
+			t.Fatalf("hostPort(%q) expected error", in)
+		}
+	}
+}
+
+// buildProxyClient builds a working client for each proxy mode and rejects
+// malformed proxy addresses.
+func TestBuildProxyClient_Modes(t *testing.T) {
+	// HTTP proxy with auth
+	c, err := buildProxyClient(proxySettings{httpProxy: "http://127.0.0.1:3128", username: "u", password: "p"})
+	if err != nil || c == nil {
+		t.Fatalf("http proxy client: %v", err)
+	}
+	if c.CheckRedirect == nil {
+		t.Fatal("client must set redirect policy")
+	}
+	// SOCKS5 with auth
+	if _, err := buildProxyClient(proxySettings{socks5Proxy: "127.0.0.1:1080", username: "u", password: "p"}); err != nil {
+		t.Fatalf("socks5 client: %v", err)
+	}
+	// invalid socks5 address
+	if _, err := buildProxyClient(proxySettings{socks5Proxy: "not-a-hostport"}); err == nil {
+		t.Fatal("invalid socks5_proxy should error")
+	}
+	// no_proxy honored (client still builds)
+	if _, err := buildProxyClient(proxySettings{httpProxy: "http://127.0.0.1:3128", noProxy: "example.com"}); err != nil {
+		t.Fatalf("no_proxy client: %v", err)
+	}
+}

--- a/internal/formats/repoproxy/docker_registry_token.go
+++ b/internal/formats/repoproxy/docker_registry_token.go
@@ -82,7 +82,7 @@ func scopeFromRegistryV2URL(u *url.URL) string {
 	return "repository:" + name + ":pull"
 }
 
-func fetchDockerRegistryToken(ctx context.Context, realm, service, scope string) (string, error) {
+func fetchDockerRegistryToken(ctx context.Context, client *http.Client, realm, service, scope string) (string, error) {
 	if realm == "" {
 		realm = "https://auth.docker.io/token"
 	}
@@ -109,7 +109,7 @@ func fetchDockerRegistryToken(ctx context.Context, realm, service, scope string)
 	}
 	req.Header.Set("User-Agent", "Nexspence/1.0 (docker-proxy)")
 
-	resp, err := UpstreamClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -139,7 +139,7 @@ func fetchDockerRegistryToken(ctx context.Context, realm, service, scope string)
 // fetchUpstreamWithDockerHubAuth performs the HTTP request; on 401 from Docker Hub it obtains
 // an anonymous Bearer token and retries once. This prevents the registry client from
 // following Hub's WWW-Authenticate challenge with Nexspence credentials (wrong host).
-func fetchUpstreamWithDockerHubAuth(ctx context.Context, method, upstreamURL, baseRemote string, hdr http.Header) (*http.Response, error) {
+func fetchUpstreamWithDockerHubAuth(ctx context.Context, client *http.Client, method, upstreamURL, baseRemote string, hdr http.Header) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, upstreamURL, nil)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func fetchUpstreamWithDockerHubAuth(ctx context.Context, method, upstreamURL, ba
 		req.Header.Set("User-Agent", "Nexspence/1.0 (proxy)")
 	}
 
-	resp, err := UpstreamClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -180,12 +180,12 @@ func fetchUpstreamWithDockerHubAuth(ctx context.Context, method, upstreamURL, ba
 	_ = resp.Body.Close()
 
 	if scope == "" {
-		return redoUpstreamWithoutAuth(ctx, method, upstreamURL, hdr)
+		return redoUpstreamWithoutAuth(ctx, client, method, upstreamURL, hdr)
 	}
 
-	tok, errTok := fetchDockerRegistryToken(ctx, realm, service, scope)
+	tok, errTok := fetchDockerRegistryToken(ctx, client, realm, service, scope)
 	if errTok != nil || tok == "" {
-		return redoUpstreamWithoutAuth(ctx, method, upstreamURL, hdr)
+		return redoUpstreamWithoutAuth(ctx, client, method, upstreamURL, hdr)
 	}
 
 	req2, err := http.NewRequestWithContext(ctx, method, upstreamURL, nil)
@@ -199,10 +199,10 @@ func fetchUpstreamWithDockerHubAuth(ctx context.Context, method, upstreamURL, ba
 		req2.Header.Set("User-Agent", "Nexspence/1.0 (proxy)")
 	}
 	req2.Header.Set("Authorization", "Bearer "+tok)
-	return UpstreamClient.Do(req2)
+	return client.Do(req2)
 }
 
-func redoUpstreamWithoutAuth(ctx context.Context, method, upstreamURL string, hdr http.Header) (*http.Response, error) {
+func redoUpstreamWithoutAuth(ctx context.Context, client *http.Client, method, upstreamURL string, hdr http.Header) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, upstreamURL, nil)
 	if err != nil {
 		return nil, err
@@ -214,5 +214,5 @@ func redoUpstreamWithoutAuth(ctx context.Context, method, upstreamURL string, hd
 	if req.Header.Get("User-Agent") == "" {
 		req.Header.Set("User-Agent", "Nexspence/1.0 (proxy)")
 	}
-	return UpstreamClient.Do(req)
+	return client.Do(req)
 }

--- a/internal/formats/repoproxy/proxyclient.go
+++ b/internal/formats/repoproxy/proxyclient.go
@@ -1,0 +1,270 @@
+package repoproxy
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/net/http/httpproxy"
+	xproxy "golang.org/x/net/proxy"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// Timeouts/limits mirror the shared UpstreamClient so proxied clients behave
+// equivalently (redirect cap, request timeout, idle-conn tuning).
+const (
+	proxyDialTimeout    = 10 * time.Second
+	proxyRequestTimeout = 5 * time.Minute
+	proxyMaxIdleConns   = 128
+	proxyIdleConnTO     = 90 * time.Second
+	proxyTLSHandshakeTO = 15 * time.Second
+	proxyMaxRedirects   = 12
+)
+
+// proxySettings is the resolved outbound-proxy configuration for a repository.
+// The zero value means "no explicit proxy" (fall back to the shared,
+// SSRF-guarded UpstreamClient which honors HTTP(S)_PROXY/NO_PROXY env vars).
+type proxySettings struct {
+	httpProxy   string
+	httpsProxy  string
+	socks5Proxy string
+	noProxy     string
+	username    string
+	password    string
+}
+
+func (s proxySettings) isEmpty() bool { return s == proxySettings{} }
+
+// key is a stable cache key for a settings value.
+func (s proxySettings) key() string {
+	return strings.Join([]string{
+		s.httpProxy, s.httpsProxy, s.socks5Proxy, s.noProxy, s.username, s.password,
+	}, "\x00")
+}
+
+// defaultProxySettings, if non-empty, is the server-wide outbound proxy applied
+// to every proxy repository that does not set its own proxy_config overrides.
+// It is optional: when empty, the shared UpstreamClient (which honors the
+// standard HTTP_PROXY/HTTPS_PROXY/NO_PROXY env vars) is used for the no-override
+// case. Guard it with defaultProxyMu.
+var (
+	defaultProxySettings proxySettings
+	defaultProxyMu       sync.RWMutex
+)
+
+// SetGlobalProxy installs a server-wide outbound proxy default. Per-repository
+// proxy_config keys still override individual fields. Pass all-empty strings to
+// clear it and fall back to env-based defaults. Intended to be called once from
+// server config loading at startup.
+func SetGlobalProxy(httpProxy, httpsProxy, socks5Proxy, noProxy, username, password string) {
+	defaultProxyMu.Lock()
+	defer defaultProxyMu.Unlock()
+	defaultProxySettings = proxySettings{
+		httpProxy:   strings.TrimSpace(httpProxy),
+		httpsProxy:  strings.TrimSpace(httpsProxy),
+		socks5Proxy: strings.TrimSpace(socks5Proxy),
+		noProxy:     strings.TrimSpace(noProxy),
+		username:    username,
+		password:    password,
+	}
+}
+
+func cfgString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if raw, ok := m[key]; ok {
+		if s, ok := raw.(string); ok {
+			return strings.TrimSpace(s)
+		}
+	}
+	return ""
+}
+
+// repoProxySettings resolves the effective proxy settings for a repo: the
+// server-wide default overlaid with any per-repo proxy_config overrides.
+func repoProxySettings(repo *domain.Repository) proxySettings {
+	defaultProxyMu.RLock()
+	s := defaultProxySettings
+	defaultProxyMu.RUnlock()
+
+	pc := repo.ProxyConfig
+	if v := cfgString(pc, "http_proxy"); v != "" {
+		s.httpProxy = v
+	}
+	if v := cfgString(pc, "https_proxy"); v != "" {
+		s.httpsProxy = v
+	}
+	if v := cfgString(pc, "socks5_proxy"); v != "" {
+		s.socks5Proxy = v
+	}
+	if v := cfgString(pc, "no_proxy"); v != "" {
+		s.noProxy = v
+	}
+	if v := cfgString(pc, "proxy_username"); v != "" {
+		s.username = v
+	}
+	if v := cfgString(pc, "proxy_password"); v != "" {
+		s.password = v
+	}
+	return s
+}
+
+var (
+	clientCache   = map[string]*http.Client{}
+	clientCacheMu sync.Mutex
+)
+
+// ClientFor returns the *http.Client to use for outbound upstream fetches for
+// repo. When the repo (and the server-wide default) specify no explicit proxy,
+// it returns the shared, SSRF-guarded UpstreamClient — preserving existing
+// behavior and keeping the guard active for direct upstream dials. When an
+// outbound proxy IS configured, it returns a per-config cached client whose
+// TCP connections go to the (admin-configured, trusted) proxy.
+//
+// SSRF-guard interaction: the guard exists because remote_url is
+// user-configured and must not be able to reach internal addresses on a DIRECT
+// dial. When a proxy is configured, the only address the process dials is the
+// proxy itself; the user-controlled upstream host is resolved by the proxy, not
+// by us, so it can never become a direct internal dial. We therefore do NOT
+// apply the guard to proxied clients (allowing a legitimately-internal
+// corporate proxy), while direct (no-proxy) clients keep the guard. This gives
+// exactly the required behavior: an explicitly-configured internal proxy is
+// reachable, but a direct internal upstream is still blocked.
+func ClientFor(repo *domain.Repository) *http.Client {
+	if repo == nil {
+		return UpstreamClient
+	}
+	s := repoProxySettings(repo)
+	if s.isEmpty() {
+		return UpstreamClient
+	}
+
+	k := s.key()
+	clientCacheMu.Lock()
+	if c, ok := clientCache[k]; ok {
+		clientCacheMu.Unlock()
+		return c
+	}
+	clientCacheMu.Unlock()
+
+	c, err := buildProxyClient(s)
+	if err != nil {
+		// Misconfiguration: fall back to the guarded default rather than
+		// silently disabling outbound fetches.
+		return UpstreamClient
+	}
+
+	clientCacheMu.Lock()
+	// Re-check in case of a concurrent build.
+	if existing, ok := clientCache[k]; ok {
+		clientCacheMu.Unlock()
+		return existing
+	}
+	clientCache[k] = c
+	clientCacheMu.Unlock()
+	return c
+}
+
+func redirectPolicy(_ *http.Request, via []*http.Request) error {
+	if len(via) >= proxyMaxRedirects {
+		return fmt.Errorf("stopped after %d redirects", proxyMaxRedirects)
+	}
+	return nil
+}
+
+// buildProxyClient constructs an *http.Client that routes outbound requests
+// through the configured proxy. SOCKS5 takes precedence over HTTP(S) proxy when
+// both are set. The dialer that reaches the proxy is intentionally NOT
+// SSRF-guarded (the proxy is admin-configured and may legitimately be internal).
+func buildProxyClient(s proxySettings) (*http.Client, error) {
+	// Dialer that connects to the proxy. No netguard.Control: the proxy is
+	// trusted/admin-configured and is frequently on an internal IP.
+	baseDialer := &net.Dialer{Timeout: proxyDialTimeout}
+
+	tr := &http.Transport{
+		MaxIdleConns:        proxyMaxIdleConns,
+		IdleConnTimeout:     proxyIdleConnTO,
+		TLSHandshakeTimeout: proxyTLSHandshakeTO,
+	}
+
+	if s.socks5Proxy != "" {
+		addr, err := hostPort(s.socks5Proxy)
+		if err != nil {
+			return nil, fmt.Errorf("invalid socks5_proxy: %w", err)
+		}
+		var auth *xproxy.Auth
+		if s.username != "" || s.password != "" {
+			auth = &xproxy.Auth{User: s.username, Password: s.password}
+		}
+		d, err := xproxy.SOCKS5("tcp", addr, auth, baseDialer)
+		if err != nil {
+			return nil, fmt.Errorf("build socks5 dialer: %w", err)
+		}
+		cd, ok := d.(xproxy.ContextDialer)
+		if !ok {
+			return nil, fmt.Errorf("socks5 dialer does not support DialContext")
+		}
+		tr.DialContext = cd.DialContext
+		// tr.Proxy stays nil: routing is done at the socket layer.
+	} else {
+		tr.DialContext = baseDialer.DialContext
+		pf, err := httpProxyFunc(s)
+		if err != nil {
+			return nil, err
+		}
+		tr.Proxy = pf
+	}
+
+	return &http.Client{
+		Transport:     tr,
+		Timeout:       proxyRequestTimeout,
+		CheckRedirect: redirectPolicy,
+	}, nil
+}
+
+// httpProxyFunc builds a per-request proxy resolver honoring http_proxy,
+// https_proxy and no_proxy, injecting optional basic-auth credentials.
+func httpProxyFunc(s proxySettings) (func(*http.Request) (*url.URL, error), error) {
+	cfg := &httpproxy.Config{
+		HTTPProxy:  s.httpProxy,
+		HTTPSProxy: s.httpsProxy,
+		NoProxy:    s.noProxy,
+	}
+	resolve := cfg.ProxyFunc()
+	return func(req *http.Request) (*url.URL, error) {
+		u, err := resolve(req.URL)
+		if err != nil || u == nil {
+			return u, err
+		}
+		if u.User == nil && (s.username != "" || s.password != "") {
+			u.User = url.UserPassword(s.username, s.password)
+		}
+		return u, nil
+	}, nil
+}
+
+// hostPort normalizes a proxy address that may be given as "host:port",
+// "scheme://host:port", or "socks5://host:port" into "host:port".
+func hostPort(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if strings.Contains(raw, "://") {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return "", err
+		}
+		if u.Host == "" {
+			return "", fmt.Errorf("no host in %q", raw)
+		}
+		return u.Host, nil
+	}
+	if _, _, err := net.SplitHostPort(raw); err != nil {
+		return "", fmt.Errorf("expected host:port, got %q", raw)
+	}
+	return raw, nil
+}

--- a/internal/formats/repoproxy/proxyclient_test.go
+++ b/internal/formats/repoproxy/proxyclient_test.go
@@ -1,0 +1,190 @@
+package repoproxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+func mkProxyRepo(name string, cfg map[string]any) *domain.Repository {
+	pc := map[string]any{"remote_url": "http://upstream.invalid"}
+	for k, v := range cfg {
+		pc[k] = v
+	}
+	return &domain.Repository{
+		ID:          "repo-" + name,
+		Name:        name,
+		Type:        domain.TypeProxy,
+		ProxyConfig: pc,
+	}
+}
+
+// (a) No proxy configured → ClientFor returns the shared, SSRF-guarded
+// UpstreamClient so existing behavior (and the test swap hook) is preserved.
+func TestClientFor_NoProxy_ReturnsUpstreamClient(t *testing.T) {
+	repo := mkProxyRepo("noproxy", nil)
+	got := ClientFor(repo)
+	if got != UpstreamClient {
+		t.Fatalf("expected ClientFor to return the shared UpstreamClient when no proxy is configured")
+	}
+}
+
+// (b) Per-repo HTTP proxy is actually used: a loopback httptest server acting
+// as an HTTP proxy must receive the (absolute-form) request.
+func TestClientFor_HTTPProxy_IsUsed(t *testing.T) {
+	var hits int32
+	var gotAbsolute atomic.Bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if r.URL.Host != "" && r.URL.Scheme != "" {
+			gotAbsolute.Store(true)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("via-proxy"))
+	}))
+	defer proxy.Close()
+
+	repo := mkProxyRepo("httpproxy", map[string]any{"http_proxy": proxy.URL})
+	client := ClientFor(repo)
+	if client == UpstreamClient {
+		t.Fatal("expected a dedicated proxied client, got the shared UpstreamClient")
+	}
+
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/some/artifact.txt", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request through proxy failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if atomic.LoadInt32(&hits) == 0 {
+		t.Fatal("proxy server was never contacted")
+	}
+	if !gotAbsolute.Load() {
+		t.Fatal("proxy did not receive an absolute-form (proxied) request")
+	}
+}
+
+// (c) SOCKS5 selection builds a dialer-based transport (no HTTP Proxy func).
+func TestBuildProxyClient_SOCKS5_BuildsDialer(t *testing.T) {
+	c, err := buildProxyClient(proxySettings{socks5Proxy: "127.0.0.1:1080"})
+	if err != nil {
+		t.Fatalf("buildProxyClient socks5: %v", err)
+	}
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatal("expected *http.Transport")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected a SOCKS5 DialContext to be set")
+	}
+	if tr.Proxy != nil {
+		t.Fatal("SOCKS5 transport must not also set an HTTP Proxy func")
+	}
+	// The dialer should try to reach the SOCKS proxy address (which is closed here).
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/", nil)
+	resp, err := c.Do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+		t.Fatal("expected dial to closed SOCKS proxy to fail")
+	}
+}
+
+// (d) Proxy auth credentials are applied to HTTP proxy connections.
+func TestClientFor_HTTPProxy_Auth(t *testing.T) {
+	var gotAuth atomic.Value
+	gotAuth.Store("")
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Proxy-Authorization"))
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer proxy.Close()
+
+	repo := mkProxyRepo("authproxy", map[string]any{
+		"http_proxy":     proxy.URL,
+		"proxy_username": "alice",
+		"proxy_password": "s3cret",
+	})
+	client := ClientFor(repo)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/x", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	auth, _ := gotAuth.Load().(string)
+	if !strings.HasPrefix(auth, "Basic ") {
+		t.Fatalf("expected Basic Proxy-Authorization header, got %q", auth)
+	}
+}
+
+// Global default applies when a repo has no per-repo proxy_config, and a
+// per-repo override wins over the global default.
+func TestClientFor_GlobalDefaultAndPerRepoOverride(t *testing.T) {
+	t.Cleanup(func() { SetGlobalProxy("", "", "", "", "", "") })
+
+	// No global, no per-repo → shared UpstreamClient.
+	if got := ClientFor(mkProxyRepo("g0", nil)); got != UpstreamClient {
+		t.Fatal("expected UpstreamClient when nothing configured")
+	}
+
+	// Global default set → a repo without its own proxy uses a dedicated client.
+	SetGlobalProxy("http://global.proxy:3128", "", "", "", "", "")
+	globalClient := ClientFor(mkProxyRepo("g1", nil))
+	if globalClient == UpstreamClient {
+		t.Fatal("expected a proxied client from the global default")
+	}
+
+	// Per-repo override differs from the global one and is its own client.
+	perRepo := ClientFor(mkProxyRepo("g2", map[string]any{"http_proxy": "http://repo.proxy:3128"}))
+	if perRepo == UpstreamClient || perRepo == globalClient {
+		t.Fatal("expected per-repo override to produce a distinct client")
+	}
+
+	// The effective settings should reflect the per-repo override, not global.
+	s := repoProxySettings(mkProxyRepo("g3", map[string]any{"http_proxy": "http://repo.proxy:3128"}))
+	if s.httpProxy != "http://repo.proxy:3128" {
+		t.Fatalf("expected per-repo http_proxy to win, got %q", s.httpProxy)
+	}
+}
+
+// (e) An explicitly-configured internal (loopback) proxy is allowed, while a
+// direct (no-proxy) dial to an internal upstream is still SSRF-blocked.
+func TestClientFor_InternalProxyAllowed_DirectInternalBlocked(t *testing.T) {
+	// Loopback proxy is internal but explicitly configured → must be reachable.
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer proxy.Close()
+
+	repoProxied := mkProxyRepo("intproxy", map[string]any{"http_proxy": proxy.URL})
+	pc := ClientFor(repoProxied)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com/whatever", nil)
+	resp, err := pc.Do(req)
+	if err != nil {
+		t.Fatalf("expected internal proxy to be reachable, got: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	// No proxy → shared guarded client → dialing an internal upstream is blocked.
+	// Use the real guarded UpstreamClient (do NOT swap it here).
+	repoDirect := mkProxyRepo("direct", nil)
+	dc := ClientFor(repoDirect)
+	// Point at a loopback address; the SSRF guard must refuse the direct dial.
+	blockedReq, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1:9/", nil)
+	blockedResp, derr := dc.Do(blockedReq)
+	if derr == nil {
+		_ = blockedResp.Body.Close()
+		t.Fatal("expected direct dial to internal address to be blocked")
+	}
+	if !strings.Contains(derr.Error(), "blocked") {
+		t.Fatalf("expected SSRF block error, got: %v", derr)
+	}
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha1" //nolint:gosec // md5/sha1 required for artifact-protocol checksums (Maven .md5/.sha1, npm shasum), not security
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -128,14 +130,102 @@ func applyChecksumHeaders(c *gin.Context, a *domain.Asset) {
 	}
 }
 
+// DefaultMetadataMaxAge is the freshness window applied to proxied repository
+// metadata (indexes, Release/InRelease, packuments, repodata, simple-index
+// pages, …) when a repository does not override it via
+// proxy_config.metadata_max_age. Immutable artifacts (.deb, .tgz, .jar, blobs
+// addressed by digest) are never revalidated — callers pass maxAge == 0 for those.
+const DefaultMetadataMaxAge = 10 * time.Minute
+
+// MetadataMaxAge returns the freshness TTL to use for proxied metadata on this
+// repository. It reads proxy_config["metadata_max_age"], interpreted as a number
+// of seconds (JSON numbers arrive as float64; strings are parsed). Any unset,
+// non-positive, or invalid value falls back to DefaultMetadataMaxAge.
+//
+// Handlers call this for metadata/index paths and pass the result as the maxAge
+// argument to ServeGET; for immutable artifact paths they pass 0 instead.
+func MetadataMaxAge(repo *domain.Repository) time.Duration {
+	if repo == nil || repo.ProxyConfig == nil {
+		return DefaultMetadataMaxAge
+	}
+	raw, ok := repo.ProxyConfig["metadata_max_age"]
+	if !ok {
+		return DefaultMetadataMaxAge
+	}
+	var secs float64
+	switch v := raw.(type) {
+	case float64:
+		secs = v
+	case float32:
+		secs = float64(v)
+	case int:
+		secs = float64(v)
+	case int64:
+		secs = float64(v)
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return DefaultMetadataMaxAge
+		}
+		secs = f
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		if err != nil {
+			return DefaultMetadataMaxAge
+		}
+		secs = f
+	default:
+		return DefaultMetadataMaxAge
+	}
+	if secs <= 0 {
+		return DefaultMetadataMaxAge
+	}
+	return time.Duration(secs * float64(time.Second))
+}
+
+// cacheFetchStore resolves the physical blob store that holds a cached asset.
+func cacheFetchStore(ctx context.Context, d formats.Deps, asset *domain.Asset) storage.BlobStore {
+	if asset.BlobStoreID != "" {
+		if bsMeta, getErr := d.Blobs.GetByID(ctx, asset.BlobStoreID); getErr == nil && bsMeta != nil {
+			return base.PhysicalStore(ctx, d, bsMeta)
+		}
+	}
+	return d.BlobStore
+}
+
+// serveCachedAsset streams (or, for HEAD, describes) a cached asset to the client.
+// It takes ownership of rc and closes it.
+func serveCachedAsset(c *gin.Context, d formats.Deps, asset *domain.Asset, rc io.ReadCloser) {
+	defer func() { _ = rc.Close() }()
+	// Count only real GETs so a HEAD probe + GET pull don't double-count.
+	if c.Request.Method == http.MethodGet && d.Downloads != nil {
+		d.Downloads.Add(asset.ID)
+	}
+	applyChecksumHeaders(c, asset)
+	if c.Request.Method == http.MethodHead {
+		c.Header("Content-Type", asset.ContentType)
+		if asset.SizeBytes > 0 {
+			c.Header("Content-Length", fmt.Sprintf("%d", asset.SizeBytes))
+		}
+		c.Status(http.StatusOK)
+		return
+	}
+	c.DataFromReader(http.StatusOK, asset.SizeBytes, asset.ContentType, rc, nil)
+}
+
 // ServeGET serves a cached asset or fetches upstream, streaming to the client
 // and persisting to the blob store on success. repo must be TypeProxy.
 // upstreamPath, when non-empty, is used only for the upstream URL (e.g. npm scoped metadata);
 // the cache key and DB asset path remain repoRelativePath.
 //
-//nolint:gocyclo // large protocol-dispatch function (proxy cache-miss/upstream handling); splitting would hurt readability
+// maxAge controls metadata freshness. maxAge == 0 means the content is immutable
+// (artifacts, blobs addressed by digest): a cache hit is served forever without
+// contacting upstream. maxAge > 0 marks the path as mutable metadata (apt
+// Release/InRelease/Packages, npm packuments, yum repodata, pypi simple pages, …):
+// when the cached copy is older than maxAge it is revalidated against upstream with
+// a conditional request before being served. See revalidateAndServe.
 func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelativePath, upstreamPath string,
-	coords base.Coords, defaultContentType string,
+	coords base.Coords, defaultContentType string, maxAge time.Duration,
 ) error {
 	ctx := c.Request.Context()
 	if repo.Type != domain.TypeProxy {
@@ -158,37 +248,31 @@ func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelat
 		return fmt.Errorf("repoproxy: asset lookup: %w", err)
 	}
 	if asset != nil {
-		var fetchStore storage.BlobStore
-		if asset.BlobStoreID != "" {
-			if bsMeta, getErr := d.Blobs.GetByID(ctx, asset.BlobStoreID); getErr == nil && bsMeta != nil {
-				fetchStore = base.PhysicalStore(ctx, d, bsMeta)
-			}
-		}
-		if fetchStore == nil {
-			fetchStore = d.BlobStore
-		}
-		rc, _, blobErr := fetchStore.Get(ctx, asset.BlobKey)
+		rc, _, blobErr := cacheFetchStore(ctx, d, asset).Get(ctx, asset.BlobKey)
 		if blobErr == nil {
-			defer func() { _ = rc.Close() }()
-			// Count only real GETs so HEAD probe + GET pulls don't double-count.
-			if c.Request.Method == http.MethodGet && d.Downloads != nil {
-				d.Downloads.Add(asset.ID)
+			// Metadata freshness: a stale cached copy of mutable metadata is
+			// revalidated against upstream before serving. Immutable content
+			// (maxAge == 0) and HEAD probes always serve straight from cache.
+			if maxAge > 0 && c.Request.Method == http.MethodGet && time.Since(asset.LastModified) > maxAge {
+				return revalidateAndServe(c, d, repo, asset, repoRelativePath, upJoin, coords, defaultContentType, rc)
 			}
-			applyChecksumHeaders(c, asset)
-			if c.Request.Method == http.MethodHead {
-				c.Header("Content-Type", asset.ContentType)
-				if asset.SizeBytes > 0 {
-					c.Header("Content-Length", fmt.Sprintf("%d", asset.SizeBytes))
-				}
-				c.Status(http.StatusOK)
-				return nil
-			}
-			c.DataFromReader(http.StatusOK, asset.SizeBytes, asset.ContentType, rc, nil)
+			serveCachedAsset(c, d, asset, rc)
 			return nil
 		}
 		// Blob file missing from cache storage (storage path changed or file deleted).
 		// Fall through to upstream fetch so the client gets content and the cache is repaired.
 	}
+
+	return fetchAndCache(c, d, repo, repoRelativePath, upJoin, coords, defaultContentType)
+}
+
+// fetchAndCache handles a cache miss (or a cache entry whose blob went missing):
+// it fetches from upstream, forwarding the client's own conditional headers, and
+// on success stores the blob and serves it.
+func fetchAndCache(c *gin.Context, d formats.Deps, repo *domain.Repository,
+	repoRelativePath, upJoin string, coords base.Coords, defaultContentType string,
+) error {
+	ctx := c.Request.Context()
 
 	baseRemote, err := RemoteURL(repo)
 	if err != nil {
@@ -220,18 +304,7 @@ func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelat
 
 	resp, err := fetchUpstreamWithDockerHubAuth(ctx, upstreamMethod, upstream, baseRemote, upHdr)
 	if err != nil {
-		if d.Webhooks != nil {
-			d.Webhooks.Dispatch(domain.WebhookPayload{
-				Event:      domain.EventProxyError,
-				Timestamp:  time.Now(),
-				Repository: repo.Name,
-				Asset: map[string]any{
-					"path":     repoRelativePath,
-					"upstream": upstream,
-					"error":    err.Error(),
-				},
-			})
-		}
+		dispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch failed: " + err.Error()})
 		return nil
 	}
@@ -249,6 +322,87 @@ func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelat
 		_, _ = io.Copy(c.Writer, resp.Body)
 		return nil
 	}
+
+	return storeAndServeResponse(c, d, repo, repoRelativePath, defaultContentType, coords, resp)
+}
+
+// revalidateAndServe is invoked when a cached metadata asset is older than its
+// TTL. It asks upstream for a fresh copy with a conditional request and:
+//   - 304 Not Modified → refresh the asset's freshness timestamp, serve the cache;
+//   - 2xx             → replace the cached blob and serve the new copy;
+//   - upstream error / other status → serve the stale cache so clients (e.g.
+//     `apt update`) keep working, and record a proxy_error for the failure.
+//
+// It takes ownership of rc (the open cache blob) and always closes it.
+func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository, asset *domain.Asset,
+	repoRelativePath, upJoin string, coords base.Coords, defaultContentType string, rc io.ReadCloser,
+) error {
+	ctx := c.Request.Context()
+
+	baseRemote, err := RemoteURL(repo)
+	if err != nil {
+		serveCachedAsset(c, d, asset, rc)
+		return nil
+	}
+	upstream, err := JoinURL(baseRemote, upJoin)
+	if err != nil {
+		serveCachedAsset(c, d, asset, rc)
+		return nil
+	}
+
+	upHdr := http.Header{}
+	if ac := c.GetHeader("Accept"); ac != "" {
+		upHdr.Set("Accept", ac)
+	}
+	// Conditional revalidation: request a fresh body only if the resource changed
+	// since we cached it. We seed If-Modified-Since from the asset's stored
+	// timestamp (the moment we last fetched/validated). We deliberately do NOT
+	// derive If-None-Match from our SHA256: upstreams don't recognize our content
+	// hash as their ETag, and per RFC 7232 If-None-Match would take precedence over
+	// If-Modified-Since, forcing a 200 on every request and defeating revalidation.
+	if !asset.LastModified.IsZero() {
+		upHdr.Set("If-Modified-Since", asset.LastModified.UTC().Format(http.TimeFormat))
+	}
+
+	resp, err := fetchUpstreamWithDockerHubAuth(ctx, http.MethodGet, upstream, baseRemote, upHdr)
+	if err != nil {
+		// Upstream unreachable → serve stale cache so metadata consumers keep working.
+		dispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
+		serveCachedAsset(c, d, asset, rc)
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusNotModified:
+		// Upstream confirms our copy is current: refresh freshness and serve cache.
+		// Use context.Background so the touch survives request cancellation.
+		if d.Assets != nil {
+			_ = d.Assets.TouchLastModified(context.Background(), asset.ID)
+		}
+		serveCachedAsset(c, d, asset, rc)
+		return nil
+	case resp.StatusCode >= 200 && resp.StatusCode <= 299:
+		// Upstream returned a newer copy: replace the cached blob and serve it.
+		_ = rc.Close()
+		return storeAndServeResponse(c, d, repo, repoRelativePath, defaultContentType, coords, resp)
+	default:
+		// Any other status (404/410/5xx): don't discard a good cache on a transient
+		// upstream hiccup — serve stale and record the anomaly.
+		dispatchProxyError(d, repo.Name, repoRelativePath, upstream,
+			fmt.Errorf("revalidation returned status %d", resp.StatusCode))
+		serveCachedAsset(c, d, asset, rc)
+		return nil
+	}
+}
+
+// storeAndServeResponse streams a successful (2xx) upstream response to the
+// client while persisting it to the blob store and registering the DB asset,
+// replacing any prior cache entry for repoRelativePath.
+func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Repository,
+	repoRelativePath, defaultContentType string, coords base.Coords, resp *http.Response,
+) error {
+	ctx := c.Request.Context()
 
 	ct := resp.Header.Get("Content-Type")
 	if ct == "" {
@@ -307,12 +461,30 @@ func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelat
 	if regErr != nil {
 		return regErr
 	}
-	// Count a download only for GET (see HEAD branch above). Otherwise a HEAD probe + GET
-	// hit would double-count the same pull.
+	// Count a download only for GET. Otherwise a HEAD probe + GET hit would
+	// double-count the same pull.
 	if regAsset != nil && regAsset.ID != "" && c.Request.Method == http.MethodGet && d.Downloads != nil {
 		d.Downloads.Add(regAsset.ID)
 	}
 	return nil
+}
+
+// dispatchProxyError records an upstream fetch/revalidation failure via the
+// webhook bus (the package's proxy-error reporting channel), if configured.
+func dispatchProxyError(d formats.Deps, repoName, repoRelativePath, upstream string, cause error) {
+	if d.Webhooks == nil {
+		return
+	}
+	d.Webhooks.Dispatch(domain.WebhookPayload{
+		Event:      domain.EventProxyError,
+		Timestamp:  time.Now(),
+		Repository: repoName,
+		Asset: map[string]any{
+			"path":     repoRelativePath,
+			"upstream": upstream,
+			"error":    cause.Error(),
+		},
+	})
 }
 
 // NPMMetadataPath returns the path segment npmjs.org uses for metadata (scoped packages use %2F).

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -377,7 +377,7 @@ func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository,
 		upHdr.Set("If-Modified-Since", asset.LastModified.UTC().Format(http.TimeFormat))
 	}
 
-	resp, err := fetchUpstreamWithDockerHubAuth(ctx, http.MethodGet, upstream, baseRemote, upHdr)
+	resp, err := fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), http.MethodGet, upstream, baseRemote, upHdr)
 	if err != nil {
 		// Upstream unreachable → serve stale cache so metadata consumers keep working.
 		dispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/net/http/httpproxy"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/formats"
@@ -28,10 +29,16 @@ import (
 )
 
 // UpstreamClient is the shared HTTP client used to fetch artifacts from upstream
-// remotes on cache miss. Its dialer is SSRF-guarded (remote_url is
-// user-configured): connections that resolve to internal addresses are refused.
+// remotes on cache miss when no explicit per-repo/global proxy is configured.
+// Its dialer is SSRF-guarded (remote_url is user-configured): connections that
+// resolve to internal addresses are refused. It honors the standard
+// HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables via Transport.Proxy;
+// for env-configured proxies the guard still applies, so internal proxies must
+// be set via per-repo proxy_config or SetGlobalProxy (see proxyclient.go),
+// which route through a client that permits the trusted proxy address.
 var UpstreamClient = &http.Client{
 	Transport: &http.Transport{
+		Proxy: envProxyFromRequest,
 		DialContext: (&net.Dialer{
 			Timeout: 10 * time.Second,
 			Control: netguard.DialControl,
@@ -47,6 +54,12 @@ var UpstreamClient = &http.Client{
 		}
 		return nil
 	},
+}
+
+// envProxyFromRequest resolves the proxy for a request from the process
+// environment (HTTP_PROXY/HTTPS_PROXY/NO_PROXY), read fresh each call.
+func envProxyFromRequest(req *http.Request) (*url.URL, error) {
+	return httpproxy.FromEnvironment().ProxyFunc()(req.URL)
 }
 
 var hopHeaders = map[string]bool{
@@ -218,7 +231,7 @@ func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelat
 		upstreamMethod = http.MethodGet
 	}
 
-	resp, err := fetchUpstreamWithDockerHubAuth(ctx, upstreamMethod, upstream, baseRemote, upHdr)
+	resp, err := fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), upstreamMethod, upstream, baseRemote, upHdr)
 	if err != nil {
 		if d.Webhooks != nil {
 			d.Webhooks.Dispatch(domain.WebhookPayload{

--- a/internal/formats/repoproxy/repoproxy_extra_test.go
+++ b/internal/formats/repoproxy/repoproxy_extra_test.go
@@ -164,7 +164,7 @@ func TestServeGET_NotProxy(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/file", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "", 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a proxy")
 }
@@ -175,7 +175,7 @@ func TestServeGET_UnsupportedMethod(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodPost, "/file", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "", 0)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported method")
 }
@@ -189,7 +189,7 @@ func TestServeGET_MissingRemoteURL(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/file", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "", 0)
 	require.NoError(t, err) // handled internally with 400
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -207,7 +207,7 @@ func TestServeGET_Upstream404(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/missing.jar", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/missing.jar", "", base.Coords{}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/missing.jar", "", base.Coords{}, "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
@@ -231,7 +231,7 @@ func TestServeGET_UpstreamError(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/file.bin", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/file.bin", "", base.Coords{}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/file.bin", "", base.Coords{}, "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusBadGateway, w.Code)
 }
@@ -256,7 +256,7 @@ func TestServeGET_UpstreamError_FiresWebhook(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/file.bin", nil)
-	_ = repoproxy.ServeGET(c, d, repo, "/file.bin", "", base.Coords{}, "")
+	_ = repoproxy.ServeGET(c, d, repo, "/file.bin", "", base.Coords{}, "", 0)
 
 	// Give the goroutine a moment — Dispatch is synchronous in stubDispatcher but
 	// ServeGET calls it directly (not in a goroutine), so no wait needed.
@@ -282,7 +282,7 @@ func TestServeGET_UpstreamNotModified(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/file", nil)
 	req.Header.Set("If-None-Match", `"abc123"`)
 	c.Request = req
-	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{}, "", 0)
 	require.NoError(t, err)
 	// gin's c.Status() flushes the code only on first write; 304 has no body so we
 	// check via the writer's status (gin exposes it on the response writer).
@@ -317,7 +317,7 @@ func TestServeGET_HEAD_CacheHit(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodHead, "/data.bin", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/data.bin", "", base.Coords{}, "application/octet-stream")
+	err := repoproxy.ServeGET(c, d, repo, "/data.bin", "", base.Coords{}, "application/octet-stream", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "", w.Body.String()) // HEAD has no body
@@ -340,7 +340,7 @@ func TestServeGET_HEAD_CacheMiss_FetchesUpstream(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodHead, "/headfile.txt", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/headfile.txt", "", base.Coords{Name: "headfile.txt"}, "text/plain")
+	err := repoproxy.ServeGET(c, d, repo, "/headfile.txt", "", base.Coords{Name: "headfile.txt"}, "text/plain", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 }
@@ -362,7 +362,7 @@ func TestServeGET_DefaultContentType(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/data", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/data", "", base.Coords{Name: "data"}, "application/octet-stream")
+	err := repoproxy.ServeGET(c, d, repo, "/data", "", base.Coords{Name: "data"}, "application/octet-stream", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "application/octet-stream", w.Header().Get("Content-Type"))
@@ -387,7 +387,7 @@ func TestServeGET_UpstreamPathOverride(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/@babel/core", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/@babel/core", "/@babel%2Fcore", base.Coords{Name: "@babel/core"}, "application/json")
+	err := repoproxy.ServeGET(c, d, repo, "/@babel/core", "/@babel%2Fcore", base.Coords{Name: "@babel/core"}, "application/json", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, body, w.Body.String())
@@ -410,7 +410,7 @@ func TestServeGET_Accept_Header_Forwarded(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/file", nil)
 	req.Header.Set("Accept", "application/vnd.npm.install-v1+json")
 	c.Request = req
-	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{Name: "file"}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/file", "", base.Coords{Name: "file"}, "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, "application/vnd.npm.install-v1+json", capturedAccept)
 }
@@ -479,7 +479,7 @@ func TestServeGET_DockerHubLike_401_Token_200(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/v2/library/alpine/manifests/latest", "", base.Coords{Name: "alpine"}, "application/json")
+	err := repoproxy.ServeGET(c, d, repo, "/v2/library/alpine/manifests/latest", "", base.Coords{Name: "alpine"}, "application/json", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.GreaterOrEqual(t, calls, 2, "should have made at least 2 upstream calls (401 + retry)")
@@ -545,7 +545,7 @@ func TestServeGET_DockerHub_NoScopeRedoWithoutAuth(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	// Use a non-/v2/ path so scopeFromRegistryV2URL returns "".
 	c.Request = httptest.NewRequest(http.MethodGet, "/ping", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/ping", "", base.Coords{Name: "ping"}, "")
+	err := repoproxy.ServeGET(c, d, repo, "/ping", "", base.Coords{Name: "ping"}, "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, 2, calls)
@@ -601,7 +601,7 @@ func TestServeGET_CacheHit_WithChecksums(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/checksummed.jar", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/checksummed.jar", "", base.Coords{}, "application/java-archive")
+	err := repoproxy.ServeGET(c, d, repo, "/checksummed.jar", "", base.Coords{}, "application/java-archive", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "abc123sha256", w.Header().Get("X-Checksum-SHA256"))
@@ -656,7 +656,7 @@ func TestServeGET_DockerHub_ScopeFromV2URL(t *testing.T) {
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/v2/library/nginx/manifests/latest", nil)
-	err := repoproxy.ServeGET(c, d, repo, "/v2/library/nginx/manifests/latest", "", base.Coords{Name: "nginx"}, "application/json")
+	err := repoproxy.ServeGET(c, d, repo, "/v2/library/nginx/manifests/latest", "", base.Coords{Name: "nginx"}, "application/json", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.True(t, tokenServerCalled, "token server should have been called with scope from URL")

--- a/internal/formats/repoproxy/repoproxy_test.go
+++ b/internal/formats/repoproxy/repoproxy_test.go
@@ -112,7 +112,7 @@ func serveGET(repo *domain.Repository, assetPath, blobContent string) *httptest.
 	c.Request = httptest.NewRequest(http.MethodGet, assetPath, nil)
 
 	coords := base.Coords{}
-	_ = repoproxy.ServeGET(c, d, repo, assetPath, "", coords, "application/octet-stream")
+	_ = repoproxy.ServeGET(c, d, repo, assetPath, "", coords, "application/octet-stream", 0)
 	return w
 }
 
@@ -150,7 +150,7 @@ func TestServeGET_CacheMiss_FetchesUpstream(t *testing.T) {
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest(http.MethodGet, "/artifact.bin", nil)
 
-	err := repoproxy.ServeGET(c, d, repo, "/artifact.bin", "", base.Coords{Name: "artifact.bin"}, "application/octet-stream")
+	err := repoproxy.ServeGET(c, d, repo, "/artifact.bin", "", base.Coords{Name: "artifact.bin"}, "application/octet-stream", 0)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, body, w.Body.String())

--- a/internal/formats/repoproxy/revalidation_test.go
+++ b/internal/formats/repoproxy/revalidation_test.go
@@ -1,0 +1,239 @@
+package repoproxy_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// fakeUpstream is a controllable upstream mirror for revalidation tests.
+type fakeUpstream struct {
+	mu sync.Mutex
+	// body is the current representation returned for a 200.
+	body string
+	// return304 makes the server answer 304 when the request carries a
+	// conditional header (If-Modified-Since / If-None-Match).
+	return304 bool
+	// requests records the total number of requests received.
+	requests int
+	// lastIfModifiedSince captures the conditional header seen on the last request.
+	lastIfModifiedSince string
+}
+
+func newFakeUpstream(body string) (*fakeUpstream, *httptest.Server) {
+	fu := &fakeUpstream{body: body}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fu.mu.Lock()
+		fu.requests++
+		fu.lastIfModifiedSince = r.Header.Get("If-Modified-Since")
+		conditional := fu.lastIfModifiedSince != "" || r.Header.Get("If-None-Match") != ""
+		want304 := fu.return304
+		body := fu.body
+		fu.mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		if want304 && conditional {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(body))
+	}))
+	return fu, srv
+}
+
+func (fu *fakeUpstream) set(body string, return304 bool) {
+	fu.mu.Lock()
+	defer fu.mu.Unlock()
+	fu.body = body
+	fu.return304 = return304
+}
+
+func (fu *fakeUpstream) count() int {
+	fu.mu.Lock()
+	defer fu.mu.Unlock()
+	return fu.requests
+}
+
+func newRevalDeps(repo *domain.Repository) (formats.Deps, *testutil.AssetRepo, *testutil.BlobStore) {
+	assets := testutil.NewAssetRepo()
+	blobStore := testutil.NewBlobStore()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     assets,
+		BlobStore:  blobStore,
+	}
+	return d, assets, blobStore
+}
+
+func revalGET(d formats.Deps, repo *domain.Repository, path string, maxAge time.Duration) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, path, nil)
+	_ = repoproxy.ServeGET(c, d, repo, path, "", base.Coords{Name: "meta", Version: "metadata"}, "text/plain", maxAge)
+	return w
+}
+
+// makeStale rewinds the cached asset's freshness timestamp so it is older than any TTL.
+func makeStale(t *testing.T, assets *testutil.AssetRepo, repoName, path string) {
+	t.Helper()
+	a, err := assets.GetByPath(nil, repoName, path) //nolint:staticcheck // mock ignores ctx
+	require.NoError(t, err)
+	a.LastModified = time.Now().Add(-1 * time.Hour)
+}
+
+// (a) Immutable content (maxAge == 0) is served from cache without contacting upstream.
+func TestServeGET_Immutable_NoRevalidation(t *testing.T) {
+	useUnguardedUpstream(t)
+	fu, srv := newFakeUpstream("artifact-v1")
+	defer srv.Close()
+
+	repo := proxyRepo("immproxy", srv.URL)
+	d, assets, _ := newRevalDeps(repo)
+
+	// First GET: cache miss → fetch upstream.
+	w1 := revalGET(d, repo, "/pkg/1.0/a.jar", 0)
+	assert.Equal(t, http.StatusOK, w1.Code)
+	assert.Equal(t, "artifact-v1", w1.Body.String())
+	require.Equal(t, 1, fu.count())
+
+	// Even after the asset is ancient, maxAge==0 must never revalidate.
+	makeStale(t, assets, "immproxy", "/pkg/1.0/a.jar")
+	w2 := revalGET(d, repo, "/pkg/1.0/a.jar", 0)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "artifact-v1", w2.Body.String())
+	assert.Equal(t, 1, fu.count(), "immutable cache hit must not contact upstream")
+}
+
+// (b) Metadata within its TTL is served from cache without revalidation.
+func TestServeGET_Metadata_WithinTTL_NoRevalidation(t *testing.T) {
+	useUnguardedUpstream(t)
+	fu, srv := newFakeUpstream("InRelease-v1")
+	defer srv.Close()
+
+	repo := proxyRepo("freshproxy", srv.URL)
+	d, _, _ := newRevalDeps(repo)
+
+	w1 := revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute)
+	require.Equal(t, http.StatusOK, w1.Code)
+	require.Equal(t, 1, fu.count())
+
+	// Second GET immediately: asset is fresh (< TTL) → cache hit, no upstream call.
+	w2 := revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "InRelease-v1", w2.Body.String())
+	assert.Equal(t, 1, fu.count(), "fresh metadata must not revalidate")
+}
+
+// (c) Metadata past its TTL triggers a conditional GET; a 304 refreshes freshness and serves cache.
+func TestServeGET_Metadata_PastTTL_304_RefreshesAndServesCache(t *testing.T) {
+	useUnguardedUpstream(t)
+	fu, srv := newFakeUpstream("InRelease-v1")
+	defer srv.Close()
+
+	repo := proxyRepo("staleproxy", srv.URL)
+	d, assets, _ := newRevalDeps(repo)
+
+	// Prime the cache.
+	require.Equal(t, http.StatusOK, revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute).Code)
+	require.Equal(t, 1, fu.count())
+
+	// Make it stale and have upstream answer 304 to conditional requests.
+	makeStale(t, assets, "staleproxy", "/dists/trixie/InRelease")
+	fu.set("InRelease-v1", true)
+
+	w := revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "InRelease-v1", w.Body.String(), "cache served after 304")
+	assert.Equal(t, 2, fu.count(), "stale metadata must revalidate against upstream")
+
+	fu.mu.Lock()
+	ims := fu.lastIfModifiedSince
+	fu.mu.Unlock()
+	assert.NotEmpty(t, ims, "revalidation must send a conditional If-Modified-Since header")
+
+	// Freshness refreshed: the asset is no longer stale, so the next GET serves cache silently.
+	a, err := assets.GetByPath(nil, "staleproxy", "/dists/trixie/InRelease") //nolint:staticcheck
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now(), a.LastModified, 5*time.Second, "304 must refresh last_modified")
+
+	require.Equal(t, http.StatusOK, revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute).Code)
+	assert.Equal(t, 2, fu.count(), "refreshed metadata is within TTL again → no second revalidation")
+}
+
+// (d) Metadata past its TTL where upstream returns 200 replaces the cached copy.
+func TestServeGET_Metadata_PastTTL_200_ReplacesCache(t *testing.T) {
+	useUnguardedUpstream(t)
+	fu, srv := newFakeUpstream("InRelease-v1")
+	defer srv.Close()
+
+	repo := proxyRepo("updateproxy", srv.URL)
+	d, assets, blobStore := newRevalDeps(repo)
+
+	require.Equal(t, http.StatusOK, revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute).Code)
+	require.Equal(t, "InRelease-v1", func() string { return blobStoreBody(t, blobStore, "updateproxy", "/dists/trixie/InRelease") }())
+
+	// Stale + upstream now serves a new representation (200, not 304).
+	makeStale(t, assets, "updateproxy", "/dists/trixie/InRelease")
+	fu.set("InRelease-v2", false)
+
+	w := revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "InRelease-v2", w.Body.String(), "updated upstream body served to client")
+	assert.Equal(t, 2, fu.count())
+
+	// Cache blob replaced with v2.
+	assert.Equal(t, "InRelease-v2", blobStoreBody(t, blobStore, "updateproxy", "/dists/trixie/InRelease"))
+
+	// A subsequent within-TTL GET serves the new copy from cache.
+	w2 := revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute)
+	assert.Equal(t, "InRelease-v2", w2.Body.String())
+	assert.Equal(t, 2, fu.count())
+}
+
+// (e) When upstream is down past the TTL, the stale cache is served rather than erroring.
+func TestServeGET_Metadata_PastTTL_UpstreamDown_ServesStale(t *testing.T) {
+	useUnguardedUpstream(t)
+	fu, srv := newFakeUpstream("InRelease-v1")
+
+	repo := proxyRepo("downproxy", srv.URL)
+	d, assets, _ := newRevalDeps(repo)
+
+	require.Equal(t, http.StatusOK, revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute).Code)
+	require.Equal(t, 1, fu.count())
+
+	// Take upstream offline and force staleness.
+	srv.Close()
+	makeStale(t, assets, "downproxy", "/dists/trixie/InRelease")
+
+	w := revalGET(d, repo, "/dists/trixie/InRelease", 10*time.Minute)
+	assert.Equal(t, http.StatusOK, w.Code, "upstream outage must not break metadata reads")
+	assert.Equal(t, "InRelease-v1", w.Body.String(), "stale cache served on upstream failure")
+}
+
+// blobStoreBody reads the cached blob for a repo path and returns it as a string.
+func blobStoreBody(t *testing.T, bs *testutil.BlobStore, repoName, path string) string {
+	t.Helper()
+	rc, _, err := bs.Get(nil, base.BlobKey(repoName, path)) //nolint:staticcheck // mock ignores ctx
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	buf, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	return string(buf)
+}

--- a/internal/formats/terraform/handler.go
+++ b/internal/formats/terraform/handler.go
@@ -327,7 +327,8 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 	// Pattern: /v1/providers/<ns>/<type>/<ver>/download/<os>/<arch>
 	if strings.HasPrefix(p, "/v1/providers/") && strings.Contains(p, "/download/") {
 		coords := base.Coords{Name: p}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/zip"); err != nil {
+		// Provider binaries are immutable per version — never revalidate.
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/zip", 0); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return
@@ -335,7 +336,8 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 	// Module source archives (actual .tar.gz, not the /download redirect or /versions JSON):
 	if strings.HasPrefix(p, "/v1/modules/") && strings.HasSuffix(p, ".tar.gz") {
 		coords := base.Coords{Name: p}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar"); err != nil {
+		// Module source archives are immutable per version — never revalidate.
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar", 0); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/terraform/handler.go
+++ b/internal/formats/terraform/handler.go
@@ -350,7 +350,7 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := repoproxy.UpstreamClient.Do(req)
+	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream: " + err.Error()})
 		return

--- a/internal/formats/yum/handler.go
+++ b/internal/formats/yum/handler.go
@@ -53,8 +53,14 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		if strings.HasSuffix(p, ".xml") {
 			ct = "application/xml"
 		}
+		// repodata/ holds mutable indexes (repomd.xml + referenced metadata);
+		// everything else is an immutable .rpm addressed by name-version.
+		var maxAge time.Duration
+		if strings.Contains(p, "/repodata/") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
 		coords := base.Coords{}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, ct); err != nil {
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, ct, maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -63,6 +63,11 @@ type AssetRepo interface {
 	ListStale(ctx context.Context, format string, repoNames []string, lastDownloadedDays, artifactAgeDays int, pathPrefix, nameGlob string, retainNVersions int, limit int) ([]domain.Asset, error)
 	Create(ctx context.Context, a *domain.Asset) error
 	Delete(ctx context.Context, id string) error
+	// TouchLastModified sets last_modified = NOW() for the asset. The proxy cache
+	// uses last_modified as the "last validated" timestamp for metadata freshness:
+	// on a successful upstream 304 revalidation the cached copy is confirmed current,
+	// so its freshness window is extended without rewriting the blob.
+	TouchLastModified(ctx context.Context, id string) error
 	// IncrementDownloads applies batched download-count increments (asset ID → count)
 	// to assets and their parent components in one transaction.
 	IncrementDownloads(ctx context.Context, counts map[string]int64) error

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -199,6 +199,10 @@ type CleanupPolicyRepo interface {
 	Get(ctx context.Context, id string) (*domain.CleanupPolicy, error)
 	Create(ctx context.Context, p *domain.CleanupPolicy) error
 	Update(ctx context.Context, p *domain.CleanupPolicy) error
+	// RecordRun persists the outcome of a cleanup run (last run time, deleted
+	// count, freed bytes). Kept separate from Update so editing a policy through
+	// the form — which carries no run stats — does not wipe them.
+	RecordRun(ctx context.Context, id string, at time.Time, count int, freed int64) error
 	Delete(ctx context.Context, id string) error
 }
 

--- a/internal/repository/postgres/asset_repo.go
+++ b/internal/repository/postgres/asset_repo.go
@@ -328,6 +328,13 @@ func (r *assetRepo) Delete(ctx context.Context, id string) error {
 	return err
 }
 
+// TouchLastModified sets last_modified = NOW() for the asset, extending the
+// proxy metadata freshness window after a successful upstream revalidation (304).
+func (r *assetRepo) TouchLastModified(ctx context.Context, id string) error {
+	_, err := r.db.Exec(ctx, `UPDATE assets SET last_modified = NOW() WHERE id = $1`, id)
+	return err
+}
+
 func (r *assetRepo) ListAllBlobKeys(ctx context.Context) ([]string, error) {
 	rows, err := r.db.Query(ctx,
 		`SELECT DISTINCT blob_key FROM assets WHERE blob_key IS NOT NULL AND TRIM(blob_key) <> ''`)

--- a/internal/repository/postgres/blobstore_repo.go
+++ b/internal/repository/postgres/blobstore_repo.go
@@ -76,9 +76,9 @@ func (r *blobStoreRepo) Create(ctx context.Context, b *domain.BlobStore) error {
 func (r *blobStoreRepo) Update(ctx context.Context, b *domain.BlobStore) error {
 	cfg, _ := json.Marshal(b.Config)
 	_, err := r.db.Exec(ctx, `
-		UPDATE blob_stores SET config=$1, quota_bytes=$2, updated_at=NOW()
-		WHERE name=$3`,
-		cfg, b.QuotaBytes, b.Name,
+		UPDATE blob_stores SET type=$1, config=$2, quota_bytes=$3, updated_at=NOW()
+		WHERE name=$4`,
+		b.Type, cfg, b.QuotaBytes, b.Name,
 	)
 	return err
 }

--- a/internal/repository/postgres/cleanup_repo.go
+++ b/internal/repository/postgres/cleanup_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -102,6 +103,22 @@ func (r *CleanupPolicyRepo) Update(ctx context.Context, p *domain.CleanupPolicy)
 	}
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("cleanup policy not found: %s", p.ID)
+	}
+	return nil
+}
+
+// RecordRun persists only the run statistics, leaving the policy's configuration
+// untouched (so a concurrent form edit is not clobbered, and vice versa).
+func (r *CleanupPolicyRepo) RecordRun(ctx context.Context, id string, at time.Time, count int, freed int64) error {
+	tag, err := r.pool.Exec(ctx, `
+		UPDATE cleanup_policies
+		SET last_run_at=$1, last_run_count=$2, last_run_freed=$3
+		WHERE id=$4`, at, count, freed, id)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("cleanup policy not found: %s", id)
 	}
 	return nil
 }

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -19,13 +19,15 @@ import (
 
 // CleanupService runs cleanup policies — finds stale assets and removes them.
 type CleanupService struct {
-	policies  repository.CleanupPolicyRepo
-	repos     repository.RepositoryRepo
-	assets    repository.AssetRepo
-	blobs     repository.BlobStoreRepo
-	blobStore storage.BlobStore
-	log       logger.Logger
-	locker    distlock.Locker
+	policies   repository.CleanupPolicyRepo
+	repos      repository.RepositoryRepo
+	assets     repository.AssetRepo
+	components repository.ComponentRepo
+	blobs      repository.BlobStoreRepo
+	blobStore  storage.BlobStore
+	resolver   StoreResolver
+	log        logger.Logger
+	locker     distlock.Locker
 
 	mu              sync.Mutex
 	cronScheduler   *cron.Cron
@@ -57,6 +59,39 @@ func NewCleanupService(
 func (s *CleanupService) WithLocker(l distlock.Locker) *CleanupService {
 	s.locker = l
 	return s
+}
+
+// WithResolver sets the store resolver so blobs are deleted from the physical
+// blob store each asset actually lives on (S3, a group member, ...) rather than
+// the global default. Without a resolver the service falls back to blobStore.
+func (s *CleanupService) WithResolver(r StoreResolver) *CleanupService {
+	s.resolver = r
+	return s
+}
+
+// WithComponents sets the component repo so components left without any assets
+// after a cleanup run are pruned. Without it, deleted assets leave empty
+// component rows that make the repository still look populated in the UI.
+func (s *CleanupService) WithComponents(c repository.ComponentRepo) *CleanupService {
+	s.components = c
+	return s
+}
+
+// storeForAsset resolves the physical blob store an asset lives on. Falls back to
+// the global default store when no resolver is configured or resolution fails.
+func (s *CleanupService) storeForAsset(ctx context.Context, a *domain.Asset) storage.BlobStore {
+	if s.resolver == nil || a.BlobStoreID == "" {
+		return s.blobStore
+	}
+	bs, err := s.blobs.GetByID(ctx, a.BlobStoreID)
+	if err != nil || bs == nil {
+		return s.blobStore
+	}
+	store, err := s.resolver.Get(ctx, storage.BlobStoreDescriptor{ID: bs.ID, Type: bs.Type, Config: bs.Config})
+	if err != nil || store == nil {
+		return s.blobStore
+	}
+	return store
 }
 
 // StartCronScheduler starts cron-based per-policy scheduling. Run as a goroutine.
@@ -118,7 +153,7 @@ func (s *CleanupService) addEntryLocked(p domain.CleanupPolicy) {
 	}
 
 	job := func() {
-		if err := s.runPolicy(context.Background(), p); err != nil {
+		if _, err := s.runPolicy(context.Background(), p); err != nil {
 			s.log.Error("cleanup cron error", "policy", p.Name, "err", err)
 		}
 	}
@@ -157,35 +192,41 @@ func (s *CleanupService) RunAll(ctx context.Context) error {
 		if !p.Enabled {
 			continue
 		}
-		if err := s.runPolicy(ctx, p); err != nil {
+		if _, err := s.runPolicy(ctx, p); err != nil {
 			s.log.Error("cleanup policy failed", "policy", p.Name, "err", err)
 		}
 	}
 	return nil
 }
 
-// RunPolicy executes a single policy by ID.
+// RunPolicy executes a single policy by ID, discarding the run summary.
+// Retained for callers (task scheduler) that only need success/failure.
 func (s *CleanupService) RunPolicy(ctx context.Context, id string) error {
+	_, err := s.RunPolicyResult(ctx, id)
+	return err
+}
+
+// RunPolicyResult executes a single policy by ID and returns a summary of what
+// happened (deleted count, freed bytes, or a skip reason). The manual-run
+// endpoint uses this to report the outcome instead of a fire-and-forget ack.
+func (s *CleanupService) RunPolicyResult(ctx context.Context, id string) (*domain.CleanupRunResult, error) {
 	p, err := s.policies.Get(ctx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if p == nil {
-		return fmt.Errorf("cleanup policy %q not found", id)
+		return nil, fmt.Errorf("cleanup policy %q not found", id)
 	}
 	return s.runPolicy(ctx, *p)
 }
 
-func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) error {
+func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) (*domain.CleanupRunResult, error) {
+	res := &domain.CleanupRunResult{PolicyID: p.ID, DryRun: p.DryRun}
+
 	lastDownloadedDays := intCriteria(p.Criteria, "lastDownloadedDays")
 	artifactAgeDays := intCriteria(p.Criteria, "artifactAgeDays")
 	pathPrefix := strCriteria(p.Criteria, "pathPrefix")
 	nameGlob := strCriteria(p.Criteria, "nameGlob")
-
-	if lastDownloadedDays == 0 && artifactAgeDays == 0 {
-		s.log.Info("cleanup: no criteria set, skipping", "policy", p.Name)
-		return nil
-	}
 
 	var repoNames []string
 	var err error
@@ -197,12 +238,24 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 	} else {
 		repoNames, err = s.repos.ListNamesByCleanupPolicyID(ctx, p.ID)
 		if err != nil {
-			return fmt.Errorf("cleanup: list repos for policy: %w", err)
+			return nil, fmt.Errorf("cleanup: list repos for policy: %w", err)
 		}
 	}
 	if len(repoNames) == 0 {
-		s.log.Info("cleanup: policy not attached to any repository (set cleanup policies on repositories), skipping", "policy", p.Name)
-		return nil
+		reason := "policy is not attached to any repository — attach it to a repository or set a scope"
+		s.log.Info("cleanup: "+reason, "policy", p.Name)
+		res.Skipped = true
+		res.SkippedReason = reason
+		return res, nil
+	}
+
+	// No age/download criteria means "delete everything matching the scope"
+	// (path/name filters and retainNVersions still apply). This is intentional
+	// for a clear-all policy; the repository targeting above is the safety gate.
+	if lastDownloadedDays == 0 && artifactAgeDays == 0 {
+		s.log.Info("cleanup: no age criteria — removing all artifacts matching scope",
+			"policy", p.Name, "repos", repoNames, "path_prefix", pathPrefix,
+			"name_glob", nameGlob, "retain_versions", p.RetainNVersions, "dry_run", p.DryRun)
 	}
 
 	const batchLimit = 500
@@ -211,7 +264,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 	for {
 		stale, err := s.assets.ListStale(ctx, p.Format, repoNames, lastDownloadedDays, artifactAgeDays, pathPrefix, nameGlob, p.RetainNVersions, batchLimit)
 		if err != nil {
-			return fmt.Errorf("cleanup: list stale assets: %w", err)
+			return nil, fmt.Errorf("cleanup: list stale assets: %w", err)
 		}
 		if len(stale) == 0 {
 			break
@@ -224,26 +277,43 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 				deleted++
 				continue
 			}
-			if err := s.blobStore.Delete(ctx, a.BlobKey); err != nil {
+			asset := a
+			if err := s.storeForAsset(ctx, &asset).Delete(ctx, a.BlobKey); err != nil {
 				s.log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
 			}
 			if err := s.assets.Delete(ctx, a.ID); err != nil {
 				s.log.Warn("cleanup: asset delete failed", "id", a.ID, "err", err)
 				continue
 			}
-			asset := a
 			_ = base.DecrementBlobStoreUsage(ctx, s.blobs, &asset)
 			freed += a.SizeBytes
 			deleted++
 		}
+		// A real run advances the cursor by deleting the batch, so the next query
+		// returns the following rows. A dry run deletes nothing, so re-querying
+		// would return the same rows forever — report the first batch and stop.
+		if p.DryRun {
+			if len(stale) == batchLimit {
+				s.log.Info("cleanup dry-run: results capped at one batch — actual run would delete more",
+					"policy", p.Name, "batch", batchLimit)
+			}
+			break
+		}
+	}
+
+	// Prune components left without any assets so the repository no longer shows
+	// empty rows in the browse UI. Skipped on dry runs (nothing was deleted).
+	if s.components != nil && !p.DryRun && deleted > 0 {
+		for _, rn := range repoNames {
+			if err := s.components.DeleteOrphans(ctx, rn); err != nil {
+				s.log.Warn("cleanup: failed to prune orphan components", "repo", rn, "err", err)
+			}
+		}
 	}
 
 	now := time.Now()
-	p.LastRunAt = &now
-	p.LastRunFreed = freed
-	p.LastRunCount = deleted
-	if err := s.policies.Update(ctx, &p); err != nil {
-		s.log.Warn("cleanup: failed to update policy stats", "policy", p.Name, "err", err)
+	if err := s.policies.RecordRun(ctx, p.ID, now, deleted, freed); err != nil {
+		s.log.Warn("cleanup: failed to record run stats", "policy", p.Name, "err", err)
 	}
 
 	s.log.Info("cleanup policy complete",
@@ -251,7 +321,10 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 		"deleted", deleted,
 		"freed_bytes", freed,
 		"dry_run", p.DryRun)
-	return nil
+
+	res.Deleted = deleted
+	res.FreedBytes = freed
+	return res, nil
 }
 
 // PreviewPolicy loads stale assets for a policy (limit 200) without deleting them.

--- a/internal/service/cleanup_service_test.go
+++ b/internal/service/cleanup_service_test.go
@@ -87,12 +87,12 @@ func TestRunAll_DeletesStaleAssets(t *testing.T) {
 	assert.Contains(t, blobs.Deleted, "bk1")
 	assert.Contains(t, blobs.Deleted, "bk2")
 
-	// Policy stats should be updated
-	require.Len(t, policies.Updates, 1)
-	upd := policies.Updates[0]
-	assert.Equal(t, 2, upd.LastRunCount)
-	assert.Equal(t, int64(300), upd.LastRunFreed)
-	assert.NotNil(t, upd.LastRunAt)
+	// Policy run stats should be recorded
+	require.Len(t, policies.RunRecords, 1)
+	rec := policies.RunRecords[0]
+	assert.Equal(t, 2, rec.Count)
+	assert.Equal(t, int64(300), rec.Freed)
+	assert.False(t, rec.At.IsZero())
 }
 
 func TestRunAll_DryRun_DoesNotDelete(t *testing.T) {
@@ -122,10 +122,10 @@ func TestRunAll_DryRun_DoesNotDelete(t *testing.T) {
 	assert.Empty(t, blobs.Deleted)
 
 	// But stats should still be recorded
-	require.Len(t, policies.Updates, 1)
-	upd := policies.Updates[0]
-	assert.Equal(t, 1, upd.LastRunCount)
-	assert.Equal(t, int64(50), upd.LastRunFreed)
+	require.Len(t, policies.RunRecords, 1)
+	rec := policies.RunRecords[0]
+	assert.Equal(t, 1, rec.Count)
+	assert.Equal(t, int64(50), rec.Freed)
 }
 
 func TestRunPolicy_NotFound(t *testing.T) {
@@ -267,4 +267,243 @@ func TestRunPolicy_RetainNVersions_PassedToListStale(t *testing.T) {
 
 	assert.Equal(t, 3, assets.LastRetainN)
 	assert.Contains(t, blobs.Deleted, "bk10")
+}
+
+// ── #62: clear-all, run reporting, per-store blob delete ──────────
+
+// A policy with no age/download criteria but attached to a repository means
+// "delete everything in that repo" (issue #62: "completely clear every 2 min").
+// Previously the service skipped any policy with both age criteria at zero, so a
+// clear-all policy did nothing and never recorded a run.
+func TestRunPolicy_NoAgeCriteria_AttachedRepo_DeletesAll(t *testing.T) {
+	staleAssets := []domain.Asset{
+		{ID: "a1", BlobKey: "bk1", SizeBytes: 100, Path: "/pool/a.deb"},
+		{ID: "a2", BlobKey: "bk2", SizeBytes: 200, Path: "/pool/b.deb"},
+	}
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "clr", Name: "clear-all", Enabled: true, Format: "*",
+		Criteria: map[string]any{}, // no age/download filter → delete everything
+	})
+	assets := testutil.NewAssetRepo()
+	assets.Stale = staleAssets
+	blobs := testutil.NewBlobStore()
+	_ = blobs.Put(context.Background(), "bk1", testutil.MakeReader("x"), 1)
+	_ = blobs.Put(context.Background(), "bk2", testutil.MakeReader("y"), 1)
+	blobRepo := testutil.NewBlobStoreRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "debian", ID: "r1", Format: domain.FormatApt,
+		CleanupPolicyIDs: []string{"clr"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	res, err := svc.RunPolicyResult(context.Background(), "clr")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	assert.False(t, res.Skipped, "attached clear-all policy must run")
+	assert.Equal(t, 2, res.Deleted)
+	assert.Equal(t, int64(300), res.FreedBytes)
+	assert.Contains(t, blobs.Deleted, "bk1")
+	assert.Contains(t, blobs.Deleted, "bk2")
+
+	require.Len(t, policies.RunRecords, 1)
+	assert.False(t, policies.RunRecords[0].At.IsZero(), "a run must be recorded")
+}
+
+// The same clear-all policy expressed via Scope.RepositoryName (no attachment).
+func TestRunPolicy_NoAgeCriteria_ScopedRepo_DeletesAll(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "clr", Name: "clear-scope", Enabled: true, Format: "apt",
+		Criteria: map[string]any{},
+		Scope:    domain.CleanupScope{RepositoryName: "debian"},
+	})
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 50, Path: "/x"}}
+	blobs := testutil.NewBlobStore()
+	_ = blobs.Put(context.Background(), "bk1", testutil.MakeReader("x"), 1)
+	blobRepo := testutil.NewBlobStoreRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{Name: "debian", ID: "r1", Format: domain.FormatApt})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	res, err := svc.RunPolicyResult(context.Background(), "clr")
+	require.NoError(t, err)
+	assert.False(t, res.Skipped)
+	assert.Equal(t, 1, res.Deleted)
+	assert.Contains(t, blobs.Deleted, "bk1")
+}
+
+// A policy attached to nothing (no scope, no repos) reports a skip with a reason
+// so the manual-run endpoint can tell the user why nothing happened — instead of
+// the old silent 202.
+func TestRunPolicyResult_NotAttached_ReportsSkip(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "orphan", Name: "orphan", Enabled: true, Format: "*",
+		Criteria: map[string]any{"artifactAgeDays": float64(30)},
+	})
+	assets := testutil.NewAssetRepo()
+	blobs := testutil.NewBlobStore()
+	blobRepo := testutil.NewBlobStoreRepo()
+	repos := testutil.NewRepoRepo() // no repos attach this policy
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	res, err := svc.RunPolicyResult(context.Background(), "orphan")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.Skipped)
+	assert.Contains(t, res.SkippedReason, "not attached")
+	assert.Equal(t, 0, res.Deleted)
+}
+
+// RunPolicyResult returns counts for a normal age-based policy too.
+func TestRunPolicyResult_ReturnsCounts(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "age", Name: "age", Enabled: true, Format: "maven2",
+		Criteria: map[string]any{"artifactAgeDays": float64(30)},
+	})
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 10, Path: "/a"}}
+	blobs := testutil.NewBlobStore()
+	_ = blobs.Put(context.Background(), "bk1", testutil.MakeReader("x"), 1)
+	blobRepo := testutil.NewBlobStoreRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "mvn", ID: "r1", Format: domain.FormatMaven2, CleanupPolicyIDs: []string{"age"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	res, err := svc.RunPolicyResult(context.Background(), "age")
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Deleted)
+	assert.Equal(t, int64(10), res.FreedBytes)
+}
+
+// #62 (S3): blobs must be deleted from the asset's own physical store, not the
+// global default. With a resolver wired, the delete hits the resolved store.
+func TestRunPolicy_DeletesFromResolvedStore(t *testing.T) {
+	defaultStore := testutil.NewBlobStore()
+	memberStore := testutil.NewBlobStore()
+	_ = memberStore.Put(context.Background(), "bk1", testutil.MakeReader("x"), 1)
+
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "s3", Name: "s3-clear", Enabled: true, Format: "*",
+		Criteria: map[string]any{"artifactAgeDays": float64(1)},
+	})
+	assets := testutil.NewAssetRepo()
+	// asset lives on a non-default store
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 100, Path: "/x", BlobStoreID: "member-1"}}
+	blobRepo := testutil.NewBlobStoreRepo(&domain.BlobStore{ID: "member-1", Name: "s3-store", Type: "s3"})
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "mvn", ID: "r1", Format: domain.FormatMaven2, CleanupPolicyIDs: []string{"s3"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, defaultStore, nopLog()).
+		WithResolver(testutil.NewFakeResolver(memberStore))
+	_, err := svc.RunPolicyResult(context.Background(), "s3")
+	require.NoError(t, err)
+
+	assert.Contains(t, memberStore.Deleted, "bk1", "delete must hit the asset's physical store")
+	assert.NotContains(t, defaultStore.Deleted, "bk1", "must not delete from the global default store")
+}
+
+// After deleting an asset, the now-orphaned component must be pruned too, or the
+// browse view keeps showing empty rows and the repo looks "not cleaned" (#62).
+func TestRunPolicy_PrunesOrphanComponents(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "clr", Name: "clear", Enabled: true, Format: "*", Criteria: map[string]any{},
+	})
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 10, Path: "/x", Repository: "debian"}}
+	blobs := testutil.NewBlobStore()
+	_ = blobs.Put(context.Background(), "bk1", testutil.MakeReader("x"), 1)
+	blobRepo := testutil.NewBlobStoreRepo()
+	comps := testutil.NewComponentRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "debian", ID: "r1", Format: domain.FormatApt, CleanupPolicyIDs: []string{"clr"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog()).
+		WithComponents(comps)
+	_, err := svc.RunPolicyResult(context.Background(), "clr")
+	require.NoError(t, err)
+
+	assert.Contains(t, comps.DeleteOrphansCalls, "debian", "orphan components must be pruned for the affected repo")
+}
+
+// A dry run must not prune components (it deletes nothing).
+func TestRunPolicy_DryRun_DoesNotPruneOrphans(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "dry", Name: "dry", Enabled: true, Format: "*", DryRun: true,
+		Criteria: map[string]any{"artifactAgeDays": float64(1)},
+	})
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 10, Path: "/x", Repository: "debian"}}
+	blobs := testutil.NewBlobStore()
+	blobRepo := testutil.NewBlobStoreRepo()
+	comps := testutil.NewComponentRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "debian", ID: "r1", Format: domain.FormatApt, CleanupPolicyIDs: []string{"dry"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog()).
+		WithComponents(comps)
+	_, err := svc.RunPolicyResult(context.Background(), "dry")
+	require.NoError(t, err)
+
+	assert.Empty(t, comps.DeleteOrphansCalls, "dry run must not prune components")
+}
+
+// A dry run must not re-process the same assets forever. Since dry runs delete
+// nothing, ListStale keeps matching the same rows; the loop must stop after one
+// batch instead of looping (previously it inflated counts into the millions).
+func TestRunPolicy_DryRun_TerminatesAndCountsOnce(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "dry", Name: "dry", Enabled: true, Format: "*", DryRun: true,
+		Criteria: map[string]any{"artifactAgeDays": float64(1)},
+	})
+	assets := testutil.NewAssetRepo()
+	assets.StaleRepeat = true // simulate real DB: rows persist across queries in dry run
+	assets.Stale = []domain.Asset{
+		{ID: "a1", BlobKey: "bk1", SizeBytes: 10, Path: "/a"},
+		{ID: "a2", BlobKey: "bk2", SizeBytes: 20, Path: "/b"},
+	}
+	blobs := testutil.NewBlobStore()
+	blobRepo := testutil.NewBlobStoreRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "mvn", ID: "r1", Format: domain.FormatMaven2, CleanupPolicyIDs: []string{"dry"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	res, err := svc.RunPolicyResult(context.Background(), "dry")
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, res.Deleted, "each stale asset counted exactly once")
+	assert.Equal(t, int64(30), res.FreedBytes)
+	assert.True(t, res.DryRun)
+	assert.Equal(t, 1, assets.ListStaleCalls, "dry run must do a single pass, not loop")
+	assert.Empty(t, blobs.Deleted, "dry run deletes nothing")
+}
+
+// Run stats are persisted via RecordRun, not the general Update. This keeps the
+// form-edit path (which carries no run stats) from wiping last-run info — and is
+// why the DB previously showed a policy as "never run" after it had run (#62).
+func TestRunPolicy_RecordsRunStats_NotViaUpdate(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "p", Name: "p", Enabled: true, Format: "*", Criteria: map[string]any{},
+	})
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 7, Path: "/x"}}
+	blobs := testutil.NewBlobStore()
+	_ = blobs.Put(context.Background(), "bk1", testutil.MakeReader("x"), 1)
+	blobRepo := testutil.NewBlobStoreRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "r", ID: "r1", Format: domain.FormatRaw, CleanupPolicyIDs: []string{"p"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	_, err := svc.RunPolicyResult(context.Background(), "p")
+	require.NoError(t, err)
+
+	require.Len(t, policies.RunRecords, 1)
+	assert.Equal(t, 1, policies.RunRecords[0].Count)
+	assert.Equal(t, int64(7), policies.RunRecords[0].Freed)
+	assert.Empty(t, policies.Updates, "run stats must not go through the config Update path")
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -265,6 +266,10 @@ type ComponentRepo struct {
 	// union of rows for the requested repo names (mirrors the SQL WHERE rep.name IN (...)).
 	DockerRowsByRepo map[string][]domain.DockerBrowseRow
 	DockerBrowseErr  error // when non-nil, ListDockerBrowseRows returns it (500-branch seam)
+	// LastListLimit/LastListOffset record the paging arguments of the most recent
+	// ListByRepoNames call so handler tests can assert the offset was decoded.
+	LastListLimit  int
+	LastListOffset int
 }
 
 func NewComponentRepo() *ComponentRepo {
@@ -275,9 +280,10 @@ func (c *ComponentRepo) List(ctx context.Context, repoName string, limit, offset
 	return c.ListByRepoNames(ctx, []string{repoName}, limit, offset)
 }
 
-func (c *ComponentRepo) ListByRepoNames(_ context.Context, names []string, _, _ int) (*domain.Page[domain.Component], error) {
+func (c *ComponentRepo) ListByRepoNames(_ context.Context, names []string, limit, offset int) (*domain.Page[domain.Component], error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.LastListLimit, c.LastListOffset = limit, offset
 	if c.Err != nil {
 		return nil, c.Err
 	}
@@ -297,7 +303,29 @@ func (c *ComponentRepo) ListByRepoNames(_ context.Context, names []string, _, _ 
 			items = append(items, *v)
 		}
 	}
-	return &domain.Page[domain.Component]{Items: items}, nil
+	// Stable order (map iteration is random) so paging is deterministic, mirroring
+	// the SQL "ORDER BY c.name, c.version".
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Name != items[j].Name {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].Version < items[j].Version
+	})
+
+	if limit <= 0 {
+		return &domain.Page[domain.Component]{Items: items}, nil
+	}
+	if offset >= len(items) {
+		return &domain.Page[domain.Component]{Items: []domain.Component{}}, nil
+	}
+	items = items[offset:]
+	var token *string
+	if len(items) > limit {
+		items = items[:limit]
+		next := strconv.Itoa(offset + limit)
+		token = &next
+	}
+	return &domain.Page[domain.Component]{Items: items, ContinuationToken: token}, nil
 }
 func (c *ComponentRepo) Get(_ context.Context, id string) (*domain.Component, error) {
 	c.mu.Lock()
@@ -352,6 +380,19 @@ func (c *ComponentRepo) ListDockerBrowseRows(_ context.Context, names []string, 
 func (c *ComponentRepo) Create(_ context.Context, comp *domain.Component) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	// Mirrors the SQL upsert key ON CONFLICT (repository_id, format, group_id,
+	// name, version): re-creating the same coordinates reuses the existing row
+	// rather than adding a duplicate.
+	key := strings.Join([]string{comp.Repository, comp.RepositoryID, comp.Format, comp.Group, comp.Name, comp.Version}, "\x00")
+	for _, existing := range c.components {
+		ek := strings.Join([]string{existing.Repository, existing.RepositoryID, existing.Format, existing.Group, existing.Name, existing.Version}, "\x00")
+		if ek == key {
+			comp.ID = existing.ID
+			comp.CreatedAt = existing.CreatedAt
+			c.components[existing.ID] = comp
+			return nil
+		}
+	}
 	c.nextID++
 	comp.ID = fmt.Sprintf("comp-%d", c.nextID)
 	c.components[comp.ID] = comp

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -512,12 +512,39 @@ func (a *AssetRepo) ListStale(_ context.Context, _ string, _ []string, _, _ int,
 func (a *AssetRepo) Create(_ context.Context, asset *domain.Asset) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	a.nextID++
-	asset.ID = fmt.Sprintf("asset-%d", a.nextID)
-	// Index by repo name (for GetByPath) — matches what postgres impl does via JOIN
+	// Mirror the postgres upsert: an existing (repo,path) keeps its ID and refreshes
+	// last_modified, rather than creating a duplicate row.
 	key := asset.Repository + ":" + asset.Path
+	if existing, ok := a.assets[key]; ok {
+		asset.ID = existing.ID
+		if asset.CreatedAt.IsZero() {
+			asset.CreatedAt = existing.CreatedAt
+		}
+	} else {
+		a.nextID++
+		asset.ID = fmt.Sprintf("asset-%d", a.nextID)
+	}
+	// The postgres impl stamps last_modified = NOW() on insert/upsert and created_at
+	// on insert; the proxy cache relies on last_modified for freshness.
+	now := time.Now()
+	asset.LastModified = now
+	if asset.CreatedAt.IsZero() {
+		asset.CreatedAt = now
+	}
+	// Index by repo name (for GetByPath) — matches what postgres impl does via JOIN
 	a.assets[key] = asset
 	a.byID[asset.ID] = asset
+	return nil
+}
+
+// TouchLastModified sets the asset's LastModified to now (mirrors the postgres
+// UPDATE used to extend proxy metadata freshness after a 304 revalidation).
+func (a *AssetRepo) TouchLastModified(_ context.Context, id string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if v, ok := a.byID[id]; ok {
+		v.LastModified = time.Now()
+	}
 	return nil
 }
 func (a *AssetRepo) Delete(_ context.Context, id string) error {

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -265,6 +265,9 @@ type ComponentRepo struct {
 	// union of rows for the requested repo names (mirrors the SQL WHERE rep.name IN (...)).
 	DockerRowsByRepo map[string][]domain.DockerBrowseRow
 	DockerBrowseErr  error // when non-nil, ListDockerBrowseRows returns it (500-branch seam)
+	// DeleteOrphansCalls records the repo names passed to DeleteOrphans so cleanup
+	// tests can assert orphan components are pruned after their assets are deleted.
+	DeleteOrphansCalls []string
 }
 
 func NewComponentRepo() *ComponentRepo {
@@ -367,7 +370,10 @@ func (c *ComponentRepo) Delete(_ context.Context, id string) error {
 	return nil
 }
 
-func (c *ComponentRepo) DeleteOrphans(_ context.Context, _ string) error {
+func (c *ComponentRepo) DeleteOrphans(_ context.Context, repoName string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.DeleteOrphansCalls = append(c.DeleteOrphansCalls, repoName)
 	return nil
 }
 
@@ -410,14 +416,21 @@ func (c *ComponentRepo) AddComponent(comp *domain.Component) {
 // ── AssetRepo ─────────────────────────────────────────────────
 
 type AssetRepo struct {
-	mu            sync.Mutex
-	assets        map[string]*domain.Asset // key: "repo:path"
-	byID          map[string]*domain.Asset
-	nextID        int
-	Stale         []domain.Asset // populated by tests to control ListStale output
-	LastRetainN   int
-	MigrationRows []domain.MigrationAssetRow
-	Err           error // when non-nil, ListByComponentID/ListByComponentIDs/SearchAssets/SumSizeByRepo return it (500-branch seam)
+	mu          sync.Mutex
+	assets      map[string]*domain.Asset // key: "repo:path"
+	byID        map[string]*domain.Asset
+	nextID      int
+	Stale       []domain.Asset // populated by tests to control ListStale output
+	LastRetainN int
+	// StaleRepeat, when true, makes ListStale return the full Stale slice on every
+	// call without consuming it — simulating a dry run where nothing is deleted, so
+	// the same rows keep matching. Used to prove the dry-run loop terminates.
+	StaleRepeat bool
+	// ListStaleCalls counts ListStale invocations so tests can assert the dry-run
+	// path does a single pass instead of looping.
+	ListStaleCalls int
+	MigrationRows  []domain.MigrationAssetRow
+	Err            error // when non-nil, ListByComponentID/ListByComponentIDs/SearchAssets/SumSizeByRepo return it (500-branch seam)
 	// ListByComponentIDsCalls counts how many times ListByComponentIDs has been called.
 	ListByComponentIDsCalls int
 	// ListByComponentIDCalls counts how many times the singular ListByComponentID has been called.
@@ -492,9 +505,18 @@ func (a *AssetRepo) SearchAssets(_ context.Context, params domain.SearchParams) 
 func (a *AssetRepo) ListStale(_ context.Context, _ string, _ []string, _, _ int, _, _ string, retainNVersions int, limit int) ([]domain.Asset, error) {
 	a.mu.Lock()
 	a.LastRetainN = retainNVersions
+	a.ListStaleCalls++
 	defer a.mu.Unlock()
 	if len(a.Stale) == 0 {
 		return nil, nil
+	}
+	// Non-consuming mode: return the same rows each call (dry-run has no deletes).
+	if a.StaleRepeat {
+		n := limit
+		if n <= 0 || n > len(a.Stale) {
+			n = len(a.Stale)
+		}
+		return append([]domain.Asset(nil), a.Stale[:n]...), nil
 	}
 	n := limit
 	if n <= 0 {
@@ -718,7 +740,17 @@ type CleanupPolicyRepo struct {
 	policies map[string]*domain.CleanupPolicy
 	nextID   int
 	Updates  []*domain.CleanupPolicy // records Update calls
-	Err      error                   // when set, List/Get/Create/Update/Delete return it (500-branch seam)
+	// RunRecords records RecordRun calls (run stats persisted after a policy run).
+	RunRecords []CleanupRunRecord
+	Err        error // when set, List/Get/Create/Update/Delete return it (500-branch seam)
+}
+
+// CleanupRunRecord captures the arguments of a RecordRun call.
+type CleanupRunRecord struct {
+	ID    string
+	At    time.Time
+	Count int
+	Freed int64
 }
 
 func NewCleanupPolicyRepo(policies ...*domain.CleanupPolicy) *CleanupPolicyRepo {
@@ -768,6 +800,20 @@ func (r *CleanupPolicyRepo) Update(_ context.Context, p *domain.CleanupPolicy) e
 	}
 	r.policies[p.ID] = p
 	r.Updates = append(r.Updates, p)
+	return nil
+}
+func (r *CleanupPolicyRepo) RecordRun(_ context.Context, id string, at time.Time, count int, freed int64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.Err != nil {
+		return r.Err
+	}
+	r.RunRecords = append(r.RunRecords, CleanupRunRecord{ID: id, At: at, Count: count, Freed: freed})
+	if p, ok := r.policies[id]; ok {
+		p.LastRunAt = &at
+		p.LastRunCount = count
+		p.LastRunFreed = freed
+	}
 	return nil
 }
 func (r *CleanupPolicyRepo) Delete(_ context.Context, id string) error {


### PR DESCRIPTION
Integration branch bundling the fixes for six open issues into the v1.22.0 release. Each fix was developed and tested on its own branch, then merged here; the full backend + frontend suites and linters are green (only the pre-existing sandbox-only `TestWebhookHandler_Test_200` loopback failure remains).

## Fixes

### #75 / #76 / #80 — Browse: assets, pagination, proxy delete
- `/service/rest/v1/components` now returns each component's assets (batched), so the browse UI deletes by the real asset path instead of the component name — npm proxy deletes no longer silently no-op and apt proxy deletes no longer 400.
- Cached proxy files get real component coordinates (name/version from `.deb` filenames, path-based for indexes) instead of collapsing into one nameless component.
- The component list honours `?offset=`, so the Browse pager actually pages.

### #62 — Cleanup policy
- Clear-all policies (no age criteria, attached to a repo/scope) now run instead of being silently skipped.
- Manual runs are synchronous and return `{deleted, freedBytes, skipped, skippedReason}`; the UI shows the outcome.
- Run stats persist (`RecordRun`), so the last-run column populates; a form edit no longer wipes them.
- Blobs are deleted from the asset's physical store (S3 / group member), not just the default; orphan components are pruned; dry runs no longer loop.

### #81 — Initial S3 config not working
- When `storage.default_type=s3`, the seed `default`/`docker` blob stores are reconciled to type `s3` on startup, so they appear in the Blob Stores list + repo-create dropdown and repositories without an explicit store write to S3.

### #77 — APT proxy metadata not updating
- Proxy metadata (apt `InRelease`/`Release`/`Packages`, npm packuments, yum/pypi indexes) is revalidated on a TTL (`proxy_config.metadata_max_age`, default 10 min) via conditional `If-Modified-Since`; immutable artifacts still serve from cache forever. Upstream outage falls back to stale cache.

### #79 — Outbound HTTP/SOCKS5 proxy for proxy repositories
- Upstream fetches honour a global (env / `proxy.*` config) or per-repo (`proxy_config.http_proxy`/`https_proxy`/`socks5_proxy`/`no_proxy`/auth) outbound proxy. An explicitly configured internal proxy is allowed while the SSRF guard still blocks direct internal upstreams. UI fields added to the proxy-repo wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
