### PR TITLE
fix(helm): accept PUT uploads to hosted chart .tgz path

### DIFF
--- a/internal/formats/helm/handler.go
+++ b/internal/formats/helm/handler.go
@@ -2,6 +2,7 @@
 //
 // GET  /index.yaml              → Chart.yaml index (generated from DB)
 // GET  /:chart-:version.tgz    → download chart archive
+// PUT  /:chart-:version.tgz    → upload chart (Nexus/ChartMuseum-compatible, `curl -T`)
 // POST /api/charts              → upload chart (multipart or raw body)
 // DELETE /api/charts/:name/:ver → delete chart version
 package helm
@@ -64,7 +65,11 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 
 	// Upload: POST /api/charts
 	case c.Request.Method == http.MethodPost && p == "/api/charts":
-		h.handleUpload(c, repoName)
+		h.handleUpload(c, repoName, "")
+
+	// Upload: PUT /:chart-:version.tgz (Nexus/ChartMuseum-compatible, `curl -T`)
+	case c.Request.Method == http.MethodPut && strings.HasSuffix(p, ".tgz"):
+		h.handleUpload(c, repoName, path.Base(p))
 
 	// Delete: DELETE /api/charts/:name/:version
 	case c.Request.Method == http.MethodDelete && strings.HasPrefix(p, "/api/charts/"):
@@ -123,13 +128,16 @@ func (h *Handler) serveIndex(c *gin.Context, repoName string) {
 	c.Data(http.StatusOK, "application/yaml", data)
 }
 
-func (h *Handler) handleUpload(c *gin.Context, repoName string) {
+// handleUpload stores an uploaded chart. pathFilename, when non-empty (PUT to the
+// .tgz path), supplies the chart filename; otherwise it comes from the multipart
+// part or the X-Chart-Name header.
+func (h *Handler) handleUpload(c *gin.Context, repoName, pathFilename string) {
 	var chartName, version, filename string
 	var data []byte
 	var size int64
 
 	ct := c.GetHeader("Content-Type")
-	if strings.HasPrefix(ct, "multipart/form-data") {
+	if pathFilename == "" && strings.HasPrefix(ct, "multipart/form-data") {
 		if err := c.Request.ParseMultipartForm(32 << 20); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
@@ -151,8 +159,12 @@ func (h *Handler) handleUpload(c *gin.Context, repoName string) {
 		_, _ = buf.ReadFrom(c.Request.Body)
 		data = buf.Bytes()
 		size = int64(len(data))
-		filename = c.GetHeader("X-Chart-Name")
-		if filename == "" {
+		switch {
+		case pathFilename != "":
+			filename = pathFilename
+		case c.GetHeader("X-Chart-Name") != "":
+			filename = c.GetHeader("X-Chart-Name")
+		default:
 			filename = "chart.tgz"
 		}
 	}

--- a/internal/formats/helm/handler_test.go
+++ b/internal/formats/helm/handler_test.go
@@ -63,6 +63,31 @@ func uploadRaw(r *gin.Engine, repoName, filename, content string) int {
 	return w.Code
 }
 
+// uploadPut uploads a chart via PUT to the .tgz path (Nexus/ChartMuseum-compatible,
+// e.g. `curl -T chart.tgz .../repository/<repo>/<chart>-<version>.tgz`).
+func uploadPut(r *gin.Engine, repoName, filename, content string) int {
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+"/"+filename,
+		strings.NewReader(content))
+	req.Header.Set("Content-Type", "application/x-tar")
+	req.ContentLength = int64(len(content))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestHelm_UploadAndDownload_Put(t *testing.T) {
+	repo := testutil.SimpleRepo("charts-put", "helm")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated, uploadPut(r, "charts-put", "nfs-helm1-0.1.1.tgz", "put-chart"))
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/charts-put/nfs-helm1-0.1.1.tgz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "put-chart", w.Body.String())
+}
+
 func TestHelm_UploadAndDownload_Multipart(t *testing.T) {
 	repo := testutil.SimpleRepo("charts", "helm")
 	r := setup(repo)


### PR DESCRIPTION
## Problem

Fixes #93.

Uploading a chart to a Helm **hosted** repository via `curl -T` (HTTP `PUT`) returned `405 Method Not Allowed`:

```
curl -v -u admin:admin123 -T nfs-helm1-0.1.1.tgz \
  http://<host>:8081/repository/helm-hosted/nfs-helm1-0.1.1.tgz
< HTTP/1.1 405 Method Not Allowed
```

## Root cause

`internal/formats/helm/handler.go` routed hosted uploads only through `POST /api/charts`. A `PUT` to the chart's `.tgz` path — the form Nexus and ChartMuseum accept — matched no `case` and fell through to `default → 405`.

## Fix

Add a `PUT /:chart-:version.tgz` route that reuses `handleUpload`, deriving the chart filename from the URL path.

## Testing

- New unit test `TestHelm_UploadAndDownload_Put` (RED→GREEN via TDD); full `helm` package: 21/21 green.
- Reproduced end-to-end on a freshly built Docker release: the exact `curl -T` command from the issue now returns `201 Created`, the chart appears in `index.yaml`, and downloads back byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk