### PR TITLE
fix(apt): accept POST uploads of .deb packages

### DIFF
--- a/internal/formats/apt/handler.go
+++ b/internal/formats/apt/handler.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"strings"
@@ -87,8 +88,11 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 
 	// Upload .deb: PUT /pool/:component/:file.deb, or a root-level PUT of a .deb
 	// (apt clients and `curl --upload-file foo.deb .../repository/<repo>/` upload
-	// to the repository root rather than an explicit pool path).
-	case c.Request.Method == http.MethodPut && (strings.HasPrefix(p, "/pool/") || strings.HasSuffix(p, ".deb")):
+	// to the repository root rather than an explicit pool path). POST is the
+	// Nexus-compatible verb: either to a .deb path (raw body) or to the repo
+	// root as multipart/form-data with a "file"/"package" field (#96).
+	case (c.Request.Method == http.MethodPut || c.Request.Method == http.MethodPost) &&
+		(p == "/" || strings.HasPrefix(p, "/pool/") || strings.HasSuffix(p, ".deb")):
 		h.handleUpload(c, repoName, p)
 
 	// Delete .deb
@@ -218,6 +222,24 @@ func proxyCoords(p string) base.Coords {
 
 func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
 	filename := path.Base(p)
+	body := io.Reader(c.Request.Body)
+	size := c.Request.ContentLength
+
+	// Nexus-style root POST: the .deb arrives as a multipart file field
+	// ("file" or "package") and the filename comes from the part, not the path.
+	if !strings.HasSuffix(filename, ".deb") {
+		f, fh, err := c.Request.FormFile("file")
+		if err != nil {
+			f, fh, err = c.Request.FormFile("package")
+		}
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "expected a *.deb path or a multipart 'file' field"})
+			return
+		}
+		defer func() { _ = f.Close() }()
+		filename, body, size = fh.Filename, f, fh.Size
+	}
+
 	pkgName, version := debCoords(filename)
 
 	// Normalize root-level uploads into the canonical pool layout so the
@@ -230,7 +252,7 @@ func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
 	coords := base.Coords{Name: pkgName, Version: version}
 	if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
 		repoName, storePath, "application/vnd.debian.binary-package",
-		coords, c.Request.Body, c.Request.ContentLength); err != nil {
+		coords, body, size); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/formats/apt/handler_test.go
+++ b/internal/formats/apt/handler_test.go
@@ -1,6 +1,8 @@
 package apt_test
 
 import (
+	"bytes"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -154,4 +156,64 @@ func TestApt_ProxyRejectMutation(t *testing.T) {
 	r := setup(repo)
 	code := putDeb(r, "debs7", "/pool/main/pkg_1.0_amd64.deb", "data")
 	assert.Equal(t, http.StatusMethodNotAllowed, code)
+}
+
+// postDeb uploads a .deb via POST to an explicit path (body = raw deb bytes).
+func postDeb(r *gin.Engine, repoName, path, content string) int {
+	req := httptest.NewRequest(http.MethodPost, "/repository/"+repoName+path,
+		strings.NewReader(content))
+	req.Header.Set("Content-Type", "application/vnd.debian.binary-package")
+	req.ContentLength = int64(len(content))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+// postDebMultipart uploads a .deb via Nexus-style POST to the repo root
+// (multipart/form-data with a "file" field carrying the filename).
+func postDebMultipart(r *gin.Engine, repoName, filename, content string) int {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, _ := mw.CreateFormFile("file", filename)
+	_, _ = part.Write([]byte(content))
+	_ = mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/repository/"+repoName+"/", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestApt_PostDebPath_Upload(t *testing.T) {
+	// Regression for #96: Nexus-compatible clients publish .deb files via
+	// POST, which previously fell through to the default 405 branch.
+	repo := testutil.SimpleRepo("debs-post", "apt")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		postDeb(r, "debs-post", "/nginx_1.25.0_amd64.deb", "deb-bytes"))
+
+	// Root-level uploads normalize into the pool layout (same as PUT, #46).
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/debs-post/pool/main/n/nginx/nginx_1.25.0_amd64.deb", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "deb-bytes", w.Body.String())
+}
+
+func TestApt_PostRootMultipart_Upload(t *testing.T) {
+	repo := testutil.SimpleRepo("debs-mp", "apt")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		postDebMultipart(r, "debs-mp", "curl_8.5.0_amd64.deb", "curl-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/debs-mp/pool/main/c/curl/curl_8.5.0_amd64.deb", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "curl-bytes", w.Body.String())
 }


### PR DESCRIPTION
Fixes #96. POST (raw .deb path / multipart root `file`/`package` field) now routes to handleUpload instead of the default 405 branch. TDD: 2 new tests (RED verified at 405 before the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk