### PR TITLE
fix(nuget): advertise PackagePublish and parse coordinates from nuspec

### DIFF
--- a/internal/formats/nuget/handler.go
+++ b/internal/formats/nuget/handler.go
@@ -15,10 +15,12 @@
 package nuget
 
 import (
+	"archive/zip"
 	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -126,6 +128,7 @@ func (h *Handler) serveIndex(c *gin.Context, repoName string) {
 		"resources": []gin.H{
 			{"@id": base2 + "/v3/flatcontainer/", "@type": "PackageBaseAddress/3.0.0"},
 			{"@id": base2 + "/v3/registration/", "@type": "RegistrationsBaseUrl/3.0.0"},
+			{"@id": base2 + "/v2/package", "@type": "PackagePublish/2.0.0"},
 			{"@id": base2 + "/v2/", "@type": "LegacyGallery/2.0.0"},
 		},
 	})
@@ -268,17 +271,7 @@ func (h *Handler) handlePush(c *gin.Context, repoName string) {
 	}
 	defer func() { _ = f.Close() }()
 
-	// Filename: id.version.nupkg
-	filename := fh.Filename
-	name2 := strings.TrimSuffix(filename, ".nupkg")
-	// Split on last dot to get version (id may contain dots)
-	lastDot := strings.LastIndex(name2, ".")
-	pkgID, version := name2, "0.0.0"
-	if lastDot > 0 {
-		pkgID = name2[:lastDot]
-		version = name2[lastDot+1:]
-	}
-	pkgID = strings.ToLower(pkgID)
+	pkgID, version := nupkgCoords(f, fh.Size, fh.Filename)
 	filePath := "/" + pkgID + "/" + version + "/" + pkgID + "." + version + ".nupkg"
 
 	coords := base.Coords{Name: pkgID, Version: version}
@@ -288,6 +281,47 @@ func (h *Handler) handlePush(c *gin.Context, repoName string) {
 		return
 	}
 	c.Status(http.StatusCreated)
+}
+
+// nuspecMeta is the subset of the .nuspec manifest needed for coordinates.
+type nuspecMeta struct {
+	Metadata struct {
+		ID      string `xml:"id"`
+		Version string `xml:"version"`
+	} `xml:"metadata"`
+}
+
+// nupkgCoords resolves the package id and version for an uploaded .nupkg.
+// The .nuspec inside the archive is authoritative; the filename is a fallback
+// (version = the trailing dot-separated parts starting at the first digit-led
+// part, so "Newtonsoft.Json.13.0.1" → id "newtonsoft.json", version "13.0.1"
+// — a naive last-dot split corrupts real semver coordinates, #100).
+func nupkgCoords(f io.ReaderAt, size int64, filename string) (string, string) {
+	if zr, err := zip.NewReader(f, size); err == nil {
+		for _, zf := range zr.File {
+			if !strings.HasSuffix(zf.Name, ".nuspec") || strings.Contains(zf.Name, "/") {
+				continue
+			}
+			rc, err := zf.Open()
+			if err != nil {
+				continue
+			}
+			var meta nuspecMeta
+			err = xml.NewDecoder(io.LimitReader(rc, 1<<20)).Decode(&meta)
+			_ = rc.Close()
+			if err == nil && meta.Metadata.ID != "" && meta.Metadata.Version != "" {
+				return strings.ToLower(meta.Metadata.ID), meta.Metadata.Version
+			}
+		}
+	}
+	name := strings.TrimSuffix(filename, ".nupkg")
+	parts := strings.Split(name, ".")
+	for i := 1; i < len(parts); i++ {
+		if parts[i] != "" && parts[i][0] >= '0' && parts[i][0] <= '9' {
+			return strings.ToLower(strings.Join(parts[:i], ".")), strings.Join(parts[i:], ".")
+		}
+	}
+	return strings.ToLower(name), "0.0.0"
 }
 
 // fetchAndRewriteNuGetIndex fetches the NuGet v3 service index from upstream,

--- a/internal/formats/nuget/handler_test.go
+++ b/internal/formats/nuget/handler_test.go
@@ -1,6 +1,7 @@
 package nuget_test
 
 import (
+	"archive/zip"
 	"bytes"
 	"fmt"
 	"mime/multipart"
@@ -235,4 +236,67 @@ func TestNuGet_ProxyServiceIndex_UpstreamError(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadGateway, w.Code)
+}
+
+func TestNuGet_ServiceIndex_AdvertisesPublish(t *testing.T) {
+	// Regression for #97: without a PackagePublish/2.0.0 resource in the
+	// service index, `dotnet nuget push` refuses to publish client-side.
+	repo := testutil.SimpleRepo("pkgs-pub", "nuget")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pkgs-pub/index.json", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "PackagePublish/2.0.0")
+	assert.Contains(t, w.Body.String(), "/repository/pkgs-pub/v2/package")
+}
+
+// buildNupkg builds a minimal real .nupkg (zip with a root .nuspec).
+func buildNupkg(t *testing.T, id, version string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	f, err := zw.Create(id + ".nuspec")
+	require.NoError(t, err)
+	_, err = f.Write([]byte(`<?xml version="1.0"?><package><metadata><id>` +
+		id + `</id><version>` + version + `</version></metadata></package>`))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func TestNuGet_Push_SemverFilename_Heuristic(t *testing.T) {
+	// Regression for #100: non-zip body falls back to filename parsing.
+	// The version must be the trailing digit-led parts, not just the
+	// last dot segment.
+	repo := testutil.SimpleRepo("pkgs-semver", "nuget")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		pushNupkg(r, "pkgs-semver", "Newtonsoft.Json.13.0.1.nupkg", "fake-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/pkgs-semver/v3/flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code,
+		"stored coordinates must be id=newtonsoft.json version=13.0.1")
+	assert.Equal(t, "fake-bytes", w.Body.String())
+}
+
+func TestNuGet_Push_NuspecAuthoritative(t *testing.T) {
+	// A real zip with a .nuspec: manifest id/version win over the filename.
+	repo := testutil.SimpleRepo("pkgs-nuspec", "nuget")
+	r := setup(repo)
+
+	nupkg := buildNupkg(t, "My.Lib", "2.1.0")
+	require.Equal(t, http.StatusCreated,
+		pushNupkg(r, "pkgs-nuspec", "whatever.nupkg", string(nupkg)))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/pkgs-nuspec/v3/flatcontainer/my.lib/2.1.0/my.lib.2.1.0.nupkg", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "coordinates must come from the .nuspec")
 }


### PR DESCRIPTION
Fixes #97. Fixes #100.

- Adds `PackagePublish/2.0.0` to the v3 service index so `dotnet nuget push` discovers the push endpoint.
- `nupkgCoords` reads the .nuspec inside the archive (authoritative) with a digit-led-part filename heuristic fallback — replaces the last-dot split that turned `Newtonsoft.Json.13.0.1.nupkg` into id `newtonsoft.json.13.0` version `1`.

TDD: 3 new tests (RED verified before each fix). Existing single-segment-version tests unaffected (heuristic reduces to old behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk