### PR TITLE
fix(conan): support Conan v2 revisions API on hosted repositories

### DIFF
--- a/internal/formats/conan/handler.go
+++ b/internal/formats/conan/handler.go
@@ -12,6 +12,9 @@
 //	PUT  /files/:name/:version/:user/:channel/:revision/package/:pkgid/:prevision/:file → upload package file
 //	GET  /files/:name/:version/:user/:channel/:revision/export/:file → download recipe file
 //	GET  /files/:name/:version/:user/:channel/:revision/package/:pkgid/:prevision/:file → download package file
+//
+// The Conan v2 revisions API (Conan 2.x clients) is served under
+// /v2/conans/... — see v2.go for the route list.
 package conan
 
 import (
@@ -51,7 +54,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		}
 		// Ping is always local
 		if p == "/ping" || p == "/v1/ping" {
-			c.JSON(http.StatusOK, gin.H{"ok": true})
+			servePing(c)
 			return
 		}
 		// Conan revision files are content-addressed (immutable); the "/latest"
@@ -70,7 +73,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	switch {
 	// Ping
 	case (p == "/ping" || p == "/v1/ping") && c.Request.Method == http.MethodGet:
-		c.JSON(http.StatusOK, gin.H{"ok": true})
+		servePing(c)
 
 	// Upload recipe/package file: PUT /files/...
 	case c.Request.Method == http.MethodPut && strings.HasPrefix(p, "/files/"):
@@ -92,9 +95,21 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	case c.Request.Method == http.MethodGet && strings.HasPrefix(p, "/v1/conans/"):
 		h.handleManifest(c, repoName, p)
 
+	// Conan v2 revisions API (Conan 2.x clients): /v2/conans/... (#95)
+	case strings.HasPrefix(p, "/v2/conans/"):
+		h.serveV2(c, repoName, p)
+
 	default:
 		c.Status(http.StatusMethodNotAllowed)
 	}
+}
+
+// servePing answers the Conan ping and advertises server capabilities.
+// Conan 2.x (and 1.x with revisions enabled) requires the "revisions"
+// capability before it will talk v2 endpoints to us.
+func servePing(c *gin.Context) {
+	c.Header("X-Conan-Server-Capabilities", "revisions")
+	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
 // parseRef extracts (name, version, user, channel) from a /v1/conans/:name/:ver/:user/:channel[/...] path.
@@ -122,14 +137,24 @@ func coordsFromRef(name, version, user, channel string) base.Coords {
 	}
 }
 
-func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
-	// Extract coords from /files/:name/:version/:user/:channel/:rev/export/:file
-	// or /files/:name/:version/:user/:channel/:rev/package/:pkgid/:prevision/:file
-	parts := strings.SplitN(strings.TrimPrefix(p, "/files/"), "/", 6)
-	coords := base.Coords{}
-	if len(parts) >= 4 {
-		coords = coordsFromRef(parts[0], parts[1], parts[2], parts[3])
+// uploadCoords derives component coordinates from a v1 /files/... or a
+// v2 /v2/conans/... upload path (both start with name/version/user/channel).
+func uploadCoords(p string) base.Coords {
+	var parts []string
+	switch {
+	case strings.HasPrefix(p, "/files/"):
+		parts = strings.SplitN(strings.TrimPrefix(p, "/files/"), "/", 6)
+	case strings.HasPrefix(p, "/v2/conans/"):
+		parts = strings.SplitN(strings.TrimPrefix(p, "/v2/conans/"), "/", 5)
 	}
+	if len(parts) >= 4 {
+		return coordsFromRef(parts[0], parts[1], parts[2], parts[3])
+	}
+	return base.Coords{}
+}
+
+func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
+	coords := uploadCoords(p)
 
 	ct := c.GetHeader("Content-Type")
 	if ct == "" {

--- a/internal/formats/conan/v2.go
+++ b/internal/formats/conan/v2.go
@@ -1,0 +1,145 @@
+package conan
+
+// Conan v2 revisions API (Conan 2.x clients, and 1.x with revisions enabled):
+//
+//	PUT  /v2/conans/:name/:ver/:user/:channel/revisions/:rrev/files/:file → upload recipe file
+//	GET  /v2/conans/:name/:ver/:user/:channel/revisions/:rrev/files/:file → download recipe file
+//	GET  /v2/conans/:name/:ver/:user/:channel/revisions/:rrev/files       → list recipe files
+//	GET  /v2/conans/:name/:ver/:user/:channel/latest                      → latest recipe revision
+//	GET  /v2/conans/:name/:ver/:user/:channel/revisions                   → list recipe revisions
+//
+// ...and the same shapes under /revisions/:rrev/packages/:pkgid/... for
+// package binaries. Files are stored verbatim under their full
+// /v2/conans/... path (the same verbatim-path convention as the v1 /files/
+// API), so listings and revision resolution are derived from asset path
+// prefixes.
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (h *Handler) serveV2(c *gin.Context, repoName, p string) {
+	m := c.Request.Method
+	switch {
+	// File upload/download: .../files/<path>
+	case m == http.MethodPut && strings.Contains(p, "/files/"):
+		h.handleUpload(c, repoName, p)
+	case m == http.MethodGet && strings.Contains(p, "/files/"):
+		h.handleDownload(c, repoName, p)
+
+	// File listing: .../files
+	case m == http.MethodGet && strings.HasSuffix(p, "/files"):
+		h.v2ListFiles(c, repoName, p)
+
+	// Latest revision (recipe or package): .../latest
+	case m == http.MethodGet && strings.HasSuffix(p, "/latest"):
+		h.v2Latest(c, repoName, p)
+
+	// Revision list (recipe or package): .../revisions
+	case m == http.MethodGet && strings.HasSuffix(p, "/revisions"):
+		h.v2ListRevisions(c, repoName, p)
+
+	default:
+		c.Status(http.StatusMethodNotAllowed)
+	}
+}
+
+// pathsUnder returns stored asset paths (relative to prefix) and their
+// timestamps for every asset under the given path prefix. The second return
+// is false when listing failed and an error response was already written.
+func (h *Handler) pathsUnder(c *gin.Context, repoName, prefix string) (map[string]time.Time, bool) {
+	page, err := h.deps.Assets.List(c.Request.Context(), repoName, 1000, 0)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return nil, false
+	}
+	out := map[string]time.Time{}
+	for _, a := range page.Items {
+		if strings.HasPrefix(a.Path, prefix) {
+			out[strings.TrimPrefix(a.Path, prefix)] = a.LastModified
+		}
+	}
+	return out, true
+}
+
+func (h *Handler) v2ListFiles(c *gin.Context, repoName, p string) {
+	rel, ok := h.pathsUnder(c, repoName, p+"/")
+	if !ok {
+		return
+	}
+	if len(rel) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no files found"})
+		return
+	}
+	files := gin.H{}
+	for f := range rel {
+		files[f] = gin.H{}
+	}
+	c.JSON(http.StatusOK, gin.H{"files": files})
+}
+
+// revisionTimes reduces relative paths ("<rev>/<file>") under a revisions/
+// prefix to revision → newest-file-time.
+func revisionTimes(rel map[string]time.Time) map[string]time.Time {
+	revs := map[string]time.Time{}
+	for f, ts := range rel {
+		rev, _, ok := strings.Cut(f, "/")
+		if !ok || rev == "" {
+			continue
+		}
+		if cur, seen := revs[rev]; !seen || ts.After(cur) {
+			revs[rev] = ts
+		}
+	}
+	return revs
+}
+
+func (h *Handler) v2Latest(c *gin.Context, repoName, p string) {
+	base := strings.TrimSuffix(p, "/latest")
+	rel, ok := h.pathsUnder(c, repoName, base+"/revisions/")
+	if !ok {
+		return
+	}
+	var bestRev string
+	var bestTime time.Time
+	for rev, ts := range revisionTimes(rel) {
+		if bestRev == "" || ts.After(bestTime) {
+			bestRev, bestTime = rev, ts
+		}
+	}
+	if bestRev == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"revision": bestRev,
+		"time":     bestTime.UTC().Format(time.RFC3339),
+	})
+}
+
+func (h *Handler) v2ListRevisions(c *gin.Context, repoName, p string) {
+	rel, ok := h.pathsUnder(c, repoName, p+"/")
+	if !ok {
+		return
+	}
+	revs := revisionTimes(rel)
+	if len(revs) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+	type revEntry struct {
+		Revision string `json:"revision"`
+		Time     string `json:"time"`
+	}
+	list := make([]revEntry, 0, len(revs))
+	for rev, ts := range revs {
+		list = append(list, revEntry{Revision: rev, Time: ts.UTC().Format(time.RFC3339)})
+	}
+	sort.Slice(list, func(i, j int) bool { return list[i].Time > list[j].Time })
+	c.JSON(http.StatusOK, gin.H{"revisions": list})
+}

--- a/internal/formats/conan/v2_test.go
+++ b/internal/formats/conan/v2_test.go
@@ -1,0 +1,113 @@
+package conan_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func v2Put(r http.Handler, url, content string) int {
+	req := httptest.NewRequest(http.MethodPut, url, strings.NewReader(content))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = int64(len(content))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func v2Get(r http.Handler, url string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestConan_PingAdvertisesRevisions(t *testing.T) {
+	// Conan 2.x refuses to talk to servers that do not advertise the
+	// "revisions" capability (#95).
+	repo := testutil.SimpleRepo("cv2-ping", "conan")
+	r := setup(repo)
+
+	w := v2Get(r, "/repository/cv2-ping/v1/ping")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("X-Conan-Server-Capabilities"), "revisions")
+}
+
+func TestConan_V2_UploadAndDownload_RecipeFile(t *testing.T) {
+	// Regression for #95: Conan 2.x uploads via the v2 revisions API fell
+	// through to the default 405 branch and were silently dropped.
+	repo := testutil.SimpleRepo("cv2-recipe", "conan")
+	r := setup(repo)
+	base := "/repository/cv2-recipe/v2/conans/boost/1.83.0/_/_/revisions/abc123/files"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, base+"/conanfile.py", "recipe-src"))
+
+	w := v2Get(r, base+"/conanfile.py")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "recipe-src", w.Body.String())
+}
+
+func TestConan_V2_UploadAndDownload_PackageFile(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-pkg", "conan")
+	r := setup(repo)
+	base := "/repository/cv2-pkg/v2/conans/boost/1.83.0/_/_/revisions/abc123/packages/pkgid1/revisions/prev1/files"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, base+"/conan_package.tgz", "pkg-bytes"))
+
+	w := v2Get(r, base+"/conan_package.tgz")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "pkg-bytes", w.Body.String())
+}
+
+func TestConan_V2_ListFiles(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-list", "conan")
+	r := setup(repo)
+	base := "/repository/cv2-list/v2/conans/boost/1.83.0/_/_/revisions/abc123/files"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, base+"/conanfile.py", "a"))
+	require.Equal(t, http.StatusCreated, v2Put(r, base+"/conanmanifest.txt", "b"))
+
+	w := v2Get(r, base)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "conanfile.py")
+	assert.Contains(t, w.Body.String(), "conanmanifest.txt")
+}
+
+func TestConan_V2_LatestRevision(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-latest", "conan")
+	r := setup(repo)
+	files := "/repository/cv2-latest/v2/conans/boost/1.83.0/_/_/revisions/abc123/files"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, files+"/conanfile.py", "x"))
+
+	w := v2Get(r, "/repository/cv2-latest/v2/conans/boost/1.83.0/_/_/latest")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "abc123")
+	assert.Contains(t, w.Body.String(), "time")
+}
+
+func TestConan_V2_ListRevisions(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-revs", "conan")
+	r := setup(repo)
+	files := "/repository/cv2-revs/v2/conans/boost/1.83.0/_/_/revisions/abc123/files"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, files+"/conanfile.py", "x"))
+
+	w := v2Get(r, "/repository/cv2-revs/v2/conans/boost/1.83.0/_/_/revisions")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "abc123")
+}
+
+func TestConan_V2_Latest_NotFound(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-404", "conan")
+	r := setup(repo)
+
+	w := v2Get(r, "/repository/cv2-404/v2/conans/nope/1.0/_/_/latest")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}


### PR DESCRIPTION
Fixes #95.

- Routes `/v2/conans/...`: file upload/download, `.../files` listings, `.../latest`, `.../revisions` — recipe and package level — on the existing verbatim-path storage.
- `servePing` now advertises `X-Conan-Server-Capabilities: revisions` (Conan 2.x refuses servers without it).
- Out of scope (follow-up if needed): `/v2` search binary matching (needs conaninfo parsing), deletes.

TDD: 7 new tests (RED verified — uploads previously 405). Proxy path unaffected (RejectMutation runs before the hosted switch; v2 GETs already proxied via ServeGET).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk