### PR TITLE
fix(proxy): rewrite proxied metadata URLs to the proxy (npm/pypi/nuget)

### DIFF
--- a/internal/formats/npm/handler.go
+++ b/internal/formats/npm/handler.go
@@ -139,7 +139,12 @@ func (h *Handler) serveMetadata(c *gin.Context, repoName, pkgPath string) {
 		up := "/" + repoproxy.NPMMetadataPath(trim)
 		coords := base.Coords{Name: pkgName, Version: "metadata"}
 		// The packument is mutable metadata (new versions appear over time).
-		if err := repoproxy.ServeGET(c, h.deps, repo, pkgPath, up, coords, "application/json", repoproxy.MetadataMaxAge(repo)); err != nil {
+		// dist.tarball URLs are rewritten on serve so installs pull tarballs
+		// through this proxy instead of upstream (#98); the cache keeps the
+		// upstream original.
+		localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repo.Name
+		rewrite := func(b []byte) []byte { return RewritePackument(b, localBase) }
+		if err := repoproxy.ServeGETRewritten(c, h.deps, repo, pkgPath, up, coords, "application/json", repoproxy.MetadataMaxAge(repo), rewrite); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/npm/rewrite.go
+++ b/internal/formats/npm/rewrite.go
@@ -1,0 +1,57 @@
+package npm
+
+import (
+	"encoding/json"
+	"net/url"
+)
+
+// RewritePackument rewrites every versions.*.dist.tarball URL in an npm
+// packument to point at this proxy (#98). Upstream registries embed absolute
+// URLs to themselves; served verbatim they make npm download tarballs directly
+// from upstream, bypassing the proxy cache. localBase is the proxy repo base
+// (e.g. "http://host/repository/npm-proxy"); the tarball's upstream path
+// ("/<pkg>/-/<file>.tgz", scoped packages included) is preserved.
+//
+// Malformed bodies are returned unchanged — serving upstream bytes verbatim
+// is strictly better than serving nothing.
+func RewritePackument(body []byte, localBase string) []byte {
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return body
+	}
+
+	versions, ok := doc["versions"].(map[string]any)
+	if !ok {
+		return body
+	}
+	changed := false
+	for _, v := range versions {
+		ver, ok := v.(map[string]any)
+		if !ok {
+			continue
+		}
+		dist, ok := ver["dist"].(map[string]any)
+		if !ok {
+			continue
+		}
+		tb, ok := dist["tarball"].(string)
+		if !ok || tb == "" {
+			continue
+		}
+		u, err := url.Parse(tb)
+		if err != nil || u.Path == "" {
+			continue
+		}
+		dist["tarball"] = localBase + u.Path
+		changed = true
+	}
+	if !changed {
+		return body
+	}
+
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return body
+	}
+	return out
+}

--- a/internal/formats/npm/rewrite_test.go
+++ b/internal/formats/npm/rewrite_test.go
@@ -1,0 +1,79 @@
+package npm_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/npm"
+)
+
+func TestRewritePackument_TarballURLs(t *testing.T) {
+	// #98: proxied packuments must point dist.tarball at this proxy, not
+	// the upstream registry, or npm installs bypass the cache entirely.
+	in := []byte(`{
+		"name": "lodash",
+		"dist-tags": {"latest": "4.17.21"},
+		"versions": {
+			"4.17.21": {
+				"name": "lodash",
+				"dist": {
+					"shasum": "abc",
+					"tarball": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+				}
+			},
+			"4.17.20": {
+				"dist": {"tarball": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz"}
+			}
+		}
+	}`)
+	out := string(npm.RewritePackument(in, "http://localhost:8080/repository/npm-proxy"))
+
+	assert.Contains(t, out, `"tarball":"http://localhost:8080/repository/npm-proxy/lodash/-/lodash-4.17.21.tgz"`)
+	assert.Contains(t, out, "lodash-4.17.20.tgz")
+	assert.NotContains(t, out, "registry.npmjs.org")
+	// Non-dist fields survive the round-trip.
+	assert.Contains(t, out, `"shasum":"abc"`)
+	assert.Contains(t, out, `"dist-tags"`)
+}
+
+func TestRewritePackument_ScopedPackage(t *testing.T) {
+	in := []byte(`{"versions":{"1.0.0":{"dist":{"tarball":"https://registry.npmjs.org/@babel/core/-/core-1.0.0.tgz"}}}}`)
+	out := string(npm.RewritePackument(in, "http://localhost:8080/repository/npm-proxy"))
+	assert.Contains(t, out, "http://localhost:8080/repository/npm-proxy/@babel/core/-/core-1.0.0.tgz")
+}
+
+func TestRewritePackument_MalformedBodyUnchanged(t *testing.T) {
+	in := []byte("not json at all")
+	out := npm.RewritePackument(in, "http://x")
+	assert.Equal(t, in, out)
+}
+
+func TestNPM_Proxy_Packument_RewritesTarballs(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"name":"left-pad","versions":{"1.3.0":{"dist":{"tarball":"%s/left-pad/-/left-pad-1.3.0.tgz"}}}}`, "https://registry.npmjs.org")
+	}))
+	defer upstream.Close()
+
+	repo := &domain.Repository{
+		ID: "np-rw", Name: "npm-rw", Format: "npm",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r := setup(repo) // BaseURL: http://localhost:8080
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/npm-rw/left-pad", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "http://localhost:8080/repository/npm-rw/left-pad/-/left-pad-1.3.0.tgz")
+	assert.NotContains(t, body, "registry.npmjs.org")
+}

--- a/internal/formats/nuget/handler.go
+++ b/internal/formats/nuget/handler.go
@@ -66,7 +66,15 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			maxAge = repoproxy.MetadataMaxAge(repo)
 		}
 		coords := base.Coords{}
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge); err != nil {
+		// Registration pages embed absolute upstream URLs (packageContent,
+		// @id) — rewrite them on serve so clients pull packages through this
+		// proxy (#98); the cache keeps the upstream original.
+		var rewrite func([]byte) []byte
+		if strings.HasPrefix(p, "/v3/registration/") {
+			localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repo.Name
+			rewrite = func(b []byte) []byte { return RewriteRegistration(b, localBase) }
+		}
+		if err := repoproxy.ServeGETRewritten(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge, rewrite); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return

--- a/internal/formats/nuget/rewrite.go
+++ b/internal/formats/nuget/rewrite.go
@@ -1,0 +1,78 @@
+package nuget
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+)
+
+// RewriteRegistration rewrites absolute upstream URLs in a proxied NuGet v3
+// registration document to point at this proxy (#98):
+//
+//   - "packageContent" is REBUILT from the sibling catalogEntry's id/version
+//     (lowercased id, our flatcontainer layout) — upstream flatcontainer path
+//     shapes vary (api.nuget.org uses /v3-flatcontainer/), so string-munging
+//     the upstream URL would be fragile.
+//   - "@id" values whose URL path contains a segment starting with
+//     "registration" are re-rooted at localBase+"/v3/registration/"+tail.
+//
+// localBase is the proxy repo base (e.g. "http://host/repository/nuget-proxy").
+// Malformed bodies are returned unchanged.
+func RewriteRegistration(body []byte, localBase string) []byte {
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return body
+	}
+	rewriteRegistrationNode(doc, localBase)
+	out, err := json.Marshal(doc)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+// rewriteRegistrationNode walks the registration JSON tree in place.
+func rewriteRegistrationNode(node any, localBase string) {
+	switch n := node.(type) {
+	case map[string]any:
+		if id, ok := n["@id"].(string); ok {
+			if rw, ok2 := rerootRegistrationID(id, localBase); ok2 {
+				n["@id"] = rw
+			}
+		}
+		if _, ok := n["packageContent"].(string); ok {
+			if ce, ok2 := n["catalogEntry"].(map[string]any); ok2 {
+				id, _ := ce["id"].(string)
+				ver, _ := ce["version"].(string)
+				if id != "" && ver != "" {
+					lid := strings.ToLower(id)
+					n["packageContent"] = localBase + "/v3/flatcontainer/" + lid + "/" + ver + "/" + lid + "." + ver + ".nupkg"
+				}
+			}
+		}
+		for _, v := range n {
+			rewriteRegistrationNode(v, localBase)
+		}
+	case []any:
+		for _, v := range n {
+			rewriteRegistrationNode(v, localBase)
+		}
+	}
+}
+
+// rerootRegistrationID maps an upstream registration URL (any host, any
+// registration* segment flavor, e.g. /v3/registration5-gz-semver2/<id>/...)
+// onto this proxy's /v3/registration/<tail>.
+func rerootRegistrationID(rawURL, localBase string) (string, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || !u.IsAbs() {
+		return "", false
+	}
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	for i, s := range segs {
+		if strings.HasPrefix(s, "registration") && i+1 < len(segs) {
+			return localBase + "/v3/registration/" + strings.Join(segs[i+1:], "/"), true
+		}
+	}
+	return "", false
+}

--- a/internal/formats/nuget/rewrite_test.go
+++ b/internal/formats/nuget/rewrite_test.go
@@ -1,0 +1,80 @@
+package nuget_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/nuget"
+)
+
+func TestRewriteRegistration_PackageContentAndIDs(t *testing.T) {
+	// #98: proxied registration pages embed absolute api.nuget.org URLs, so
+	// clients following registration metadata pull .nupkg files from
+	// upstream, bypassing the proxy cache.
+	in := []byte(`{
+		"@id": "https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/index.json",
+		"count": 1,
+		"items": [{
+			"@id": "https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/page/1.0.0/13.0.1.json",
+			"items": [{
+				"@id": "https://api.nuget.org/v3/registration5-gz-semver2/newtonsoft.json/13.0.1.json",
+				"packageContent": "https://api.nuget.org/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg",
+				"catalogEntry": {
+					"id": "Newtonsoft.Json",
+					"version": "13.0.1",
+					"listed": true
+				}
+			}]
+		}]
+	}`)
+	local := "http://localhost:8080/repository/nuget-proxy"
+	out := string(nuget.RewriteRegistration(in, local))
+
+	// packageContent is rebuilt from catalogEntry (lowercased id), not string-munged.
+	assert.Contains(t, out,
+		`"packageContent":"http://localhost:8080/repository/nuget-proxy/v3/flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg"`)
+	// @id URLs with a registration* segment are re-rooted at the local registration base.
+	assert.Contains(t, out,
+		`"@id":"http://localhost:8080/repository/nuget-proxy/v3/registration/newtonsoft.json/index.json"`)
+	assert.Contains(t, out,
+		`"@id":"http://localhost:8080/repository/nuget-proxy/v3/registration/newtonsoft.json/13.0.1.json"`)
+	assert.NotContains(t, out, "api.nuget.org")
+	// catalogEntry survives.
+	assert.Contains(t, out, `"listed":true`)
+}
+
+func TestRewriteRegistration_MalformedBodyUnchanged(t *testing.T) {
+	in := []byte("<html>not json</html>")
+	out := nuget.RewriteRegistration(in, "http://x")
+	assert.Equal(t, in, out)
+}
+
+func TestNuGet_Proxy_Registration_Rewrites(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"items":[{"items":[{"packageContent":"https://api.nuget.org/v3-flatcontainer/my.lib/2.1.0/my.lib.2.1.0.nupkg","catalogEntry":{"id":"My.Lib","version":"2.1.0"}}]}]}`)
+	}))
+	defer upstream.Close()
+
+	repo := &domain.Repository{
+		ID: "ng-rw", Name: "nuget-rw", Format: "nuget",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r := setup(repo) // BaseURL: http://localhost:8080
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/nuget-rw/v3/registration/my.lib/index.json", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "http://localhost:8080/repository/nuget-rw/v3/flatcontainer/my.lib/2.1.0/my.lib.2.1.0.nupkg")
+	assert.NotContains(t, body, "api.nuget.org")
+}

--- a/internal/formats/pypi/handler.go
+++ b/internal/formats/pypi/handler.go
@@ -67,7 +67,11 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			normalized := normalizePackageName(pkgName)
 			coords := base.Coords{Name: normalized, Version: "simple-page"}
 			// A per-package simple page is mutable metadata (new releases appear).
-			if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8", repoproxy.MetadataMaxAge(repo)); err != nil {
+			// File hrefs are rewritten on serve so pip pulls wheels/sdists through
+			// this proxy instead of upstream (#98); the cache keeps the original.
+			localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repo.Name
+			rewrite := func(b []byte) []byte { return RewriteSimplePage(b, localBase) }
+			if err := repoproxy.ServeGETRewritten(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8", repoproxy.MetadataMaxAge(repo), rewrite); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			}
 			return

--- a/internal/formats/pypi/rewrite.go
+++ b/internal/formats/pypi/rewrite.go
@@ -1,0 +1,33 @@
+package pypi
+
+import (
+	"regexp"
+	"strings"
+)
+
+// hrefRe matches href attribute values on PyPI simple pages (PEP 503 pages
+// are machine-generated anchor lists, so attribute-level matching is safe).
+var hrefRe = regexp.MustCompile(`href="([^"]+)"`)
+
+// RewriteSimplePage rewrites absolute package-file links on a proxied PyPI
+// simple page to point at this proxy (#98). Upstream pages embed absolute
+// URLs (e.g. https://files.pythonhosted.org/packages/...), which make pip
+// download release files directly from upstream, bypassing the proxy cache.
+// Every absolute href containing "/packages/" is re-rooted at
+// localBase+"/packages/<tail>", preserving the path tail and any #sha256=
+// fragment. Relative hrefs and URLs without a /packages/ segment are left
+// untouched. Malformed input is returned unchanged by construction (regex
+// replacement only touches matching attributes).
+func RewriteSimplePage(body []byte, localBase string) []byte {
+	return hrefRe.ReplaceAllFunc(body, func(m []byte) []byte {
+		href := string(m[len(`href="`) : len(m)-1])
+		if !strings.HasPrefix(href, "http://") && !strings.HasPrefix(href, "https://") {
+			return m
+		}
+		idx := strings.Index(href, "/packages/")
+		if idx < 0 {
+			return m
+		}
+		return []byte(`href="` + localBase + href[idx:] + `"`)
+	})
+}

--- a/internal/formats/pypi/rewrite_test.go
+++ b/internal/formats/pypi/rewrite_test.go
@@ -1,0 +1,61 @@
+package pypi_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/pypi"
+)
+
+func TestRewriteSimplePage_Hrefs(t *testing.T) {
+	// #98: proxied simple pages carry absolute files.pythonhosted.org links,
+	// so pip downloads wheels directly from upstream, bypassing the cache.
+	in := []byte(`<html><body>
+<a href="https://files.pythonhosted.org/packages/ab/cd/xyz/requests-2.31.0-py3-none-any.whl#sha256=deadbeef">requests-2.31.0-py3-none-any.whl</a>
+<a href="https://files.pythonhosted.org/packages/ef/12/abc/requests-2.31.0.tar.gz">requests-2.31.0.tar.gz</a>
+</body></html>`)
+	out := string(pypi.RewriteSimplePage(in, "http://localhost:8080/repository/pypi-proxy"))
+
+	assert.Contains(t, out,
+		`href="http://localhost:8080/repository/pypi-proxy/packages/ab/cd/xyz/requests-2.31.0-py3-none-any.whl#sha256=deadbeef"`,
+		"path tail and #sha256 fragment must be preserved")
+	assert.Contains(t, out,
+		`href="http://localhost:8080/repository/pypi-proxy/packages/ef/12/abc/requests-2.31.0.tar.gz"`)
+	assert.NotContains(t, out, "files.pythonhosted.org")
+}
+
+func TestRewriteSimplePage_LeavesOtherHrefsAlone(t *testing.T) {
+	in := []byte(`<a href="../relative/thing">x</a> <a href="https://example.com/no-pkg/file.whl">y</a>`)
+	out := string(pypi.RewriteSimplePage(in, "http://local/repository/p"))
+	assert.Equal(t, string(in), out, "relative hrefs and URLs without /packages/ stay untouched")
+}
+
+func TestPyPI_Proxy_SimplePage_RewritesLinks(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><a href="https://files.pythonhosted.org/packages/aa/bb/flask-3.0.0-py3-none-any.whl#sha256=cafe">flask</a></body></html>`)
+	}))
+	defer upstream.Close()
+
+	repo := &domain.Repository{
+		ID: "py-rw", Name: "pypi-rw", Format: "pypi",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r := setup(repo) // BaseURL: http://localhost:8080
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-rw/simple/flask/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "http://localhost:8080/repository/pypi-rw/packages/aa/bb/flask-3.0.0-py3-none-any.whl#sha256=cafe")
+	assert.NotContains(t, body, "files.pythonhosted.org")
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -2,6 +2,7 @@
 package repoproxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"  //nolint:gosec // md5/sha1 required for artifact-protocol checksums (Maven .md5/.sha1, npm shasum), not security
 	"crypto/sha1" //nolint:gosec // md5/sha1 required for artifact-protocol checksums (Maven .md5/.sha1, npm shasum), not security
@@ -207,8 +208,9 @@ func cacheFetchStore(ctx context.Context, d formats.Deps, asset *domain.Asset) s
 }
 
 // serveCachedAsset streams (or, for HEAD, describes) a cached asset to the client.
-// It takes ownership of rc and closes it.
-func serveCachedAsset(c *gin.Context, d formats.Deps, asset *domain.Asset, rc io.ReadCloser) {
+// A non-nil rewrite is applied to the body on the way out (the cache keeps the
+// upstream original). It takes ownership of rc and closes it.
+func serveCachedAsset(c *gin.Context, d formats.Deps, asset *domain.Asset, rc io.ReadCloser, rewrite func([]byte) []byte) {
 	defer func() { _ = rc.Close() }()
 	// Count only real GETs so a HEAD probe + GET pull don't double-count.
 	if c.Request.Method == http.MethodGet && d.Downloads != nil {
@@ -217,10 +219,19 @@ func serveCachedAsset(c *gin.Context, d formats.Deps, asset *domain.Asset, rc io
 	applyChecksumHeaders(c, asset)
 	if c.Request.Method == http.MethodHead {
 		c.Header("Content-Type", asset.ContentType)
-		if asset.SizeBytes > 0 {
+		if asset.SizeBytes > 0 && rewrite == nil {
 			c.Header("Content-Length", fmt.Sprintf("%d", asset.SizeBytes))
 		}
 		c.Status(http.StatusOK)
+		return
+	}
+	if rewrite != nil {
+		body, err := io.ReadAll(rc)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "cache read: " + err.Error()})
+			return
+		}
+		c.Data(http.StatusOK, asset.ContentType, rewrite(body))
 		return
 	}
 	c.DataFromReader(http.StatusOK, asset.SizeBytes, asset.ContentType, rc, nil)
@@ -239,6 +250,19 @@ func serveCachedAsset(c *gin.Context, d formats.Deps, asset *domain.Asset, rc io
 // a conditional request before being served. See revalidateAndServe.
 func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelativePath, upstreamPath string,
 	coords base.Coords, defaultContentType string, maxAge time.Duration,
+) error {
+	return ServeGETRewritten(c, d, repo, repoRelativePath, upstreamPath, coords, defaultContentType, maxAge, nil)
+}
+
+// ServeGETRewritten is ServeGET for metadata documents whose body must be
+// transformed before serving — e.g. rewriting embedded upstream download URLs
+// to this proxy (#98). The blob cache stores the upstream ORIGINAL and rewrite
+// runs on every response (cache hit, miss, and revalidation), so a BaseURL
+// change never invalidates cached metadata. A nil rewrite streams exactly like
+// ServeGET. rewrite must be pure and tolerate arbitrary input (on malformed
+// bodies, return the input unchanged).
+func ServeGETRewritten(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelativePath, upstreamPath string,
+	coords base.Coords, defaultContentType string, maxAge time.Duration, rewrite func([]byte) []byte,
 ) error {
 	ctx := c.Request.Context()
 	if repo.Type != domain.TypeProxy {
@@ -267,23 +291,23 @@ func ServeGET(c *gin.Context, d formats.Deps, repo *domain.Repository, repoRelat
 			// revalidated against upstream before serving. Immutable content
 			// (maxAge == 0) and HEAD probes always serve straight from cache.
 			if maxAge > 0 && c.Request.Method == http.MethodGet && time.Since(asset.LastModified) > maxAge {
-				return revalidateAndServe(c, d, repo, asset, repoRelativePath, upJoin, coords, defaultContentType, rc)
+				return revalidateAndServe(c, d, repo, asset, repoRelativePath, upJoin, coords, defaultContentType, rc, rewrite)
 			}
-			serveCachedAsset(c, d, asset, rc)
+			serveCachedAsset(c, d, asset, rc, rewrite)
 			return nil
 		}
 		// Blob file missing from cache storage (storage path changed or file deleted).
 		// Fall through to upstream fetch so the client gets content and the cache is repaired.
 	}
 
-	return fetchAndCache(c, d, repo, repoRelativePath, upJoin, coords, defaultContentType)
+	return fetchAndCache(c, d, repo, repoRelativePath, upJoin, coords, defaultContentType, rewrite)
 }
 
 // fetchAndCache handles a cache miss (or a cache entry whose blob went missing):
 // it fetches from upstream, forwarding the client's own conditional headers, and
 // on success stores the blob and serves it.
 func fetchAndCache(c *gin.Context, d formats.Deps, repo *domain.Repository,
-	repoRelativePath, upJoin string, coords base.Coords, defaultContentType string,
+	repoRelativePath, upJoin string, coords base.Coords, defaultContentType string, rewrite func([]byte) []byte,
 ) error {
 	ctx := c.Request.Context()
 
@@ -336,7 +360,7 @@ func fetchAndCache(c *gin.Context, d formats.Deps, repo *domain.Repository,
 		return nil
 	}
 
-	return storeAndServeResponse(c, d, repo, repoRelativePath, defaultContentType, coords, resp)
+	return storeAndServeResponse(c, d, repo, repoRelativePath, defaultContentType, coords, resp, rewrite)
 }
 
 // revalidateAndServe is invoked when a cached metadata asset is older than its
@@ -348,18 +372,18 @@ func fetchAndCache(c *gin.Context, d formats.Deps, repo *domain.Repository,
 //
 // It takes ownership of rc (the open cache blob) and always closes it.
 func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository, asset *domain.Asset,
-	repoRelativePath, upJoin string, coords base.Coords, defaultContentType string, rc io.ReadCloser,
+	repoRelativePath, upJoin string, coords base.Coords, defaultContentType string, rc io.ReadCloser, rewrite func([]byte) []byte,
 ) error {
 	ctx := c.Request.Context()
 
 	baseRemote, err := RemoteURL(repo)
 	if err != nil {
-		serveCachedAsset(c, d, asset, rc)
+		serveCachedAsset(c, d, asset, rc, rewrite)
 		return nil
 	}
 	upstream, err := JoinURL(baseRemote, upJoin)
 	if err != nil {
-		serveCachedAsset(c, d, asset, rc)
+		serveCachedAsset(c, d, asset, rc, rewrite)
 		return nil
 	}
 
@@ -381,7 +405,7 @@ func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository,
 	if err != nil {
 		// Upstream unreachable → serve stale cache so metadata consumers keep working.
 		dispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
-		serveCachedAsset(c, d, asset, rc)
+		serveCachedAsset(c, d, asset, rc, rewrite)
 		return nil
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -393,18 +417,18 @@ func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository,
 		if d.Assets != nil {
 			_ = d.Assets.TouchLastModified(context.Background(), asset.ID)
 		}
-		serveCachedAsset(c, d, asset, rc)
+		serveCachedAsset(c, d, asset, rc, rewrite)
 		return nil
 	case resp.StatusCode >= 200 && resp.StatusCode <= 299:
 		// Upstream returned a newer copy: replace the cached blob and serve it.
 		_ = rc.Close()
-		return storeAndServeResponse(c, d, repo, repoRelativePath, defaultContentType, coords, resp)
+		return storeAndServeResponse(c, d, repo, repoRelativePath, defaultContentType, coords, resp, rewrite)
 	default:
 		// Any other status (404/410/5xx): don't discard a good cache on a transient
 		// upstream hiccup — serve stale and record the anomaly.
 		dispatchProxyError(d, repo.Name, repoRelativePath, upstream,
 			fmt.Errorf("revalidation returned status %d", resp.StatusCode))
-		serveCachedAsset(c, d, asset, rc)
+		serveCachedAsset(c, d, asset, rc, rewrite)
 		return nil
 	}
 }
@@ -413,13 +437,35 @@ func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository,
 // client while persisting it to the blob store and registering the DB asset,
 // replacing any prior cache entry for repoRelativePath.
 func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Repository,
-	repoRelativePath, defaultContentType string, coords base.Coords, resp *http.Response,
+	repoRelativePath, defaultContentType string, coords base.Coords, resp *http.Response, rewrite func([]byte) []byte,
 ) error {
 	ctx := c.Request.Context()
 
 	ct := resp.Header.Get("Content-Type")
 	if ct == "" {
 		ct = defaultContentType
+	}
+
+	// Rewritten metadata cannot stream: buffer the upstream body, persist the
+	// ORIGINAL to the cache (hashes over the original), and serve the client
+	// the transformed copy. Metadata documents are small, so buffering is fine.
+	if rewrite != nil {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("proxy metadata read: %w", readErr)
+		}
+		if err := storeOriginal(ctx, c, d, repo, repoRelativePath, ct, coords, body); err != nil {
+			return err
+		}
+		copyRespHeaders(c.Writer.Header(), resp.Header)
+		c.Writer.Header().Del("Content-Length") // length changes after rewrite
+		if c.Request.Method == http.MethodHead {
+			c.Header("Content-Type", ct)
+			c.Status(resp.StatusCode)
+			return nil
+		}
+		c.Data(resp.StatusCode, ct, rewrite(body))
+		return nil
 	}
 
 	copyRespHeaders(c.Writer.Header(), resp.Header)
@@ -476,6 +522,33 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 	}
 	// Count a download only for GET. Otherwise a HEAD probe + GET hit would
 	// double-count the same pull.
+	if regAsset != nil && regAsset.ID != "" && c.Request.Method == http.MethodGet && d.Downloads != nil {
+		d.Downloads.Add(regAsset.ID)
+	}
+	return nil
+}
+
+// storeOriginal persists an already-buffered upstream body to the blob store
+// and registers the DB asset (the buffered counterpart of the streaming path
+// in storeAndServeResponse, used when a rewrite forces buffering).
+func storeOriginal(ctx context.Context, c *gin.Context, d formats.Deps, repo *domain.Repository,
+	repoRelativePath, ct string, coords base.Coords, body []byte,
+) error {
+	blobKey := base.BlobKey(repo.Name, repoRelativePath)
+	resolvedID, resolvedName, physStore := base.ResolveBlobStore(ctx, d, repo)
+	if err := physStore.Put(ctx, blobKey, bytes.NewReader(body), int64(len(body))); err != nil {
+		return fmt.Errorf("proxy cache write: %w", err)
+	}
+	sha256sum := fmt.Sprintf("%x", sha256.Sum256(body))
+	sha1sum := fmt.Sprintf("%x", sha1.Sum(body)) //nolint:gosec // protocol checksum, not security
+	md5sum := fmt.Sprintf("%x", md5.Sum(body))   //nolint:gosec // protocol checksum, not security
+
+	// context.Background so DB registration survives request cancellation.
+	regAsset, regErr := base.RegisterStoredBlob(context.Background(), d, repo, repoRelativePath, ct, coords,
+		blobKey, sha256sum, sha1sum, md5sum, int64(len(body)), resolvedID, resolvedName)
+	if regErr != nil {
+		return regErr
+	}
 	if regAsset != nil && regAsset.ID != "" && c.Request.Method == http.MethodGet && d.Downloads != nil {
 		d.Downloads.Add(regAsset.ID)
 	}

--- a/internal/formats/repoproxy/rewrite_test.go
+++ b/internal/formats/repoproxy/rewrite_test.go
@@ -29,7 +29,7 @@ func TestServeGETRewritten_MissAndHit_RewriteOnServe(t *testing.T) {
 
 	repo := proxyRepo("rw1", upstream.URL)
 	d := makeDeps(repo)
-	rewrite := func(b []byte) []byte { return bytes.ToUpper(b) }
+	rewrite := bytes.ToUpper
 
 	// Cache miss → fetch upstream, serve rewritten.
 	w := httptest.NewRecorder()

--- a/internal/formats/repoproxy/rewrite_test.go
+++ b/internal/formats/repoproxy/rewrite_test.go
@@ -1,0 +1,81 @@
+package repoproxy_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// ServeGETRewritten must apply the rewrite on every serve path (cache miss,
+// cache hit) while the blob cache keeps the upstream ORIGINAL — BaseURL
+// changes must never invalidate cached metadata (#98).
+func TestServeGETRewritten_MissAndHit_RewriteOnServe(t *testing.T) {
+	useUnguardedUpstream(t)
+	hits := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		_, _ = w.Write([]byte("hello world"))
+	}))
+	defer upstream.Close()
+
+	repo := proxyRepo("rw1", upstream.URL)
+	d := makeDeps(repo)
+	rewrite := func(b []byte) []byte { return bytes.ToUpper(b) }
+
+	// Cache miss → fetch upstream, serve rewritten.
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/meta.json", nil)
+	err := repoproxy.ServeGETRewritten(c, d, repo, "/meta.json", "", base.Coords{}, "text/plain", 0, rewrite)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "HELLO WORLD", w.Body.String())
+
+	// Cache hit (immutable maxAge=0 → no upstream) → still rewritten.
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Request = httptest.NewRequest(http.MethodGet, "/meta.json", nil)
+	err = repoproxy.ServeGETRewritten(c2, d, repo, "/meta.json", "", base.Coords{}, "text/plain", 0, rewrite)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "HELLO WORLD", w2.Body.String())
+	assert.Equal(t, 1, hits, "second request must be served from cache")
+
+	// The stored blob holds the upstream original, not the rewritten bytes.
+	asset, err := d.Assets.GetByPath(context.Background(), "rw1", "/meta.json")
+	require.NoError(t, err)
+	rc, _, err := d.BlobStore.Get(context.Background(), asset.BlobKey)
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	var stored bytes.Buffer
+	_, _ = stored.ReadFrom(rc)
+	assert.Equal(t, "hello world", stored.String())
+}
+
+// A nil rewrite must behave exactly like ServeGET (streaming path untouched).
+func TestServeGETRewritten_NilRewrite_Streams(t *testing.T) {
+	useUnguardedUpstream(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("raw-bytes"))
+	}))
+	defer upstream.Close()
+
+	repo := proxyRepo("rw2", upstream.URL)
+	d := makeDeps(repo)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/f.bin", nil)
+	err := repoproxy.ServeGETRewritten(c, d, repo, "/f.bin", "", base.Coords{}, "", 0, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "raw-bytes", w.Body.String())
+}


### PR DESCRIPTION
Fixes #98.

Proxied metadata documents were cached and served verbatim, so their embedded absolute upstream URLs sent clients straight to the upstream registry — the proxy cache was bypassed for actual artifact downloads.

## Design
New `repoproxy.ServeGETRewritten` threads an optional `rewrite func([]byte) []byte` through all three serve paths (cache hit, fetch miss, revalidation). **The blob cache stores the upstream original** — a BaseURL change never invalidates cached metadata; the rewrite runs on every response. `nil` rewrite streams exactly as before (no change for binaries).

## Per-format rewrites (pure funcs, unit-tested)
- **npm** `RewritePackument`: every `versions.*.dist.tarball` re-rooted at the proxy, upstream path preserved (scoped packages included).
- **pypi** `RewriteSimplePage`: absolute hrefs containing `/packages/` re-rooted at the proxy, `#sha256=` fragments preserved.
- **nuget** `RewriteRegistration`: `packageContent` rebuilt from the sibling `catalogEntry` (upstream flatcontainer path shapes vary); `@id` URLs with a `registration*` segment re-rooted locally.

Malformed bodies are always served unchanged.

TDD: 10 new tests (RED verified per cycle). Full suite green except the known sandbox-only webhook network failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk