### PR TITLE
fix(group): merge index documents across members (maven/npm/pypi)

### DIFF
--- a/internal/formats/group/handler.go
+++ b/internal/formats/group/handler.go
@@ -97,7 +97,7 @@ func (h *Handler) serveGet(c *gin.Context) {
 			continue
 		}
 
-		rec := h.callMember(c, ctx, memberName, filePath, handler)
+		rec := h.callMember(ctx, c, memberName, filePath, handler)
 
 		code := rec.Code
 		if code == 0 {
@@ -142,7 +142,7 @@ func (h *Handler) eligibleMember(ctx context.Context, memberName string, groupDe
 }
 
 // callMember invokes a member's format handler on a cloned request/recorder.
-func (h *Handler) callMember(c *gin.Context, ctx context.Context, memberName, filePath string, handler formats.FormatHandler) *httptest.ResponseRecorder {
+func (h *Handler) callMember(ctx context.Context, c *gin.Context, memberName, filePath string, handler formats.FormatHandler) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	sub, _ := gin.CreateTestContext(rec)
 	sub.Request = c.Request.Clone(ctx)
@@ -180,7 +180,7 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 			continue
 		}
 
-		rec := h.callMember(c, ctx, memberName, source, handler)
+		rec := h.callMember(ctx, c, memberName, source, handler)
 		code := rec.Code
 		if code == 0 {
 			code = http.StatusOK

--- a/internal/formats/group/handler.go
+++ b/internal/formats/group/handler.go
@@ -10,10 +10,12 @@
 package group
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -71,18 +73,23 @@ func (h *Handler) serveGet(c *gin.Context) {
 		rule, _ = h.deps.RoutingRules.Get(ctx, *repoDef.RoutingRuleID)
 	}
 
+	// Index documents are merged across ALL members (member order = priority)
+	// instead of first-non-404: a single member's index would hide the others,
+	// and formats whose "not found" is an empty 200 would shadow every member
+	// behind them (#99).
+	if merger, ok := h.formatRegistry[string(repoDef.Format)].(formats.GroupIndexMerger); ok {
+		if source, isIndex := merger.GroupIndexSourcePath(filePath); isIndex {
+			h.serveMergedIndex(c, repoDef, members, rule, merger, source, filePath)
+			return
+		}
+	}
+
 	for _, memberName := range members {
 		if !service.Allow(rule, filePath) {
 			continue
 		}
-		memberRepo, err := h.deps.Repos.Get(ctx, memberName)
-		if err != nil || memberRepo == nil || !memberRepo.Online {
-			continue
-		}
-		if memberRepo.Type == domain.TypeGroup {
-			continue
-		}
-		if string(memberRepo.Format) != string(repoDef.Format) {
+		memberRepo := h.eligibleMember(ctx, memberName, repoDef)
+		if memberRepo == nil {
 			continue
 		}
 		handler, ok := h.formatRegistry[string(memberRepo.Format)]
@@ -90,15 +97,7 @@ func (h *Handler) serveGet(c *gin.Context) {
 			continue
 		}
 
-		rec := httptest.NewRecorder()
-		sub, _ := gin.CreateTestContext(rec)
-		sub.Request = c.Request.Clone(ctx)
-		sub.Params = gin.Params{
-			{Key: "repoName", Value: memberName},
-			{Key: "path", Value: filePath},
-		}
-
-		handler.ServeHTTP(sub)
+		rec := h.callMember(c, ctx, memberName, filePath, handler)
 
 		code := rec.Code
 		if code == 0 {
@@ -124,6 +123,90 @@ func (h *Handler) serveGet(c *gin.Context) {
 	c.JSON(http.StatusNotFound, gin.H{
 		"error": fmt.Sprintf("artifact not found in any member of group %q", repoName),
 	})
+}
+
+// eligibleMember resolves a member repo eligible for fan-out: online,
+// not a nested group, and format-matched to the group. Returns nil otherwise.
+func (h *Handler) eligibleMember(ctx context.Context, memberName string, groupDef *domain.Repository) *domain.Repository {
+	memberRepo, err := h.deps.Repos.Get(ctx, memberName)
+	if err != nil || memberRepo == nil || !memberRepo.Online {
+		return nil
+	}
+	if memberRepo.Type == domain.TypeGroup {
+		return nil
+	}
+	if string(memberRepo.Format) != string(groupDef.Format) {
+		return nil
+	}
+	return memberRepo
+}
+
+// callMember invokes a member's format handler on a cloned request/recorder.
+func (h *Handler) callMember(c *gin.Context, ctx context.Context, memberName, filePath string, handler formats.FormatHandler) *httptest.ResponseRecorder {
+	rec := httptest.NewRecorder()
+	sub, _ := gin.CreateTestContext(rec)
+	sub.Request = c.Request.Clone(ctx)
+	sub.Params = gin.Params{
+		{Key: "repoName", Value: memberName},
+		{Key: "path", Value: filePath},
+	}
+	handler.ServeHTTP(sub)
+	sub.Writer.WriteHeaderNow() // flush buffered status to rec.Code
+	return rec
+}
+
+// serveMergedIndex fans an index request out to every eligible member on the
+// merger's source path, collects the 2xx bodies (member order preserved,
+// failing members skipped so the group survives a down upstream), and serves
+// the merged document. A merge failure degrades to the first member body —
+// never a 500 for a merge bug.
+func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, members []string,
+	rule *domain.RoutingRule, merger formats.GroupIndexMerger, source, requestPath string,
+) {
+	ctx := c.Request.Context()
+
+	var parts []formats.GroupIndexPart
+	var contributing []string
+	for _, memberName := range members {
+		if !service.Allow(rule, source) {
+			continue
+		}
+		memberRepo := h.eligibleMember(ctx, memberName, repoDef)
+		if memberRepo == nil {
+			continue
+		}
+		handler, ok := h.formatRegistry[string(memberRepo.Format)]
+		if !ok {
+			continue
+		}
+
+		rec := h.callMember(c, ctx, memberName, source, handler)
+		code := rec.Code
+		if code == 0 {
+			code = http.StatusOK
+		}
+		if code < 200 || code > 299 {
+			continue
+		}
+		parts = append(parts, formats.GroupIndexPart{Member: memberName, Body: rec.Body.Bytes()})
+		contributing = append(contributing, memberName)
+	}
+
+	if len(parts) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": fmt.Sprintf("index not found in any member of group %q", repoDef.Name),
+		})
+		return
+	}
+
+	c.Writer.Header().Set("X-Nexspence-Source", strings.Join(contributing, ","))
+	body, contentType, err := merger.MergeGroupIndex(repoDef.Name, requestPath, parts)
+	if err != nil {
+		// Degrade to the first member's document rather than failing the group.
+		c.Data(http.StatusOK, "application/octet-stream", parts[0].Body)
+		return
+	}
+	c.Data(http.StatusOK, contentType, body)
 }
 
 func (h *Handler) serveWrite(c *gin.Context) {

--- a/internal/formats/group/merge_maven_test.go
+++ b/internal/formats/group/merge_maven_test.go
@@ -1,0 +1,84 @@
+package group_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/formats/maven"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// End-to-end через реальный maven handler: metadata из двух hosted членов
+// мержится, latest пересчитывается, checksum считается от merged-документа.
+func TestGroupMerge_MavenEndToEnd(t *testing.T) {
+	m1 := testutil.SimpleRepo("mv1", "maven2")
+	m2 := testutil.SimpleRepo("mv2", "maven2")
+	g := &domain.Repository{
+		ID: "repo-mvg", Name: "mvg", Format: "maven2",
+		Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": []interface{}{"mv1", "mv2"}},
+	}
+
+	repoRepo := testutil.NewRepoRepo(m1, m2, g)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	mavenH := maven.New(d)
+	registry := map[string]formats.FormatHandler{"maven2": mavenH}
+	groupH := group.New(d, registry)
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		mavenH.ServeHTTP(c)
+	})
+
+	put := func(repoName, p, body string) {
+		req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+p, strings.NewReader(body))
+		req.ContentLength = int64(len(body))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Contains(t, []int{http.StatusCreated, http.StatusOK}, w.Code)
+	}
+
+	meta := func(versions ...string) string {
+		s := "<metadata><groupId>com.x</groupId><artifactId>lib</artifactId><versioning><versions>"
+		for _, v := range versions {
+			s += "<version>" + v + "</version>"
+		}
+		return s + "</versions></versioning></metadata>"
+	}
+	put("mv1", "/com/x/lib/maven-metadata.xml", meta("1.0"))
+	put("mv2", "/com/x/lib/maven-metadata.xml", meta("2.0"))
+
+	w := get(r, "/repository/mvg/com/x/lib/maven-metadata.xml")
+	assert.Equal(t, http.StatusOK, w.Code)
+	out := w.Body.String()
+	assert.Contains(t, out, "<version>1.0</version>")
+	assert.Contains(t, out, "<version>2.0</version>")
+	assert.Contains(t, out, "<latest>2.0</latest>")
+	assert.Equal(t, "mv1,mv2", w.Header().Get("X-Nexspence-Source"))
+
+	// Checksum of the MERGED doc, not any member's copy (40 hex chars).
+	ws := get(r, "/repository/mvg/com/x/lib/maven-metadata.xml.sha1")
+	assert.Equal(t, http.StatusOK, ws.Code)
+	assert.Len(t, strings.TrimSpace(ws.Body.String()), 40)
+}

--- a/internal/formats/group/merge_test.go
+++ b/internal/formats/group/merge_test.go
@@ -1,0 +1,193 @@
+package group_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// mergeFmt is a fake format handler implementing formats.GroupIndexMerger.
+// Members serve "<member-body>" at /index (from FormatConfig["body"]) and 404
+// elsewhere; the merger concatenates parts as "member=body;".
+type mergeFmt struct {
+	deps     formats.Deps
+	failWith error // when non-nil, MergeGroupIndex fails
+}
+
+func (m *mergeFmt) Name() string { return "mergefmt" }
+
+func (m *mergeFmt) ServeHTTP(c *gin.Context) {
+	repoName := c.Param("repoName")
+	p := c.Param("path")
+	repo, _ := m.deps.Repos.Get(c.Request.Context(), repoName)
+	if p == "/index" && repo != nil {
+		body, _ := repo.FormatConfig["body"].(string)
+		if body == "FAIL" {
+			c.String(http.StatusBadGateway, "upstream down")
+			return
+		}
+		// An empty body still returns 200 — models the 200-on-empty
+		// shadowing formats (pypi simple, nuget version list).
+		c.String(http.StatusOK, body)
+		return
+	}
+	c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+}
+
+func (m *mergeFmt) GroupIndexSourcePath(path string) (string, bool) {
+	if path == "/index" || path == "/index.sha1" {
+		return "/index", true
+	}
+	return "", false
+}
+
+func (m *mergeFmt) MergeGroupIndex(groupName, path string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	if m.failWith != nil {
+		return nil, "", m.failWith
+	}
+	var sb strings.Builder
+	for _, p := range parts {
+		fmt.Fprintf(&sb, "%s=%s;", p.Member, p.Body)
+	}
+	if path == "/index.sha1" {
+		return []byte("sha1(" + sb.String() + ")"), "text/plain", nil
+	}
+	return []byte(sb.String()), "text/merged", nil
+}
+
+func mergeMember(name, body string) *domain.Repository {
+	return &domain.Repository{
+		ID: "repo-" + name, Name: name, Format: "mergefmt",
+		Type: domain.TypeHosted, Online: true,
+		FormatConfig: map[string]any{"body": body},
+	}
+}
+
+func mergeGroup(name string, members ...string) *domain.Repository {
+	ms := make([]interface{}, len(members))
+	for i, m := range members {
+		ms[i] = m
+	}
+	return &domain.Repository{
+		ID: "repo-" + name, Name: name, Format: "mergefmt",
+		Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": ms},
+	}
+}
+
+func buildMergeEngine(failWith error, repos ...*domain.Repository) *gin.Engine {
+	repoRepo := testutil.NewRepoRepo(repos...)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	mh := &mergeFmt{deps: d, failWith: failWith}
+	registry := map[string]formats.FormatHandler{"mergefmt": mh}
+	groupH := group.New(d, registry)
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		mh.ServeHTTP(c)
+	})
+	return r
+}
+
+func get(r *gin.Engine, url string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestGroupMerge_UnionAcrossMembers(t *testing.T) {
+	r := buildMergeEngine(nil,
+		mergeGroup("g", "m1", "m2"),
+		mergeMember("m1", "aaa"), mergeMember("m2", "bbb"))
+
+	w := get(r, "/repository/g/index")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "m1=aaa;m2=bbb;", w.Body.String())
+	assert.Equal(t, "text/merged", w.Header().Get("Content-Type"))
+	assert.Equal(t, "m1,m2", w.Header().Get("X-Nexspence-Source"))
+}
+
+func TestGroupMerge_EmptyMemberDoesNotShadow(t *testing.T) {
+	// The 200-on-empty member must not stop the fan-out (#99 shadowing).
+	r := buildMergeEngine(nil,
+		mergeGroup("g2", "empty", "full"),
+		mergeMember("empty", ""), mergeMember("full", "pkg"))
+
+	w := get(r, "/repository/g2/index")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "full=pkg;")
+}
+
+func TestGroupMerge_FailingMemberSkipped(t *testing.T) {
+	r := buildMergeEngine(nil,
+		mergeGroup("g3", "down", "ok"),
+		mergeMember("down", "FAIL"), mergeMember("ok", "xyz"))
+
+	w := get(r, "/repository/g3/index")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "ok=xyz;", w.Body.String())
+	assert.Equal(t, "ok", w.Header().Get("X-Nexspence-Source"))
+}
+
+func TestGroupMerge_SourcePathMapping(t *testing.T) {
+	// /index.sha1 fans out on /index and returns the merged checksum doc.
+	r := buildMergeEngine(nil,
+		mergeGroup("g4", "m1", "m2"),
+		mergeMember("m1", "a"), mergeMember("m2", "b"))
+
+	w := get(r, "/repository/g4/index.sha1")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "sha1(m1=a;m2=b;)", w.Body.String())
+}
+
+func TestGroupMerge_AllMiss404(t *testing.T) {
+	r := buildMergeEngine(nil,
+		mergeGroup("g5", "down1", "down2"),
+		mergeMember("down1", "FAIL"), mergeMember("down2", "FAIL"))
+
+	w := get(r, "/repository/g5/index")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGroupMerge_MergeErrorServesFirstPart(t *testing.T) {
+	r := buildMergeEngine(fmt.Errorf("boom"),
+		mergeGroup("g6", "m1", "m2"),
+		mergeMember("m1", "first"), mergeMember("m2", "second"))
+
+	w := get(r, "/repository/g6/index")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "first", w.Body.String(), "merge failure degrades to the first member body")
+}
+
+func TestGroupMerge_NonIndexPathKeepsFirstNon404(t *testing.T) {
+	// Artifact paths keep the lazy first-non-404 behavior.
+	r := buildMergeEngine(nil,
+		mergeGroup("g7", "m1", "m2"),
+		mergeMember("m1", "a"), mergeMember("m2", "b"))
+
+	w := get(r, "/repository/g7/some/artifact.bin")
+	assert.Equal(t, http.StatusNotFound, w.Code) // members 404 everything but /index
+}

--- a/internal/formats/group_merge.go
+++ b/internal/formats/group_merge.go
@@ -1,0 +1,24 @@
+package formats
+
+// GroupIndexPart is one member's successful index response, in member order.
+type GroupIndexPart struct {
+	Member string // member repo name — used to rewrite member URLs to the group
+	Body   []byte
+}
+
+// GroupIndexMerger is optionally implemented by format handlers whose index
+// documents must be merged across group members (#99). Without it, the group
+// layer returns the first non-404 member response — correct for artifacts,
+// wrong for aggregated indexes (only one member's content is visible, and
+// formats whose "not found" is an empty 200 shadow every member after them).
+type GroupIndexMerger interface {
+	// GroupIndexSourcePath maps a requested path to the member path whose
+	// bodies feed the merge, and reports whether path is a mergeable index.
+	// Usually source == path; maven checksum paths (.sha1/.md5/.sha256) map
+	// to maven-metadata.xml itself so the checksum is computed over the
+	// MERGED document.
+	GroupIndexSourcePath(path string) (source string, ok bool)
+	// MergeGroupIndex merges member bodies (member order = priority, first
+	// wins on conflict) into one document rooted at the group's URL.
+	MergeGroupIndex(groupName, path string, parts []GroupIndexPart) (body []byte, contentType string, err error)
+}

--- a/internal/formats/maven/groupindex.go
+++ b/internal/formats/maven/groupindex.go
@@ -1,0 +1,151 @@
+package maven
+
+// Group index merging (#99): maven-metadata.xml is merged across group
+// members — a single member's copy hides versions held by the others and
+// breaks LATEST/RELEASE/version-range resolution. Checksum sidecars are
+// computed over the MERGED document via GroupIndexSourcePath.
+
+import (
+	"crypto/md5"  //nolint:gosec // maven protocol checksum, not security
+	"crypto/sha1" //nolint:gosec // maven protocol checksum, not security
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+const metadataFile = "maven-metadata.xml"
+
+// mavenMetadata mirrors the maven-metadata.xml structure we merge.
+type mavenMetadata struct {
+	XMLName    xml.Name `xml:"metadata"`
+	GroupID    string   `xml:"groupId"`
+	ArtifactID string   `xml:"artifactId"`
+	Versioning struct {
+		Latest      string   `xml:"latest,omitempty"`
+		Release     string   `xml:"release,omitempty"`
+		Versions    []string `xml:"versions>version"`
+		LastUpdated string   `xml:"lastUpdated,omitempty"`
+	} `xml:"versioning"`
+}
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	base := path.Base(p)
+	if base == metadataFile {
+		return p, true
+	}
+	for _, ext := range []string{".sha1", ".md5", ".sha256"} {
+		if base == metadataFile+ext {
+			return strings.TrimSuffix(p, ext), true
+		}
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	merged := mavenMetadata{}
+	seen := map[string]bool{}
+	for _, part := range parts {
+		var m mavenMetadata
+		if err := xml.Unmarshal(part.Body, &m); err != nil {
+			continue // malformed member copy — merge the rest
+		}
+		if merged.GroupID == "" {
+			merged.GroupID, merged.ArtifactID = m.GroupID, m.ArtifactID
+		}
+		for _, v := range m.Versioning.Versions {
+			if !seen[v] {
+				seen[v] = true
+				merged.Versioning.Versions = append(merged.Versioning.Versions, v)
+			}
+		}
+		if m.Versioning.LastUpdated > merged.Versioning.LastUpdated {
+			merged.Versioning.LastUpdated = m.Versioning.LastUpdated
+		}
+	}
+	if len(merged.Versioning.Versions) == 0 && merged.GroupID == "" {
+		return nil, "", fmt.Errorf("maven group merge: no parsable maven-metadata.xml among %d members", len(parts))
+	}
+
+	// latest/release are recomputed over the union — taking any single
+	// member's value would hide newer versions held by other members.
+	for _, v := range merged.Versioning.Versions {
+		if compareVersions(v, merged.Versioning.Latest) > 0 {
+			merged.Versioning.Latest = v
+		}
+		if !strings.Contains(strings.ToUpper(v), "SNAPSHOT") &&
+			compareVersions(v, merged.Versioning.Release) > 0 {
+			merged.Versioning.Release = v
+		}
+	}
+
+	out, err := xml.Marshal(merged)
+	if err != nil {
+		return nil, "", err
+	}
+	doc := append([]byte(xml.Header), out...)
+
+	switch path.Ext(path.Base(p)) {
+	case ".sha1":
+		return []byte(fmt.Sprintf("%x", sha1.Sum(doc))), "text/plain", nil //nolint:gosec
+	case ".md5":
+		return []byte(fmt.Sprintf("%x", md5.Sum(doc))), "text/plain", nil //nolint:gosec
+	case ".sha256":
+		return []byte(fmt.Sprintf("%x", sha256.Sum256(doc))), "text/plain", nil
+	}
+	return doc, "application/xml", nil
+}
+
+// compareVersions orders maven-ish version strings: dot/dash-split segments,
+// numeric segments compare numerically, otherwise lexicographically. An empty
+// string sorts first. Good enough for latest/release selection; not a full
+// maven ComparableVersion implementation.
+func compareVersions(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return -1
+	}
+	if b == "" {
+		return 1
+	}
+	split := func(s string) []string {
+		return strings.FieldsFunc(s, func(r rune) bool { return r == '.' || r == '-' })
+	}
+	as, bs := split(a), split(b)
+	for i := 0; i < len(as) && i < len(bs); i++ {
+		an, aErr := strconv.Atoi(as[i])
+		bn, bErr := strconv.Atoi(bs[i])
+		switch {
+		case aErr == nil && bErr == nil:
+			if an != bn {
+				if an < bn {
+					return -1
+				}
+				return 1
+			}
+		case aErr == nil: // numeric beats qualifier ("1.0" > "1.0-SNAPSHOT" segment-wise)
+			return 1
+		case bErr == nil:
+			return -1
+		default:
+			if c := strings.Compare(as[i], bs[i]); c != 0 {
+				return c
+			}
+		}
+	}
+	switch {
+	case len(as) < len(bs):
+		return -1
+	case len(as) > len(bs):
+		return 1
+	}
+	return 0
+}

--- a/internal/formats/maven/groupindex_test.go
+++ b/internal/formats/maven/groupindex_test.go
@@ -1,0 +1,110 @@
+package maven_test
+
+import (
+	"crypto/sha1" //nolint:gosec // maven protocol checksum
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/maven"
+)
+
+func metadataXML(latest, release string, versions ...string) []byte {
+	s := "<metadata><groupId>com.foo</groupId><artifactId>bar</artifactId><versioning>"
+	if latest != "" {
+		s += "<latest>" + latest + "</latest>"
+	}
+	if release != "" {
+		s += "<release>" + release + "</release>"
+	}
+	s += "<versions>"
+	for _, v := range versions {
+		s += "<version>" + v + "</version>"
+	}
+	s += "</versions><lastUpdated>20240101000000</lastUpdated></versioning></metadata>"
+	return []byte(s)
+}
+
+func TestMaven_GroupIndexSourcePath(t *testing.T) {
+	h := maven.New(formats.Deps{})
+
+	src, ok := h.GroupIndexSourcePath("/com/foo/bar/maven-metadata.xml")
+	require.True(t, ok)
+	assert.Equal(t, "/com/foo/bar/maven-metadata.xml", src)
+
+	// Checksum paths feed off the base metadata document (#99: the checksum
+	// must be computed over the MERGED doc, not any single member's copy).
+	src, ok = h.GroupIndexSourcePath("/com/foo/bar/maven-metadata.xml.sha1")
+	require.True(t, ok)
+	assert.Equal(t, "/com/foo/bar/maven-metadata.xml", src)
+
+	_, ok = h.GroupIndexSourcePath("/com/foo/bar/1.0/bar-1.0.jar")
+	assert.False(t, ok)
+	_, ok = h.GroupIndexSourcePath("/com/foo/bar/1.0/bar-1.0.jar.sha1")
+	assert.False(t, ok)
+}
+
+func TestMaven_MergeGroupIndex_UnionsVersions(t *testing.T) {
+	h := maven.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: metadataXML("1.0", "1.0", "0.9", "1.0")},
+		{Member: "m2", Body: metadataXML("2.0", "2.0", "1.0", "2.0")},
+	}
+
+	body, ct, err := h.MergeGroupIndex("g", "/com/foo/bar/maven-metadata.xml", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "xml")
+	out := string(body)
+	assert.Contains(t, out, "<version>0.9</version>")
+	assert.Contains(t, out, "<version>1.0</version>")
+	assert.Contains(t, out, "<version>2.0</version>")
+	// latest/release recomputed over the union — m2's 2.0 must win even
+	// though m1 is first.
+	assert.Contains(t, out, "<latest>2.0</latest>")
+	assert.Contains(t, out, "<release>2.0</release>")
+	assert.Contains(t, out, "<groupId>com.foo</groupId>")
+}
+
+func TestMaven_MergeGroupIndex_ReleaseSkipsSnapshots(t *testing.T) {
+	h := maven.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: metadataXML("1.0", "1.0", "1.0")},
+		{Member: "m2", Body: metadataXML("2.0-SNAPSHOT", "", "2.0-SNAPSHOT")},
+	}
+
+	body, _, err := h.MergeGroupIndex("g", "/x/maven-metadata.xml", parts)
+	require.NoError(t, err)
+	out := string(body)
+	assert.Contains(t, out, "<latest>2.0-SNAPSHOT</latest>")
+	assert.Contains(t, out, "<release>1.0</release>", "release must skip SNAPSHOT versions")
+}
+
+func TestMaven_MergeGroupIndex_ChecksumOfMergedDoc(t *testing.T) {
+	h := maven.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: metadataXML("1.0", "1.0", "1.0")},
+		{Member: "m2", Body: metadataXML("2.0", "2.0", "2.0")},
+	}
+
+	merged, _, err := h.MergeGroupIndex("g", "/x/maven-metadata.xml", parts)
+	require.NoError(t, err)
+	sum, ct, err := h.MergeGroupIndex("g", "/x/maven-metadata.xml.sha1", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "text/plain")
+	assert.Equal(t, fmt.Sprintf("%x", sha1.Sum(merged)), string(sum)) //nolint:gosec
+}
+
+func TestMaven_MergeGroupIndex_MalformedPartSkipped(t *testing.T) {
+	h := maven.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "bad", Body: []byte("not xml")},
+		{Member: "ok", Body: metadataXML("1.0", "1.0", "1.0")},
+	}
+
+	body, _, err := h.MergeGroupIndex("g", "/x/maven-metadata.xml", parts)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "<version>1.0</version>")
+}

--- a/internal/formats/npm/groupindex.go
+++ b/internal/formats/npm/groupindex.go
@@ -1,0 +1,117 @@
+package npm
+
+// Group index merging (#99): the packument is merged across group members —
+// a single member's copy hides versions held by the others. Member order is
+// the priority contract: first member wins per version key and per dist-tag.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger. Any GET path that
+// is not the repo root, a tarball, or a /-/ API path is a packument request.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if p == "/" || p == "" || strings.Contains(p, "/-/") || strings.HasPrefix(p, "/-") {
+		return "", false
+	}
+	return p, true
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(groupName, _ string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	groupBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + groupName
+
+	merged := map[string]any{}
+	versions := map[string]any{}
+	distTags := map[string]any{}
+	times := map[string]any{}
+
+	for _, part := range parts {
+		var doc map[string]any
+		if err := json.Unmarshal(part.Body, &doc); err != nil {
+			continue // malformed member copy — merge the rest
+		}
+		// Scalar fields (name, description, …): first member wins.
+		for k, v := range doc {
+			switch k {
+			case "versions", "dist-tags", "time":
+			default:
+				if _, seen := merged[k]; !seen {
+					merged[k] = v
+				}
+			}
+		}
+		if vs, ok := doc["versions"].(map[string]any); ok {
+			for ver, vdoc := range vs {
+				if _, seen := versions[ver]; seen {
+					continue // first member wins per version
+				}
+				rewriteVersionTarball(vdoc, part.Member, groupBase)
+				versions[ver] = vdoc
+			}
+		}
+		if tags, ok := doc["dist-tags"].(map[string]any); ok {
+			for tag, v := range tags {
+				if _, seen := distTags[tag]; !seen {
+					distTags[tag] = v // first member wins per tag
+				}
+			}
+		}
+		if tm, ok := doc["time"].(map[string]any); ok {
+			for k, v := range tm {
+				if _, seen := times[k]; !seen {
+					times[k] = v
+				}
+			}
+		}
+	}
+
+	if len(versions) == 0 && len(merged) == 0 {
+		return nil, "", fmt.Errorf("npm group merge: no parsable packument among %d members", len(parts))
+	}
+
+	merged["versions"] = versions
+	if len(distTags) > 0 {
+		merged["dist-tags"] = distTags
+	}
+	if len(times) > 0 {
+		merged["time"] = times
+	}
+
+	out, err := json.Marshal(merged)
+	if err != nil {
+		return nil, "", err
+	}
+	return out, "application/json", nil
+}
+
+// rewriteVersionTarball re-roots a version's dist.tarball from the member
+// repo at the group: the member handler minted a /repository/<member>/ URL,
+// which would steer the client off the group (and its RBAC).
+func rewriteVersionTarball(vdoc any, member, groupBase string) {
+	ver, ok := vdoc.(map[string]any)
+	if !ok {
+		return
+	}
+	dist, ok := ver["dist"].(map[string]any)
+	if !ok {
+		return
+	}
+	tb, ok := dist["tarball"].(string)
+	if !ok || tb == "" {
+		return
+	}
+	u, err := url.Parse(tb)
+	if err != nil {
+		return
+	}
+	memberPrefix := "/repository/" + member
+	if tail, found := strings.CutPrefix(u.Path, memberPrefix); found {
+		dist["tarball"] = groupBase + tail
+	}
+}

--- a/internal/formats/npm/groupindex_test.go
+++ b/internal/formats/npm/groupindex_test.go
@@ -1,0 +1,79 @@
+package npm_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/npm"
+)
+
+func TestNPM_GroupIndexSourcePath(t *testing.T) {
+	h := npm.New(formats.Deps{})
+
+	src, ok := h.GroupIndexSourcePath("/lodash")
+	require.True(t, ok)
+	assert.Equal(t, "/lodash", src)
+
+	_, ok = h.GroupIndexSourcePath("/@babel/core")
+	assert.True(t, ok, "scoped packuments are indexes too")
+
+	_, ok = h.GroupIndexSourcePath("/lodash/-/lodash-4.17.21.tgz")
+	assert.False(t, ok, "tarballs keep first-non-404")
+	_, ok = h.GroupIndexSourcePath("/-/package/lodash/dist-tags")
+	assert.False(t, ok, "dist-tags API keeps first-non-404")
+	_, ok = h.GroupIndexSourcePath("/")
+	assert.False(t, ok, "repo root is not a packument")
+}
+
+func TestNPM_MergeGroupIndex_UnionsVersionsAndRewritesTarballs(t *testing.T) {
+	deps := formats.Deps{BaseURL: "http://localhost:8080"}
+	h := npm.New(deps)
+
+	m1 := []byte(`{"name":"lp","dist-tags":{"latest":"1.0.0"},"versions":{
+		"1.0.0":{"dist":{"tarball":"http://localhost:8080/repository/m1/lp/-/lp-1.0.0.tgz"}}}}`)
+	m2 := []byte(`{"name":"lp","dist-tags":{"latest":"2.0.0","beta":"2.1.0-beta"},"versions":{
+		"1.0.0":{"dist":{"tarball":"http://localhost:8080/repository/m2/lp/-/lp-1.0.0.tgz"},"m2marker":true},
+		"2.0.0":{"dist":{"tarball":"http://localhost:8080/repository/m2/lp/-/lp-2.0.0.tgz"}}}}`)
+
+	body, ct, err := h.MergeGroupIndex("npm-group", "/lp", []formats.GroupIndexPart{
+		{Member: "m1", Body: m1}, {Member: "m2", Body: m2},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "json")
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(body, &doc))
+	versions := doc["versions"].(map[string]any)
+	require.Len(t, versions, 2)
+
+	// First member wins per version key: 1.0.0 comes from m1 (no m2marker).
+	v1 := versions["1.0.0"].(map[string]any)
+	assert.Nil(t, v1["m2marker"], "member order = priority; m1's 1.0.0 must win")
+	// Union brings in m2's 2.0.0.
+	v2 := versions["2.0.0"].(map[string]any)
+
+	// Every tarball is re-rooted at the GROUP, never a member.
+	tb1 := v1["dist"].(map[string]any)["tarball"].(string)
+	tb2 := v2["dist"].(map[string]any)["tarball"].(string)
+	assert.Equal(t, "http://localhost:8080/repository/npm-group/lp/-/lp-1.0.0.tgz", tb1)
+	assert.Equal(t, "http://localhost:8080/repository/npm-group/lp/-/lp-2.0.0.tgz", tb2)
+
+	// dist-tags: first member wins per tag; m2 contributes its unique tag.
+	tags := doc["dist-tags"].(map[string]any)
+	assert.Equal(t, "1.0.0", tags["latest"], "m1 is first — its latest wins")
+	assert.Equal(t, "2.1.0-beta", tags["beta"])
+}
+
+func TestNPM_MergeGroupIndex_MalformedPartSkipped(t *testing.T) {
+	h := npm.New(formats.Deps{BaseURL: "http://x"})
+	body, _, err := h.MergeGroupIndex("g", "/p", []formats.GroupIndexPart{
+		{Member: "bad", Body: []byte("<html>")},
+		{Member: "ok", Body: []byte(`{"name":"p","versions":{"1.0.0":{}}}`)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"1.0.0"`)
+}

--- a/internal/formats/pypi/groupindex.go
+++ b/internal/formats/pypi/groupindex.go
@@ -1,0 +1,64 @@
+package pypi
+
+// Group index merging (#99): PEP 503 simple pages are merged across group
+// members. Hosted pypi members answer 200 with an empty link list for unknown
+// packages, which under first-non-404 fan-out shadowed every member behind
+// them; merging makes the empty page just an anchor-less contribution.
+
+import (
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// anchorRe extracts <a href="...">text</a> pairs from PEP 503 pages
+// (machine-generated anchor lists, so regex extraction is safe).
+var anchorRe = regexp.MustCompile(`<a\s+href="([^"]+)"[^>]*>([^<]+)</a>`)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if p == "/simple" || strings.HasPrefix(p, "/simple/") {
+		return p, true
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(groupName, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	groupBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + groupName
+
+	type anchor struct{ href, text string }
+	var anchors []anchor
+	seen := map[string]bool{}
+
+	for _, part := range parts {
+		memberPrefix := "/repository/" + part.Member
+		for _, m := range anchorRe.FindAllStringSubmatch(string(part.Body), -1) {
+			href, text := m[1], strings.TrimSpace(m[2])
+			if seen[text] {
+				continue // first member wins per filename/package name
+			}
+			seen[text] = true
+			// Re-root member URLs at the group; leave anything else as-is.
+			if i := strings.Index(href, memberPrefix); i >= 0 {
+				href = groupBase + href[i+len(memberPrefix):]
+			}
+			anchors = append(anchors, anchor{href: href, text: text})
+		}
+	}
+
+	title := "Links for " + path.Base(p)
+	if p == "/simple" {
+		title = "Simple index"
+	}
+	var sb strings.Builder
+	sb.WriteString("<!DOCTYPE html><html><head><title>" + title + "</title></head><body><h1>" + title + "</h1>\n")
+	for _, a := range anchors {
+		fmt.Fprintf(&sb, `<a href="%s">%s</a><br/>`+"\n", a.href, a.text)
+	}
+	sb.WriteString("</body></html>\n")
+	return []byte(sb.String()), "text/html; charset=utf-8", nil
+}

--- a/internal/formats/pypi/groupindex_test.go
+++ b/internal/formats/pypi/groupindex_test.go
@@ -1,0 +1,68 @@
+package pypi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/pypi"
+)
+
+func TestPyPI_GroupIndexSourcePath(t *testing.T) {
+	h := pypi.New(formats.Deps{})
+
+	_, ok := h.GroupIndexSourcePath("/simple")
+	assert.True(t, ok)
+	src, ok := h.GroupIndexSourcePath("/simple/requests")
+	require.True(t, ok)
+	assert.Equal(t, "/simple/requests", src)
+
+	_, ok = h.GroupIndexSourcePath("/packages/ab/cd/requests-2.31.0.whl")
+	assert.False(t, ok, "release files keep first-non-404")
+}
+
+func TestPyPI_MergeGroupIndex_UnionsAnchors(t *testing.T) {
+	h := pypi.New(formats.Deps{BaseURL: "http://localhost:8080"})
+
+	m1 := []byte(`<html><body><h1>Links for pkg</h1>
+<a href="http://localhost:8080/repository/m1/packages/aa/pkg-1.0.whl#sha256=aaa">pkg-1.0.whl</a>
+</body></html>`)
+	m2 := []byte(`<html><body><h1>Links for pkg</h1>
+<a href="http://localhost:8080/repository/m2/packages/bb/pkg-1.0.whl#sha256=OTHER">pkg-1.0.whl</a>
+<a href="http://localhost:8080/repository/m2/packages/cc/pkg-2.0.whl#sha256=ccc">pkg-2.0.whl</a>
+</body></html>`)
+
+	body, ct, err := h.MergeGroupIndex("py-group", "/simple/pkg", []formats.GroupIndexPart{
+		{Member: "m1", Body: m1}, {Member: "m2", Body: m2},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "text/html")
+	out := string(body)
+
+	// Union with first-member priority on duplicate filenames.
+	assert.Contains(t, out, "http://localhost:8080/repository/py-group/packages/aa/pkg-1.0.whl#sha256=aaa")
+	assert.NotContains(t, out, "sha256=OTHER", "m1's pkg-1.0.whl must win")
+	assert.Contains(t, out, "http://localhost:8080/repository/py-group/packages/cc/pkg-2.0.whl#sha256=ccc")
+	// No member URLs leak.
+	assert.NotContains(t, out, "/repository/m1/")
+	assert.NotContains(t, out, "/repository/m2/")
+}
+
+func TestPyPI_MergeGroupIndex_EmptyPartContributesNothing(t *testing.T) {
+	// The 200-on-empty page (#99 shadowing) is just an anchor-less part.
+	h := pypi.New(formats.Deps{BaseURL: "http://localhost:8080"})
+
+	empty := []byte(`<html><body><h1>Links for pkg</h1></body></html>`)
+	full := []byte(`<html><body><h1>Links for pkg</h1>
+<a href="http://localhost:8080/repository/full/packages/dd/pkg-3.0.whl">pkg-3.0.whl</a>
+</body></html>`)
+
+	body, _, err := h.MergeGroupIndex("g", "/simple/pkg", []formats.GroupIndexPart{
+		{Member: "empty", Body: empty}, {Member: "full", Body: full},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "pkg-3.0.whl")
+	assert.Contains(t, string(body), "/repository/g/packages/dd/pkg-3.0.whl")
+}


### PR DESCRIPTION
Part of #99 (Phase 1 — infrastructure + maven/npm/pypi; Phase 2 covers apt/yum/conda/nuget/gomod/terraform).

## Problem
The group layer returned the first non-404 member response for everything. For index documents that meant: only one member's index was visible; formats whose "not found" is an empty 200 (pypi simple) shadowed every member behind them; member-built indexes embedded `/repository/<member>/` URLs that steered clients off the group.

## Design (spec: docs/superpowers/specs/2026-07-26-group-index-merge-design.md)
New optional interface `formats.GroupIndexMerger` implemented by format handlers:
- `GroupIndexSourcePath(path)` — is this a mergeable index (maven checksum paths map to the base metadata so the checksum is computed over the MERGED doc);
- `MergeGroupIndex(group, path, parts)` — merge member bodies, member order = priority, URLs re-rooted at the group.

`group.serveGet` fans index requests out to ALL members, collects 2xx bodies, merges. Failing members are skipped (group survives a down upstream); merge errors degrade to the first member body. Artifact paths keep lazy first-non-404.

## Mergers
- **maven** `maven-metadata.xml` (+ .sha1/.md5/.sha256): versions union, latest/release recomputed over the union (release skips SNAPSHOTs), checksums over the merged doc.
- **npm** packument: versions/dist-tags/time union (first wins per key), every `dist.tarball` re-rooted at the group.
- **pypi** `/simple[/pkg]`: anchors union (first wins per filename), PEP 503 page, hrefs re-rooted. Kills the empty-200 shadowing.

TDD: 18 new tests (group fan-out with a fake merger, per-format pure-func units, maven end-to-end through a real group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk