### PR TITLE
fix(group): merge indexes for apt/yum/conda/nuget/gomod/terraform (phase 2)

### DIFF
--- a/internal/formats/apt/groupindex.go
+++ b/internal/formats/apt/groupindex.go
@@ -1,0 +1,73 @@
+package apt
+
+// Group index merging (#99 phase 2): the Packages index answers 200-empty
+// for members without matching debs, shadowing later members under
+// first-non-404 fan-out, and a single member's index hides the others'
+// packages. Stanzas are unioned, deduped by Filename. Release/InRelease
+// are generated boilerplate (no member URLs) and stay on plain fan-out.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger. The .gz flavor
+// fans out on the PLAIN document — members serve plain text, the merger
+// gzips the merged result.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if !strings.HasPrefix(p, "/dists/") || !strings.Contains(p, "/Packages") {
+		return "", false
+	}
+	return strings.TrimSuffix(p, ".gz"), true
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	var stanzas []string
+	seen := map[string]bool{}
+	for _, part := range parts {
+		for _, stanza := range strings.Split(strings.TrimSpace(string(part.Body)), "\n\n") {
+			stanza = strings.TrimSpace(stanza)
+			if stanza == "" {
+				continue
+			}
+			key := stanzaFilename(stanza)
+			if key != "" && seen[key] {
+				continue // first member wins per Filename
+			}
+			if key != "" {
+				seen[key] = true
+			}
+			stanzas = append(stanzas, stanza)
+		}
+	}
+
+	var sb strings.Builder
+	for _, s := range stanzas {
+		sb.WriteString(s)
+		sb.WriteString("\n\n")
+	}
+	plain := []byte(sb.String())
+
+	if strings.HasSuffix(p, ".gz") {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, _ = gw.Write(plain)
+		_ = gw.Close()
+		return buf.Bytes(), "application/x-gzip", nil
+	}
+	return plain, "text/plain; charset=utf-8", nil
+}
+
+// stanzaFilename extracts the Filename: field used as the dedup key.
+func stanzaFilename(stanza string) string {
+	for _, line := range strings.Split(stanza, "\n") {
+		if strings.HasPrefix(line, "Filename:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "Filename:"))
+		}
+	}
+	return ""
+}

--- a/internal/formats/apt/groupindex_test.go
+++ b/internal/formats/apt/groupindex_test.go
@@ -1,0 +1,79 @@
+package apt_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/apt"
+)
+
+const (
+	stanzaCurl  = "Package: curl\nVersion: 8.0.0\nFilename: /pool/main/c/curl/curl_8.0.0_amd64.deb\n"
+	stanzaNginx = "Package: nginx\nVersion: 1.25.0\nFilename: /pool/main/n/nginx/nginx_1.25.0_amd64.deb\n"
+)
+
+func TestApt_GroupIndexSourcePath(t *testing.T) {
+	h := apt.New(formats.Deps{})
+
+	src, ok := h.GroupIndexSourcePath("/dists/focal/main/binary-amd64/Packages")
+	require.True(t, ok)
+	assert.Equal(t, "/dists/focal/main/binary-amd64/Packages", src)
+
+	// .gz fans out on the PLAIN document; the merger gzips the result.
+	src, ok = h.GroupIndexSourcePath("/dists/focal/main/binary-amd64/Packages.gz")
+	require.True(t, ok)
+	assert.Equal(t, "/dists/focal/main/binary-amd64/Packages", src)
+
+	_, ok = h.GroupIndexSourcePath("/pool/main/c/curl/curl_8.0.0_amd64.deb")
+	assert.False(t, ok, ".deb downloads keep first-non-404")
+	_, ok = h.GroupIndexSourcePath("/dists/focal/Release")
+	assert.False(t, ok, "Release is boilerplate — not merged")
+}
+
+func TestApt_MergeGroupIndex_UnionsStanzas(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(stanzaCurl + "\n")},
+		{Member: "m2", Body: []byte(stanzaCurl + "\n" + stanzaNginx + "\n")}, // curl duplicated
+	}
+
+	body, ct, err := h.MergeGroupIndex("g", "/dists/focal/main/binary-amd64/Packages", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "text/plain")
+	out := string(body)
+	assert.Contains(t, out, "Package: curl")
+	assert.Contains(t, out, "Package: nginx")
+	assert.Equal(t, 1, bytes.Count(body, []byte("Package: curl")), "dedup by Filename")
+}
+
+func TestApt_MergeGroupIndex_GzipOutput(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{{Member: "m1", Body: []byte(stanzaCurl + "\n")}}
+
+	body, ct, err := h.MergeGroupIndex("g", "/dists/focal/main/binary-amd64/Packages.gz", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "gzip")
+
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	require.NoError(t, err)
+	plain, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	assert.Contains(t, string(plain), "Package: curl")
+}
+
+func TestApt_MergeGroupIndex_EmptyMemberContributesNothing(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "empty", Body: []byte("")}, // apt hosted answers 200-empty (#99 shadowing)
+		{Member: "full", Body: []byte(stanzaNginx + "\n")},
+	}
+	body, _, err := h.MergeGroupIndex("g", "/dists/focal/main/binary-amd64/Packages", parts)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Package: nginx")
+}

--- a/internal/formats/base/version.go
+++ b/internal/formats/base/version.go
@@ -1,0 +1,64 @@
+package base
+
+import (
+	"strconv"
+	"strings"
+)
+
+// CompareLooseVersions orders version strings loosely: dot/dash-split
+// segments, numeric segments compare numerically, otherwise lexicographic;
+// a numeric segment beats a qualifier at the same position ("1.0" >
+// "1.0-SNAPSHOT" segment-wise); the empty string sorts first. Good enough
+// for latest/release selection across formats; not a full semver or maven
+// ComparableVersion implementation.
+func CompareLooseVersions(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return -1
+	}
+	if b == "" {
+		return 1
+	}
+	split := func(s string) []string {
+		return strings.FieldsFunc(s, func(r rune) bool { return r == '.' || r == '-' })
+	}
+	as, bs := split(a), split(b)
+	for i := 0; i < len(as) && i < len(bs); i++ {
+		an, aErr := strconv.Atoi(as[i])
+		bn, bErr := strconv.Atoi(bs[i])
+		switch {
+		case aErr == nil && bErr == nil:
+			if an != bn {
+				if an < bn {
+					return -1
+				}
+				return 1
+			}
+		case aErr == nil:
+			return 1
+		case bErr == nil:
+			return -1
+		default:
+			if c := strings.Compare(as[i], bs[i]); c != 0 {
+				return c
+			}
+		}
+	}
+	// Tail rule: a numeric extra segment extends the version upward
+	// ("1.0.1" > "1.0"); a qualifier tail lowers it ("1.0-SNAPSHOT" < "1.0").
+	switch {
+	case len(as) < len(bs):
+		if _, err := strconv.Atoi(bs[len(as)]); err != nil {
+			return 1
+		}
+		return -1
+	case len(as) > len(bs):
+		if _, err := strconv.Atoi(as[len(bs)]); err != nil {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}

--- a/internal/formats/base/version_test.go
+++ b/internal/formats/base/version_test.go
@@ -16,7 +16,7 @@ func TestCompareLooseVersions(t *testing.T) {
 		{"1.0", "1.0", 0},
 		{"1.0", "2.0", -1},
 		{"2.0", "1.0", 1},
-		{"1.10", "1.9", 1},        // numeric, not lexicographic
+		{"1.10", "1.9", 1},         // numeric, not lexicographic
 		{"1.0", "1.0-SNAPSHOT", 1}, // numeric beats qualifier
 		{"1.0-alpha", "1.0-beta", -1},
 		{"", "1.0", -1},

--- a/internal/formats/base/version_test.go
+++ b/internal/formats/base/version_test.go
@@ -1,0 +1,29 @@
+package base_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+)
+
+func TestCompareLooseVersions(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0", "1.0", 0},
+		{"1.0", "2.0", -1},
+		{"2.0", "1.0", 1},
+		{"1.10", "1.9", 1},        // numeric, not lexicographic
+		{"1.0", "1.0-SNAPSHOT", 1}, // numeric beats qualifier
+		{"1.0-alpha", "1.0-beta", -1},
+		{"", "1.0", -1},
+		{"1.0.1", "1.0", 1}, // longer wins on equal prefix
+		{"v1.2.0", "v1.10.0", -1},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, base.CompareLooseVersions(tc.a, tc.b), "%s vs %s", tc.a, tc.b)
+	}
+}

--- a/internal/formats/conda/groupindex.go
+++ b/internal/formats/conda/groupindex.go
@@ -1,0 +1,62 @@
+package conda
+
+// Group index merging (#99 phase 2): repodata.json is merged across group
+// members — a single member's index hides packages held by the others, so
+// `conda install` could not resolve them even though the package files
+// themselves are reachable through fan-out.
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if path.Base(p) == "repodata.json" && strings.Count(strings.Trim(p, "/"), "/") == 1 {
+		return p, true
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(_, _ string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	type repodata struct {
+		Info          map[string]any             `json:"info"`
+		Packages      map[string]json.RawMessage `json:"packages"`
+		PackagesConda map[string]json.RawMessage `json:"packages.conda"`
+	}
+	merged := repodata{
+		Packages:      map[string]json.RawMessage{},
+		PackagesConda: map[string]json.RawMessage{},
+	}
+	parsed := false
+	for _, part := range parts {
+		var doc repodata
+		if err := json.Unmarshal(part.Body, &doc); err != nil {
+			continue // malformed member copy — merge the rest
+		}
+		parsed = true
+		if merged.Info == nil {
+			merged.Info = doc.Info
+		}
+		for k, v := range doc.Packages {
+			if _, seen := merged.Packages[k]; !seen {
+				merged.Packages[k] = v // first member wins per filename
+			}
+		}
+		for k, v := range doc.PackagesConda {
+			if _, seen := merged.PackagesConda[k]; !seen {
+				merged.PackagesConda[k] = v
+			}
+		}
+	}
+	if !parsed {
+		return nil, "", fmt.Errorf("conda group merge: no parsable repodata.json among %d members", len(parts))
+	}
+	out, err := json.Marshal(merged)
+	return out, "application/json", err
+}

--- a/internal/formats/conda/groupindex_test.go
+++ b/internal/formats/conda/groupindex_test.go
@@ -1,0 +1,59 @@
+package conda_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/conda"
+)
+
+func TestConda_GroupIndexSourcePath(t *testing.T) {
+	h := conda.New(formats.Deps{})
+
+	src, ok := h.GroupIndexSourcePath("/linux-64/repodata.json")
+	require.True(t, ok)
+	assert.Equal(t, "/linux-64/repodata.json", src)
+	_, ok = h.GroupIndexSourcePath("/noarch/repodata.json")
+	assert.True(t, ok)
+
+	_, ok = h.GroupIndexSourcePath("/linux-64/numpy-1.0-py310.tar.bz2")
+	assert.False(t, ok, "package files keep first-non-404")
+}
+
+func TestConda_MergeGroupIndex_UnionsPackages(t *testing.T) {
+	h := conda.New(formats.Deps{})
+	m1 := []byte(`{"info":{"subdir":"linux-64"},"packages":{"numpy-1.0.tar.bz2":{"name":"numpy","version":"1.0","m1":true}},"packages.conda":{}}`)
+	m2 := []byte(`{"info":{"subdir":"linux-64"},"packages":{"numpy-1.0.tar.bz2":{"name":"numpy","version":"1.0"},"scipy-2.0.tar.bz2":{"name":"scipy","version":"2.0"}},"packages.conda":{"pandas-3.0.conda":{"name":"pandas"}}}`)
+
+	body, ct, err := h.MergeGroupIndex("g", "/linux-64/repodata.json", []formats.GroupIndexPart{
+		{Member: "m1", Body: m1}, {Member: "m2", Body: m2},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "json")
+
+	var doc struct {
+		Info          map[string]any            `json:"info"`
+		Packages      map[string]map[string]any `json:"packages"`
+		PackagesConda map[string]map[string]any `json:"packages.conda"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	assert.Equal(t, "linux-64", doc.Info["subdir"])
+	require.Len(t, doc.Packages, 2, "numpy deduped, scipy unioned in")
+	assert.Equal(t, true, doc.Packages["numpy-1.0.tar.bz2"]["m1"], "first member wins per filename")
+	assert.NotNil(t, doc.Packages["scipy-2.0.tar.bz2"])
+	assert.NotNil(t, doc.PackagesConda["pandas-3.0.conda"])
+}
+
+func TestConda_MergeGroupIndex_MalformedPartSkipped(t *testing.T) {
+	h := conda.New(formats.Deps{})
+	body, _, err := h.MergeGroupIndex("g", "/noarch/repodata.json", []formats.GroupIndexPart{
+		{Member: "bad", Body: []byte("nope")},
+		{Member: "ok", Body: []byte(`{"info":{"subdir":"noarch"},"packages":{"a-1.tar.bz2":{"name":"a"}}}`)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "a-1.tar.bz2")
+}

--- a/internal/formats/gomod/groupindex.go
+++ b/internal/formats/gomod/groupindex.go
@@ -1,0 +1,68 @@
+package gomod
+
+// Group index merging (#99 phase 2): @v/list and @latest are merged across
+// group members — @v/list answers 200 with an empty body when a member has
+// no versions, which under first-non-404 fan-out shadowed later members.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if strings.HasSuffix(p, "/@v/list") || strings.HasSuffix(p, "/@latest") {
+		return p, true
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	if strings.HasSuffix(p, "/@latest") {
+		return mergeLatest(parts)
+	}
+	// @v/list: newline-separated versions — union, dedup, member order.
+	var out []string
+	seen := map[string]bool{}
+	for _, part := range parts {
+		for _, v := range strings.Split(strings.TrimSpace(string(part.Body)), "\n") {
+			v = strings.TrimSpace(v)
+			if v == "" || seen[v] {
+				continue
+			}
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	body := strings.Join(out, "\n")
+	if body != "" {
+		body += "\n"
+	}
+	return []byte(body), "text/plain; charset=utf-8", nil
+}
+
+// mergeLatest picks the highest Version across members' @latest documents.
+func mergeLatest(parts []formats.GroupIndexPart) ([]byte, string, error) {
+	var best []byte
+	bestVer := ""
+	for _, part := range parts {
+		var doc struct {
+			Version string `json:"Version"`
+		}
+		if err := json.Unmarshal(part.Body, &doc); err != nil || doc.Version == "" {
+			continue // malformed member copy — merge the rest
+		}
+		if best == nil || base.CompareLooseVersions(doc.Version, bestVer) > 0 {
+			best, bestVer = part.Body, doc.Version
+		}
+	}
+	if best == nil {
+		return nil, "", fmt.Errorf("gomod group merge: no parsable @latest among %d members", len(parts))
+	}
+	return best, "application/json", nil
+}

--- a/internal/formats/gomod/groupindex_test.go
+++ b/internal/formats/gomod/groupindex_test.go
@@ -1,0 +1,59 @@
+package gomod_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/gomod"
+)
+
+func TestGomod_GroupIndexSourcePath(t *testing.T) {
+	h := gomod.New(formats.Deps{})
+
+	src, ok := h.GroupIndexSourcePath("/github.com/foo/bar/@v/list")
+	require.True(t, ok)
+	assert.Equal(t, "/github.com/foo/bar/@v/list", src)
+
+	_, ok = h.GroupIndexSourcePath("/github.com/foo/bar/@latest")
+	assert.True(t, ok)
+
+	_, ok = h.GroupIndexSourcePath("/github.com/foo/bar/@v/v1.0.0.zip")
+	assert.False(t, ok, "module files keep first-non-404")
+	_, ok = h.GroupIndexSourcePath("/github.com/foo/bar/@v/v1.0.0.info")
+	assert.False(t, ok)
+}
+
+func TestGomod_MergeGroupIndex_ListUnion(t *testing.T) {
+	h := gomod.New(formats.Deps{})
+	body, ct, err := h.MergeGroupIndex("g", "/m/@v/list", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte("v1.0.0\nv1.1.0\n")},
+		{Member: "m2", Body: []byte("v1.1.0\nv2.0.0\n")},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "text/plain")
+	assert.Equal(t, "v1.0.0\nv1.1.0\nv2.0.0\n", string(body), "union, dedup, member order")
+}
+
+func TestGomod_MergeGroupIndex_LatestPicksMax(t *testing.T) {
+	h := gomod.New(formats.Deps{})
+	body, ct, err := h.MergeGroupIndex("g", "/m/@latest", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(`{"Version":"v1.0.0","Time":"2024-01-01T00:00:00Z"}`)},
+		{Member: "m2", Body: []byte(`{"Version":"v2.0.0","Time":"2025-01-01T00:00:00Z"}`)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "json")
+	assert.Contains(t, string(body), `"v2.0.0"`, "the max version across members wins")
+}
+
+func TestGomod_MergeGroupIndex_MalformedLatestSkipped(t *testing.T) {
+	h := gomod.New(formats.Deps{})
+	body, _, err := h.MergeGroupIndex("g", "/m/@latest", []formats.GroupIndexPart{
+		{Member: "bad", Body: []byte("not json")},
+		{Member: "ok", Body: []byte(`{"Version":"v1.0.0"}`)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "v1.0.0")
+}

--- a/internal/formats/maven/groupindex.go
+++ b/internal/formats/maven/groupindex.go
@@ -12,10 +12,10 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path"
-	"strconv"
 	"strings"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
 )
 
 const metadataFile = "maven-metadata.xml"
@@ -76,11 +76,11 @@ func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) (
 	// latest/release are recomputed over the union — taking any single
 	// member's value would hide newer versions held by other members.
 	for _, v := range merged.Versioning.Versions {
-		if compareVersions(v, merged.Versioning.Latest) > 0 {
+		if base.CompareLooseVersions(v, merged.Versioning.Latest) > 0 {
 			merged.Versioning.Latest = v
 		}
 		if !strings.Contains(strings.ToUpper(v), "SNAPSHOT") &&
-			compareVersions(v, merged.Versioning.Release) > 0 {
+			base.CompareLooseVersions(v, merged.Versioning.Release) > 0 {
 			merged.Versioning.Release = v
 		}
 	}
@@ -100,52 +100,4 @@ func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) (
 		return []byte(fmt.Sprintf("%x", sha256.Sum256(doc))), "text/plain", nil
 	}
 	return doc, "application/xml", nil
-}
-
-// compareVersions orders maven-ish version strings: dot/dash-split segments,
-// numeric segments compare numerically, otherwise lexicographically. An empty
-// string sorts first. Good enough for latest/release selection; not a full
-// maven ComparableVersion implementation.
-func compareVersions(a, b string) int {
-	if a == b {
-		return 0
-	}
-	if a == "" {
-		return -1
-	}
-	if b == "" {
-		return 1
-	}
-	split := func(s string) []string {
-		return strings.FieldsFunc(s, func(r rune) bool { return r == '.' || r == '-' })
-	}
-	as, bs := split(a), split(b)
-	for i := 0; i < len(as) && i < len(bs); i++ {
-		an, aErr := strconv.Atoi(as[i])
-		bn, bErr := strconv.Atoi(bs[i])
-		switch {
-		case aErr == nil && bErr == nil:
-			if an != bn {
-				if an < bn {
-					return -1
-				}
-				return 1
-			}
-		case aErr == nil: // numeric beats qualifier ("1.0" > "1.0-SNAPSHOT" segment-wise)
-			return 1
-		case bErr == nil:
-			return -1
-		default:
-			if c := strings.Compare(as[i], bs[i]); c != 0 {
-				return c
-			}
-		}
-	}
-	switch {
-	case len(as) < len(bs):
-		return -1
-	case len(as) > len(bs):
-		return 1
-	}
-	return 0
 }

--- a/internal/formats/nuget/groupindex.go
+++ b/internal/formats/nuget/groupindex.go
@@ -1,0 +1,66 @@
+package nuget
+
+// Group index merging (#99 phase 2): the flatcontainer version list answers
+// 200 with {"versions":[]} for unknown packages, which under first-non-404
+// fan-out shadowed every member behind the first; the service index embeds
+// member-scoped URLs. Registration is NOT merged this phase — it 404s on
+// miss, so plain fan-out reaches the right member.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if p == "/index.json" {
+		return p, true
+	}
+	if strings.HasPrefix(p, "/v3/flatcontainer/") && strings.HasSuffix(p, "/index.json") {
+		return p, true
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(groupName, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	if p == "/index.json" {
+		// Service index: first member's document re-rooted at the group —
+		// the resource shapes are identical across members.
+		body := strings.ReplaceAll(string(parts[0].Body),
+			"/repository/"+parts[0].Member+"/", "/repository/"+groupName+"/")
+		return []byte(body), "application/json", nil
+	}
+
+	// Flatcontainer version list: union across members, member order.
+	var out []string
+	seen := map[string]bool{}
+	parsed := false
+	for _, part := range parts {
+		var doc struct {
+			Versions []string `json:"versions"`
+		}
+		if err := json.Unmarshal(part.Body, &doc); err != nil {
+			continue // malformed member copy — merge the rest
+		}
+		parsed = true
+		for _, v := range doc.Versions {
+			if v == "" || seen[v] {
+				continue
+			}
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	if !parsed {
+		return nil, "", fmt.Errorf("nuget group merge: no parsable version list among %d members", len(parts))
+	}
+	if out == nil {
+		out = []string{}
+	}
+	body, err := json.Marshal(map[string]any{"versions": out})
+	return body, "application/json", err
+}

--- a/internal/formats/nuget/groupindex_test.go
+++ b/internal/formats/nuget/groupindex_test.go
@@ -1,0 +1,57 @@
+package nuget_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/nuget"
+)
+
+func TestNuGet_GroupIndexSourcePath(t *testing.T) {
+	h := nuget.New(formats.Deps{})
+
+	_, ok := h.GroupIndexSourcePath("/v3/flatcontainer/my.lib/index.json")
+	assert.True(t, ok)
+	_, ok = h.GroupIndexSourcePath("/index.json")
+	assert.True(t, ok, "service index needs member→group URL rewrite")
+
+	_, ok = h.GroupIndexSourcePath("/v3/flatcontainer/my.lib/2.1.0/my.lib.2.1.0.nupkg")
+	assert.False(t, ok, "packages keep first-non-404")
+	_, ok = h.GroupIndexSourcePath("/v3/registration/my.lib/index.json")
+	assert.False(t, ok, "registration 404s on miss — fan-out works; not merged this phase")
+}
+
+func TestNuGet_MergeGroupIndex_VersionListUnion(t *testing.T) {
+	// Kills the 200-on-empty shadowing: the empty version list is just a part.
+	h := nuget.New(formats.Deps{})
+	body, ct, err := h.MergeGroupIndex("g", "/v3/flatcontainer/pkg/index.json", []formats.GroupIndexPart{
+		{Member: "empty", Body: []byte(`{"versions":[]}`)},
+		{Member: "m1", Body: []byte(`{"versions":["1.0.0","1.1.0"]}`)},
+		{Member: "m2", Body: []byte(`{"versions":["1.1.0","2.0.0"]}`)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "json")
+
+	var doc struct {
+		Versions []string `json:"versions"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	assert.Equal(t, []string{"1.0.0", "1.1.0", "2.0.0"}, doc.Versions)
+}
+
+func TestNuGet_MergeGroupIndex_ServiceIndexRewritesMemberURLs(t *testing.T) {
+	h := nuget.New(formats.Deps{BaseURL: "http://localhost:8080"})
+	m1 := []byte(`{"version":"3.0.0","resources":[{"@id":"http://localhost:8080/repository/m1/v3/flatcontainer/","@type":"PackageBaseAddress/3.0.0"}]}`)
+
+	body, _, err := h.MergeGroupIndex("ng-group", "/index.json", []formats.GroupIndexPart{
+		{Member: "m1", Body: m1},
+	})
+	require.NoError(t, err)
+	out := string(body)
+	assert.Contains(t, out, "/repository/ng-group/v3/flatcontainer/")
+	assert.NotContains(t, out, "/repository/m1/")
+}

--- a/internal/formats/terraform/groupindex.go
+++ b/internal/formats/terraform/groupindex.go
@@ -1,0 +1,109 @@
+package terraform
+
+// Group index merging (#99 phase 2): provider/module version lists answer
+// 200-empty for members without the artifact, shadowing later members under
+// first-non-404 fan-out; the discovery document embeds member-scoped URLs.
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	switch {
+	case strings.HasSuffix(p, "/versions") &&
+		(strings.HasPrefix(p, "/v1/providers/") || strings.HasPrefix(p, "/v1/modules/")):
+		return p, true
+	case p == "/.well-known/terraform.json":
+		return p, true
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(groupName, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	switch {
+	case p == "/.well-known/terraform.json":
+		// Discovery: first member's document with its URLs re-rooted at the
+		// group — the shape is identical across members.
+		body := string(parts[0].Body)
+		body = strings.ReplaceAll(body, "/repository/"+parts[0].Member+"/", "/repository/"+groupName+"/")
+		return []byte(body), "application/json", nil
+
+	case strings.HasPrefix(p, "/v1/modules/"):
+		return mergeModuleVersions(parts)
+
+	default: // /v1/providers/.../versions
+		return mergeProviderVersions(parts)
+	}
+}
+
+func mergeProviderVersions(parts []formats.GroupIndexPart) ([]byte, string, error) {
+	var out []any
+	seen := map[string]bool{}
+	parsed := false
+	for _, part := range parts {
+		var doc struct {
+			Versions []map[string]any `json:"versions"`
+		}
+		if err := json.Unmarshal(part.Body, &doc); err != nil {
+			continue // malformed member copy — merge the rest
+		}
+		parsed = true
+		for _, v := range doc.Versions {
+			ver, _ := v["version"].(string)
+			if ver == "" || seen[ver] {
+				continue // first member wins per version
+			}
+			seen[ver] = true
+			out = append(out, v)
+		}
+	}
+	if !parsed {
+		return nil, "", fmt.Errorf("terraform group merge: no parsable provider versions among %d members", len(parts))
+	}
+	if out == nil {
+		out = []any{}
+	}
+	body, err := json.Marshal(map[string]any{"versions": out})
+	return body, "application/json", err
+}
+
+func mergeModuleVersions(parts []formats.GroupIndexPart) ([]byte, string, error) {
+	var out []any
+	seen := map[string]bool{}
+	parsed := false
+	for _, part := range parts {
+		var doc struct {
+			Modules []struct {
+				Versions []map[string]any `json:"versions"`
+			} `json:"modules"`
+		}
+		if err := json.Unmarshal(part.Body, &doc); err != nil {
+			continue
+		}
+		parsed = true
+		for _, m := range doc.Modules {
+			for _, v := range m.Versions {
+				ver, _ := v["version"].(string)
+				if ver == "" || seen[ver] {
+					continue
+				}
+				seen[ver] = true
+				out = append(out, v)
+			}
+		}
+	}
+	if !parsed {
+		return nil, "", fmt.Errorf("terraform group merge: no parsable module versions among %d members", len(parts))
+	}
+	if out == nil {
+		out = []any{}
+	}
+	body, err := json.Marshal(map[string]any{"modules": []map[string]any{{"versions": out}}})
+	return body, "application/json", err
+}

--- a/internal/formats/terraform/groupindex_test.go
+++ b/internal/formats/terraform/groupindex_test.go
@@ -1,0 +1,85 @@
+package terraform_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/terraform"
+)
+
+func TestTerraform_GroupIndexSourcePath(t *testing.T) {
+	h := terraform.New(formats.Deps{})
+
+	_, ok := h.GroupIndexSourcePath("/v1/providers/hashicorp/aws/versions")
+	assert.True(t, ok)
+	_, ok = h.GroupIndexSourcePath("/v1/modules/ns/vpc/aws/versions")
+	assert.True(t, ok)
+	_, ok = h.GroupIndexSourcePath("/.well-known/terraform.json")
+	assert.True(t, ok)
+
+	_, ok = h.GroupIndexSourcePath("/v1/providers/hashicorp/aws/1.0.0/download/linux/amd64")
+	assert.False(t, ok, "downloads keep first-non-404")
+}
+
+func TestTerraform_MergeGroupIndex_ProviderVersionsUnion(t *testing.T) {
+	h := terraform.New(formats.Deps{})
+	m1 := []byte(`{"versions":[{"version":"1.0.0","protocols":["5.0"],"platforms":[{"os":"linux","arch":"amd64"}]}]}`)
+	m2 := []byte(`{"versions":[{"version":"1.0.0","protocols":["5.0"],"platforms":[{"os":"darwin","arch":"arm64"}]},{"version":"2.0.0","protocols":["5.0"],"platforms":[]}]}`)
+
+	body, ct, err := h.MergeGroupIndex("g", "/v1/providers/ns/aws/versions", []formats.GroupIndexPart{
+		{Member: "m1", Body: m1}, {Member: "m2", Body: m2},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "json")
+
+	var doc struct {
+		Versions []map[string]any `json:"versions"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	require.Len(t, doc.Versions, 2, "1.0.0 deduped (first wins), 2.0.0 unioned in")
+
+	vers := map[string]map[string]any{}
+	for _, v := range doc.Versions {
+		vers[v["version"].(string)] = v
+	}
+	// first member wins for 1.0.0 → its platforms are linux/amd64
+	p := vers["1.0.0"]["platforms"].([]any)[0].(map[string]any)
+	assert.Equal(t, "linux", p["os"])
+	assert.NotNil(t, vers["2.0.0"])
+}
+
+func TestTerraform_MergeGroupIndex_ModuleVersionsUnion(t *testing.T) {
+	h := terraform.New(formats.Deps{})
+	m1 := []byte(`{"modules":[{"versions":[{"version":"0.1.0"}]}]}`)
+	m2 := []byte(`{"modules":[{"versions":[{"version":"0.1.0"},{"version":"0.2.0"}]}]}`)
+
+	body, _, err := h.MergeGroupIndex("g", "/v1/modules/ns/vpc/aws/versions", []formats.GroupIndexPart{
+		{Member: "m1", Body: m1}, {Member: "m2", Body: m2},
+	})
+	require.NoError(t, err)
+	var doc struct {
+		Modules []struct {
+			Versions []map[string]string `json:"versions"`
+		} `json:"modules"`
+	}
+	require.NoError(t, json.Unmarshal(body, &doc))
+	require.Len(t, doc.Modules, 1)
+	assert.Len(t, doc.Modules[0].Versions, 2)
+}
+
+func TestTerraform_MergeGroupIndex_DiscoveryRewritesMemberURLs(t *testing.T) {
+	h := terraform.New(formats.Deps{BaseURL: "http://localhost:8080"})
+	m1 := []byte(`{"providers.v1":"http://localhost:8080/repository/m1/v1/providers/","modules.v1":"http://localhost:8080/repository/m1/v1/modules/"}`)
+
+	body, _, err := h.MergeGroupIndex("tf-group", "/.well-known/terraform.json", []formats.GroupIndexPart{
+		{Member: "m1", Body: m1},
+	})
+	require.NoError(t, err)
+	out := string(body)
+	assert.Contains(t, out, "/repository/tf-group/v1/providers/")
+	assert.NotContains(t, out, "/repository/m1/")
+}

--- a/internal/formats/yum/groupindex.go
+++ b/internal/formats/yum/groupindex.go
@@ -18,10 +18,10 @@ import (
 // GroupIndexSourcePath implements formats.GroupIndexMerger. The .gz flavor
 // of primary fans out on the PLAIN document — the merger gzips the result.
 func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
-	switch {
-	case p == "/repodata/repomd.xml":
+	switch p {
+	case "/repodata/repomd.xml":
 		return p, true
-	case p == "/repodata/primary.xml" || p == "/repodata/primary.xml.gz":
+	case "/repodata/primary.xml", "/repodata/primary.xml.gz":
 		return "/repodata/primary.xml", true
 	}
 	return "", false

--- a/internal/formats/yum/groupindex.go
+++ b/internal/formats/yum/groupindex.go
@@ -1,0 +1,81 @@
+package yum
+
+// Group index merging (#99 phase 2): repodata is merged across group members
+// — a single member's primary.xml hid the others' rpms from dnf, and
+// repomd.xml embedded a member-scoped href that steered clients off the
+// group.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/xml"
+	"fmt"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger. The .gz flavor
+// of primary fans out on the PLAIN document — the merger gzips the result.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	switch {
+	case p == "/repodata/repomd.xml":
+		return p, true
+	case p == "/repodata/primary.xml" || p == "/repodata/primary.xml.gz":
+		return "/repodata/primary.xml", true
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(groupName, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	if p == "/repodata/repomd.xml" {
+		// repomd shapes are identical across members; take the first and
+		// re-root its member-scoped hrefs at the group.
+		body := strings.ReplaceAll(string(parts[0].Body),
+			"/repository/"+parts[0].Member+"/", "/repository/"+groupName+"/")
+		return []byte(body), "application/xml; charset=utf-8", nil
+	}
+
+	// primary.xml: union <package> entries across members, dedup by location
+	// href (first member wins), recount the packages attribute.
+	merged := primaryXML{XMLNS: "http://linux.duke.edu/metadata/common"}
+	seen := map[string]bool{}
+	parsed := false
+	for _, part := range parts {
+		var doc primaryXML
+		if err := xml.Unmarshal(part.Body, &doc); err != nil {
+			continue // malformed member copy — merge the rest
+		}
+		parsed = true
+		for _, pkg := range doc.Packages {
+			key := pkg.Location.Href
+			if key != "" && seen[key] {
+				continue
+			}
+			if key != "" {
+				seen[key] = true
+			}
+			merged.Packages = append(merged.Packages, pkg)
+		}
+	}
+	if !parsed {
+		return nil, "", fmt.Errorf("yum group merge: no parsable primary.xml among %d members", len(parts))
+	}
+	merged.Count = len(merged.Packages)
+
+	out, err := xml.Marshal(merged)
+	if err != nil {
+		return nil, "", err
+	}
+	doc := append([]byte(xml.Header), out...)
+
+	if strings.HasSuffix(p, ".gz") {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, _ = gw.Write(doc)
+		_ = gw.Close()
+		return buf.Bytes(), "application/x-gzip", nil
+	}
+	return doc, "application/xml; charset=utf-8", nil
+}

--- a/internal/formats/yum/groupindex_test.go
+++ b/internal/formats/yum/groupindex_test.go
@@ -1,0 +1,73 @@
+package yum_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/yum"
+)
+
+const primaryM1 = `<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common" packages="1"><package type="rpm"><name>curl</name><arch>x86_64</arch><version epoch="0" ver="8.0.0" rel="1"></version><size package="100"></size><location href="/pool/curl-8.0.0-1.x86_64.rpm"></location></package></metadata>`
+
+const primaryM2 = `<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns="http://linux.duke.edu/metadata/common" packages="2"><package type="rpm"><name>curl</name><arch>x86_64</arch><version epoch="0" ver="8.0.0" rel="1"></version><size package="100"></size><location href="/pool/curl-8.0.0-1.x86_64.rpm"></location></package><package type="rpm"><name>vim</name><arch>x86_64</arch><version epoch="0" ver="9.0" rel="2"></version><size package="200"></size><location href="/pool/vim-9.0-2.x86_64.rpm"></location></package></metadata>`
+
+func TestYum_GroupIndexSourcePath(t *testing.T) {
+	h := yum.New(formats.Deps{})
+
+	_, ok := h.GroupIndexSourcePath("/repodata/repomd.xml")
+	assert.True(t, ok)
+	src, ok := h.GroupIndexSourcePath("/repodata/primary.xml.gz")
+	require.True(t, ok)
+	assert.Equal(t, "/repodata/primary.xml", src, ".gz fans out on the plain doc")
+
+	_, ok = h.GroupIndexSourcePath("/pool/curl-8.0.0-1.x86_64.rpm")
+	assert.False(t, ok, "rpm downloads keep first-non-404")
+}
+
+func TestYum_MergeGroupIndex_PrimaryUnion(t *testing.T) {
+	h := yum.New(formats.Deps{})
+	body, ct, err := h.MergeGroupIndex("g", "/repodata/primary.xml", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(primaryM1)},
+		{Member: "m2", Body: []byte(primaryM2)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "xml")
+	out := string(body)
+	assert.Contains(t, out, "<name>curl</name>")
+	assert.Contains(t, out, "<name>vim</name>")
+	assert.Equal(t, 1, bytes.Count(body, []byte("<name>curl</name>")), "dedup by location href")
+	assert.Contains(t, out, `packages="2"`, "package count recomputed")
+}
+
+func TestYum_MergeGroupIndex_PrimaryGzip(t *testing.T) {
+	h := yum.New(formats.Deps{})
+	body, ct, err := h.MergeGroupIndex("g", "/repodata/primary.xml.gz", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(primaryM1)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, ct, "gzip")
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	require.NoError(t, err)
+	plain, _ := io.ReadAll(zr)
+	assert.Contains(t, string(plain), "<name>curl</name>")
+}
+
+func TestYum_MergeGroupIndex_RepomdRewritesMemberHref(t *testing.T) {
+	h := yum.New(formats.Deps{})
+	repomd := []byte(`<repomd><data type="primary"><location href="/repository/m1/repodata/primary.xml.gz"/></data></repomd>`)
+	body, _, err := h.MergeGroupIndex("yum-group", "/repodata/repomd.xml", []formats.GroupIndexPart{
+		{Member: "m1", Body: repomd},
+	})
+	require.NoError(t, err)
+	out := string(body)
+	assert.Contains(t, out, "/repository/yum-group/repodata/primary.xml.gz")
+	assert.NotContains(t, out, "/repository/m1/")
+}


### PR DESCRIPTION
Closes #99 (Phase 2 — completes the format coverage; Phase 1 infra + maven/npm/pypi shipped in v1.24.0 / PR #109).

Each format implements `formats.GroupIndexMerger` — no group-layer changes:

- **gomod**: `@v/list` unioned (kills 200-empty shadowing); `@latest` picks the highest version across members.
- **terraform**: provider/module `/versions` unioned; `/.well-known/terraform.json` re-rooted at the group.
- **conda**: `repodata.json` packages/packages.conda unioned (first member wins per filename).
- **nuget**: flatcontainer version list unioned (kills `{"versions":[]}` shadowing); service index re-rooted at the group. Registration keeps plain fan-out (404s on miss).
- **apt**: Packages stanzas unioned (dedup by Filename); `.gz` fans out on the plain doc and gzips the merge. Release stays plain fan-out (boilerplate).
- **yum**: primary.xml packages unioned (dedup by location href, count recomputed, .gz supported); repomd.xml hrefs re-rooted at the group.

Also extracts `base.CompareLooseVersions` (shared by maven/gomod; qualifier tails now sort below the bare version).

TDD: 20 new tests, RED verified per merger. Full suite green except the known sandbox-only webhook network failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk