### PR TITLE
fix(yum): real repodata checksums, relative hrefs, filelists/other

### DIFF
--- a/internal/formats/yum/handler.go
+++ b/internal/formats/yum/handler.go
@@ -12,8 +12,6 @@
 package yum
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/xml"
 	"fmt"
 	"net/http"
@@ -77,7 +75,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 
 	// filelists.xml, other.xml — return empty valid XML for now
 	case c.Request.Method == http.MethodGet && strings.HasPrefix(p, "/repodata/"):
-		h.serveEmptyMetadata(c, p)
+		h.serveOtherMetadata(c, repoName, p)
 
 	// Upload RPM
 	case c.Request.Method == http.MethodPut && strings.HasSuffix(p, ".rpm"):
@@ -108,10 +106,13 @@ type repomdXML struct {
 	Data     []repomdEntry `xml:"data"`
 }
 type repomdEntry struct {
-	Type      string      `xml:"type,attr"`
-	Location  repomdLoc   `xml:"location"`
-	Checksum  repomdCksum `xml:"checksum"`
-	Timestamp int64       `xml:"timestamp"`
+	Type         string       `xml:"type,attr"`
+	Location     repomdLoc    `xml:"location"`
+	Checksum     repomdCksum  `xml:"checksum"`
+	OpenChecksum *repomdCksum `xml:"open-checksum,omitempty"`
+	Timestamp    int64        `xml:"timestamp"`
+	Size         int64        `xml:"size,omitempty"`
+	OpenSize     int64        `xml:"open-size,omitempty"`
 }
 type repomdLoc struct {
 	Href string `xml:"href,attr"`
@@ -122,23 +123,12 @@ type repomdCksum struct {
 }
 
 func (h *Handler) serveRepomd(c *gin.Context, repoName string) {
-	base2 := "/repository/" + repoName
-	now := time.Now().Unix()
-	doc := repomdXML{
-		XMLNS:    "http://linux.duke.edu/metadata/repo",
-		Revision: now,
-		Data: []repomdEntry{
-			{
-				Type:      "primary",
-				Location:  repomdLoc{Href: base2 + "/repodata/primary.xml.gz"},
-				Checksum:  repomdCksum{Type: "sha256", Value: ""},
-				Timestamp: now,
-			},
-		},
+	docs, err := h.buildRepodata(c.Request.Context(), repoName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
-	out, _ := xml.Marshal(doc)
-	c.Data(http.StatusOK, "application/xml; charset=utf-8",
-		append([]byte(xml.Header), out...))
+	c.Data(http.StatusOK, "application/xml; charset=utf-8", docs.Repomd)
 }
 
 // primaryXML is the minimal primary.xml structure
@@ -149,12 +139,13 @@ type primaryXML struct {
 	Packages []rpmPackage `xml:"package"`
 }
 type rpmPackage struct {
-	Type     string     `xml:"type,attr"`
-	Name     string     `xml:"name"`
-	Arch     string     `xml:"arch"`
-	Version  rpmVersion `xml:"version"`
-	Size     rpmSize    `xml:"size"`
-	Location rpmLoc     `xml:"location"`
+	Type     string      `xml:"type,attr"`
+	Name     string      `xml:"name"`
+	Arch     string      `xml:"arch"`
+	Version  rpmVersion  `xml:"version"`
+	Checksum rpmChecksum `xml:"checksum"`
+	Size     rpmSize     `xml:"size"`
+	Location rpmLoc      `xml:"location"`
 }
 type rpmVersion struct {
 	Epoch string `xml:"epoch,attr"`
@@ -169,101 +160,59 @@ type rpmLoc struct {
 }
 
 func (h *Handler) servePrimary(c *gin.Context, repoName, p string) {
-	gzipped := strings.HasSuffix(p, ".gz")
-
-	page, err := h.deps.Components.Search(c.Request.Context(), domain.SearchParams{
-		Repository: repoName, Limit: 1000,
-	})
+	docs, err := h.buildRepodata(c.Request.Context(), repoName)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-
-	assetPage, err := h.deps.Assets.List(c.Request.Context(), repoName, 1000, 0)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if strings.HasSuffix(p, ".gz") {
+		c.Data(http.StatusOK, "application/x-gzip", docs.PrimaryGz)
 		return
 	}
-
-	compMap := map[string]*domain.Component{}
-	for i := range page.Items {
-		compMap[page.Items[i].ID] = &page.Items[i]
-	}
-
-	doc := primaryXML{
-		XMLNS: "http://linux.duke.edu/metadata/common",
-	}
-	for _, a := range assetPage.Items {
-		if !strings.HasSuffix(a.Path, ".rpm") {
-			continue
-		}
-		comp := compMap[a.ComponentID]
-		if comp == nil {
-			continue
-		}
-		arch := "x86_64"
-		filename := path.Base(a.Path)
-		// name-version-release.arch.rpm
-		parts := strings.Split(strings.TrimSuffix(filename, ".rpm"), ".")
-		if len(parts) >= 2 {
-			arch = parts[len(parts)-1]
-		}
-		doc.Packages = append(doc.Packages, rpmPackage{
-			Type: "rpm",
-			Name: comp.Name,
-			Arch: arch,
-			Version: rpmVersion{
-				Epoch: "0",
-				Ver:   comp.Version,
-				Rel:   "1",
-			},
-			Size:     rpmSize{Package: a.SizeBytes},
-			Location: rpmLoc{Href: a.Path},
-		})
-	}
-	doc.Count = len(doc.Packages)
-
-	out, _ := xml.Marshal(doc)
-	data := append([]byte(xml.Header), out...)
-
-	if gzipped {
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		_, _ = gw.Write(data)
-		_ = gw.Close()
-		c.Data(http.StatusOK, "application/x-gzip", buf.Bytes())
-		return
-	}
-	c.Data(http.StatusOK, "application/xml; charset=utf-8", data)
+	c.Data(http.StatusOK, "application/xml; charset=utf-8", docs.Primary)
 }
 
-func (h *Handler) serveEmptyMetadata(c *gin.Context, p string) {
-	gzipped := strings.HasSuffix(p, ".gz")
-	data := []byte(xml.Header + `<metadata xmlns="http://linux.duke.edu/metadata/common" packages="0"/>`)
-	if gzipped {
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		_, _ = gw.Write(data)
-		_ = gw.Close()
-		c.Data(http.StatusOK, "application/x-gzip", buf.Bytes())
+// serveOtherMetadata serves filelists/other (and unknown repodata paths as
+// valid empty metadata) from the same snapshot repomd was built from.
+func (h *Handler) serveOtherMetadata(c *gin.Context, repoName, p string) {
+	docs, err := h.buildRepodata(c.Request.Context(), repoName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.Data(http.StatusOK, "application/xml; charset=utf-8", data)
+	gzipped := strings.HasSuffix(p, ".gz")
+	var plain, gz []byte
+	switch {
+	case strings.HasPrefix(p, "/repodata/filelists"):
+		plain, gz = docs.Filelists, docs.FilelistsGz
+	case strings.HasPrefix(p, "/repodata/other"):
+		plain, gz = docs.Other, docs.OtherGz
+	default:
+		plain = []byte(xml.Header + `<metadata xmlns="http://linux.duke.edu/metadata/common" packages="0"/>`)
+		gz = gzipBytes(plain)
+	}
+	if gzipped {
+		c.Data(http.StatusOK, "application/x-gzip", gz)
+		return
+	}
+	c.Data(http.StatusOK, "application/xml; charset=utf-8", plain)
 }
 
 func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
 	filename := path.Base(p)
-	// Parse: name-version-release.arch.rpm
+	// Parse NVR: name-version-release.arch.rpm — the last two dash segments
+	// are version and release ("curl-8.0.0-1.x86_64.rpm" → curl / 8.0.0).
 	name := strings.TrimSuffix(filename, ".rpm")
+	if dot := strings.LastIndex(name, "."); dot > 0 { // strip .arch
+		name = name[:dot]
+	}
 	parts := strings.Split(name, "-")
 	pkgName, version := name, "0"
-	if len(parts) >= 2 {
-		pkgName = strings.Join(parts[:len(parts)-1], "-")
-		version = parts[len(parts)-1]
-		// strip arch from version: "1.0-1.x86_64" → version="1.0", release="1.x86_64"
-		if dot := strings.LastIndex(version, "."); dot > 0 {
-			version = version[:dot]
-		}
+	if len(parts) >= 3 {
+		pkgName = strings.Join(parts[:len(parts)-2], "-")
+		version = parts[len(parts)-2]
+	} else if len(parts) == 2 {
+		pkgName, version = parts[0], parts[1]
 	}
 
 	coords := base.Coords{Name: pkgName, Version: version}

--- a/internal/formats/yum/repodata.go
+++ b/internal/formats/yum/repodata.go
@@ -1,0 +1,158 @@
+package yum
+
+// repodata builder (#102): primary/filelists/other and repomd.xml are built
+// from one snapshot so the checksums repomd advertises always match the
+// documents actually served — dnf verifies them and rejects mismatches.
+// Hrefs are RELATIVE (repodata/..., pool/...) so they resolve against the
+// repo — or group — base URL the client is already using.
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// repodataDocs is one consistent snapshot of the generated repo metadata.
+type repodataDocs struct {
+	Primary     []byte // plain XML
+	PrimaryGz   []byte
+	Filelists   []byte
+	FilelistsGz []byte
+	Other       []byte
+	OtherGz     []byte
+	Repomd      []byte
+}
+
+type filelistsXML struct {
+	XMLName  xml.Name        `xml:"filelists"`
+	XMLNS    string          `xml:"xmlns,attr"`
+	Count    int             `xml:"packages,attr"`
+	Packages []fileListEntry `xml:"package"`
+}
+type otherXML struct {
+	XMLName  xml.Name        `xml:"otherdata"`
+	XMLNS    string          `xml:"xmlns,attr"`
+	Count    int             `xml:"packages,attr"`
+	Packages []fileListEntry `xml:"package"`
+}
+type fileListEntry struct {
+	PkgID   string     `xml:"pkgid,attr"`
+	Name    string     `xml:"name,attr"`
+	Arch    string     `xml:"arch,attr"`
+	Version rpmVersion `xml:"version"`
+}
+
+// rpmChecksum carries the package digest dnf uses as the pkgid.
+type rpmChecksum struct {
+	Type  string `xml:"type,attr"`
+	PkgID string `xml:"pkgid,attr"`
+	Value string `xml:",chardata"`
+}
+
+func gzipBytes(data []byte) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, _ = gw.Write(data)
+	_ = gw.Close()
+	return buf.Bytes()
+}
+
+// buildRepodata generates the full metadata snapshot for a repo.
+func (h *Handler) buildRepodata(ctx context.Context, repoName string) (*repodataDocs, error) {
+	page, err := h.deps.Components.Search(ctx, domain.SearchParams{
+		Repository: repoName, Limit: 1000,
+	})
+	if err != nil {
+		return nil, err
+	}
+	assetPage, err := h.deps.Assets.List(ctx, repoName, 1000, 0)
+	if err != nil {
+		return nil, err
+	}
+	compMap := map[string]*domain.Component{}
+	for i := range page.Items {
+		compMap[page.Items[i].ID] = &page.Items[i]
+	}
+
+	primary := primaryXML{XMLNS: "http://linux.duke.edu/metadata/common"}
+	filelists := filelistsXML{XMLNS: "http://linux.duke.edu/metadata/filelists"}
+	other := otherXML{XMLNS: "http://linux.duke.edu/metadata/other"}
+
+	for _, a := range assetPage.Items {
+		if !strings.HasSuffix(a.Path, ".rpm") {
+			continue
+		}
+		comp := compMap[a.ComponentID]
+		if comp == nil {
+			continue
+		}
+		arch := "x86_64"
+		filename := path.Base(a.Path)
+		// name-version-release.arch.rpm
+		parts := strings.Split(strings.TrimSuffix(filename, ".rpm"), ".")
+		if len(parts) >= 2 {
+			arch = parts[len(parts)-1]
+		}
+		ver := rpmVersion{Epoch: "0", Ver: comp.Version, Rel: "1"}
+		primary.Packages = append(primary.Packages, rpmPackage{
+			Type:     "rpm",
+			Name:     comp.Name,
+			Arch:     arch,
+			Version:  ver,
+			Checksum: rpmChecksum{Type: "sha256", PkgID: "YES", Value: a.SHA256},
+			Size:     rpmSize{Package: a.SizeBytes},
+			// Relative to the repo root so it resolves under the repo or group URL.
+			Location: rpmLoc{Href: strings.TrimPrefix(a.Path, "/")},
+		})
+		entry := fileListEntry{PkgID: a.SHA256, Name: comp.Name, Arch: arch, Version: ver}
+		filelists.Packages = append(filelists.Packages, entry)
+		other.Packages = append(other.Packages, entry)
+	}
+	primary.Count = len(primary.Packages)
+	filelists.Count = len(filelists.Packages)
+	other.Count = len(other.Packages)
+
+	docs := &repodataDocs{}
+	marshal := func(v any) []byte {
+		out, _ := xml.Marshal(v)
+		return append([]byte(xml.Header), out...)
+	}
+	docs.Primary = marshal(primary)
+	docs.PrimaryGz = gzipBytes(docs.Primary)
+	docs.Filelists = marshal(filelists)
+	docs.FilelistsGz = gzipBytes(docs.Filelists)
+	docs.Other = marshal(other)
+	docs.OtherGz = gzipBytes(docs.Other)
+
+	now := time.Now().Unix()
+	entry := func(typ string, gz, plain []byte) repomdEntry {
+		return repomdEntry{
+			Type:         typ,
+			Location:     repomdLoc{Href: "repodata/" + typ + ".xml.gz"},
+			Checksum:     repomdCksum{Type: "sha256", Value: fmt.Sprintf("%x", sha256.Sum256(gz))},
+			OpenChecksum: &repomdCksum{Type: "sha256", Value: fmt.Sprintf("%x", sha256.Sum256(plain))},
+			Size:         int64(len(gz)),
+			OpenSize:     int64(len(plain)),
+			Timestamp:    now,
+		}
+	}
+	repomd := repomdXML{
+		XMLNS:    "http://linux.duke.edu/metadata/repo",
+		Revision: now,
+		Data: []repomdEntry{
+			entry("primary", docs.PrimaryGz, docs.Primary),
+			entry("filelists", docs.FilelistsGz, docs.Filelists),
+			entry("other", docs.OtherGz, docs.Other),
+		},
+	}
+	docs.Repomd = marshal(repomd)
+	return docs, nil
+}

--- a/internal/formats/yum/repodata_test.go
+++ b/internal/formats/yum/repodata_test.go
@@ -1,0 +1,133 @@
+package yum_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// repomdDoc mirrors the served repomd.xml for assertions.
+type repomdDoc struct {
+	Data []struct {
+		Type     string `xml:"type,attr"`
+		Location struct {
+			Href string `xml:"href,attr"`
+		} `xml:"location"`
+		Checksum struct {
+			Type  string `xml:"type,attr"`
+			Value string `xml:",chardata"`
+		} `xml:"checksum"`
+		OpenChecksum struct {
+			Value string `xml:",chardata"`
+		} `xml:"open-checksum"`
+	} `xml:"data"`
+}
+
+func fetch(t *testing.T, r *gin.Engine, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, url)
+	return w
+}
+
+func setupWithRPM(t *testing.T, repoName string) *gin.Engine {
+	t.Helper()
+	repo := testutil.SimpleRepo(repoName, "yum")
+	r := setup(repo)
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+"/pool/curl-8.0.0-1.x86_64.rpm",
+		strings.NewReader("rpm-bytes"))
+	req.ContentLength = int64(len("rpm-bytes"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	return r
+}
+
+// #102: dnf verifies the primary checksum advertised in repomd.xml against
+// the actual primary.xml.gz bytes — an empty checksum makes it reject the repo.
+func TestYum_Repomd_RealPrimaryChecksum(t *testing.T) {
+	r := setupWithRPM(t, "rpms-ck")
+
+	var doc repomdDoc
+	require.NoError(t, xml.Unmarshal(fetch(t, r, "/repository/rpms-ck/repodata/repomd.xml").Body.Bytes(), &doc))
+
+	var primary *struct {
+		Type     string `xml:"type,attr"`
+		Location struct {
+			Href string `xml:"href,attr"`
+		} `xml:"location"`
+		Checksum struct {
+			Type  string `xml:"type,attr"`
+			Value string `xml:",chardata"`
+		} `xml:"checksum"`
+		OpenChecksum struct {
+			Value string `xml:",chardata"`
+		} `xml:"open-checksum"`
+	}
+	for i := range doc.Data {
+		if doc.Data[i].Type == "primary" {
+			primary = &doc.Data[i]
+		}
+	}
+	require.NotNil(t, primary, "repomd must declare primary")
+
+	// Relative href — resolves against the repo (or group) base URL.
+	assert.Equal(t, "repodata/primary.xml.gz", primary.Location.Href)
+
+	gz := fetch(t, r, "/repository/rpms-ck/repodata/primary.xml.gz").Body.Bytes()
+	assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(gz)), strings.TrimSpace(primary.Checksum.Value),
+		"repomd checksum must match the served primary.xml.gz")
+
+	zr, err := gzip.NewReader(bytes.NewReader(gz))
+	require.NoError(t, err)
+	plain, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(plain)), strings.TrimSpace(primary.OpenChecksum.Value),
+		"open-checksum must match the uncompressed primary.xml")
+}
+
+func TestYum_Repomd_DeclaresFilelistsAndOther(t *testing.T) {
+	r := setupWithRPM(t, "rpms-fl")
+
+	var doc repomdDoc
+	require.NoError(t, xml.Unmarshal(fetch(t, r, "/repository/rpms-fl/repodata/repomd.xml").Body.Bytes(), &doc))
+
+	types := map[string]string{}
+	for _, d := range doc.Data {
+		types[d.Type] = strings.TrimSpace(d.Checksum.Value)
+	}
+	require.Contains(t, types, "filelists")
+	require.Contains(t, types, "other")
+	assert.Len(t, types["filelists"], 64, "real sha256")
+	assert.Len(t, types["other"], 64)
+
+	// The declared docs are actually served and valid XML with per-package entries.
+	fl := fetch(t, r, "/repository/rpms-fl/repodata/filelists.xml").Body.String()
+	assert.Contains(t, fl, `name="curl"`)
+	oth := fetch(t, r, "/repository/rpms-fl/repodata/other.xml").Body.String()
+	assert.Contains(t, oth, `name="curl"`)
+}
+
+func TestYum_Primary_RelativeHrefAndPkgid(t *testing.T) {
+	r := setupWithRPM(t, "rpms-href")
+
+	primary := fetch(t, r, "/repository/rpms-href/repodata/primary.xml").Body.String()
+	assert.Contains(t, primary, `href="pool/curl-8.0.0-1.x86_64.rpm"`,
+		"location href must be relative to the repo root (no leading slash)")
+	assert.Contains(t, primary, `pkgid="YES"`, "primary must carry the package checksum for dnf pkgid matching")
+}


### PR DESCRIPTION
Fixes #102.

- All repo metadata (primary/filelists/other, plain+gz) built from one snapshot — the checksums `repomd.xml` advertises always match the served documents (dnf verifies and previously rejected the empty checksum).
- `repomd.xml`: real `checksum`/`open-checksum`/`size`/`open-size` per entry, **relative** hrefs (`repodata/primary.xml.gz`) — resolve against repo or group URL alike.
- `primary.xml`: package sha256 as `pkgid`, relative `location href` (was absolute `/pool/...`).
- `filelists`/`other`: declared in repomd and served with per-package entries (were undeclared empty stubs).
- Upload NVR parse fixed: `curl-8.0.0-1.x86_64.rpm` → name `curl`, version `8.0.0` (was `curl-8.0.0`/`1`).

TDD: 3 new tests (RED verified: empty checksum, absolute hrefs, missing filelists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk