### PR TITLE
fix(apt): arch-filtered Packages and checksummed Release

### DIFF
--- a/internal/formats/apt/handler.go
+++ b/internal/formats/apt/handler.go
@@ -12,10 +12,14 @@ package apt
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
+	"crypto/md5" //nolint:gosec // apt protocol checksum, not security
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -108,27 +112,28 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	}
 }
 
-func (h *Handler) servePackagesIndex(c *gin.Context, repoName, p string) {
-	gzipped := strings.HasSuffix(p, ".gz")
+// debArch extracts the architecture from a "name_version_arch.deb" filename.
+func debArch(filePath string) string {
+	filename := path.Base(filePath)
+	if parts := strings.Split(strings.TrimSuffix(filename, ".deb"), "_"); len(parts) >= 3 {
+		return parts[len(parts)-1]
+	}
+	return "amd64" // default for non-conforming names
+}
 
-	// Parse: /dists/:dist/:component/binary-:arch/Packages[.gz]
-	// We use all components regardless of the specific path for now
-	page, err := h.deps.Components.Search(c.Request.Context(), domain.SearchParams{
+// buildPackagesIndex generates the Packages index. arch filters to that
+// architecture (plus "all" debs, per Debian convention); empty = no filter.
+func (h *Handler) buildPackagesIndex(ctx context.Context, repoName, arch string) ([]byte, error) {
+	page, err := h.deps.Components.Search(ctx, domain.SearchParams{
 		Repository: repoName, Limit: 1000,
 	})
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
+		return nil, err
 	}
-
-	// List assets to get file details
-	assetPage, err := h.deps.Assets.List(c.Request.Context(), repoName, 1000, 0)
+	assetPage, err := h.deps.Assets.List(ctx, repoName, 1000, 0)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
+		return nil, err
 	}
-
-	// Build component → asset map
 	compMap := map[string]*domain.Component{}
 	for i := range page.Items {
 		compMap[page.Items[i].ID] = &page.Items[i]
@@ -143,17 +148,13 @@ func (h *Handler) servePackagesIndex(c *gin.Context, repoName, p string) {
 		if comp == nil {
 			continue
 		}
-		// Minimal Packages stanza
-		pkgName := comp.Name
-		version := comp.Version
-		arch := "amd64" // default; ideally parsed from filename
-		filename := path.Base(a.Path)
-		if parts := strings.Split(strings.TrimSuffix(filename, ".deb"), "_"); len(parts) >= 3 {
-			arch = parts[len(parts)-1]
+		debA := debArch(a.Path)
+		if arch != "" && debA != arch && debA != "all" {
+			continue // the binary-<arch> index lists that arch plus "all" (#103)
 		}
-		fmt.Fprintf(&sb, "Package: %s\n", pkgName)
-		fmt.Fprintf(&sb, "Version: %s\n", version)
-		fmt.Fprintf(&sb, "Architecture: %s\n", arch)
+		fmt.Fprintf(&sb, "Package: %s\n", comp.Name)
+		fmt.Fprintf(&sb, "Version: %s\n", comp.Version)
+		fmt.Fprintf(&sb, "Architecture: %s\n", debA)
 		fmt.Fprintf(&sb, "Filename: %s\n", a.Path)
 		fmt.Fprintf(&sb, "Size: %d\n", a.SizeBytes)
 		if a.SHA256 != "" {
@@ -164,8 +165,26 @@ func (h *Handler) servePackagesIndex(c *gin.Context, repoName, p string) {
 		}
 		sb.WriteString("\n")
 	}
+	return []byte(sb.String()), nil
+}
 
-	data := []byte(sb.String())
+func (h *Handler) servePackagesIndex(c *gin.Context, repoName, p string) {
+	gzipped := strings.HasSuffix(p, ".gz")
+
+	// Parse the requested architecture from /dists/:dist/:component/binary-:arch/...
+	arch := ""
+	for _, seg := range strings.Split(p, "/") {
+		if a, found := strings.CutPrefix(seg, "binary-"); found {
+			arch = a
+			break
+		}
+	}
+
+	data, err := h.buildPackagesIndex(c.Request.Context(), repoName, arch)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 	if gzipped {
 		var buf bytes.Buffer
 		gw := gzip.NewWriter(&buf)
@@ -177,7 +196,31 @@ func (h *Handler) servePackagesIndex(c *gin.Context, repoName, p string) {
 	c.Data(http.StatusOK, "text/plain; charset=utf-8", data)
 }
 
-func (h *Handler) serveRelease(c *gin.Context, _, p string) {
+// repoArchitectures collects the set of architectures present in the repo.
+func (h *Handler) repoArchitectures(ctx context.Context, repoName string) []string {
+	assetPage, err := h.deps.Assets.List(ctx, repoName, 1000, 0)
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var archs []string
+	for _, a := range assetPage.Items {
+		if !strings.HasSuffix(a.Path, ".deb") {
+			continue
+		}
+		arch := debArch(a.Path)
+		if arch == "all" || seen[arch] {
+			continue
+		}
+		seen[arch] = true
+		archs = append(archs, arch)
+	}
+	sort.Strings(archs)
+	return archs
+}
+
+func (h *Handler) serveRelease(c *gin.Context, repoName, p string) {
+	ctx := c.Request.Context()
 	// Parse distribution from path: /dists/:dist/Release
 	parts := strings.Split(strings.TrimPrefix(p, "/dists/"), "/")
 	dist := "stable"
@@ -185,17 +228,51 @@ func (h *Handler) serveRelease(c *gin.Context, _, p string) {
 		dist = parts[0]
 	}
 
+	archs := h.repoArchitectures(ctx, repoName)
+	archList := strings.Join(append(append([]string{}, archs...), "all"), " ")
+
+	// apt verifies the Packages indexes against these checksum sections —
+	// without them a default (verifying) client rejects the repo (#103).
+	type indexFile struct {
+		relPath string
+		body    []byte
+	}
+	var files []indexFile
+	for _, arch := range archs {
+		plain, err := h.buildPackagesIndex(ctx, repoName, arch)
+		if err != nil {
+			continue
+		}
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, _ = gw.Write(plain)
+		_ = gw.Close()
+		files = append(files,
+			indexFile{relPath: "main/binary-" + arch + "/Packages", body: plain},
+			indexFile{relPath: "main/binary-" + arch + "/Packages.gz", body: buf.Bytes()},
+		)
+	}
+
 	now := time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 UTC")
-	release := fmt.Sprintf(`Origin: Nexspence
+	var sb strings.Builder
+	fmt.Fprintf(&sb, `Origin: Nexspence
 Label: Nexspence
 Suite: %s
 Codename: %s
 Date: %s
-Architectures: amd64 arm64 all
-Components: main contrib non-free
+Architectures: %s
+Components: main
 Description: Nexspence APT Repository
-`, dist, dist, now)
-	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(release))
+`, dist, dist, now, archList)
+	sb.WriteString("MD5Sum:\n")
+	for _, f := range files {
+		fmt.Fprintf(&sb, " %x %d %s\n", md5.Sum(f.body), len(f.body), f.relPath) //nolint:gosec // apt protocol checksum
+	}
+	sb.WriteString("SHA256:\n")
+	for _, f := range files {
+		fmt.Fprintf(&sb, " %x %d %s\n", sha256.Sum256(f.body), len(f.body), f.relPath)
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(sb.String()))
 }
 
 // debCoords parses the Debian "name_version_arch.deb" filename convention.

--- a/internal/formats/apt/release_test.go
+++ b/internal/formats/apt/release_test.go
@@ -1,0 +1,67 @@
+package apt_test
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func fetch(t *testing.T, r *gin.Engine, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, url)
+	return w
+}
+
+// #103: the Packages index must honor the binary-<arch> path segment.
+func TestApt_PackagesIndex_FiltersByArch(t *testing.T) {
+	repo := testutil.SimpleRepo("debs-arch", "apt")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-arch", "/pool/main/curl_8.0.0_amd64.deb", "a"))
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-arch", "/pool/main/vim_9.0_arm64.deb", "b"))
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-arch", "/pool/main/tzdata_2024a_all.deb", "c"))
+
+	amd := fetch(t, r, "/repository/debs-arch/dists/focal/main/binary-amd64/Packages").Body.String()
+	assert.Contains(t, amd, "Package: curl")
+	assert.NotContains(t, amd, "Package: vim", "arm64 deb must not appear in binary-amd64")
+	assert.Contains(t, amd, "Package: tzdata", "arch 'all' appears in every index")
+
+	arm := fetch(t, r, "/repository/debs-arch/dists/focal/main/binary-arm64/Packages").Body.String()
+	assert.Contains(t, arm, "Package: vim")
+	assert.NotContains(t, arm, "Package: curl")
+}
+
+// #103: apt verifies the Packages files against the checksums in Release.
+func TestApt_Release_ChecksumsMatchServedPackages(t *testing.T) {
+	repo := testutil.SimpleRepo("debs-rel", "apt")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-rel", "/pool/main/curl_8.0.0_amd64.deb", "curl-bytes"))
+
+	release := fetch(t, r, "/repository/debs-rel/dists/focal/Release").Body.String()
+	assert.Contains(t, release, "SHA256:")
+	assert.Contains(t, release, "MD5Sum:")
+	assert.Regexp(t, `Architectures:.*amd64`, release, "real archs listed")
+
+	// The SHA256 line for main/binary-amd64/Packages must match the actually
+	// served index (hash + size).
+	pkgs := fetch(t, r, "/repository/debs-rel/dists/focal/main/binary-amd64/Packages").Body.Bytes()
+	wantHash := fmt.Sprintf("%x", sha256.Sum256(pkgs))
+	re := regexp.MustCompile(`(?m)^\s+([0-9a-f]{64})\s+(\d+)\s+main/binary-amd64/Packages$`)
+	m := re.FindStringSubmatch(release)
+	require.NotNil(t, m, "Release must list main/binary-amd64/Packages under SHA256:\n%s", release)
+	assert.Equal(t, wantHash, m[1])
+	assert.Equal(t, fmt.Sprintf("%d", len(pkgs)), m[2])
+}


### PR DESCRIPTION
Part of #103 (GPG signing remains — needs a signing-key config decision and a PGP dependency; keeping the issue open for it).

- `binary-<arch>/Packages` now lists only that architecture plus `all` debs (was: every deb regardless of arch, defaulting arm64 requests to amd64 content).
- `Release` lists the real `Architectures:` and `MD5Sum:`/`SHA256:` sections enumerating `main/binary-<arch>/Packages[.gz]` with hashes+sizes that match the actually-served indexes — apt can now verify file integrity ([trusted=yes] still required until GPG lands).
- Extracted `buildPackagesIndex(ctx, repo, arch)` shared by the index and Release paths.

TDD: 2 new tests (RED verified: no arch filter, no checksum sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUa2euV3MQk2vp4Vw5CGQk