### PR TITLE
fix(npm): drop scope from published tarball filename (#113)

### DIFF
--- a/internal/formats/npm/handler.go
+++ b/internal/formats/npm/handler.go
@@ -239,7 +239,9 @@ func (h *Handler) handlePublish(c *gin.Context, repoName, pkgPath string) {
 		if ct == "" {
 			ct = "application/octet-stream"
 		}
-		filePath := "/" + pkgName + "/-/" + filename
+		// npm names the attachment "@scope/name-ver.tgz" but requests the
+		// tarball at /@scope/name/-/name-ver.tgz (#113) — drop the scope.
+		filePath := "/" + pkgName + "/-/" + path.Base(filename)
 		coords := base.Coords{Name: pkgName, Version: version}
 		if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
 			repoName, filePath, ct, coords,

--- a/internal/formats/npm/handler_test.go
+++ b/internal/formats/npm/handler_test.go
@@ -88,6 +88,37 @@ func TestNPM_PublishAndDownload(t *testing.T) {
 	assert.Equal(t, "fake-tgz-content", w2.Body.String())
 }
 
+// TestNPM_PublishScoped_TarballPathDropsScope covers #113: npm names the
+// attachment "@scope/name-ver.tgz" but requests the tarball at
+// /@scope/name/-/name-ver.tgz, so the scope must not leak into the filename.
+func TestNPM_PublishScoped_TarballPathDropsScope(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-scoped", "npm")
+	r := setup(repo)
+
+	body := publishBody("@babel/runtime", "7.29.7", "fake-tgz-content")
+	req := httptest.NewRequest(http.MethodPut, "/repository/npm-scoped/@babel/runtime",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	req2 := httptest.NewRequest(http.MethodGet,
+		"/repository/npm-scoped/@babel/runtime/-/runtime-7.29.7.tgz", nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "fake-tgz-content", w2.Body.String())
+
+	// The packument must advertise exactly that URL.
+	req3 := httptest.NewRequest(http.MethodGet, "/repository/npm-scoped/@babel/runtime", nil)
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, req3)
+	require.Equal(t, http.StatusOK, w3.Code)
+	assert.Contains(t, w3.Body.String(),
+		"http://localhost:8080/repository/npm-scoped/@babel/runtime/-/runtime-7.29.7.tgz")
+}
+
 func TestNPM_Metadata_NotFound(t *testing.T) {
 	repo := testutil.SimpleRepo("npm-empty", "npm")
 	r := setup(repo)


### PR DESCRIPTION
Closes #113.

## Problem

`npm publish` puts the tarball into `_attachments` under a key that carries the full package name — `@babel/runtime-7.29.7.tgz`. `handlePublish` used that key verbatim when building the asset path:

```
/@babel/runtime/-/@babel/runtime-7.29.7.tgz
```

Clients, however, fetch the tarball from `/@babel/runtime/-/runtime-7.29.7.tgz` — the very URL the packument we generate already advertised (it applies `path.Base` to the package name). As a result, any scoped package published to a hosted repository failed to install with `E404`.

## Fix

Apply `path.Base(filename)` when building the asset path, so the stored name drops the scope and matches what the packument advertises. As a side effect, an attachment key like `../..` can no longer escape the package prefix.

## Tests (TDD)

`TestNPM_PublishScoped_TarballPathDropsScope` publishes `@babel/runtime@7.29.7`, downloads the tarball and asserts `dist.tarball` in the packument. It failed with a 404 on download before the fix.

`go test ./internal/formats/npm/...` — 33 passed.

## Note

Packages published before this fix are stored under the old, broken path and will keep returning 404 — they need to be re-published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8M6vasTswsV3AbsQsagMf