### PR TITLE
fix(formats): npm dist-tags/unpublish, apt GPG signing, HA docker uploads

### DIFF
--- a/docs/apt-signing.md
+++ b/docs/apt-signing.md
@@ -1,0 +1,66 @@
+# Signing an APT Repository
+
+By default an `apt` client refuses a repository it cannot verify, which is why
+an unsigned Nexspence apt repository only works from a source marked
+`[trusted=yes]`. Configure a GPG key on the repository and Nexspence signs its
+release metadata, so the repository can be used from a normal source line.
+
+## Generate a key
+
+```bash
+gpg --batch --quick-generate-key "Nexspence APT <apt@example.com>" rsa4096 sign never
+gpg --armor --export-secret-keys apt@example.com > apt-signing.key
+```
+
+Use `--passphrase` (or an empty one, as above) deliberately: the passphrase has
+to be stored alongside the key for Nexspence to unlock it.
+
+## Configure the repository
+
+Set the armored private key in the repository's `formatConfig`:
+
+```bash
+curl -X PUT "$NEXSPENCE/api/v1/repositories/apt-hosted" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --rawfile key apt-signing.key '{
+        formatConfig: { signing_key: $key }
+      }')"
+```
+
+| Field | Meaning |
+|---|---|
+| `signing_key` | ASCII-armored **private** key. Empty/absent = repository stays unsigned. |
+| `signing_key_passphrase` | Passphrase, when the key is protected. |
+
+The key is stored in the repository configuration and is readable by anyone
+allowed to read that configuration — treat it like any other repository
+credential and give the repository a key of its own rather than reusing a
+personal one.
+
+## What clients get
+
+| Path | Content |
+|---|---|
+| `/repository/<repo>/dists/<dist>/Release` | The release document. |
+| `/repository/<repo>/dists/<dist>/InRelease` | The same document, clearsigned (plain when unsigned). |
+| `/repository/<repo>/dists/<dist>/Release.gpg` | Detached signature; `404` when unsigned. |
+| `/repository/<repo>/public.gpg` | Public half of the signing key; `404` when unsigned. |
+
+Signatures are SHA-256; apt rejects SHA-1.
+
+`Release` is byte-identical between requests — its `Date` follows the newest
+package rather than the wall clock, because apt fetches `Release` and
+`Release.gpg` separately and verifies one against the other.
+
+## Use it
+
+```bash
+curl -fsSL "$NEXSPENCE/repository/apt-hosted/public.gpg" \
+  | gpg --dearmor | sudo tee /usr/share/keyrings/nexspence.gpg > /dev/null
+
+echo "deb [signed-by=/usr/share/keyrings/nexspence.gpg] $NEXSPENCE/repository/apt-hosted/ stable main" \
+  | sudo tee /etc/apt/sources.list.d/nexspence.list
+
+sudo apt update
+```

--- a/docs/ha-setup.md
+++ b/docs/ha-setup.md
@@ -77,6 +77,16 @@ readinessProbe:
 | Cleanup lock | `nexspence:lock:cleanup:run` | 30 min |
 | Blob migration lock | `nexspence:lock:blobmig:<repo>` | 2 hours |
 
+## Docker Blob Uploads
+
+A `docker push` is a chain of requests (POST → PATCH → PUT) that a load balancer
+may spread over different nodes. The in-progress upload is staged in the blob
+store under `_uploads/docker/<id>`, not in a node's memory, so the chain works
+without sticky sessions and survives a restart mid-push. Abandoned uploads are
+unreferenced blobs and are reclaimed by the blob GC once older than its minimum
+age. This does require every node to share one blob store — the same assumption
+the rest of HA already makes.
+
 ## Production Redis
 
 For production, use Redis Sentinel (for automatic failover) or Redis Cluster

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/nexspence-oss/nexspence
 go 1.26.5
 
 require (
+	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/aws/aws-sdk-go-v2 v1.43.0
 	github.com/aws/aws-sdk-go-v2/config v1.32.31
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.30
@@ -61,6 +62,7 @@ require (
 	github.com/bytedance/sonic/loader v0.5.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/cloudflare/circl v1.6.4 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
+github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e h1:4dAU9FXIyQktpoUAgOJK3OTFc/xug0PCXYCqU0FgDKI=
 github.com/alexbrainman/sspi v0.0.0-20250919150558-7d374ff0d59e/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
@@ -72,6 +74,8 @@ github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK3
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cloudflare/circl v1.6.4 h1:pOXuDTCEYyzydgUpQ0CQz3LsinKjiSk6nNP5Lt5K64U=
+github.com/cloudflare/circl v1.6.4/go.mod h1:YxarevkLlbaHuWsxG6vmYNWBEsSp4pnp7j+4VljMavY=
 github.com/cloudwego/base64x v0.1.7 h1:NppS+Fgzg5ovhn4NkUXaDT3x9jldgH5ToMCqzBSi2zI=
 github.com/cloudwego/base64x v0.1.7/go.mod h1:Cu1PV9zfrSf7ET2tIbWbbEy7jO7HHJ13q4X2SQ8aWYg=
 github.com/containerd/continuity v0.4.5 h1:ZRoN1sXq9u7V6QoHMcVWGhOwDFqZ4B9i5H6un1Wh0x4=

--- a/internal/formats/apt/handler.go
+++ b/internal/formats/apt/handler.go
@@ -73,18 +73,31 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		return
 	}
 
+	h.serveHosted(c, repo, repoName, p)
+}
+
+// serveHosted routes the hosted (non-proxy) surface of the apt protocol.
+func (h *Handler) serveHosted(c *gin.Context, repo *domain.Repository, repoName, p string) {
 	switch {
 	// Packages index (plain or gzip)
 	case c.Request.Method == http.MethodGet && strings.HasPrefix(p, "/dists/") && strings.Contains(p, "/Packages"):
 		h.servePackagesIndex(c, repoName, p)
 
+	// Public half of the signing key, so clients can trust this repository.
+	case c.Request.Method == http.MethodGet && p == "/public.gpg":
+		h.servePublicKey(c, repo)
+
+	// Detached signature of Release (#103)
+	case c.Request.Method == http.MethodGet && strings.HasSuffix(p, "/Release.gpg"):
+		h.serveReleaseSignature(c, repo, repoName, strings.TrimSuffix(p, ".gpg"))
+
 	// Release file
 	case c.Request.Method == http.MethodGet && strings.HasSuffix(p, "/Release"):
 		h.serveRelease(c, repoName, p)
 
-	// InRelease (signed — serve same as Release for compatibility)
+	// InRelease — the same document, signed inline when a key is configured.
 	case c.Request.Method == http.MethodGet && strings.HasSuffix(p, "/InRelease"):
-		h.serveRelease(c, repoName, p)
+		h.serveInRelease(c, repo, repoName, p)
 
 	// Download .deb
 	case (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) && strings.HasPrefix(p, "/pool/"):
@@ -220,11 +233,78 @@ func (h *Handler) repoArchitectures(ctx context.Context, repoName string) []stri
 }
 
 func (h *Handler) serveRelease(c *gin.Context, repoName, p string) {
-	ctx := c.Request.Context()
+	body, err := h.buildRelease(c.Request.Context(), repoName, p)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", body)
+}
+
+// serveInRelease serves the clearsigned Release. Unsigned repositories keep
+// serving the plain document, which is what [trusted=yes] sources expect.
+func (h *Handler) serveInRelease(c *gin.Context, repo *domain.Repository, repoName, p string) {
+	body, err := h.buildRelease(c.Request.Context(), repoName, p)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if !signingConfigured(repo) {
+		c.Data(http.StatusOK, "text/plain; charset=utf-8", body)
+		return
+	}
+	signed, err := clearSign(repo, body)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", signed)
+}
+
+// serveReleaseSignature serves Release.gpg — the detached signature apt checks
+// against the Release document it fetched separately.
+func (h *Handler) serveReleaseSignature(c *gin.Context, repo *domain.Repository, repoName, releasePath string) {
+	if !signingConfigured(repo) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "repository is not signed"})
+		return
+	}
+	body, err := h.buildRelease(c.Request.Context(), repoName, releasePath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	sig, err := detachSign(repo, body)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Data(http.StatusOK, "application/pgp-signature", sig)
+}
+
+func (h *Handler) servePublicKey(c *gin.Context, repo *domain.Repository) {
+	if !signingConfigured(repo) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "repository is not signed"})
+		return
+	}
+	key, err := armoredPublicKey(repo)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Data(http.StatusOK, "application/pgp-keys", key)
+}
+
+// buildRelease renders the Release document for the distribution named in p.
+//
+// The result must be byte-identical across requests: apt fetches Release and
+// its signature separately and verifies one against the other, so a wall-clock
+// Date would break verification. The date therefore tracks the content — the
+// newest package in the repository (#103).
+func (h *Handler) buildRelease(ctx context.Context, repoName, p string) ([]byte, error) {
 	// Parse distribution from path: /dists/:dist/Release
 	parts := strings.Split(strings.TrimPrefix(p, "/dists/"), "/")
 	dist := "stable"
-	if len(parts) > 0 {
+	if len(parts) > 0 && parts[0] != "" {
 		dist = parts[0]
 	}
 
@@ -253,7 +333,7 @@ func (h *Handler) serveRelease(c *gin.Context, repoName, p string) {
 		)
 	}
 
-	now := time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 UTC")
+	date := h.releaseDate(ctx, repoName).UTC().Format("Mon, 02 Jan 2006 15:04:05 UTC")
 	var sb strings.Builder
 	fmt.Fprintf(&sb, `Origin: Nexspence
 Label: Nexspence
@@ -263,7 +343,7 @@ Date: %s
 Architectures: %s
 Components: main
 Description: Nexspence APT Repository
-`, dist, dist, now, archList)
+`, dist, dist, date, archList)
 	sb.WriteString("MD5Sum:\n")
 	for _, f := range files {
 		fmt.Fprintf(&sb, " %x %d %s\n", md5.Sum(f.body), len(f.body), f.relPath) //nolint:gosec // apt protocol checksum
@@ -272,7 +352,30 @@ Description: Nexspence APT Repository
 	for _, f := range files {
 		fmt.Fprintf(&sb, " %x %d %s\n", sha256.Sum256(f.body), len(f.body), f.relPath)
 	}
-	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(sb.String()))
+	return []byte(sb.String()), nil
+}
+
+// releaseDate is the timestamp stamped into Release. It follows the newest
+// stored package so the document only changes when its content does; an empty
+// repository has nothing to pin it to and falls back to the current time.
+func (h *Handler) releaseDate(ctx context.Context, repoName string) time.Time {
+	assetPage, err := h.deps.Assets.List(ctx, repoName, 1000, 0)
+	if err != nil {
+		return time.Now()
+	}
+	var newest time.Time
+	for _, a := range assetPage.Items {
+		if !strings.HasSuffix(a.Path, ".deb") {
+			continue
+		}
+		if a.LastModified.After(newest) {
+			newest = a.LastModified
+		}
+	}
+	if newest.IsZero() {
+		return time.Now()
+	}
+	return newest
 }
 
 // debCoords parses the Debian "name_version_arch.deb" filename convention.

--- a/internal/formats/apt/signing.go
+++ b/internal/formats/apt/signing.go
@@ -1,0 +1,134 @@
+package apt
+
+import (
+	"bytes"
+	"crypto"
+	"fmt"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// Signing is configured per repository:
+//
+//	formatConfig.signing_key            ASCII-armored private key
+//	formatConfig.signing_key_passphrase passphrase, when the key is protected
+//
+// Without a key the repository stays unsigned and only works for apt sources
+// marked [trusted=yes] — which is what #103 is about.
+const (
+	signingKeyField     = "signing_key"
+	signingKeyPassField = "signing_key_passphrase"
+)
+
+func configString(repo *domain.Repository, field string) string {
+	if repo == nil || repo.FormatConfig == nil {
+		return ""
+	}
+	s, _ := repo.FormatConfig[field].(string)
+	return strings.TrimSpace(s)
+}
+
+// signingConfigured reports whether the repository has a signing key at all.
+func signingConfigured(repo *domain.Repository) bool {
+	return configString(repo, signingKeyField) != ""
+}
+
+// signingEntity parses (and, if needed, unlocks) the configured private key.
+func signingEntity(repo *domain.Repository) (*openpgp.Entity, error) {
+	armored := configString(repo, signingKeyField)
+	if armored == "" {
+		return nil, fmt.Errorf("no signing key configured")
+	}
+	ring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(armored))
+	if err != nil {
+		return nil, fmt.Errorf("signing key: %w", err)
+	}
+	if len(ring) == 0 {
+		return nil, fmt.Errorf("signing key: no key found")
+	}
+	entity := ring[0]
+	if entity.PrivateKey == nil {
+		return nil, fmt.Errorf("signing key: public key only, cannot sign")
+	}
+	pass := []byte(configString(repo, signingKeyPassField))
+	if entity.PrivateKey.Encrypted {
+		if err := entity.PrivateKey.Decrypt(pass); err != nil {
+			return nil, fmt.Errorf("signing key: %w", err)
+		}
+	}
+	for _, sub := range entity.Subkeys {
+		if sub.PrivateKey != nil && sub.PrivateKey.Encrypted {
+			// A subkey we cannot unlock is not fatal: the primary key signs.
+			_ = sub.PrivateKey.Decrypt(pass)
+		}
+	}
+	return entity, nil
+}
+
+// signingConfig pins the digest to SHA-256; apt rejects SHA-1 signatures.
+func signingConfig() *packet.Config {
+	return &packet.Config{DefaultHash: crypto.SHA256}
+}
+
+// clearSign wraps the document in an inline signature — the InRelease format.
+func clearSign(repo *domain.Repository, body []byte) ([]byte, error) {
+	entity, err := signingEntity(repo)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	w, err := clearsign.Encode(&buf, entity.PrivateKey, signingConfig())
+	if err != nil {
+		return nil, fmt.Errorf("clearsign: %w", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return nil, fmt.Errorf("clearsign: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("clearsign: %w", err)
+	}
+	// A trailing newline keeps the armor block well-formed for apt's parser.
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
+}
+
+// detachSign produces the Release.gpg counterpart of a Release document.
+func detachSign(repo *domain.Repository, body []byte) ([]byte, error) {
+	entity, err := signingEntity(repo)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := openpgp.ArmoredDetachSign(&buf, entity, bytes.NewReader(body), signingConfig()); err != nil {
+		return nil, fmt.Errorf("detached sign: %w", err)
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
+}
+
+// armoredPublicKey exports the public half so clients can trust the repository.
+func armoredPublicKey(repo *domain.Repository) ([]byte, error) {
+	entity, err := signingEntity(repo)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		return nil, fmt.Errorf("public key: %w", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		return nil, fmt.Errorf("public key: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return nil, fmt.Errorf("public key: %w", err)
+	}
+	buf.WriteByte('\n')
+	return buf.Bytes(), nil
+}

--- a/internal/formats/apt/signing_test.go
+++ b/internal/formats/apt/signing_test.go
@@ -1,0 +1,147 @@
+package apt_test
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/armor"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// newSigningKey mints a throwaway key and returns it ASCII-armored, plus the
+// entity list to verify signatures against.
+func newSigningKey(t *testing.T) (armored string, keyring openpgp.EntityList) {
+	t.Helper()
+	entity, err := openpgp.NewEntity("Nexspence Test", "apt signing", "apt@example.test", nil)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PrivateKeyType, nil)
+	require.NoError(t, err)
+	require.NoError(t, entity.SerializePrivateWithoutSigning(w, nil))
+	require.NoError(t, w.Close())
+
+	ring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(buf.String()))
+	require.NoError(t, err)
+	return buf.String(), ring
+}
+
+// signedRepo is an apt repository configured to sign its Release files.
+func signedRepo(t *testing.T, name string) (*domain.Repository, openpgp.EntityList) {
+	t.Helper()
+	armored, ring := newSigningKey(t)
+	repo := testutil.SimpleRepo(name, "apt")
+	repo.FormatConfig = map[string]any{"signing_key": armored}
+	return repo, ring
+}
+
+// A default apt client rejects an unsigned repository, so InRelease must carry
+// an inline signature when a signing key is configured (#103).
+func TestApt_InRelease_IsClearsigned(t *testing.T) {
+	repo, ring := signedRepo(t, "debs-signed")
+	r := setup(repo)
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-signed", "/pool/main/hello_1.0_amd64.deb", "deb-bytes"))
+
+	w := get(t, r, "/repository/debs-signed/dists/stable/InRelease")
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.Bytes()
+	require.True(t, bytes.HasPrefix(body, []byte("-----BEGIN PGP SIGNED MESSAGE-----")),
+		"InRelease must be clearsigned, got: %.60s", body)
+
+	block, rest := clearsign.Decode(body)
+	require.NotNil(t, block, "clearsign block must parse (trailing: %q)", string(rest))
+	assert.Contains(t, string(block.Plaintext), "Suite: stable")
+	assert.Contains(t, string(block.Plaintext), "SHA256:")
+
+	_, err := openpgp.CheckDetachedSignature(ring, bytes.NewReader(block.Bytes), block.ArmoredSignature.Body, nil)
+	assert.NoError(t, err, "signature must verify against the configured key")
+}
+
+// apt fetches Release and Release.gpg separately, so the detached signature has
+// to verify against the body served by the other request.
+func TestApt_ReleaseGPG_VerifiesAgainstRelease(t *testing.T) {
+	repo, ring := signedRepo(t, "debs-detached")
+	r := setup(repo)
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-detached", "/pool/main/hello_1.0_amd64.deb", "deb-bytes"))
+
+	release := get(t, r, "/repository/debs-detached/dists/stable/Release")
+	require.Equal(t, http.StatusOK, release.Code)
+
+	sig := get(t, r, "/repository/debs-detached/dists/stable/Release.gpg")
+	require.Equal(t, http.StatusOK, sig.Code)
+	assert.True(t, strings.HasPrefix(sig.Body.String(), "-----BEGIN PGP SIGNATURE-----"),
+		"Release.gpg must be an armored detached signature, got: %.60s", sig.Body.String())
+
+	_, err := openpgp.CheckArmoredDetachedSignature(ring,
+		bytes.NewReader(release.Body.Bytes()), strings.NewReader(sig.Body.String()), nil)
+	assert.NoError(t, err)
+}
+
+// The signature is generated over one snapshot of Release while apt verifies it
+// against another fetch, so the file has to be byte-identical across requests.
+func TestApt_Release_IsStableAcrossRequests(t *testing.T) {
+	repo := testutil.SimpleRepo("debs-stable", "apt")
+	r := setup(repo)
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-stable", "/pool/main/hello_1.0_amd64.deb", "deb-bytes"))
+
+	first := get(t, r, "/repository/debs-stable/dists/stable/Release")
+	// apt fetches Release and its signature seconds apart; a wall-clock Date
+	// makes the two disagree and verification fails.
+	time.Sleep(1100 * time.Millisecond)
+	second := get(t, r, "/repository/debs-stable/dists/stable/Release")
+	require.Equal(t, http.StatusOK, first.Code)
+	assert.Equal(t, first.Body.String(), second.Body.String(),
+		"Release must not change between requests (its Date must not be 'now')")
+}
+
+// Without a key nothing can be signed: Release.gpg has no answer, and InRelease
+// keeps serving the plain document (what apt [trusted=yes] sources rely on).
+func TestApt_Signing_NotConfigured(t *testing.T) {
+	repo := testutil.SimpleRepo("debs-unsigned", "apt")
+	r := setup(repo)
+	require.Equal(t, http.StatusCreated, putDeb(r, "debs-unsigned", "/pool/main/hello_1.0_amd64.deb", "deb-bytes"))
+
+	assert.Equal(t, http.StatusNotFound, get(t, r, "/repository/debs-unsigned/dists/stable/Release.gpg").Code)
+	assert.Equal(t, http.StatusNotFound, get(t, r, "/repository/debs-unsigned/public.gpg").Code)
+
+	inRelease := get(t, r, "/repository/debs-unsigned/dists/stable/InRelease")
+	require.Equal(t, http.StatusOK, inRelease.Code)
+	assert.Contains(t, inRelease.Body.String(), "Suite: stable")
+	assert.NotContains(t, inRelease.Body.String(), "BEGIN PGP")
+}
+
+// Clients need the public half to trust the repository.
+func TestApt_PublicKey_Served(t *testing.T) {
+	repo, ring := signedRepo(t, "debs-pubkey")
+	r := setup(repo)
+
+	w := get(t, r, "/repository/debs-pubkey/public.gpg")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, strings.HasPrefix(w.Body.String(), "-----BEGIN PGP PUBLIC KEY BLOCK-----"),
+		"expected an armored public key, got: %.60s", w.Body.String())
+
+	served, err := openpgp.ReadArmoredKeyRing(strings.NewReader(w.Body.String()))
+	require.NoError(t, err)
+	require.Len(t, served, 1)
+	assert.Equal(t, ring[0].PrimaryKey.KeyId, served[0].PrimaryKey.KeyId)
+	assert.Nil(t, served[0].PrivateKey, "the private key must never be served")
+}
+
+// A malformed key must not take the whole repository down.
+func TestApt_Signing_BrokenKey_500(t *testing.T) {
+	repo := testutil.SimpleRepo("debs-badkey", "apt")
+	repo.FormatConfig = map[string]any{"signing_key": "not-a-pgp-key"}
+	r := setup(repo)
+
+	assert.Equal(t, http.StatusInternalServerError,
+		get(t, r, "/repository/debs-badkey/dists/stable/InRelease").Code)
+}

--- a/internal/formats/docker/docker_extra_test.go
+++ b/internal/formats/docker/docker_extra_test.go
@@ -1,6 +1,7 @@
 package docker_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -395,6 +396,137 @@ func TestDocker_ProxyBlob_Get_FallsThrough(t *testing.T) {
 	r.ServeHTTP(w, req)
 	// Proxy branch taken; upstream unreachable → non-200
 	assert.NotEqual(t, http.StatusOK, w.Code)
+}
+
+// ── Proxy DELETE (blob) ───────────────────────────────────────
+
+// Deleting a blob from a proxy repository must be rejected like every other
+// mutation (#104) — otherwise the request evicts the locally cached copy.
+func TestDocker_ProxyBlob_Delete_Rejected(t *testing.T) {
+	repo := testutil.SimpleRepo("dreg-proxy-del", "docker")
+	repo.Type = "proxy"
+	repo.ProxyConfig = map[string]any{"remote_url": "http://127.0.0.1:1"}
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/repository/dreg-proxy-del/v2/library/alpine/blobs/sha256:deadbeef", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+// ── Blob upload across instances (HA) ─────────────────────────
+
+// engineFor wires one gin engine per Handler so a test can drive several
+// handler instances that share the same Deps — the multi-node deployment where
+// consecutive requests of one push land on different nodes.
+func engineFor(h *docker.Handler) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+// A blob push must survive landing on different instances: upload state lives in
+// shared storage, not in one process's memory (#104).
+func TestDocker_BlobUpload_SpansInstances(t *testing.T) {
+	repo := testutil.SimpleRepo("dreg-ha", "docker")
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	node1, node2 := engineFor(docker.New(d)), engineFor(docker.New(d))
+
+	const first, second = "layer-part-one|", "layer-part-two"
+	dgst := digest(first + second)
+
+	// Initiate on node 1.
+	req := httptest.NewRequest(http.MethodPost, "/repository/dreg-ha/v2/app/blobs/uploads/", nil)
+	w := httptest.NewRecorder()
+	node1.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	loc := w.Header().Get("Location")
+	require.NotEmpty(t, loc)
+
+	// First chunk on node 2.
+	req2 := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader(first))
+	req2.ContentLength = int64(len(first))
+	w2 := httptest.NewRecorder()
+	node2.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusAccepted, w2.Code)
+	assert.Equal(t, fmt.Sprintf("0-%d", len(first)-1), w2.Header().Get("Range"))
+
+	// Second chunk back on node 1 — appends to what node 2 wrote.
+	req3 := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader(second))
+	req3.ContentLength = int64(len(second))
+	w3 := httptest.NewRecorder()
+	node1.ServeHTTP(w3, req3)
+	require.Equal(t, http.StatusAccepted, w3.Code)
+	assert.Equal(t, fmt.Sprintf("0-%d", len(first+second)-1), w3.Header().Get("Range"))
+
+	// Progress query on node 2 sees the full offset.
+	req4 := httptest.NewRequest(http.MethodGet, loc, nil)
+	w4 := httptest.NewRecorder()
+	node2.ServeHTTP(w4, req4)
+	require.Equal(t, http.StatusNoContent, w4.Code)
+	assert.Equal(t, fmt.Sprintf("0-%d", len(first+second)-1), w4.Header().Get("Range"))
+
+	// Finalize on node 2.
+	req5 := httptest.NewRequest(http.MethodPut, loc+"?digest="+dgst, nil)
+	w5 := httptest.NewRecorder()
+	node2.ServeHTTP(w5, req5)
+	require.Equal(t, http.StatusCreated, w5.Code)
+
+	// The stored blob is the concatenation of both chunks.
+	req6 := httptest.NewRequest(http.MethodGet, "/repository/dreg-ha/v2/app/blobs/"+dgst, nil)
+	w6 := httptest.NewRecorder()
+	node1.ServeHTTP(w6, req6)
+	require.Equal(t, http.StatusOK, w6.Code)
+	assert.Equal(t, first+second, w6.Body.String())
+
+	// The session is gone after finalize — a stale retry must not resurrect it.
+	req7 := httptest.NewRequest(http.MethodGet, loc, nil)
+	w7 := httptest.NewRecorder()
+	node1.ServeHTTP(w7, req7)
+	assert.Equal(t, http.StatusNotFound, w7.Code)
+}
+
+// Upload ids must be unpredictable rather than a per-process counter, so two
+// instances never hand out the same id (#104).
+func TestDocker_BlobUpload_IDsAreUnguessable(t *testing.T) {
+	repo := testutil.SimpleRepo("dreg-uuid", "docker")
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	node1, node2 := engineFor(docker.New(d)), engineFor(docker.New(d))
+
+	ids := map[string]bool{}
+	for _, node := range []*gin.Engine{node1, node2, node1, node2} {
+		req := httptest.NewRequest(http.MethodPost, "/repository/dreg-uuid/v2/app/blobs/uploads/", nil)
+		w := httptest.NewRecorder()
+		node.ServeHTTP(w, req)
+		require.Equal(t, http.StatusAccepted, w.Code)
+		id := w.Header().Get("Docker-Upload-UUID")
+		require.NotEmpty(t, id)
+		require.False(t, ids[id], "upload id %q handed out twice", id)
+		// A counter suffix ("...-1", "...-2") is guessable from another node.
+		require.NotRegexp(t, `-\d+$`, id)
+		require.GreaterOrEqual(t, len(id), 32, "id should carry enough entropy")
+		ids[id] = true
+	}
 }
 
 // ── Monolithic PUT (body included in finalize) ────────────────

--- a/internal/formats/docker/handler.go
+++ b/internal/formats/docker/handler.go
@@ -18,11 +18,9 @@ package docker
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -34,22 +32,16 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/requestctx"
 )
 
-// uploadSession stores an in-progress blob upload.
-type uploadSession struct {
-	repoName string
-	buf      bytes.Buffer
-	mu       sync.Mutex
-	created  time.Time
-}
-
 // Handler implements the Docker registry v2 / OCI Distribution API.
 type Handler struct {
 	deps    formats.Deps
-	uploads sync.Map // uuid → *uploadSession
+	uploads uploadStore
 }
 
 // New creates a Docker format Handler with the given dependencies.
-func New(deps formats.Deps) *Handler { return &Handler{deps: deps} }
+func New(deps formats.Deps) *Handler {
+	return &Handler{deps: deps, uploads: uploadStore{deps: deps}}
+}
 
 // Name returns the format identifier.
 func (h *Handler) Name() string { return "docker" }
@@ -267,6 +259,11 @@ func (h *Handler) handleBlobs(c *gin.Context, repoName, imageName, digest string
 		}
 		h.pullBlob(c, repoName, imageName, digest)
 	case http.MethodDelete:
+		// A proxy repository is read-only: deleting here would evict the cached
+		// copy, which manifest DELETE and the upload flow already reject (#104).
+		if repoproxy.RejectMutation(c, repo) {
+			return
+		}
 		fp := blobPath(imageName, digest)
 		if err := base.DeleteArtifact(c.Request.Context(), h.deps, repoName, fp); err != nil {
 			dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
@@ -333,15 +330,11 @@ func (h *Handler) handleBlobUploads(c *gin.Context, repoName, imageName, uuid st
 			c.Status(http.StatusNotFound)
 			return
 		}
-		raw, ok := h.uploads.Load(uuid)
+		offset, ok := h.uploads.size(c.Request.Context(), uuid)
 		if !ok {
 			dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
 			return
 		}
-		sess := raw.(*uploadSession)
-		sess.mu.Lock()
-		offset := int64(sess.buf.Len())
-		sess.mu.Unlock()
 		c.Header("Range", fmt.Sprintf("0-%d", offset-1))
 		c.Header("Docker-Upload-UUID", uuid)
 		c.Status(http.StatusNoContent)
@@ -351,17 +344,17 @@ func (h *Handler) handleBlobUploads(c *gin.Context, repoName, imageName, uuid st
 	}
 }
 
-func (h *Handler) initiateUpload(c *gin.Context, repoName, _ string) {
+func (h *Handler) initiateUpload(c *gin.Context, _, _ string) {
 	if !requireDockerAuth(c) {
 		return
 	}
 	// Cross-repo mount shortcut: ?mount=<digest>&from=<repo>
 	// We ignore mount for now and always start a fresh upload
-	uuid := newUUID()
-	h.uploads.Store(uuid, &uploadSession{
-		repoName: repoName,
-		created:  time.Now(),
-	})
+	uuid, err := h.uploads.create(c.Request.Context())
+	if err != nil {
+		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
+		return
+	}
 	// The Location must stay under the same /v2/ prefix (and short/long path
 	// form) the client authenticated against. Deriving it from the request's
 	// own URL keeps the blob PATCH/PUT on the authenticated /v2/ surface; a
@@ -375,20 +368,15 @@ func (h *Handler) initiateUpload(c *gin.Context, repoName, _ string) {
 }
 
 func (h *Handler) patchUpload(c *gin.Context, _, _, uuid string) {
-	raw, ok := h.uploads.Load(uuid)
+	offset, ok, err := h.uploads.append(c.Request.Context(), uuid, c.Request.Body)
 	if !ok {
 		dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
 		return
 	}
-	sess := raw.(*uploadSession)
-	sess.mu.Lock()
-	defer sess.mu.Unlock()
-
-	if _, err := io.Copy(&sess.buf, c.Request.Body); err != nil {
+	if err != nil {
 		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
 		return
 	}
-	offset := int64(sess.buf.Len())
 	// The request URL already is the upload location — echo it verbatim so the
 	// finalizing PUT stays on the same authenticated /v2/ path (see #47).
 	c.Header("Location", c.Request.URL.Path)
@@ -404,23 +392,30 @@ func (h *Handler) finalizeUpload(c *gin.Context, repoName, imageName, uuid strin
 		return
 	}
 
-	raw, ok := h.uploads.Load(uuid)
+	ctx := c.Request.Context()
+
+	// Any remaining body data (e.g. monolithic PUT with body)
+	if c.Request.ContentLength > 0 {
+		if _, ok, err := h.uploads.append(ctx, uuid, c.Request.Body); !ok {
+			dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
+			return
+		} else if err != nil {
+			dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
+			return
+		}
+	}
+
+	data, ok, err := h.uploads.read(ctx, uuid)
 	if !ok {
 		dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
 		return
 	}
-	sess := raw.(*uploadSession)
-
-	sess.mu.Lock()
-	defer sess.mu.Unlock()
-
-	// Any remaining body data (e.g. monolithic PUT with body)
-	if c.Request.ContentLength > 0 {
-		_, _ = io.Copy(&sess.buf, c.Request.Body)
+	if err != nil {
+		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
+		return
 	}
 
 	fp := blobPath(imageName, digest)
-	data := sess.buf.Bytes()
 	coords := base.Coords{Name: imageName, Version: digest}
 	if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
 		repoName, fp, "application/octet-stream", coords,
@@ -429,7 +424,7 @@ func (h *Handler) finalizeUpload(c *gin.Context, repoName, imageName, uuid strin
 		return
 	}
 	// Delete session only after successful store — allows retry on failure.
-	h.uploads.Delete(uuid)
+	h.uploads.remove(ctx, uuid)
 
 	c.Header("Docker-Content-Digest", digest)
 	// Point at the stored blob under the same /v2/ prefix the client used.
@@ -490,17 +485,6 @@ func segmentIndex(parts []string, seg string) int {
 		}
 	}
 	return -1
-}
-
-var uuidCounter uint64
-var uuidMu sync.Mutex
-
-func newUUID() string {
-	uuidMu.Lock()
-	uuidCounter++
-	n := uuidCounter
-	uuidMu.Unlock()
-	return fmt.Sprintf("%016x-%d", time.Now().UnixNano(), n)
 }
 
 func normPath(p string) string {

--- a/internal/formats/docker/uploads.go
+++ b/internal/formats/docker/uploads.go
@@ -1,0 +1,117 @@
+package docker
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// uploadKeyPrefix namespaces in-progress blob uploads inside the blob store.
+// Staging there rather than in process memory keeps a push alive when its
+// POST/PATCH/PUT chain is spread over several instances, or when the process
+// restarts mid-push (#104). Abandoned sessions are plain unreferenced blobs, so
+// the blob GC reclaims them once they pass its minimum-age gate.
+const uploadKeyPrefix = "_uploads/docker/"
+
+// uploadStore keeps in-progress blob uploads in the default blob store.
+//
+// The Docker protocol drives one upload strictly sequentially (POST, then
+// PATCH per chunk, then PUT), so appends need no cross-request locking; two
+// clients racing on the same upload id is already undefined by the spec.
+type uploadStore struct{ deps formats.Deps }
+
+// newUploadID returns an unguessable upload id. It must not be derived from
+// process-local state: two instances would otherwise hand out the same id.
+func newUploadID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("upload id: %w", err)
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// validUploadID guards the blob key against path traversal via the URL: ids we
+// mint are hex, so anything else cannot name an existing session anyway.
+func validUploadID(id string) bool {
+	if len(id) != 32 {
+		return false
+	}
+	_, err := hex.DecodeString(id)
+	return err == nil
+}
+
+func (s uploadStore) key(id string) string { return uploadKeyPrefix + id }
+
+// create starts an empty session and returns its id.
+func (s uploadStore) create(ctx context.Context) (string, error) {
+	id, err := newUploadID()
+	if err != nil {
+		return "", err
+	}
+	if err := s.deps.BlobStore.Put(ctx, s.key(id), bytes.NewReader(nil), 0); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// size returns the bytes received so far; ok is false when the session is unknown.
+func (s uploadStore) size(ctx context.Context, id string) (n int64, ok bool) {
+	if !validUploadID(id) {
+		return 0, false
+	}
+	exists, err := s.deps.BlobStore.Exists(ctx, s.key(id))
+	if err != nil || !exists {
+		return 0, false
+	}
+	n, err = s.deps.BlobStore.Size(ctx, s.key(id))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// read returns everything received so far; ok is false when the session is unknown.
+func (s uploadStore) read(ctx context.Context, id string) (data []byte, ok bool, err error) {
+	if _, ok = s.size(ctx, id); !ok {
+		return nil, false, nil
+	}
+	rc, _, err := s.deps.BlobStore.Get(ctx, s.key(id))
+	if err != nil {
+		return nil, true, err
+	}
+	defer func() { _ = rc.Close() }()
+	data, err = io.ReadAll(rc)
+	return data, true, err
+}
+
+// append adds a chunk and returns the new total size. ok is false when the
+// session is unknown. The blob store API is whole-object, so the chunk is
+// concatenated onto what is already staged.
+func (s uploadStore) append(ctx context.Context, id string, r io.Reader) (total int64, ok bool, err error) {
+	existing, ok, err := s.read(ctx, id)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	var buf bytes.Buffer
+	buf.Write(existing)
+	if _, err := io.Copy(&buf, r); err != nil {
+		return 0, true, err
+	}
+	if err := s.deps.BlobStore.Put(ctx, s.key(id), bytes.NewReader(buf.Bytes()), int64(buf.Len())); err != nil {
+		return 0, true, err
+	}
+	return int64(buf.Len()), true, nil
+}
+
+// remove drops a finished (or abandoned) session.
+func (s uploadStore) remove(ctx context.Context, id string) {
+	if !validUploadID(id) {
+		return
+	}
+	_ = s.deps.BlobStore.Delete(ctx, s.key(id))
+}

--- a/internal/formats/npm/disttags.go
+++ b/internal/formats/npm/disttags.go
@@ -1,0 +1,375 @@
+package npm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// distTagsPrefix is the npm CLI's dist-tag API surface:
+//
+//	GET    /-/package/:pkg/dist-tags        → the tag → version map
+//	PUT    /-/package/:pkg/dist-tags/:tag   → body is a bare JSON string version
+//	DELETE /-/package/:pkg/dist-tags/:tag   → drop the tag
+const distTagsPrefix = "/-/package/"
+
+// parseDistTags splits a dist-tags request path. The package name may be scoped
+// and therefore contain a slash, so the segment is located by the "/dist-tags"
+// marker rather than by counting path elements.
+func parseDistTags(p string) (pkg, tag string, ok bool) {
+	if !strings.HasPrefix(p, distTagsPrefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(p, distTagsPrefix)
+	i := strings.Index(rest, "/dist-tags")
+	if i <= 0 {
+		return "", "", false
+	}
+	pkg = rest[:i]
+	tag = strings.Trim(strings.TrimPrefix(rest[i+len("/dist-tags"):], "/"), "/")
+	return pkg, tag, true
+}
+
+// packageComponents returns the components of exactly this package. The search
+// filter matches names loosely (ILIKE %name%), so "lib" would otherwise pull in
+// "mylib" — the exact match has to happen here.
+func (h *Handler) packageComponents(ctx context.Context, repoName, pkgName string) ([]domain.Component, error) {
+	page, err := h.deps.Components.Search(ctx, domain.SearchParams{
+		Repository: repoName, Name: pkgName, Limit: 200,
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.Component, 0, len(page.Items))
+	for _, comp := range page.Items {
+		if comp.Name == pkgName {
+			out = append(out, comp)
+		}
+	}
+	return out, nil
+}
+
+// distTagsOf builds the tag → version map. A package always has a "latest":
+// when no version is explicitly tagged, the highest one wins.
+func distTagsOf(comps []domain.Component) map[string]string {
+	tags := map[string]string{}
+	for _, comp := range comps {
+		for _, t := range comp.Tags {
+			tags[t] = comp.Version
+		}
+	}
+	if _, ok := tags["latest"]; !ok {
+		if v := highestVersion(comps); v != "" {
+			tags["latest"] = v
+		}
+	}
+	return tags
+}
+
+func highestVersion(comps []domain.Component) string {
+	latest := ""
+	for _, comp := range comps {
+		if latest == "" || base.CompareLooseVersions(comp.Version, latest) > 0 {
+			latest = comp.Version
+		}
+	}
+	return latest
+}
+
+func (h *Handler) handleDistTags(c *gin.Context, repoName, pkgName, tag string) {
+	ctx := c.Request.Context()
+	repo, err := h.deps.Repos.Get(ctx, repoName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if repoproxy.RejectMutation(c, repo) {
+		return
+	}
+
+	switch c.Request.Method {
+	case http.MethodGet:
+		comps, err := h.packageComponents(ctx, repoName, pkgName)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		if len(comps) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+			return
+		}
+		c.JSON(http.StatusOK, distTagsOf(comps))
+
+	case http.MethodPut:
+		if tag == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "tag required"})
+			return
+		}
+		// The body is a bare JSON string, e.g. "1.0.0" — not an object.
+		var version string
+		if err := c.ShouldBindJSON(&version); err != nil || version == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "body must be a version string"})
+			return
+		}
+		if err := h.setDistTag(ctx, repoName, pkgName, tag, version); err != nil {
+			writeTagError(c, err)
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{"ok": true})
+
+	case http.MethodDelete:
+		if tag == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "tag required"})
+			return
+		}
+		if err := h.removeDistTag(ctx, repoName, pkgName, tag); err != nil {
+			writeTagError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+
+	default:
+		c.Status(http.StatusMethodNotAllowed)
+	}
+}
+
+// errNoSuchTagTarget marks "the thing you asked me to tag/untag is not here",
+// which the npm client expects as a 404 rather than a 500.
+type errNoSuchTagTarget struct{ msg string }
+
+func (e errNoSuchTagTarget) Error() string { return e.msg }
+
+func writeTagError(c *gin.Context, err error) {
+	var notFound errNoSuchTagTarget
+	if errorsAs(err, &notFound) {
+		c.JSON(http.StatusNotFound, gin.H{"error": notFound.msg})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+}
+
+// errorsAs is errors.As specialised to errNoSuchTagTarget, kept local so the
+// rest of the file reads without an extra import alias.
+func errorsAs(err error, target *errNoSuchTagTarget) bool {
+	if e, ok := err.(errNoSuchTagTarget); ok { //nolint:errorlint // no wrapping in this package
+		*target = e
+		return true
+	}
+	return false
+}
+
+// setDistTag points tag at version, moving it off whatever version held it.
+func (h *Handler) setDistTag(ctx context.Context, repoName, pkgName, tag, version string) error {
+	comps, err := h.packageComponents(ctx, repoName, pkgName)
+	if err != nil {
+		return err
+	}
+	found := false
+	for _, comp := range comps {
+		if comp.Version == version {
+			found = true
+		}
+	}
+	if !found {
+		return errNoSuchTagTarget{msg: pkgName + "@" + version + " not found"}
+	}
+	for _, comp := range comps {
+		want := withoutTag(comp.Tags, tag)
+		if comp.Version == version {
+			want = append(want, tag)
+		}
+		if sameTags(comp.Tags, want) {
+			continue
+		}
+		if err := h.deps.Components.SetTags(ctx, comp.ID, want); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (h *Handler) removeDistTag(ctx context.Context, repoName, pkgName, tag string) error {
+	comps, err := h.packageComponents(ctx, repoName, pkgName)
+	if err != nil {
+		return err
+	}
+	removed := false
+	for _, comp := range comps {
+		want := withoutTag(comp.Tags, tag)
+		if sameTags(comp.Tags, want) {
+			continue
+		}
+		if err := h.deps.Components.SetTags(ctx, comp.ID, want); err != nil {
+			return err
+		}
+		removed = true
+	}
+	if !removed {
+		return errNoSuchTagTarget{msg: "tag " + tag + " not found"}
+	}
+	return nil
+}
+
+func withoutTag(tags []string, tag string) []string {
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if t != tag {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func sameTags(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ─── unpublish ──────────────────────────────────────────────────
+
+// splitRev strips npm's "/-rev/:rev" suffix. The revision itself is
+// meaningless here: we do not implement optimistic concurrency.
+func splitRev(p string) (string, bool) {
+	i := strings.Index(p, "/-rev/")
+	if i < 0 {
+		return p, false
+	}
+	return p[:i], true
+}
+
+// handleUnpublish serves every DELETE the npm client makes: a single tarball
+// (with or without a -rev suffix) or a whole package. Deleting something that
+// is not there is a 404 — reporting "ok" while nothing happened is what made
+// unpublish look successful (#101).
+func (h *Handler) handleUnpublish(c *gin.Context, repoName, p string) {
+	ctx := c.Request.Context()
+	target, _ := splitRev(p)
+
+	if strings.Contains(target, "/-/") {
+		if err := h.deleteAsset(ctx, repoName, target); err != nil {
+			writeTagError(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+		return
+	}
+
+	pkgName := strings.Trim(strings.TrimPrefix(target, "/"), "/")
+	comps, err := h.packageComponents(ctx, repoName, pkgName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(comps) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+		return
+	}
+	for i := range comps {
+		if err := h.unpublishComponent(ctx, repoName, comps[i]); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+// deleteAsset removes one stored file and, when it was the last file of its
+// component, the now-empty component row.
+func (h *Handler) deleteAsset(ctx context.Context, repoName, assetPath string) error {
+	asset, err := h.deps.Assets.GetByPath(ctx, repoName, assetPath)
+	if err != nil || asset == nil {
+		return errNoSuchTagTarget{msg: "not found: " + assetPath}
+	}
+	componentID := asset.ComponentID
+	if err := base.DeleteArtifact(ctx, h.deps, repoName, assetPath); err != nil {
+		return err
+	}
+	if componentID == "" {
+		return nil
+	}
+	remaining, err := h.deps.Assets.ListByComponentID(ctx, componentID)
+	if err == nil && len(remaining) == 0 {
+		_ = h.deps.Components.Delete(ctx, componentID)
+	}
+	return nil
+}
+
+// unpublishComponent removes one published version: its files first, then the
+// component row itself.
+func (h *Handler) unpublishComponent(ctx context.Context, repoName string, comp domain.Component) error {
+	assets, err := h.deps.Assets.ListByComponentID(ctx, comp.ID)
+	if err != nil {
+		return err
+	}
+	for _, a := range assets {
+		if err := base.DeleteArtifact(ctx, h.deps, repoName, a.Path); err != nil {
+			return err
+		}
+	}
+	return h.deps.Components.Delete(ctx, comp.ID)
+}
+
+// handleRevPut serves `PUT /:pkg/-rev/:rev`, which the npm client sends as the
+// first half of `npm unpublish <pkg>@<version>`: the body is the packument with
+// that version removed. Versions missing from the body are unpublished.
+// A body carrying attachments is an ordinary publish.
+func (h *Handler) handleRevPut(c *gin.Context, repoName, pkgPath string) {
+	ctx := c.Request.Context()
+	pkgName := strings.Trim(strings.TrimPrefix(pkgPath, "/"), "/")
+
+	var doc map[string]json.RawMessage
+	if err := c.ShouldBindJSON(&doc); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if raw, ok := doc["_attachments"]; ok {
+		var attachments map[string]json.RawMessage
+		if json.Unmarshal(raw, &attachments) == nil && len(attachments) > 0 {
+			h.publishDoc(c, repoName, pkgName, doc)
+			return
+		}
+	}
+
+	keep := map[string]bool{}
+	if raw, ok := doc["versions"]; ok {
+		var versions map[string]json.RawMessage
+		_ = json.Unmarshal(raw, &versions)
+		for v := range versions {
+			keep[v] = true
+		}
+	}
+
+	comps, err := h.packageComponents(ctx, repoName, pkgName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if len(comps) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
+		return
+	}
+	for i := range comps {
+		if keep[comps[i].Version] {
+			continue
+		}
+		if err := h.unpublishComponent(ctx, repoName, comps[i]); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}

--- a/internal/formats/npm/disttags_test.go
+++ b/internal/formats/npm/disttags_test.go
@@ -1,0 +1,233 @@
+package npm_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// publish PUTs a package version and asserts it was stored.
+func publish(t *testing.T, r http.Handler, repoName, pkg, version string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+"/"+pkg,
+		strings.NewReader(publishBody(pkg, version, "tgz-"+version)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+}
+
+// getJSON performs a GET and decodes the JSON body.
+func getJSON(t *testing.T, r http.Handler, url string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	var out map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &out)
+	return w.Code, out
+}
+
+func status(t *testing.T, r http.Handler, method, url string, body string) int {
+	t.Helper()
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, url, nil)
+	} else {
+		req = httptest.NewRequest(method, url, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+// ─── dist-tags (#101) ───────────────────────────────────────────
+
+// `npm dist-tag add pkg@1.0.0 beta` PUTs a bare JSON string to
+// /-/package/:pkg/dist-tags/:tag. That used to hit the publish handler and 400.
+func TestNPM_DistTagAdd_SetsTag(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-dt", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-dt", "mylib", "1.0.0")
+	publish(t, r, "npm-dt", "mylib", "2.0.0")
+
+	code := status(t, r, http.MethodPut, "/repository/npm-dt/-/package/mylib/dist-tags/beta", `"1.0.0"`)
+	require.Equal(t, http.StatusCreated, code)
+
+	code, tags := getJSON(t, r, "/repository/npm-dt/-/package/mylib/dist-tags")
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "1.0.0", tags["beta"])
+	assert.Equal(t, "2.0.0", tags["latest"], "latest is the highest published version")
+
+	// The packument must advertise the same tags.
+	code, meta := getJSON(t, r, "/repository/npm-dt/mylib")
+	require.Equal(t, http.StatusOK, code)
+	dt, _ := meta["dist-tags"].(map[string]any)
+	require.NotNil(t, dt)
+	assert.Equal(t, "1.0.0", dt["beta"])
+	assert.Equal(t, "2.0.0", dt["latest"])
+}
+
+// Moving a tag to another version must not leave it pointing at both.
+func TestNPM_DistTagAdd_MovesTagBetweenVersions(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-dt-move", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-dt-move", "mylib", "1.0.0")
+	publish(t, r, "npm-dt-move", "mylib", "2.0.0")
+
+	require.Equal(t, http.StatusCreated,
+		status(t, r, http.MethodPut, "/repository/npm-dt-move/-/package/mylib/dist-tags/beta", `"1.0.0"`))
+	require.Equal(t, http.StatusCreated,
+		status(t, r, http.MethodPut, "/repository/npm-dt-move/-/package/mylib/dist-tags/beta", `"2.0.0"`))
+
+	_, tags := getJSON(t, r, "/repository/npm-dt-move/-/package/mylib/dist-tags")
+	assert.Equal(t, "2.0.0", tags["beta"])
+}
+
+func TestNPM_DistTagAdd_UnknownVersion_404(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-dt-404", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-dt-404", "mylib", "1.0.0")
+
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodPut, "/repository/npm-dt-404/-/package/mylib/dist-tags/beta", `"9.9.9"`))
+}
+
+func TestNPM_DistTagRm_RemovesTag(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-dt-rm", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-dt-rm", "mylib", "1.0.0")
+	require.Equal(t, http.StatusCreated,
+		status(t, r, http.MethodPut, "/repository/npm-dt-rm/-/package/mylib/dist-tags/beta", `"1.0.0"`))
+
+	require.Equal(t, http.StatusOK,
+		status(t, r, http.MethodDelete, "/repository/npm-dt-rm/-/package/mylib/dist-tags/beta", ""))
+
+	_, tags := getJSON(t, r, "/repository/npm-dt-rm/-/package/mylib/dist-tags")
+	_, ok := tags["beta"]
+	assert.False(t, ok, "tag should be gone, got %v", tags)
+
+	// Removing it again reports that there is nothing to remove.
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodDelete, "/repository/npm-dt-rm/-/package/mylib/dist-tags/beta", ""))
+}
+
+func TestNPM_DistTags_ScopedPackage(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-dt-scope", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-dt-scope", "@acme/lib", "1.0.0")
+
+	require.Equal(t, http.StatusCreated,
+		status(t, r, http.MethodPut, "/repository/npm-dt-scope/-/package/@acme/lib/dist-tags/next", `"1.0.0"`))
+
+	_, tags := getJSON(t, r, "/repository/npm-dt-scope/-/package/@acme/lib/dist-tags")
+	assert.Equal(t, "1.0.0", tags["next"])
+}
+
+func TestNPM_DistTags_ProxyRejectsMutation(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	r, _ := proxySetup(upstream)
+	assert.Equal(t, http.StatusMethodNotAllowed,
+		status(t, r, http.MethodPut, "/repository/npm-proxy/-/package/pkg/dist-tags/beta", `"1.0.0"`))
+}
+
+// ─── unpublish (#101) ───────────────────────────────────────────
+
+// `npm unpublish pkg@1.0.0` finishes by DELETEing the tarball with a -rev
+// suffix. That used to return 200 while deleting nothing.
+func TestNPM_Unpublish_Version_DeletesTarball(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-unp-v", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-unp-v", "mylib", "1.0.0")
+	publish(t, r, "npm-unp-v", "mylib", "2.0.0")
+
+	require.Equal(t, http.StatusOK,
+		status(t, r, http.MethodDelete, "/repository/npm-unp-v/mylib/-/mylib-1.0.0.tgz/-rev/3-abc", ""))
+
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodGet, "/repository/npm-unp-v/mylib/-/mylib-1.0.0.tgz", ""))
+	assert.Equal(t, http.StatusOK,
+		status(t, r, http.MethodGet, "/repository/npm-unp-v/mylib/-/mylib-2.0.0.tgz", ""),
+		"the other version must survive")
+}
+
+// `npm unpublish pkg --force` DELETEs the whole package by revision.
+func TestNPM_Unpublish_Package_DeletesEveryVersion(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-unp-p", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-unp-p", "mylib", "1.0.0")
+	publish(t, r, "npm-unp-p", "mylib", "2.0.0")
+
+	require.Equal(t, http.StatusOK,
+		status(t, r, http.MethodDelete, "/repository/npm-unp-p/mylib/-rev/3-abc", ""))
+
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodGet, "/repository/npm-unp-p/mylib", ""))
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodGet, "/repository/npm-unp-p/mylib/-/mylib-1.0.0.tgz", ""))
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodGet, "/repository/npm-unp-p/mylib/-/mylib-2.0.0.tgz", ""))
+}
+
+// Deleting what is not there must say so instead of reporting success.
+func TestNPM_Unpublish_Unknown_404(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-unp-404", "npm")
+	r := setup(repo)
+
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodDelete, "/repository/npm-unp-404/ghost/-rev/1-abc", ""))
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodDelete, "/repository/npm-unp-404/ghost/-/ghost-1.0.0.tgz", ""))
+}
+
+// `npm unpublish pkg@1.0.0` first PUTs the packument without that version.
+// Versions missing from the body are unpublished.
+func TestNPM_Unpublish_RevPut_DropsMissingVersions(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-unp-rev", "npm")
+	r := setup(repo)
+	publish(t, r, "npm-unp-rev", "mylib", "1.0.0")
+	publish(t, r, "npm-unp-rev", "mylib", "2.0.0")
+
+	body := `{"name":"mylib","versions":{"2.0.0":{"name":"mylib","version":"2.0.0"}}}`
+	require.Equal(t, http.StatusOK,
+		status(t, r, http.MethodPut, "/repository/npm-unp-rev/mylib/-rev/3-abc", body))
+
+	code, meta := getJSON(t, r, "/repository/npm-unp-rev/mylib")
+	require.Equal(t, http.StatusOK, code)
+	versions, _ := meta["versions"].(map[string]any)
+	require.NotNil(t, versions)
+	_, has1 := versions["1.0.0"]
+	_, has2 := versions["2.0.0"]
+	assert.False(t, has1, "1.0.0 should be unpublished")
+	assert.True(t, has2, "2.0.0 should remain")
+
+	assert.Equal(t, http.StatusNotFound,
+		status(t, r, http.MethodGet, "/repository/npm-unp-rev/mylib/-/mylib-1.0.0.tgz", ""))
+}
+
+// The component row must go with its assets, not linger as an empty package.
+func TestNPM_Unpublish_Package_RemovesComponents(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-unp-comp", "npm")
+	r, comps := setupWithComponents(repo)
+	publish(t, r, "npm-unp-comp", "mylib", "1.0.0")
+
+	require.Equal(t, http.StatusOK,
+		status(t, r, http.MethodDelete, "/repository/npm-unp-comp/mylib/-rev/3-abc", ""))
+
+	page, err := comps.Search(t.Context(), domain.SearchParams{Repository: "npm-unp-comp", Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, page.Items, "component rows should be gone")
+}

--- a/internal/formats/npm/handler.go
+++ b/internal/formats/npm/handler.go
@@ -43,6 +43,13 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		return
 	}
 
+	// dist-tag API. Matched before anything else: these paths also contain
+	// "/-/", which would otherwise route them to the tarball handler (#101).
+	if pkgName, tag, ok := parseDistTags(p); ok {
+		h.handleDistTags(c, repoName, pkgName, tag)
+		return
+	}
+
 	switch c.Request.Method {
 	case http.MethodGet, http.MethodHead:
 		// Tarball: contains "/-/" in path
@@ -61,6 +68,12 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		if repoproxy.RejectMutation(c, repo) {
 			return
 		}
+		// PUT /:pkg/-rev/:rev rewrites the packument — that is how the npm
+		// client unpublishes a single version (#101).
+		if target, ok := splitRev(p); ok {
+			h.handleRevPut(c, repoName, target)
+			return
+		}
 		h.handlePublish(c, repoName, p)
 
 	case http.MethodDelete:
@@ -72,11 +85,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		if repoproxy.RejectMutation(c, repo) {
 			return
 		}
-		if err := base.DeleteArtifact(c.Request.Context(), h.deps, repoName, p); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-		c.JSON(http.StatusOK, gin.H{"ok": true})
+		h.handleUnpublish(c, repoName, p)
 
 	default:
 		c.Status(http.StatusMethodNotAllowed)
@@ -150,21 +159,18 @@ func (h *Handler) serveMetadata(c *gin.Context, repoName, pkgPath string) {
 		return
 	}
 
-	page, err := h.deps.Components.Search(ctx, domain.SearchParams{
-		Repository: repoName, Name: pkgName, Limit: 200,
-	})
+	comps, err := h.packageComponents(ctx, repoName, pkgName)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	if len(page.Items) == 0 {
+	if len(comps) == 0 {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Not found"})
 		return
 	}
 
 	versions := map[string]any{}
-	latest := ""
-	for _, comp := range page.Items {
+	for _, comp := range comps {
 		baseName := path.Base(pkgName)
 		tarball := h.deps.BaseURL + "/repository/" + repoName +
 			"/" + pkgName + "/-/" + baseName + "-" + comp.Version + ".tgz"
@@ -173,24 +179,27 @@ func (h *Handler) serveMetadata(c *gin.Context, repoName, pkgPath string) {
 			"version": comp.Version,
 			"dist":    map[string]any{"tarball": tarball},
 		}
-		latest = comp.Version
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"name":      pkgName,
 		"versions":  versions,
-		"dist-tags": gin.H{"latest": latest},
+		"dist-tags": distTagsOf(comps),
 	})
 }
 
 func (h *Handler) handlePublish(c *gin.Context, repoName, pkgPath string) {
-	pkgName := strings.TrimPrefix(pkgPath, "/")
-
 	var doc map[string]json.RawMessage
 	if err := c.ShouldBindJSON(&doc); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	h.publishDoc(c, repoName, strings.TrimPrefix(pkgPath, "/"), doc)
+}
 
+// publishDoc stores the tarballs carried by an already-parsed packument and
+// applies its dist-tags. Shared with the `-rev` PUT, which carries the same
+// document shape.
+func (h *Handler) publishDoc(c *gin.Context, repoName, pkgName string, doc map[string]json.RawMessage) {
 	// Parse dist-tags for version
 	version := ""
 	if raw, ok := doc["dist-tags"]; ok {
@@ -248,6 +257,22 @@ func (h *Handler) handlePublish(c *gin.Context, repoName, pkgPath string) {
 			strings.NewReader(string(data)), int64(len(data))); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
+		}
+	}
+	// Honor the tags the client published under (`npm publish --tag beta`);
+	// a plain publish carries "latest" (#101).
+	if raw, ok := doc["dist-tags"]; ok {
+		var tags map[string]string
+		if json.Unmarshal(raw, &tags) == nil {
+			for tag, ver := range tags {
+				if tag == "" || ver == "" {
+					continue
+				}
+				if err := h.setDistTag(c.Request.Context(), repoName, pkgName, tag, ver); err != nil {
+					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+					return
+				}
+			}
 		}
 	}
 	c.JSON(http.StatusCreated, gin.H{"ok": true})

--- a/internal/formats/npm/handler_test.go
+++ b/internal/formats/npm/handler_test.go
@@ -57,6 +57,24 @@ func publishBody(pkgName, version, tgzContent string) string {
 	return string(b)
 }
 
+// setupWithComponents is setup plus a handle on the component store, for tests
+// that assert on rows rather than on responses.
+func setupWithComponents(repo *domain.Repository) (*gin.Engine, *testutil.ComponentRepo) {
+	comps := testutil.NewComponentRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := npm.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps
+}
+
 func TestNPM_Ping(t *testing.T) {
 	repo := testutil.SimpleRepo("npm-repo", "npm")
 	r := setup(repo)

--- a/internal/formats/npm/npm_extra_test.go
+++ b/internal/formats/npm/npm_extra_test.go
@@ -79,6 +79,14 @@ func TestNPM_Delete_Hosted(t *testing.T) {
 	r.ServeHTTP(w, req2)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"ok"`)
+
+	// …and the tarball is really gone. Asserting only on the 200 above let an
+	// idempotent no-op pass for a delete (#101).
+	req3 := httptest.NewRequest(http.MethodGet,
+		"/repository/npm-del/todelete/-/todelete-1.0.0.tgz", nil)
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, req3)
+	assert.Equal(t, http.StatusNotFound, w3.Code)
 }
 
 func TestNPM_Delete_ProxyRejected(t *testing.T) {


### PR DESCRIPTION
Closes #101. Closes #103. Closes #104.

The three findings left over from the format audit, done TDD (every fix has a test that failed first).

## npm — dist-tags and unpublish (#101)

`npm dist-tag add` returned 400 and `dist-tag rm` / `unpublish` returned `{"ok":true}` while deleting nothing.

- The dist-tag API (`/-/package/:pkg/dist-tags[/:tag]`) gets its own route, matched before the tarball rule that used to claim it via `/-/`. `PUT` parses the bare JSON string body npm sends.
- Tags live on the component row (`components.tags`), so `dist-tag ls`, the packument's `dist-tags` and `npm publish --tag beta` all agree. `latest` falls back to the highest version rather than to whichever row came back last.
- Unpublish resolves the assets it is asked to remove — a single tarball, the whole package, or the `-rev` PUT that rewrites the packument to drop one version — deletes the component rows with them, and answers **404** when there is nothing to delete.
- Package lookups now match the name exactly. The search filter behind them is a substring `ILIKE`, so a packument for `lib` used to list versions of `mylib`.

`TestNPM_Delete_Hosted` asserted only the 200 and so passed against a no-op delete; it now asserts the tarball is really gone.

## apt — GPG signing (#103)

Checksums and arch filtering shipped in v1.24.2; signing was what remained.

- `formatConfig.signing_key` (armored private key) + optional `signing_key_passphrase`.
- `InRelease` is clearsigned, `Release.gpg` is a detached armored signature (404 when unsigned), `/public.gpg` serves the public half so clients can trust the repo. SHA-256 digests — apt rejects SHA-1.
- Without a key, behaviour is unchanged: `InRelease` stays plain, for `[trusted=yes]` sources.
- `Release` had to become byte-identical across requests: apt fetches it separately from its signature and verifies one against the other, so a wall-clock `Date` breaks verification a second later. It now follows the newest package.

Documented in `docs/apt-signing.md`. Note the key is stored in the repository configuration and is readable by anyone who can read that configuration — same as the existing `proxy_password`. Worth a follow-up if repository secrets get encrypted at rest.

## docker — proxy DELETE and HA uploads (#104)

- Blob `DELETE` on a proxy repository is rejected like every other mutation, instead of evicting the cached copy.
- Blob uploads are staged in the blob store under `_uploads/docker/<id>` instead of a `sync.Map`, with ids from `crypto/rand` instead of a per-process counter. A push survives being spread across instances (no sticky sessions needed) or a restart mid-upload; abandoned sessions are unreferenced blobs and the blob GC reclaims them. Documented in `docs/ha-setup.md`.

## Tests

New: cross-instance blob push, unguessable upload ids, proxy blob DELETE, dist-tag add/move/rm/404/scoped/proxy-rejected, unpublish by tarball / package / `-rev` PUT / unknown, clearsigned InRelease and detached `Release.gpg` verified against the served `Release` with a real generated key, `Release` stability across a second, unsigned and broken-key paths.

`go test ./internal/...` — 1544 passed; the one failure is `TestWebhookHandler_Test_200`, which needs outbound network the sandbox denies. `golangci-lint run ./...` clean. Coverage: apt 84.4%, npm 82.9%, docker 87.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8M6vasTswsV3AbsQsagMf