### PR TITLE
fix(npm): keep published package metadata in the packument

### DIFF
--- a/internal/formats/npm/disttags.go
+++ b/internal/formats/npm/disttags.go
@@ -37,6 +37,10 @@ func parseDistTags(p string) (pkg, tag string, ok bool) {
 	return pkg, tag, true
 }
 
+// sentinelVersion is the pseudo-version a proxy stores its cached packument
+// under. It is not a package version and must never be served as one (#131).
+const sentinelVersion = "metadata"
+
 // packageComponents returns the components of exactly this package. The search
 // filter matches names loosely (ILIKE %name%), so "lib" would otherwise pull in
 // "mylib" — the exact match has to happen here.
@@ -49,7 +53,7 @@ func (h *Handler) packageComponents(ctx context.Context, repoName, pkgName strin
 	}
 	out := make([]domain.Component, 0, len(page.Items))
 	for _, comp := range page.Items {
-		if comp.Name == pkgName {
+		if comp.Name == pkgName && comp.Version != sentinelVersion {
 			out = append(out, comp)
 		}
 	}

--- a/internal/formats/npm/handler.go
+++ b/internal/formats/npm/handler.go
@@ -9,6 +9,7 @@
 package npm
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -174,17 +175,46 @@ func (h *Handler) serveMetadata(c *gin.Context, repoName, pkgPath string) {
 		baseName := path.Base(pkgName)
 		tarball := h.deps.BaseURL + "/repository/" + repoName +
 			"/" + pkgName + "/-/" + baseName + "-" + comp.Version + ".tgz"
-		versions[comp.Version] = map[string]any{
-			"name":    pkgName,
-			"version": comp.Version,
-			"dist":    map[string]any{"tarball": tarball},
+		manifest := manifestOf(comp)
+		if manifest == nil {
+			manifest = h.backfillManifest(ctx, repoName, comp)
 		}
+		versions[comp.Version] = versionDocument(manifest, pkgName, comp.Version, tarball)
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"name":      pkgName,
 		"versions":  versions,
 		"dist-tags": distTagsOf(comps),
 	})
+}
+
+// backfillManifest recovers the package.json of a version stored before the
+// manifest was persisted (#131) by reading it out of the tarball, and caches it
+// on the component so the archive is opened once. Best effort: a version whose
+// manifest cannot be recovered keeps the bare document it had before.
+func (h *Handler) backfillManifest(ctx context.Context, repoName string, comp domain.Component) map[string]any {
+	assets, err := h.deps.Assets.ListByComponentID(ctx, comp.ID)
+	if err != nil {
+		return nil
+	}
+	for _, asset := range assets {
+		if !strings.HasSuffix(asset.Path, ".tgz") {
+			continue
+		}
+		rc, _, err := base.FetchArtifact(ctx, h.deps, repoName, asset.Path)
+		if err != nil {
+			continue
+		}
+		manifest := manifestFromTarball(rc)
+		_ = rc.Close()
+		if manifest == nil {
+			continue
+		}
+		manifest = withDistShasum(manifest, asset.SHA1)
+		_ = h.deps.Components.UpdateExtra(ctx, comp.ID, map[string]any{extraManifestKey: manifest})
+		return manifest
+	}
+	return nil
 }
 
 func (h *Handler) handlePublish(c *gin.Context, repoName, pkgPath string) {
@@ -252,9 +282,24 @@ func (h *Handler) publishDoc(c *gin.Context, repoName, pkgName string, doc map[s
 		// tarball at /@scope/name/-/name-ver.tgz (#113) — drop the scope.
 		filePath := "/" + pkgName + "/-/" + path.Base(filename)
 		coords := base.Coords{Name: pkgName, Version: version}
-		if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
+		res, err := base.StoreArtifact(c.Request.Context(), h.deps,
 			repoName, filePath, ct, coords,
-			strings.NewReader(string(data)), int64(len(data))); err != nil {
+			strings.NewReader(string(data)), int64(len(data)))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// Keep the published package.json — it is the only place the dependency
+		// lists exist outside the tarball (#131).
+		if res == nil || res.Asset == nil || res.Asset.ComponentID == "" {
+			continue
+		}
+		manifest := withDistShasum(manifestFromPublish(doc, version), res.SHA1)
+		if manifest == nil {
+			continue
+		}
+		if err := h.deps.Components.UpdateExtra(c.Request.Context(),
+			res.Asset.ComponentID, map[string]any{extraManifestKey: manifest}); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/formats/npm/manifest.go
+++ b/internal/formats/npm/manifest.go
@@ -1,0 +1,129 @@
+package npm
+
+// Version manifests (#131). `npm publish` sends the full package.json of the
+// version inside the packument; without it the registry document we serve back
+// carries no dependency lists, and resolvers that trust the registry document
+// over the tarball (pnpm, yarn) install a package whose deps are missing.
+// The manifest is kept on the component row and replayed on every GET.
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// extraManifestKey is the component.Extra key holding the published package.json.
+const extraManifestKey = "npm_manifest"
+
+// maxManifestBytes caps how much of a tarball entry is parsed as package.json.
+// Real manifests are a few kB; the limit keeps a crafted archive from becoming
+// a memory problem.
+const maxManifestBytes = 4 << 20
+
+// manifestOf returns the stored package.json of a published version, or nil.
+func manifestOf(comp domain.Component) map[string]any {
+	m, _ := comp.Extra[extraManifestKey].(map[string]any)
+	return m
+}
+
+// versionDocument builds one entry of the packument "versions" map: the
+// published manifest with the fields this registry owns (name, version and the
+// tarball URL pointing at this instance) written over it.
+func versionDocument(manifest map[string]any, pkgName, version, tarball string) map[string]any {
+	doc := map[string]any{}
+	for k, v := range manifest {
+		doc[k] = v
+	}
+	doc["name"] = pkgName
+	doc["version"] = version
+
+	dist := map[string]any{}
+	if d, ok := doc["dist"].(map[string]any); ok {
+		for k, v := range d {
+			dist[k] = v
+		}
+	}
+	dist["tarball"] = tarball
+	doc["dist"] = dist
+	return doc
+}
+
+// withDistShasum records the SHA-1 of the stored tarball in the manifest's dist
+// block when the client did not send one. Clients refuse to install a version
+// whose document carries no checksum at all.
+func withDistShasum(manifest map[string]any, sha1Hex string) map[string]any {
+	if manifest == nil || sha1Hex == "" {
+		return manifest
+	}
+	dist, ok := manifest["dist"].(map[string]any)
+	if !ok {
+		dist = map[string]any{}
+		manifest["dist"] = dist
+	}
+	if s, ok := dist["shasum"].(string); !ok || s == "" {
+		dist["shasum"] = sha1Hex
+	}
+	return manifest
+}
+
+// manifestFromPublish pulls the package.json of the version being published out
+// of the packument body.
+func manifestFromPublish(doc map[string]json.RawMessage, version string) map[string]any {
+	raw, ok := doc["versions"]
+	if !ok {
+		return nil
+	}
+	var versions map[string]json.RawMessage
+	if json.Unmarshal(raw, &versions) != nil {
+		return nil
+	}
+	vraw, ok := versions[version]
+	if !ok {
+		return nil
+	}
+	var manifest map[string]any
+	if json.Unmarshal(vraw, &manifest) != nil {
+		return nil
+	}
+	return manifest
+}
+
+// manifestFromTarball reads package.json out of a stored npm tarball. It is the
+// fallback for versions published before the manifest was persisted: the file
+// inside the archive is the same document the client sent. Returns nil for
+// anything that is not a readable npm tarball.
+func manifestFromTarball(r io.Reader) map[string]any {
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = gz.Close() }()
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err != nil {
+			return nil
+		}
+		if !isRootPackageJSON(hdr.Name) {
+			continue
+		}
+		var manifest map[string]any
+		if json.NewDecoder(io.LimitReader(tr, maxManifestBytes)).Decode(&manifest) != nil {
+			return nil
+		}
+		return manifest
+	}
+}
+
+// isRootPackageJSON matches the manifest npm puts at the root of the archive
+// ("package/package.json"), and not the package.json of a bundled dependency.
+func isRootPackageJSON(name string) bool {
+	clean := strings.TrimPrefix(path.Clean(strings.TrimPrefix(name, "./")), "/")
+	return path.Base(clean) == "package.json" && strings.Count(clean, "/") == 1
+}

--- a/internal/formats/npm/publish_metadata_test.go
+++ b/internal/formats/npm/publish_metadata_test.go
@@ -1,0 +1,256 @@
+package npm_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// publishBodyWithManifest builds a publish payload whose version document is a
+// full package.json, the way the npm CLI sends it.
+func publishBodyWithManifest(pkgName, version string, manifest map[string]any, tgzContent string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(tgzContent))
+	body := map[string]any{
+		"name":      pkgName,
+		"dist-tags": map[string]string{"latest": version},
+		"versions":  map[string]any{version: manifest},
+		"_attachments": map[string]any{
+			pkgName + "-" + version + ".tgz": map[string]any{
+				"data":         encoded,
+				"content_type": "application/octet-stream",
+				"length":       len(tgzContent),
+			},
+		},
+	}
+	b, _ := json.Marshal(body)
+	return string(b)
+}
+
+func publishRaw(t *testing.T, r http.Handler, repoName, pkgName, body string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+"/"+pkgName,
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+}
+
+func getPackument(t *testing.T, r http.Handler, repoName, pkgName string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/repository/"+repoName+"/"+pkgName, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+	return doc
+}
+
+// versionDoc digs versions[ver] out of a packument.
+func versionDoc(t *testing.T, packument map[string]any, ver string) map[string]any {
+	t.Helper()
+	versions, ok := packument["versions"].(map[string]any)
+	require.True(t, ok, "packument has no versions object")
+	v, ok := versions[ver].(map[string]any)
+	require.True(t, ok, "packument has no version %s", ver)
+	return v
+}
+
+// TestNPM_Publish_PreservesDependencies covers #131: the packument served for a
+// published package must carry the dependency lists from the published
+// package.json — pnpm resolves from the registry document, not the tarball, and
+// fails the install when they are missing.
+func TestNPM_Publish_PreservesDependencies(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-hosted", "npm")
+	r := setup(repo)
+
+	manifest := map[string]any{
+		"name":    "fast-glob",
+		"version": "3.3.3",
+		"dependencies": map[string]any{
+			"glob-parent": "^5.1.2",
+			"merge2":      "^1.3.0",
+		},
+		"peerDependencies":     map[string]any{"typescript": "^5.0.0"},
+		"optionalDependencies": map[string]any{"fsevents": "^2.3.2"},
+		"engines":              map[string]any{"node": ">=8.6.0"},
+	}
+	publishRaw(t, r, "npm-hosted", "fast-glob", publishBodyWithManifest("fast-glob", "3.3.3", manifest, "tgz-bytes"))
+
+	v := versionDoc(t, getPackument(t, r, "npm-hosted", "fast-glob"), "3.3.3")
+
+	assert.Equal(t, map[string]any{"glob-parent": "^5.1.2", "merge2": "^1.3.0"}, v["dependencies"])
+	assert.Equal(t, map[string]any{"typescript": "^5.0.0"}, v["peerDependencies"])
+	assert.Equal(t, map[string]any{"fsevents": "^2.3.2"}, v["optionalDependencies"])
+	assert.Equal(t, map[string]any{"node": ">=8.6.0"}, v["engines"])
+}
+
+// TestNPM_Publish_FillsDistChecksum covers #131: clients verify the tarball
+// against dist.shasum/dist.integrity. A manifest that carries neither (npm only
+// adds them from the local tarball it built) must be completed from the stored
+// blob, or the install fails on an unverifiable package.
+func TestNPM_Publish_FillsDistChecksum(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-sums", "npm")
+	r := setup(repo)
+
+	const tgz = "tgz-bytes"
+	manifest := map[string]any{"name": "nodist", "version": "1.0.0"}
+	publishRaw(t, r, "npm-sums", "nodist", publishBodyWithManifest("nodist", "1.0.0", manifest, tgz))
+
+	v := versionDoc(t, getPackument(t, r, "npm-sums", "nodist"), "1.0.0")
+	dist, ok := v["dist"].(map[string]any)
+	require.True(t, ok, "version doc has no dist object")
+
+	sum := sha1.Sum([]byte(tgz))
+	assert.Equal(t, hex.EncodeToString(sum[:]), dist["shasum"])
+}
+
+// TestNPM_Publish_KeepsPublishedIntegrity covers #131: when the client did send
+// dist.integrity/shasum, they are the client's own hashes of the very bytes we
+// stored — they must survive the round trip untouched.
+func TestNPM_Publish_KeepsPublishedIntegrity(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-integrity", "npm")
+	r := setup(repo)
+
+	manifest := map[string]any{
+		"name":    "withdist",
+		"version": "2.0.0",
+		"dist": map[string]any{
+			"integrity": "sha512-deadbeef==",
+			"shasum":    "0123456789abcdef0123456789abcdef01234567",
+			"tarball":   "https://registry.npmjs.org/withdist/-/withdist-2.0.0.tgz",
+		},
+	}
+	publishRaw(t, r, "npm-integrity", "withdist", publishBodyWithManifest("withdist", "2.0.0", manifest, "tgz"))
+
+	v := versionDoc(t, getPackument(t, r, "npm-integrity", "withdist"), "2.0.0")
+	dist := v["dist"].(map[string]any)
+	assert.Equal(t, "sha512-deadbeef==", dist["integrity"])
+	assert.Equal(t, "0123456789abcdef0123456789abcdef01234567", dist["shasum"])
+	// The tarball URL is ours, never the upstream one the client sent.
+	assert.Equal(t, "http://localhost:8080/repository/npm-integrity/withdist/-/withdist-2.0.0.tgz",
+		dist["tarball"])
+}
+
+// TestNPM_Metadata_HidesCachedPackumentSentinel covers #131: a proxy caches the
+// upstream packument as the component version "metadata". When such a row ends
+// up in a hosted repository (import, replication) it must not be advertised as
+// a package version — "metadata" is not a version and resolvers choke on it.
+func TestNPM_Metadata_HidesCachedPackumentSentinel(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-sentinel", "npm")
+	r, comps := setupWithComponents(repo)
+
+	publishRaw(t, r, "npm-sentinel", "fast-glob",
+		publishBodyWithManifest("fast-glob", "3.3.3",
+			map[string]any{"name": "fast-glob", "version": "3.3.3"}, "tgz"))
+	require.NoError(t, comps.Create(context.Background(), &domain.Component{
+		Repository: "npm-sentinel", Format: "npm", Name: "fast-glob", Version: "metadata",
+	}))
+
+	packument := getPackument(t, r, "npm-sentinel", "fast-glob")
+	versions := packument["versions"].(map[string]any)
+
+	assert.Contains(t, versions, "3.3.3")
+	assert.NotContains(t, versions, "metadata")
+	assert.Equal(t, "3.3.3", packument["dist-tags"].(map[string]any)["latest"])
+}
+
+// npmTarball builds a package tarball with the given package.json, the layout
+// npm produces: every entry under a "package/" prefix.
+func npmTarball(t *testing.T, manifest map[string]any) string {
+	t.Helper()
+	pkgJSON, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name: "package/package.json", Mode: 0o644, Size: int64(len(pkgJSON)),
+	}))
+	_, err = tw.Write(pkgJSON)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gz.Close())
+	return buf.String()
+}
+
+// publishBodyWithoutManifest mimics a publish that carried no version document,
+// which is what every package stored before #131 was fixed looks like.
+func publishBodyWithoutManifest(pkgName, version, tgzContent string) string {
+	body := map[string]any{
+		"name":      pkgName,
+		"dist-tags": map[string]string{"latest": version},
+		"_attachments": map[string]any{
+			pkgName + "-" + version + ".tgz": map[string]any{
+				"data":         base64.StdEncoding.EncodeToString([]byte(tgzContent)),
+				"content_type": "application/octet-stream",
+				"length":       len(tgzContent),
+			},
+		},
+	}
+	b, _ := json.Marshal(body)
+	return string(b)
+}
+
+// TestNPM_Metadata_BackfillsManifestFromTarball covers #131: versions published
+// before the manifest was persisted must not stay broken until someone
+// republishes them — the package.json inside the stored tarball is the same
+// document, so the packument is completed from there.
+func TestNPM_Metadata_BackfillsManifestFromTarball(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-legacy", "npm")
+	r := setup(repo)
+
+	tgz := npmTarball(t, map[string]any{
+		"name":         "legacy",
+		"version":      "1.0.0",
+		"dependencies": map[string]any{"glob-parent": "^5.1.2"},
+		"engines":      map[string]any{"node": ">=8.6.0"},
+	})
+	publishRaw(t, r, "npm-legacy", "legacy", publishBodyWithoutManifest("legacy", "1.0.0", tgz))
+
+	v := versionDoc(t, getPackument(t, r, "npm-legacy", "legacy"), "1.0.0")
+
+	assert.Equal(t, map[string]any{"glob-parent": "^5.1.2"}, v["dependencies"])
+	assert.Equal(t, map[string]any{"node": ">=8.6.0"}, v["engines"])
+}
+
+// TestNPM_Metadata_BackfillIsCached covers #131: the extracted manifest is
+// written back to the component, so the tarball is opened once and not on every
+// packument request.
+func TestNPM_Metadata_BackfillIsCached(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-legacy-cache", "npm")
+	r, comps := setupWithComponents(repo)
+
+	tgz := npmTarball(t, map[string]any{
+		"name": "legacy", "version": "1.0.0",
+		"dependencies": map[string]any{"glob-parent": "^5.1.2"},
+	})
+	publishRaw(t, r, "npm-legacy-cache", "legacy", publishBodyWithoutManifest("legacy", "1.0.0", tgz))
+	getPackument(t, r, "npm-legacy-cache", "legacy")
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{
+		Repository: "npm-legacy-cache", Name: "legacy", Limit: 10,
+	})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	manifest, ok := page.Items[0].Extra["npm_manifest"].(map[string]any)
+	require.True(t, ok, "manifest was not cached on the component: %v", page.Items[0].Extra)
+	assert.Equal(t, map[string]any{"glob-parent": "^5.1.2"}, manifest["dependencies"])
+}


### PR DESCRIPTION
Closes #131.

## Problem

`npm publish` sends the version's full `package.json` inside the packument, but `publishDoc` only stored the tarball attachment and dropped the version document. `serveMetadata` then re-synthesised each entry as `{name, version, dist:{tarball}}`, so the registry document carried no dependency lists at all.

npm survives this because it reads `package.json` out of the tarball; pnpm and yarn resolve from the registry document, so the reporter's build failed with `Cannot find module 'glob-parent'`.

The report also shows the proxy's cached-packument sentinel (`"metadata"`) being advertised as a package version.

## Fix

- persist the published manifest in `component.Extra["npm_manifest"]` (the mechanism conda already uses) and replay it on every metadata GET, overriding only `name`, `version` and `dist.tarball`
- fill `dist.shasum` from the stored blob when the client sent no checksum; client-sent `integrity`/`shasum` survive untouched
- versions published *before* this change are not left broken: the `package.json` inside the stored tarball is read on the first packument request and cached on the component, so no republish is needed
- stop serving the `metadata` sentinel as a version

## Tests

Six new tests in `internal/formats/npm/publish_metadata_test.go`, each written failing first: dependency preservation, checksum fill-in, integrity round-trip, sentinel filtering, tarball backfill and its caching. `go test ./internal/...` and `golangci-lint run` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScQjqsvQFnWFGVPB2RDLsR