### PR TITLE
fix: redact stored credentials and surface proxy URL / group members in the UI

### DIFF
--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -77,6 +77,76 @@ describe('AdminPage — Info tab', () => {
 })
 
 describe('AdminPage — Blob Stores tab', () => {
+  const s3Store = {
+    id: 'bs-2',
+    name: 'archive',
+    type: 's3',
+    usedBytes: 1024,
+    quotaBytes: null,
+    config: {
+      bucket: 'artifacts',
+      region: 'eu-central-1',
+      access_key: 'AKIAEXAMPLE',
+      secret_key_set: true,
+    },
+  }
+
+  /** Opens the archive store's detail modal and switches it into edit mode. */
+  async function openS3Edit() {
+    server.use(
+      http.get('/service/rest/v1/blobstores', () => HttpResponse.json([s3Store])),
+      http.get('/api/v1/blob-stores/:name/usage', () =>
+        HttpResponse.json({ store: s3Store, linkedRepositories: [], totalAssetBytes: 0 }),
+      ),
+    )
+    renderAdmin('blobs')
+    fireEvent.click(await screen.findByText('archive'))
+    await screen.findByText('Blob Store: archive')
+    fireEvent.click(await screen.findByRole('button', { name: /Edit Config/i }))
+    await screen.findByText('Edit Configuration')
+  }
+
+  it('never receives the S3 secret key from the API', async () => {
+    await openS3Edit()
+    // The redacted payload carries a marker instead of the credential.
+    expect(screen.getByText(/A secret key is stored/i)).toBeInTheDocument()
+  })
+
+  it('omits secret_key on save when the field is left blank', async () => {
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/blobstores/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(s3Store)
+      }),
+    )
+    await openS3Edit()
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const cfg = (put! as { config?: Record<string, unknown> }).config
+    expect(cfg).not.toHaveProperty('secret_key')
+    expect(cfg).not.toHaveProperty('secret_key_set')
+    expect(cfg?.bucket).toBe('artifacts')
+    expect(cfg?.access_key).toBe('AKIAEXAMPLE')
+  })
+
+  it('sends secret_key on save when a new one is typed', async () => {
+    const user = userEvent.setup()
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/blobstores/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(s3Store)
+      }),
+    )
+    await openS3Edit()
+    await user.type(screen.getByPlaceholderText('unchanged'), 'rotat3d')
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const cfg = (put! as { config?: Record<string, unknown> }).config
+    expect(cfg?.secret_key).toBe('rotat3d')
+  })
+
   it('shows empty state', async () => {
     server.use(http.get('/service/rest/v1/blobstores', () => HttpResponse.json([])))
     renderAdmin('blobs')

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1613,10 +1613,12 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
   const editMut = useMutation({
     mutationFn: () => {
       if (!bs) return Promise.reject('no store')
-      const secret = editSecretKey || (bs.config?.secret_key as string) || ''
+      // The API never sends the secret key back (only a secret_key_set marker), so an
+      // untouched field must omit it entirely — the server then keeps the stored one.
       const config: Record<string, unknown> = bs.type === 's3'
         ? { bucket: editBucket, region: editRegion, endpoint: editEndpoint,
-            access_key: editAccessKey, secret_key: secret }
+            access_key: editAccessKey,
+            ...(editSecretKey ? { secret_key: editSecretKey } : {}) }
         : { path: editPath }
       return nexusApi.updateBlobStore(bs.type, bs.name, { config, quotaBytes: bs.quotaBytes ?? null })
     },
@@ -1776,6 +1778,11 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
                     <div>
                       <label style={{ fontSize: 11, color: 'var(--holo-text-faint)', display: 'block', marginBottom: 3 }}>Secret Key (leave blank to keep)</label>
                       <HoloInput type="password" value={editSecretKey} onChange={e => setEditSecretKey(e.target.value)} placeholder="unchanged" />
+                      <div style={{ fontSize: 11, color: 'var(--holo-text-faint)', marginTop: 3 }}>
+                        {bs.config?.secret_key_set
+                          ? 'A secret key is stored. It is never sent to the browser — leave this blank to keep it.'
+                          : 'No secret key stored; the store falls back to the instance IAM role.'}
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/RepositoriesPage.test.tsx
+++ b/frontend/src/pages/RepositoriesPage.test.tsx
@@ -632,4 +632,203 @@ describe('RepositoriesPage', () => {
     await waitFor(() => expect(started).toBe(true))
     expect(await screen.findByText(/Migrating content…/)).toBeInTheDocument()
   })
+
+  // ── proxy remote URL & group members (issue #134) ──────────────
+
+  const proxyRepo = fixtures.repository({
+    id: 'repo-2',
+    name: 'npm-proxy',
+    format: 'npm',
+    type: 'proxy',
+    online: true,
+    proxyConfig: {
+      remote_url: 'https://registry.npmjs.org/',
+      proxy_username: 'svc',
+      proxy_password_set: true,
+    },
+  })
+
+  const groupRepo = fixtures.repository({
+    id: 'repo-3',
+    name: 'docker-group',
+    format: 'docker',
+    type: 'group',
+    online: true,
+    formatConfig: { member_names: ['docker-hosted'] },
+  })
+
+  const dockerHosted = fixtures.repository({
+    id: 'repo-4', name: 'docker-hosted', format: 'docker', type: 'hosted', online: true,
+  })
+
+  const dockerProxy = fixtures.repository({
+    id: 'repo-5', name: 'docker-proxy', format: 'docker', type: 'proxy', online: true,
+    proxyConfig: { remote_url: 'https://registry-1.docker.io/' },
+  })
+
+  /** Opens the settings modal for the row whose name is `name`. */
+  async function openSettingsFor(name: string) {
+    const label = await screen.findByText(name)
+    const row = label.closest('div[tabindex]') as HTMLElement
+    fireEvent.click(within(row).getByTitle('Settings'))
+    await screen.findByText('Repository settings')
+  }
+
+  it('shows the remote URL of a proxy repository in the list', async () => {
+    seedRepos([proxyRepo])
+    renderWithProviders(<RepositoriesPage />)
+    expect(await screen.findByText('https://registry.npmjs.org/')).toBeInTheDocument()
+  })
+
+  it('prefills the remote URL when editing a proxy repository', async () => {
+    seedRepos([proxyRepo])
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('npm-proxy')
+    expect(screen.getByDisplayValue('https://registry.npmjs.org/')).toBeInTheDocument()
+  })
+
+  it('saves a changed remote URL for a proxy repository', async () => {
+    const user = userEvent.setup()
+    seedRepos([proxyRepo])
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(proxyRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('npm-proxy')
+    const remote = screen.getByDisplayValue('https://registry.npmjs.org/')
+    await user.clear(remote)
+    await user.type(remote, 'https://npm.mirror.internal/')
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const pc = (put! as { proxyConfig?: Record<string, unknown> }).proxyConfig
+    expect(pc?.remote_url).toBe('https://npm.mirror.internal/')
+    expect(pc?.proxy_username).toBe('svc')
+  })
+
+  it('omits proxy_password on save when the password field is left untouched', async () => {
+    seedRepos([proxyRepo])
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(proxyRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('npm-proxy')
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const pc = (put! as { proxyConfig?: Record<string, unknown> }).proxyConfig
+    expect(pc).not.toHaveProperty('proxy_password')
+    expect(pc).not.toHaveProperty('proxy_password_set')
+  })
+
+  it('sends proxy_password on save when a new password is typed', async () => {
+    const user = userEvent.setup()
+    seedRepos([proxyRepo])
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(proxyRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('npm-proxy')
+    await user.click(screen.getByText(/Outbound proxy/))
+    await user.type(screen.getByPlaceholderText('Leave blank to keep current'), 'n3w')
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const pc = (put! as { proxyConfig?: Record<string, unknown> }).proxyConfig
+    expect(pc?.proxy_password).toBe('n3w')
+  })
+
+  it('rejects an empty remote URL when editing a proxy repository', async () => {
+    const user = userEvent.setup()
+    seedRepos([proxyRepo])
+    let called = false
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', () => {
+        called = true
+        return HttpResponse.json(proxyRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('npm-proxy')
+    await user.clear(screen.getByDisplayValue('https://registry.npmjs.org/'))
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    expect(await screen.findByText(/Remote URL is required/)).toBeInTheDocument()
+    expect(called).toBe(false)
+  })
+
+  it('does not show remote URL fields when editing a hosted repository', async () => {
+    seedRepos([fixtures.repository({ id: 'repo-1', name: 'maven-hosted' })])
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('maven-hosted')
+    expect(screen.queryByText('Remote URL *')).not.toBeInTheDocument()
+  })
+
+  it('lists group members with the current selection checked', async () => {
+    seedRepos([groupRepo, dockerHosted, dockerProxy])
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('docker-group')
+    const hosted = await screen.findByRole('checkbox', { name: /docker-hosted/ })
+    const proxy = screen.getByRole('checkbox', { name: /docker-proxy/ })
+    expect(hosted).toBeChecked()
+    expect(proxy).not.toBeChecked()
+  })
+
+  it('saves an updated member list for a group repository', async () => {
+    const user = userEvent.setup()
+    seedRepos([groupRepo, dockerHosted, dockerProxy])
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(groupRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('docker-group')
+    await user.click(await screen.findByRole('checkbox', { name: /docker-proxy/ }))
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const fc = (put! as { formatConfig?: { member_names?: string[] } }).formatConfig
+    expect(fc?.member_names).toEqual(['docker-hosted', 'docker-proxy'])
+  })
+
+  it('rejects an empty member list when editing a group repository', async () => {
+    const user = userEvent.setup()
+    seedRepos([groupRepo, dockerHosted, dockerProxy])
+    let called = false
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', () => {
+        called = true
+        return HttpResponse.json(groupRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('docker-group')
+    await user.click(await screen.findByRole('checkbox', { name: /docker-hosted/ }))
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    expect(await screen.findByText(/at least one member/i)).toBeInTheDocument()
+    expect(called).toBe(false)
+  })
+
+  it('does not show a member list when editing a hosted repository', async () => {
+    seedRepos([fixtures.repository({ id: 'repo-1', name: 'maven-hosted' })])
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('maven-hosted')
+    expect(screen.queryByText('Member Repositories *')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -21,6 +21,20 @@ interface Repository {
   quotaBytes?: number | null
   blobStoreId?: string | null
   routingRuleId?: string | null
+  proxyConfig?: Record<string, unknown> | null
+  formatConfig?: Record<string, unknown> | null
+}
+
+/** Reads a string entry out of a repository config map, tolerating absent/typed-wrong values. */
+function cfgString(cfg: Record<string, unknown> | null | undefined, key: string): string {
+  const v = cfg?.[key]
+  return typeof v === 'string' ? v : ''
+}
+
+/** Ordered member repository names of a group repo. */
+function groupMemberNames(repo: Repository): string[] {
+  const raw = repo.formatConfig?.['member_names']
+  return Array.isArray(raw) ? raw.filter((n): n is string => typeof n === 'string') : []
 }
 
 interface BlobStoreLite {
@@ -306,6 +320,15 @@ function RepoRow({
             {repo.description || (storeName ? `on ${storeName}` : '')}
           </div>
         )}
+        {repo.type === 'proxy' && cfgString(repo.proxyConfig, 'remote_url') && (
+          <div
+            title={cfgString(repo.proxyConfig, 'remote_url')}
+            style={{ fontSize: 11, color: 'var(--holo-text-faint)', fontFamily: 'ui-monospace,monospace', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}
+          >
+            <span aria-hidden="true">↗ </span>
+            <span>{cfgString(repo.proxyConfig, 'remote_url')}</span>
+          </div>
+        )}
       </div>
       <HoloPill tone={repo.type === 'hosted' ? 'success' : repo.type === 'proxy' ? 'default' : 'warn'}>
         {TYPE_LABELS[repo.type] ?? repo.type}
@@ -372,6 +395,13 @@ const PROXY_DEFAULTS: Record<string, string> = {
   raw:       '',
   conda:     'https://conda.anaconda.org/conda-forge/',
   terraform: 'https://registry.terraform.io/',
+}
+
+/** Sets a trimmed value on cfg, or removes the key entirely when the field was cleared. */
+function assignOrDelete(cfg: Record<string, unknown>, key: string, value: string) {
+  const v = value.trim()
+  if (v) cfg[key] = v
+  else delete cfg[key]
 }
 
 const LABEL_STYLE = { fontSize: 12, fontWeight: 500, color: 'var(--holo-text-dim)', textTransform: 'uppercase' as const, letterSpacing: '0.4px' }
@@ -778,6 +808,11 @@ function EditRepoModal({
     queryKey: ['routing-rules'],
     queryFn: () => nexusApi.listRoutingRules().then(r => r.data),
   })
+  const { data: allRepos = [] } = useQuery<Repository[]>({
+    queryKey: ['repositories'],
+    queryFn: () => nexusApi.listRepositories({}).then(r => r.data),
+    enabled: repo.type === 'group',
+  })
 
   const applicable = cleanupPoliciesForFormat(policies, repo.format)
   const [description, setDescription] = useState(repo.description ?? '')
@@ -789,6 +824,19 @@ function EditRepoModal({
   )
   const [blobStoreId, setBlobStoreId] = useState<string>(repo.blobStoreId ?? '')
   const [routingRuleId, setRoutingRuleId] = useState<string>(repo.routingRuleId ?? '')
+  const [remoteUrl, setRemoteUrl] = useState(cfgString(repo.proxyConfig, 'remote_url'))
+  const [httpProxy, setHttpProxy] = useState(cfgString(repo.proxyConfig, 'http_proxy'))
+  const [httpsProxy, setHttpsProxy] = useState(cfgString(repo.proxyConfig, 'https_proxy'))
+  const [socks5Proxy, setSocks5Proxy] = useState(cfgString(repo.proxyConfig, 'socks5_proxy'))
+  const [noProxy, setNoProxy] = useState(cfgString(repo.proxyConfig, 'no_proxy'))
+  const [proxyUsername, setProxyUsername] = useState(cfgString(repo.proxyConfig, 'proxy_username'))
+  // Passwords are never sent back by the API (see domain.RedactedRepository); an empty
+  // field means "keep the stored one", so it starts blank regardless of what is stored.
+  const [proxyPassword, setProxyPassword] = useState('')
+  const [clearProxyPassword, setClearProxyPassword] = useState(false)
+  const hasStoredProxyPassword = repo.proxyConfig?.['proxy_password_set'] === true
+  const [memberNames, setMemberNames] = useState<string[]>(groupMemberNames(repo))
+  const memberCandidates = allRepos.filter(r => r.format === repo.format && r.type !== 'group')
   const originalStoreId = repo.blobStoreId ?? ''
   const storeChanged = blobStoreId !== originalStoreId
   const [error, setError] = useState('')
@@ -850,9 +898,24 @@ function EditRepoModal({
     }
   }
 
+  const togglePolicyMember = (name: string) => {
+    setMemberNames(prev =>
+      prev.includes(name) ? prev.filter(n => n !== name) : [...prev, name],
+    )
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
+
+    if (repo.type === 'proxy' && !remoteUrl.trim()) {
+      setError('Remote URL is required for proxy repositories')
+      return
+    }
+    if (repo.type === 'group' && memberNames.length === 0) {
+      setError('Select at least one member repository')
+      return
+    }
 
     // Enforce repo quota <= blob store quota (backend also checks).
     if (repo.type !== 'group' && quotaGB.trim() !== '') {
@@ -882,6 +945,26 @@ function EditRepoModal({
       }
       if (repo.type === 'group') {
         updateBody.routingRuleId = routingRuleId || null
+        // Preserve any other formatConfig entries (e.g. writable_member) the API set.
+        const { proxy_password_set: _drop, ...rest } = (repo.formatConfig ?? {}) as Record<string, unknown>
+        void _drop
+        updateBody.formatConfig = { ...rest, member_names: memberNames }
+      }
+      if (repo.type === 'proxy') {
+        const proxyConfig: Record<string, unknown> = {}
+        for (const [k, v] of Object.entries(repo.proxyConfig ?? {})) {
+          if (k !== 'proxy_password_set') proxyConfig[k] = v
+        }
+        proxyConfig.remote_url = remoteUrl.trim()
+        assignOrDelete(proxyConfig, 'http_proxy', httpProxy)
+        assignOrDelete(proxyConfig, 'https_proxy', httpsProxy)
+        assignOrDelete(proxyConfig, 'socks5_proxy', socks5Proxy)
+        assignOrDelete(proxyConfig, 'no_proxy', noProxy)
+        assignOrDelete(proxyConfig, 'proxy_username', proxyUsername)
+        // Omitted proxy_password means "unchanged"; an explicit empty string clears it.
+        if (proxyPassword) proxyConfig.proxy_password = proxyPassword
+        else if (clearProxyPassword) proxyConfig.proxy_password = ''
+        updateBody.proxyConfig = proxyConfig
       }
       await nexusApi.updateRepository(repo.format, repo.type, repo.name, updateBody)
       onSaved()
@@ -932,6 +1015,118 @@ function EditRepoModal({
             placeholder="Optional"
           />
         </div>
+        {repo.type === 'proxy' && (
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>Remote URL *</label>
+            <HoloInput
+              type="url"
+              value={remoteUrl}
+              onChange={e => setRemoteUrl(e.target.value)}
+              placeholder="https://registry.example.com/"
+            />
+            <span className={styles.hint}>
+              URL of the upstream registry to proxy and cache. Already-cached artifacts are kept;
+              new fetches go to the new upstream.
+            </span>
+          </div>
+        )}
+        {repo.type === 'proxy' && (
+          <details className={styles.formRow}>
+            <summary style={{ cursor: 'pointer', ...LABEL_STYLE }}>Outbound proxy (optional)</summary>
+            <span className={styles.hint}>
+              Route upstream fetches through an HTTP or SOCKS5 proxy. Leave blank to use the
+              server default (HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment).
+            </span>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>HTTP proxy</label>
+              <HoloInput
+                value={httpProxy}
+                onChange={e => setHttpProxy(e.target.value)}
+                placeholder="http://proxy.internal:3128"
+              />
+            </div>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>HTTPS proxy</label>
+              <HoloInput
+                value={httpsProxy}
+                onChange={e => setHttpsProxy(e.target.value)}
+                placeholder="http://secure-proxy.internal:3128"
+              />
+            </div>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>SOCKS5 proxy</label>
+              <HoloInput
+                value={socks5Proxy}
+                onChange={e => setSocks5Proxy(e.target.value)}
+                placeholder="socks5://proxy.internal:1080"
+              />
+            </div>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>No proxy</label>
+              <HoloInput
+                value={noProxy}
+                onChange={e => setNoProxy(e.target.value)}
+                placeholder="localhost,.internal.example.com"
+              />
+            </div>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>Proxy username</label>
+              <HoloInput
+                value={proxyUsername}
+                onChange={e => setProxyUsername(e.target.value)}
+                placeholder="Optional"
+              />
+            </div>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>Proxy password</label>
+              <HoloInput
+                type="password"
+                value={proxyPassword}
+                onChange={e => { setProxyPassword(e.target.value); setClearProxyPassword(false) }}
+                placeholder="Leave blank to keep current"
+              />
+              {hasStoredProxyPassword && (
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--holo-text)', cursor: 'pointer', marginTop: 6 }}>
+                  <input
+                    type="checkbox"
+                    checked={clearProxyPassword}
+                    disabled={proxyPassword !== ''}
+                    onChange={e => setClearProxyPassword(e.target.checked)}
+                  />
+                  Remove the stored password
+                </label>
+              )}
+              <span className={styles.hint}>
+                {hasStoredProxyPassword
+                  ? 'A password is stored. It is never sent to the browser — leave this blank to keep it.'
+                  : 'No password stored for this repository.'}
+              </span>
+            </div>
+          </details>
+        )}
+        {repo.type === 'group' && (
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>Member Repositories *</label>
+            {memberCandidates.length === 0 ? (
+              <p className={styles.hint}>No {repo.format} hosted/proxy repos found. Create them first.</p>
+            ) : (
+              <div className={styles.memberList}>
+                {memberCandidates.map(r => (
+                  <label key={r.id} className={styles.memberItem}>
+                    <input
+                      type="checkbox"
+                      checked={memberNames.includes(r.name)}
+                      onChange={() => togglePolicyMember(r.name)}
+                    />
+                    <span className={styles.memberName}>{r.name}</span>
+                    <span className={styles.memberType}>{r.type}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+            <span className={styles.hint}>Members are searched in the order shown; the first hit wins.</span>
+          </div>
+        )}
         {repo.type !== 'group' && blobStores.length > 0 && (
           <div className={styles.formRow}>
             <label style={LABEL_STYLE}>Blob Store</label>

--- a/internal/api/handlers/blobstores.go
+++ b/internal/api/handlers/blobstores.go
@@ -66,7 +66,7 @@ func (h *BlobStoreHandler) List(c *gin.Context) {
 	if stores == nil {
 		stores = []domain.BlobStore{}
 	}
-	c.JSON(http.StatusOK, stores)
+	c.JSON(http.StatusOK, domain.RedactedBlobStores(stores))
 }
 
 // Get handles GET /service/rest/v1/blobstores/:name
@@ -81,7 +81,36 @@ func (h *BlobStoreHandler) Get(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, bs)
+	c.JSON(http.StatusOK, domain.RedactedBlobStore(*bs))
+}
+
+// mergeBlobStoreConfig produces the config to persist from the stored one and the
+// caller's replacement. The replacement wins wholesale, except for the S3 secret key:
+// clients read a redacted config (see domain.RedactedBlobStore), so an omitted
+// secret_key means "unchanged" rather than "clear it". Sending an explicit empty
+// secret_key clears the credential. The read-only secret_key_set marker a client may
+// echo back is always dropped.
+func mergeBlobStoreConfig(stored, updates map[string]any) map[string]any {
+	if updates == nil {
+		return nil
+	}
+	merged := make(map[string]any, len(updates)+1)
+	for k, v := range updates {
+		if k == domain.SecretKeySetKey {
+			continue
+		}
+		merged[k] = v
+	}
+	if secret, sent := merged[domain.SecretKeyKey]; sent {
+		if s, _ := secret.(string); s == "" {
+			delete(merged, domain.SecretKeyKey)
+		}
+		return merged
+	}
+	if secret, ok := stored[domain.SecretKeyKey].(string); ok && secret != "" {
+		merged[domain.SecretKeyKey] = secret
+	}
+	return merged
 }
 
 var validFillPolicies = map[string]bool{
@@ -170,6 +199,7 @@ func (h *BlobStoreHandler) Create(c *gin.Context) {
 		return
 	}
 	bs.Type = blobType
+	delete(bs.Config, domain.SecretKeySetKey)
 
 	if bs.Name == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
@@ -187,7 +217,7 @@ func (h *BlobStoreHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusCreated, bs)
+	c.JSON(http.StatusCreated, domain.RedactedBlobStore(bs))
 }
 
 // Update handles PUT /service/rest/v1/blobstores/:type/:name
@@ -211,6 +241,7 @@ func (h *BlobStoreHandler) Update(c *gin.Context) {
 	}
 	updates.Name = name
 	updates.Type = existing.Type
+	updates.Config = mergeBlobStoreConfig(existing.Config, updates.Config)
 
 	if updates.Type == "group" {
 		if msg := h.validateGroupConfig(c.Request.Context(), updates.Config); msg != "" {
@@ -226,7 +257,7 @@ func (h *BlobStoreHandler) Update(c *gin.Context) {
 	if h.registry != nil && existing.ID != "" {
 		h.registry.Invalidate(existing.ID)
 	}
-	c.JSON(http.StatusOK, updates)
+	c.JSON(http.StatusOK, domain.RedactedBlobStore(updates))
 }
 
 // Delete handles DELETE /service/rest/v1/blobstores/:name

--- a/internal/api/handlers/blobstores_test.go
+++ b/internal/api/handlers/blobstores_test.go
@@ -339,3 +339,121 @@ func TestBlobStore_Compact_Delete_Success(t *testing.T) {
 	assert.Equal(t, 1, res.Orphans)
 	assert.False(t, blobStore.Has("orphan-key"))
 }
+
+// ── secret_key redaction ──────────────────────────────────────
+
+func s3Store(name, secret string) *domain.BlobStore {
+	return &domain.BlobStore{
+		ID: name, Name: name, Type: "s3",
+		Config: map[string]any{
+			"bucket":     "artifacts",
+			"access_key": "AKIAEXAMPLE",
+			"secret_key": secret,
+		},
+	}
+}
+
+func TestBlobStoreHandler_List_RedactsSecretKey(t *testing.T) {
+	r, _, _, _, _ := mountBlobStores(t, s3Store("archive", "sup3rs3cret"))
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/blobstores", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "sup3rs3cret")
+
+	var got []domain.BlobStore
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.NotContains(t, got[0].Config, "secret_key")
+	assert.Equal(t, true, got[0].Config[domain.SecretKeySetKey])
+	assert.Equal(t, "AKIAEXAMPLE", got[0].Config["access_key"])
+}
+
+func TestBlobStoreHandler_Get_RedactsSecretKey(t *testing.T) {
+	r, _, _, _, _ := mountBlobStores(t, s3Store("archive", "sup3rs3cret"))
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/blobstores/archive", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "sup3rs3cret")
+
+	var got domain.BlobStore
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.NotContains(t, got.Config, "secret_key")
+	assert.Equal(t, true, got.Config[domain.SecretKeySetKey])
+}
+
+func TestBlobStoreHandler_Create_RedactsSecretKeyInResponse(t *testing.T) {
+	r, blobs, _, _, _ := mountBlobStores(t)
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/blobstores/s3", map[string]any{
+		"name":   "archive",
+		"config": map[string]any{"bucket": "artifacts", "secret_key": "sup3rs3cret"},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "sup3rs3cret")
+
+	stored, err := blobs.Get(testContext(), "archive")
+	require.NoError(t, err)
+	assert.Equal(t, "sup3rs3cret", stored.Config["secret_key"], "the secret is still persisted")
+}
+
+func TestBlobStoreHandler_Create_DropsSecretKeySetMarker(t *testing.T) {
+	r, blobs, _, _, _ := mountBlobStores(t)
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/blobstores/s3", map[string]any{
+		"name":   "archive",
+		"config": map[string]any{"bucket": "artifacts", domain.SecretKeySetKey: true},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	stored, err := blobs.Get(testContext(), "archive")
+	require.NoError(t, err)
+	assert.NotContains(t, stored.Config, domain.SecretKeySetKey, "the read-only marker must never be stored")
+}
+
+func TestBlobStoreHandler_Update_KeepsSecretKeyWhenOmitted(t *testing.T) {
+	r, blobs, _, _, _ := mountBlobStores(t, s3Store("archive", "sup3rs3cret"))
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/blobstores/s3/archive", map[string]any{
+		"config": map[string]any{"bucket": "artifacts-v2", "access_key": "AKIAEXAMPLE"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "sup3rs3cret")
+
+	stored, err := blobs.Get(testContext(), "archive")
+	require.NoError(t, err)
+	assert.Equal(t, "sup3rs3cret", stored.Config["secret_key"], "omitted secret must survive the edit")
+	assert.Equal(t, "artifacts-v2", stored.Config["bucket"])
+}
+
+func TestBlobStoreHandler_Update_ReplacesSecretKeyWhenProvided(t *testing.T) {
+	r, blobs, _, _, _ := mountBlobStores(t, s3Store("archive", "sup3rs3cret"))
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/blobstores/s3/archive", map[string]any{
+		"config": map[string]any{"bucket": "artifacts", "secret_key": "rotat3d"},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	stored, err := blobs.Get(testContext(), "archive")
+	require.NoError(t, err)
+	assert.Equal(t, "rotat3d", stored.Config["secret_key"])
+}
+
+func TestBlobStoreHandler_Update_ClearsSecretKeyWhenEmpty(t *testing.T) {
+	r, blobs, _, _, _ := mountBlobStores(t, s3Store("archive", "sup3rs3cret"))
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/blobstores/s3/archive", map[string]any{
+		"config": map[string]any{"bucket": "artifacts", "secret_key": ""},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	stored, err := blobs.Get(testContext(), "archive")
+	require.NoError(t, err)
+	assert.NotContains(t, stored.Config, "secret_key", "an explicit empty secret clears the credential")
+}
+
+func TestBlobStoreHandler_Update_DropsSecretKeySetMarker(t *testing.T) {
+	r, blobs, _, _, _ := mountBlobStores(t, s3Store("archive", "sup3rs3cret"))
+	// A client that round-trips a redacted payload sends the marker back.
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/blobstores/s3/archive", map[string]any{
+		"config": map[string]any{"bucket": "artifacts", domain.SecretKeySetKey: true},
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	stored, err := blobs.Get(testContext(), "archive")
+	require.NoError(t, err)
+	assert.NotContains(t, stored.Config, domain.SecretKeySetKey)
+	assert.Equal(t, "sup3rs3cret", stored.Config["secret_key"])
+}

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -39,7 +39,7 @@ func (h *RepositoryHandler) List(c *gin.Context) {
 	repos = h.rbacSvc.FilterRepos(c.Request.Context(),
 		stringVal(userID), stringSliceVal(roles), repos)
 
-	c.JSON(http.StatusOK, repos)
+	c.JSON(http.StatusOK, domain.RedactedRepositories(repos))
 }
 
 func stringVal(v any) string        { s, _ := v.(string); return s }
@@ -57,7 +57,7 @@ func (h *RepositoryHandler) Get(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, r)
+	c.JSON(http.StatusOK, domain.RedactedRepository(*r))
 }
 
 // Create handles POST /service/rest/v1/repositories/:format/:type
@@ -85,7 +85,7 @@ func (h *RepositoryHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusCreated, r)
+	c.JSON(http.StatusCreated, domain.RedactedRepository(r))
 }
 
 // Update handles PUT /service/rest/v1/repositories/:format/:type/:name
@@ -111,7 +111,7 @@ func (h *RepositoryHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, r)
+	c.JSON(http.StatusOK, domain.RedactedRepository(*r))
 }
 
 // Patch handles PATCH /service/rest/v1/repositories/:name — partial update (currently: online toggle only)
@@ -145,7 +145,7 @@ func (h *RepositoryHandler) Patch(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
-	c.JSON(http.StatusOK, r)
+	c.JSON(http.StatusOK, domain.RedactedRepository(*r))
 }
 
 // Delete handles DELETE /service/rest/v1/repositories/:name

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -354,3 +354,86 @@ func TestRepositoryHandler_Delete_RepoError_500(t *testing.T) {
 	rec := do(t, r, http.MethodDelete, "/service/rest/v1/repositories/any", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// ── proxy_password redaction ──────────────────────────────────
+
+func proxyRepo(name, password string) *domain.Repository {
+	return &domain.Repository{
+		ID: name, Name: name, Format: domain.FormatMaven2, Type: domain.TypeProxy,
+		ProxyConfig: map[string]any{
+			"remote_url":     "https://repo1.maven.org/maven2/",
+			"proxy_username": "svc",
+			"proxy_password": password,
+		},
+	}
+}
+
+func TestRepositoryHandler_List_RedactsProxyPassword(t *testing.T) {
+	r, repos, _, _ := mountRepos(t)
+	seedRepo(t, repos, proxyRepo("maven-proxy", "s3cret"))
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/repositories", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "s3cret")
+
+	var got []domain.Repository
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got, 1)
+	assert.NotContains(t, got[0].ProxyConfig, "proxy_password")
+	assert.Equal(t, true, got[0].ProxyConfig[domain.ProxyPasswordSetKey])
+	assert.Equal(t, "https://repo1.maven.org/maven2/", got[0].ProxyConfig["remote_url"])
+}
+
+func TestRepositoryHandler_Get_RedactsProxyPassword(t *testing.T) {
+	r, repos, _, _ := mountRepos(t)
+	seedRepo(t, repos, proxyRepo("maven-proxy", "s3cret"))
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/repositories/maven-proxy", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "s3cret")
+
+	var got domain.Repository
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.NotContains(t, got.ProxyConfig, "proxy_password")
+	assert.Equal(t, true, got.ProxyConfig[domain.ProxyPasswordSetKey])
+}
+
+func TestRepositoryHandler_Create_RedactsProxyPasswordInResponse(t *testing.T) {
+	r, _, _, _ := mountRepos(t)
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/repositories/maven2/proxy",
+		map[string]any{
+			"name":        "maven-proxy",
+			"proxyConfig": map[string]any{"remote_url": "https://repo1.maven.org/maven2/", "proxy_password": "s3cret"},
+		})
+	require.Equal(t, http.StatusCreated, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "s3cret")
+}
+
+func TestRepositoryHandler_Update_RedactsProxyPasswordInResponse(t *testing.T) {
+	r, repos, _, _ := mountRepos(t)
+	seedRepo(t, repos, proxyRepo("maven-proxy", "s3cret"))
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/repositories/maven2/proxy/maven-proxy",
+		map[string]any{"description": "updated"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "s3cret")
+}
+
+func TestRepositoryHandler_Patch_RedactsProxyPasswordInResponse(t *testing.T) {
+	r, repos, _, _ := mountRepos(t)
+	seedRepo(t, repos, proxyRepo("maven-proxy", "s3cret"))
+	rec := do(t, r, http.MethodPatch, "/service/rest/v1/repositories/maven-proxy",
+		map[string]any{"online": false})
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "s3cret")
+}
+
+func TestRepositoryHandler_Create_KeepsProxyPasswordStored(t *testing.T) {
+	r, repos, _, _ := mountRepos(t)
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/repositories/maven2/proxy",
+		map[string]any{
+			"name":        "maven-proxy",
+			"proxyConfig": map[string]any{"remote_url": "https://repo1.maven.org/maven2/", "proxy_password": "s3cret"},
+		})
+	require.Equal(t, http.StatusCreated, rec.Code)
+	stored, err := repos.Get(testContext(), "maven-proxy")
+	require.NoError(t, err)
+	assert.Equal(t, "s3cret", stored.ProxyConfig["proxy_password"])
+}

--- a/internal/domain/redact.go
+++ b/internal/domain/redact.go
@@ -1,0 +1,73 @@
+package domain
+
+const (
+	// ProxyPasswordKey is the proxyConfig entry holding the upstream proxy password.
+	ProxyPasswordKey = "proxy_password"
+	// ProxyPasswordSetKey is a read-only proxyConfig marker the API adds in place of
+	// ProxyPasswordKey so clients can tell a password is stored without receiving it.
+	ProxyPasswordSetKey = "proxy_password_set"
+	// SecretKeyKey is the blob store config entry holding the S3 secret access key.
+	SecretKeyKey = "secret_key"
+	// SecretKeySetKey is the read-only blob store config marker the API adds in place
+	// of SecretKeyKey, mirroring ProxyPasswordSetKey.
+	SecretKeySetKey = "secret_key_set"
+)
+
+// redactedConfig copies cfg without secretKey, substituting a `<secretKey>_set: true`
+// marker when a non-empty secret is present. A nil cfg is returned unchanged.
+func redactedConfig(cfg map[string]any, secretKey, setKey string) map[string]any {
+	if cfg == nil {
+		return nil
+	}
+	out := make(map[string]any, len(cfg))
+	for k, v := range cfg {
+		if k == secretKey || k == setKey {
+			continue
+		}
+		out[k] = v
+	}
+	if s, ok := cfg[secretKey].(string); ok && s != "" {
+		out[setKey] = true
+	}
+	return out
+}
+
+// RedactedBlobStore returns a copy of bs with the S3 secret access key stripped from
+// its config, so blob store payloads can be served to any reader. When a secret is
+// stored, SecretKeySetKey is set to true in its place. The input is untouched.
+func RedactedBlobStore(bs BlobStore) BlobStore {
+	bs.Config = redactedConfig(bs.Config, SecretKeyKey, SecretKeySetKey)
+	return bs
+}
+
+// RedactedBlobStores applies RedactedBlobStore to every entry, leaving the input slice intact.
+func RedactedBlobStores(list []BlobStore) []BlobStore {
+	if list == nil {
+		return nil
+	}
+	out := make([]BlobStore, len(list))
+	for i, bs := range list {
+		out[i] = RedactedBlobStore(bs)
+	}
+	return out
+}
+
+// RedactedRepository returns a copy of r with proxy credentials stripped from
+// proxyConfig, so repository payloads can be served to any reader. When a password
+// is stored, ProxyPasswordSetKey is set to true in its place. The input is untouched.
+func RedactedRepository(r Repository) Repository {
+	r.ProxyConfig = redactedConfig(r.ProxyConfig, ProxyPasswordKey, ProxyPasswordSetKey)
+	return r
+}
+
+// RedactedRepositories applies RedactedRepository to every entry, leaving the input slice intact.
+func RedactedRepositories(list []Repository) []Repository {
+	if list == nil {
+		return nil
+	}
+	out := make([]Repository, len(list))
+	for i, r := range list {
+		out[i] = RedactedRepository(r)
+	}
+	return out
+}

--- a/internal/domain/redact_test.go
+++ b/internal/domain/redact_test.go
@@ -1,0 +1,166 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactedRepository_StripsProxyPassword(t *testing.T) {
+	t.Parallel()
+	r := Repository{
+		Name: "maven-proxy",
+		ProxyConfig: map[string]any{
+			"remote_url":     "https://repo1.maven.org/maven2/",
+			"proxy_username": "svc",
+			"proxy_password": "s3cret",
+		},
+	}
+
+	got := RedactedRepository(r)
+
+	_, hasPassword := got.ProxyConfig["proxy_password"]
+	require.False(t, hasPassword, "proxy_password must not be exposed")
+	require.Equal(t, true, got.ProxyConfig[ProxyPasswordSetKey])
+	require.Equal(t, "https://repo1.maven.org/maven2/", got.ProxyConfig["remote_url"])
+	require.Equal(t, "svc", got.ProxyConfig["proxy_username"])
+}
+
+func TestRedactedRepository_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	r := Repository{
+		ProxyConfig: map[string]any{"proxy_password": "s3cret"},
+	}
+
+	_ = RedactedRepository(r)
+
+	require.Equal(t, "s3cret", r.ProxyConfig["proxy_password"], "input must stay intact")
+	require.NotContains(t, r.ProxyConfig, ProxyPasswordSetKey)
+}
+
+func TestRedactedRepository_NoPasswordLeavesFlagUnset(t *testing.T) {
+	t.Parallel()
+	r := Repository{
+		ProxyConfig: map[string]any{"remote_url": "https://example.test/"},
+	}
+
+	got := RedactedRepository(r)
+
+	require.NotContains(t, got.ProxyConfig, ProxyPasswordSetKey)
+	require.Equal(t, "https://example.test/", got.ProxyConfig["remote_url"])
+}
+
+func TestRedactedRepository_EmptyPasswordLeavesFlagUnset(t *testing.T) {
+	t.Parallel()
+	r := Repository{
+		ProxyConfig: map[string]any{"proxy_password": ""},
+	}
+
+	got := RedactedRepository(r)
+
+	require.NotContains(t, got.ProxyConfig, "proxy_password")
+	require.NotContains(t, got.ProxyConfig, ProxyPasswordSetKey)
+}
+
+func TestRedactedRepository_NilProxyConfig(t *testing.T) {
+	t.Parallel()
+	r := Repository{Name: "hosted"}
+
+	got := RedactedRepository(r)
+
+	require.Nil(t, got.ProxyConfig)
+	require.Equal(t, "hosted", got.Name)
+}
+
+func TestRedactedRepositories_RedactsEveryEntry(t *testing.T) {
+	t.Parallel()
+	list := []Repository{
+		{Name: "a", ProxyConfig: map[string]any{"proxy_password": "one"}},
+		{Name: "b"},
+		{Name: "c", ProxyConfig: map[string]any{"proxy_password": "three"}},
+	}
+
+	got := RedactedRepositories(list)
+
+	require.Len(t, got, 3)
+	require.NotContains(t, got[0].ProxyConfig, "proxy_password")
+	require.NotContains(t, got[2].ProxyConfig, "proxy_password")
+	require.Equal(t, "one", list[0].ProxyConfig["proxy_password"], "input must stay intact")
+}
+
+func TestRedactedRepositories_Nil(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, RedactedRepositories(nil))
+}
+
+func TestRedactedBlobStore_StripsSecretKey(t *testing.T) {
+	t.Parallel()
+	bs := BlobStore{
+		Name: "archive", Type: "s3",
+		Config: map[string]any{
+			"bucket":     "artifacts",
+			"region":     "eu-central-1",
+			"access_key": "AKIAEXAMPLE",
+			"secret_key": "sup3rs3cret",
+		},
+	}
+
+	got := RedactedBlobStore(bs)
+
+	require.NotContains(t, got.Config, "secret_key")
+	require.Equal(t, true, got.Config[SecretKeySetKey])
+	require.Equal(t, "artifacts", got.Config["bucket"])
+	require.Equal(t, "AKIAEXAMPLE", got.Config["access_key"], "the key id is not a secret and stays visible")
+}
+
+func TestRedactedBlobStore_DoesNotMutateInput(t *testing.T) {
+	t.Parallel()
+	bs := BlobStore{Config: map[string]any{"secret_key": "sup3rs3cret"}}
+
+	_ = RedactedBlobStore(bs)
+
+	require.Equal(t, "sup3rs3cret", bs.Config["secret_key"], "input must stay intact")
+	require.NotContains(t, bs.Config, SecretKeySetKey)
+}
+
+func TestRedactedBlobStore_EmptySecretLeavesFlagUnset(t *testing.T) {
+	t.Parallel()
+	bs := BlobStore{Config: map[string]any{"secret_key": "", "bucket": "artifacts"}}
+
+	got := RedactedBlobStore(bs)
+
+	require.NotContains(t, got.Config, "secret_key")
+	require.NotContains(t, got.Config, SecretKeySetKey)
+	require.Equal(t, "artifacts", got.Config["bucket"])
+}
+
+func TestRedactedBlobStore_NilConfig(t *testing.T) {
+	t.Parallel()
+	bs := BlobStore{Name: "local"}
+
+	got := RedactedBlobStore(bs)
+
+	require.Nil(t, got.Config)
+	require.Equal(t, "local", got.Name)
+}
+
+func TestRedactedBlobStores_RedactsEveryEntry(t *testing.T) {
+	t.Parallel()
+	list := []BlobStore{
+		{Name: "a", Config: map[string]any{"secret_key": "one"}},
+		{Name: "b"},
+		{Name: "c", Config: map[string]any{"secret_key": "three"}},
+	}
+
+	got := RedactedBlobStores(list)
+
+	require.Len(t, got, 3)
+	require.NotContains(t, got[0].Config, "secret_key")
+	require.NotContains(t, got[2].Config, "secret_key")
+	require.Equal(t, "one", list[0].Config["secret_key"], "input must stay intact")
+}
+
+func TestRedactedBlobStores_Nil(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, RedactedBlobStores(nil))
+}

--- a/internal/service/repository_service.go
+++ b/internal/service/repository_service.go
@@ -93,14 +93,15 @@ func (s *RepositoryService) Create(ctx context.Context, r *domain.Repository) er
 		return fmt.Errorf("%w: repository %q", ErrAlreadyExists, r.Name)
 	}
 
+	if r.ProxyConfig != nil {
+		delete(r.ProxyConfig, domain.ProxyPasswordSetKey)
+	}
 	if r.Type == domain.TypeProxy {
 		if r.ProxyConfig == nil {
 			return fmt.Errorf("%w: proxy repositories require proxy_config with remote_url", ErrInvalidInput)
 		}
-		raw, ok := r.ProxyConfig["remote_url"]
-		s, strOK := raw.(string)
-		if !ok || !strOK || s == "" {
-			return fmt.Errorf("%w: proxy_config.remote_url must be a non-empty string", ErrInvalidInput)
+		if err := validateRemoteURL(r.ProxyConfig); err != nil {
+			return err
 		}
 	}
 
@@ -169,7 +170,12 @@ func (s *RepositoryService) Update(ctx context.Context, name string, updates *do
 		r.HTTPConfig = updates.HTTPConfig
 	}
 	if updates.ProxyConfig != nil {
-		r.ProxyConfig = updates.ProxyConfig
+		r.ProxyConfig = mergeProxyConfig(r.ProxyConfig, updates.ProxyConfig)
+		if r.Type == domain.TypeProxy {
+			if err := validateRemoteURL(r.ProxyConfig); err != nil {
+				return nil, err
+			}
+		}
 	}
 	if updates.QuotaBytes != nil {
 		r.QuotaBytes = updates.QuotaBytes
@@ -230,6 +236,42 @@ func (s *RepositoryService) Update(ctx context.Context, name string, updates *do
 	return r, nil
 }
 
+// mergeProxyConfig produces the proxyConfig to persist from the stored one and the
+// caller's replacement. The replacement wins wholesale, except for the password:
+// clients read a redacted config (see domain.RedactedRepository), so an omitted
+// proxy_password means "unchanged" rather than "clear it". Sending an explicit empty
+// proxy_password clears the credential. The read-only proxy_password_set marker a
+// client may echo back is always dropped.
+func mergeProxyConfig(stored, updates map[string]any) map[string]any {
+	merged := make(map[string]any, len(updates)+1)
+	for k, v := range updates {
+		if k == domain.ProxyPasswordSetKey {
+			continue
+		}
+		merged[k] = v
+	}
+	if pw, sent := merged[domain.ProxyPasswordKey]; sent {
+		if s, _ := pw.(string); s == "" {
+			delete(merged, domain.ProxyPasswordKey)
+		}
+		return merged
+	}
+	if pw, ok := stored[domain.ProxyPasswordKey].(string); ok && pw != "" {
+		merged[domain.ProxyPasswordKey] = pw
+	}
+	return merged
+}
+
+// validateRemoteURL rejects a proxy config whose remote_url is missing or blank.
+func validateRemoteURL(pc map[string]any) error {
+	raw, ok := pc["remote_url"]
+	s, strOK := raw.(string)
+	if !ok || !strOK || strings.TrimSpace(s) == "" {
+		return fmt.Errorf("%w: proxy_config.remote_url must be a non-empty string", ErrInvalidInput)
+	}
+	return nil
+}
+
 // validateRepoQuotaAgainstStore rejects a repository quota that exceeds the
 // owning blob store's quota. Either quota being nil (unlimited) passes.
 func validateRepoQuotaAgainstStore(repoQuota *int64, bs *domain.BlobStore) error {
@@ -272,7 +314,13 @@ func (s *RepositoryService) validateGroupMembers(ctx context.Context, group *dom
 	if len(names) == 0 {
 		return fmt.Errorf("%w: group repositories require formatConfig.member_names with at least one member", ErrInvalidInput)
 	}
+	seen := make(map[string]struct{}, len(names))
 	for _, name := range names {
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("%w: group member %q is listed more than once", ErrInvalidInput, name)
+		}
+		seen[name] = struct{}{}
+
 		m, err := s.repos.Get(ctx, name)
 		if errors.Is(err, repository.ErrNotFound) {
 			return fmt.Errorf("%w: group member repository %q does not exist", ErrInvalidInput, name)

--- a/internal/service/repository_service_group_test.go
+++ b/internal/service/repository_service_group_test.go
@@ -1,0 +1,89 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// rawGroup builds a stored raw group repository over the given members.
+func rawGroup(members ...string) *domain.Repository {
+	return &domain.Repository{
+		ID: "g1", Name: "raw-group", Format: domain.FormatRaw, Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": members},
+	}
+}
+
+func TestRepositoryService_Update_ChangesGroupMembers(t *testing.T) {
+	repos := testutil.NewRepoRepo(
+		rawGroup("raw-a"),
+		testutil.SimpleRepo("raw-a", "raw"),
+		testutil.SimpleRepo("raw-b", "raw"),
+	)
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	got, err := svc.Update(context.Background(), "raw-group", &domain.Repository{
+		FormatConfig: map[string]any{"member_names": []string{"raw-b", "raw-a"}},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"raw-b", "raw-a"}, domain.GroupMemberNames(got), "member order is the resolution order")
+
+	stored, err := repos.Get(context.Background(), "raw-group")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"raw-b", "raw-a"}, domain.GroupMemberNames(stored))
+}
+
+func TestRepositoryService_Update_RejectsEmptyGroupMembers(t *testing.T) {
+	repos := testutil.NewRepoRepo(rawGroup("raw-a"), testutil.SimpleRepo("raw-a", "raw"))
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	_, err := svc.Update(context.Background(), "raw-group", &domain.Repository{
+		FormatConfig: map[string]any{"member_names": []string{}},
+	})
+
+	require.ErrorIs(t, err, service.ErrInvalidInput)
+}
+
+func TestRepositoryService_Update_RejectsGroupMemberOfOtherFormat(t *testing.T) {
+	repos := testutil.NewRepoRepo(
+		rawGroup("raw-a"),
+		testutil.SimpleRepo("raw-a", "raw"),
+		testutil.SimpleRepo("mvn-a", "maven2"),
+	)
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	_, err := svc.Update(context.Background(), "raw-group", &domain.Repository{
+		FormatConfig: map[string]any{"member_names": []string{"mvn-a"}},
+	})
+
+	require.ErrorIs(t, err, service.ErrInvalidInput)
+}
+
+func TestRepositoryService_Update_RejectsGroupMemberSelfReference(t *testing.T) {
+	repos := testutil.NewRepoRepo(rawGroup("raw-a"), testutil.SimpleRepo("raw-a", "raw"))
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	_, err := svc.Update(context.Background(), "raw-group", &domain.Repository{
+		FormatConfig: map[string]any{"member_names": []string{"raw-group"}},
+	})
+
+	require.ErrorIs(t, err, service.ErrInvalidInput)
+}
+
+func TestRepositoryService_Update_RejectsDuplicateGroupMembers(t *testing.T) {
+	repos := testutil.NewRepoRepo(rawGroup("raw-a"), testutil.SimpleRepo("raw-a", "raw"))
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	_, err := svc.Update(context.Background(), "raw-group", &domain.Repository{
+		FormatConfig: map[string]any{"member_names": []string{"raw-a", "raw-a"}},
+	})
+
+	require.ErrorIs(t, err, service.ErrInvalidInput)
+}

--- a/internal/service/repository_service_proxy_test.go
+++ b/internal/service/repository_service_proxy_test.go
@@ -1,0 +1,130 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// seededProxy returns a stored maven proxy repository carrying an upstream proxy password.
+func seededProxy() *domain.Repository {
+	return &domain.Repository{
+		ID: "p1", Name: "maven-proxy", Format: domain.FormatMaven2, Type: domain.TypeProxy,
+		ProxyConfig: map[string]any{
+			"remote_url":     "https://repo1.maven.org/maven2/",
+			"proxy_username": "svc",
+			"proxy_password": "s3cret",
+		},
+	}
+}
+
+func TestRepositoryService_Update_KeepsProxyPasswordWhenOmitted(t *testing.T) {
+	repos := testutil.NewRepoRepo(seededProxy())
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	got, err := svc.Update(context.Background(), "maven-proxy", &domain.Repository{
+		ProxyConfig: map[string]any{
+			"remote_url":     "https://my.mirror/maven/",
+			"proxy_username": "svc",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "https://my.mirror/maven/", got.ProxyConfig["remote_url"])
+	assert.Equal(t, "s3cret", got.ProxyConfig["proxy_password"], "omitted password must survive the edit")
+}
+
+func TestRepositoryService_Update_ReplacesProxyPasswordWhenProvided(t *testing.T) {
+	repos := testutil.NewRepoRepo(seededProxy())
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	got, err := svc.Update(context.Background(), "maven-proxy", &domain.Repository{
+		ProxyConfig: map[string]any{
+			"remote_url":     "https://repo1.maven.org/maven2/",
+			"proxy_password": "n3w",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "n3w", got.ProxyConfig["proxy_password"])
+}
+
+func TestRepositoryService_Update_ClearsProxyPasswordWhenEmpty(t *testing.T) {
+	repos := testutil.NewRepoRepo(seededProxy())
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	got, err := svc.Update(context.Background(), "maven-proxy", &domain.Repository{
+		ProxyConfig: map[string]any{
+			"remote_url":     "https://repo1.maven.org/maven2/",
+			"proxy_password": "",
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotContains(t, got.ProxyConfig, "proxy_password", "an explicit empty password clears the credential")
+}
+
+func TestRepositoryService_Update_DropsProxyPasswordSetMarker(t *testing.T) {
+	repos := testutil.NewRepoRepo(seededProxy())
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	// A client that round-trips a redacted payload sends the marker back.
+	got, err := svc.Update(context.Background(), "maven-proxy", &domain.Repository{
+		ProxyConfig: map[string]any{
+			"remote_url":               "https://repo1.maven.org/maven2/",
+			domain.ProxyPasswordSetKey: true,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.NotContains(t, got.ProxyConfig, domain.ProxyPasswordSetKey, "the read-only marker must never be stored")
+	assert.Equal(t, "s3cret", got.ProxyConfig["proxy_password"])
+}
+
+func TestRepositoryService_Update_RejectsEmptyRemoteURLForProxy(t *testing.T) {
+	repos := testutil.NewRepoRepo(seededProxy())
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	_, err := svc.Update(context.Background(), "maven-proxy", &domain.Repository{
+		ProxyConfig: map[string]any{"remote_url": "   "},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote_url")
+}
+
+func TestRepositoryService_Create_RejectsBlankRemoteURL(t *testing.T) {
+	repos := testutil.NewRepoRepo()
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	err := svc.Create(context.Background(), &domain.Repository{
+		Name: "maven-proxy", Format: domain.FormatMaven2, Type: domain.TypeProxy,
+		ProxyConfig: map[string]any{"remote_url": "   "},
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "remote_url")
+}
+
+func TestRepositoryService_Create_DropsProxyPasswordSetMarker(t *testing.T) {
+	repos := testutil.NewRepoRepo()
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	err := svc.Create(context.Background(), &domain.Repository{
+		Name: "maven-proxy", Format: domain.FormatMaven2, Type: domain.TypeProxy,
+		ProxyConfig: map[string]any{
+			"remote_url":               "https://repo1.maven.org/maven2/",
+			domain.ProxyPasswordSetKey: true,
+		},
+	})
+
+	require.NoError(t, err)
+	stored, err := repos.Get(context.Background(), "maven-proxy")
+	require.NoError(t, err)
+	assert.NotContains(t, stored.ProxyConfig, domain.ProxyPasswordSetKey)
+}


### PR DESCRIPTION
Closes #134.

## What

Two related changes, split across the commits.

### 1. `fix(api)`: stored credentials were served in cleartext

`GET /service/rest/v1/repositories` returned `proxyConfig.proxy_password`, and `GET /service/rest/v1/blobstores` returned `config.secret_key`. Both routes sit on the **authenticated** group, not the admin group — any user with read access could read the upstream proxy password and the S3 secret access key.

Both are now redacted on the way out and replaced with a read-only `proxy_password_set` / `secret_key_set` marker, so clients can still tell a credential is stored without receiving it.

Because clients now read a redacted config, writes **merge** rather than replace:

| Client sends | Result |
|---|---|
| no secret field | stored secret kept |
| `"secret": "new"` | replaced |
| `"secret": ""` | cleared |
| `*_set: true` (echoed marker) | dropped, never stored |

Without the merge, editing any other field would silently wipe the credential — which is exactly what the blob store edit form used to rely on (it read `config.secret_key` back out of the API response).

### 2. `feat(ui)`: the three gaps from #134

All three were UI-only; the API already accepted these updates.

1. **Proxy remote URL was invisible** — now shown under the repository name in the list.
2. **Remote URL was create-only** — Repository settings now expose it plus the outbound proxy fields (HTTP/HTTPS/SOCKS5, no-proxy, credentials). The password field starts blank, is only sent when filled, and has an explicit checkbox to remove a stored one.
3. **Group members were create-only** — Repository settings now list members with the current selection checked and refuse to save an empty list.

Server-side, `proxy_config.remote_url` is now validated on update (it was only checked on create) and duplicate group members are rejected.

## Test plan

Written test-first throughout — every test was watched fail before the code existed.

- `internal/domain`: redaction is non-mutating, skips empty secrets, handles nil configs
- `internal/api/handlers`: List/Get/Create/Update/Patch never emit a secret; the secret is still persisted; update merge covers omit / replace / clear / echoed-marker
- `internal/service`: password survives an unrelated edit, blank `remote_url` rejected on create and update, duplicate group members rejected
- `frontend`: remote URL rendered and prefilled, `proxy_password` omitted when untouched and sent when typed, member list checked/saved/validated, blob store `secret_key` omitted when blank

Backend `1595 passed`, frontend `478 passed`, `tsc` / `eslint` / `golangci-lint` clean on changed files, `vite build` OK.

`TestWebhookHandler_Test_200` fails locally in both this branch and a clean `main` — it dials a loopback HTTP server that the sandbox blocks. Unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0199SRge2sYxDhpsqarLvn8q