### PR TITLE
fix(storage): fsync local blobs before publishing them

### DIFF
--- a/internal/formats/base/base_extra_test.go
+++ b/internal/formats/base/base_extra_test.go
@@ -30,6 +30,11 @@ func TestHTTPStatusForError_WrappedQuotaExceeded(t *testing.T) {
 	assert.Equal(t, http.StatusInsufficientStorage, base.HTTPStatusForError(wrapped))
 }
 
+func TestHTTPStatusForError_NoSpaceLeft(t *testing.T) {
+	wrapped := fmt.Errorf("store blob: %w", storage.ErrNoSpace)
+	assert.Equal(t, http.StatusInsufficientStorage, base.HTTPStatusForError(wrapped))
+}
+
 func TestHTTPStatusForError_OtherError(t *testing.T) {
 	code := base.HTTPStatusForError(errors.New("some other error"))
 	assert.Equal(t, http.StatusInternalServerError, code)

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -25,9 +25,10 @@ import (
 var ErrQuotaExceeded = errors.New("storage quota exceeded")
 
 // HTTPStatusForError maps known storage errors to appropriate HTTP status codes.
-// Returns 507 Insufficient Storage for quota errors, 500 for everything else.
+// Returns 507 Insufficient Storage for quota and out-of-space errors, 500 for
+// everything else.
 func HTTPStatusForError(err error) int {
-	if errors.Is(err, ErrQuotaExceeded) {
+	if errors.Is(err, ErrQuotaExceeded) || errors.Is(err, storage.ErrNoSpace) {
 		return http.StatusInsufficientStorage
 	}
 	return http.StatusInternalServerError

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -2,18 +2,23 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 )
 
 // LocalBlobStore stores blobs as files under a base directory.
 // Key "ab/cd/abcdef123..." maps to <basePath>/ab/cd/abcdef123...
 type LocalBlobStore struct {
 	basePath string
+	// syncFile flushes a file (or directory) to durable storage. It is a field so
+	// tests can simulate fsync failures, which cannot be provoked otherwise.
+	syncFile func(*os.File) error
 }
 
 // NewLocalBlobStore creates a LocalBlobStore rooted at basePath, creating the directory if needed.
@@ -21,7 +26,7 @@ func NewLocalBlobStore(basePath string) (*LocalBlobStore, error) {
 	if err := os.MkdirAll(basePath, 0o750); err != nil {
 		return nil, fmt.Errorf("create blob store dir %s: %w", basePath, err)
 	}
-	return &LocalBlobStore{basePath: basePath}, nil
+	return &LocalBlobStore{basePath: basePath, syncFile: (*os.File).Sync}, nil
 }
 
 func (s *LocalBlobStore) keyPath(key string) (string, error) {
@@ -61,13 +66,46 @@ func (s *LocalBlobStore) Put(_ context.Context, key string, r io.Reader, _ int64
 	if _, err := io.Copy(f, r); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)
-		return err
+		return classifyWriteErr(err)
+	}
+	// Rename is atomic with respect to the name only: without an fsync the bytes
+	// may still be in the page cache, so a crash could publish a truncated blob.
+	if err := s.syncFile(f); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return classifyWriteErr(err)
 	}
 	if err := f.Close(); err != nil {
 		_ = os.Remove(tmp)
 		return err
 	}
-	return os.Rename(tmp, dst)
+	if err := os.Rename(tmp, dst); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	s.syncDir(filepath.Dir(dst))
+	return nil
+}
+
+// classifyWriteErr tags a full-disk failure with ErrNoSpace so handlers can
+// answer 507 Insufficient Storage; any other error is returned unchanged.
+func classifyWriteErr(err error) error {
+	if errors.Is(err, syscall.ENOSPC) {
+		return fmt.Errorf("%w: %w", ErrNoSpace, err)
+	}
+	return err
+}
+
+// syncDir flushes a directory entry so a completed rename survives a crash.
+// Best effort: some filesystems reject fsync on directories, and by this point
+// the blob contents are already durable.
+func (s *LocalBlobStore) syncDir(dir string) {
+	d, err := os.Open(dir) //nolint:gosec // dir is derived from a key validated by keyPath
+	if err != nil {
+		return
+	}
+	_ = s.syncFile(d)
+	_ = d.Close()
 }
 
 // Get opens the blob for key and returns its reader and size.

--- a/internal/storage/local_internal_test.go
+++ b/internal/storage/local_internal_test.go
@@ -1,0 +1,108 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syncCall records one fsync performed by Put and whether the blob was already
+// visible at its final path when the fsync happened.
+type syncCall struct {
+	name      string
+	dstExists bool
+}
+
+// recordSyncs replaces the store's fsync hook with one that records every call
+// (and still performs the real fsync), returning a pointer to the call log.
+func recordSyncs(s *LocalBlobStore, dst string) *[]syncCall {
+	calls := make([]syncCall, 0, 2)
+	s.syncFile = func(f *os.File) error {
+		_, statErr := os.Stat(dst)
+		calls = append(calls, syncCall{name: f.Name(), dstExists: statErr == nil})
+		return f.Sync()
+	}
+	return &calls
+}
+
+func TestLocalBlobStore_Put_SyncsBlobBeforeRename(t *testing.T) {
+	base := t.TempDir()
+	s, err := NewLocalBlobStore(base)
+	require.NoError(t, err)
+
+	const key = "abcdef1234567890"
+	dst := filepath.Join(base, "ab", "cd", key)
+	calls := recordSyncs(s, dst)
+
+	require.NoError(t, s.Put(context.Background(), key, strings.NewReader("payload"), 7))
+
+	require.NotEmpty(t, *calls, "Put must fsync the blob contents before renaming it into place")
+	first := (*calls)[0]
+	assert.Equal(t, dst+".tmp", first.name, "the staged temp file must be the first thing fsynced")
+	assert.False(t, first.dstExists, "the fsync must happen before the rename, not after")
+}
+
+func TestLocalBlobStore_Put_SyncsParentDirAfterRename(t *testing.T) {
+	base := t.TempDir()
+	s, err := NewLocalBlobStore(base)
+	require.NoError(t, err)
+
+	const key = "abcdef1234567890"
+	dst := filepath.Join(base, "ab", "cd", key)
+	calls := recordSyncs(s, dst)
+
+	require.NoError(t, s.Put(context.Background(), key, strings.NewReader("payload"), 7))
+
+	require.Len(t, *calls, 2, "Put must fsync the blob and then its parent directory")
+	last := (*calls)[1]
+	assert.Equal(t, filepath.Dir(dst), last.name, "the parent directory must be fsynced so the rename is durable")
+	assert.True(t, last.dstExists, "the directory fsync must happen after the rename")
+}
+
+func TestLocalBlobStore_Put_SyncFailure_LeavesNoBlob(t *testing.T) {
+	base := t.TempDir()
+	s, err := NewLocalBlobStore(base)
+	require.NoError(t, err)
+
+	const key = "abcdef1234567890"
+	dst := filepath.Join(base, "ab", "cd", key)
+	syncErr := errors.New("fsync failed")
+	s.syncFile = func(f *os.File) error {
+		if f.Name() == dst+".tmp" {
+			return syncErr
+		}
+		return f.Sync()
+	}
+
+	err = s.Put(context.Background(), key, strings.NewReader("payload"), 7)
+
+	require.ErrorIs(t, err, syncErr, "a failed fsync must fail the Put")
+	assert.NoFileExists(t, dst, "no blob may be published when its contents were not flushed to disk")
+	assert.NoFileExists(t, dst+".tmp", "the temp file must be cleaned up")
+}
+
+func TestLocalBlobStore_Put_DirSyncFailure_IsNotFatal(t *testing.T) {
+	base := t.TempDir()
+	s, err := NewLocalBlobStore(base)
+	require.NoError(t, err)
+
+	const key = "abcdef1234567890"
+	dst := filepath.Join(base, "ab", "cd", key)
+	s.syncFile = func(f *os.File) error {
+		if f.Name() == filepath.Dir(dst) {
+			return errors.New("fsync on directory not supported")
+		}
+		return f.Sync()
+	}
+
+	// Some filesystems reject fsync on a directory; the blob itself is already
+	// durable at that point, so Put must still succeed.
+	require.NoError(t, s.Put(context.Background(), key, strings.NewReader("payload"), 7))
+	assert.FileExists(t, dst)
+}

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -3,9 +3,11 @@ package storage_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -89,6 +91,26 @@ func TestLocalBlobStore_Put_PathTraversal_Rejected(t *testing.T) {
 	require.Error(t, err)
 	_, err = store.Size(ctx, traversalKey)
 	require.Error(t, err)
+}
+
+// A full disk must surface as a distinguishable sentinel so callers can map it
+// to 507 Insufficient Storage instead of an opaque 500.
+func TestLocalBlobStore_Put_DiskFull_ReturnsErrNoSpace(t *testing.T) {
+	store := newLocal(t)
+
+	err := store.Put(context.Background(), "abcdef1234567890", failingReader{err: syscall.ENOSPC}, 10)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, storage.ErrNoSpace)
+}
+
+func TestLocalBlobStore_Put_OtherWriteError_IsNotNoSpace(t *testing.T) {
+	store := newLocal(t)
+
+	err := store.Put(context.Background(), "abcdef1234567890", failingReader{err: errors.New("boom")}, 10)
+
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, storage.ErrNoSpace)
 }
 
 func TestLocalBlobStore_Delete_Existing(t *testing.T) {
@@ -201,6 +223,12 @@ func newLocal(t *testing.T) *storage.LocalBlobStore {
 	require.NoError(t, err)
 	return s
 }
+
+// failingReader fails every read with err, standing in for an I/O error hit
+// while streaming a blob to disk (e.g. ENOSPC on a full filesystem).
+type failingReader struct{ err error }
+
+func (r failingReader) Read([]byte) (int, error) { return 0, r.err }
 
 // writeFile creates a plain file at path with content (used to create a
 // path that is a file so sub-directory creation fails).

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -2,9 +2,14 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"io"
 	"time"
 )
+
+// ErrNoSpace reports that a write failed because the backing storage ran out of
+// space. Callers map it to 507 Insufficient Storage instead of an opaque 500.
+var ErrNoSpace = errors.New("no space left on device")
 
 // BlobStore is the interface every storage backend must implement.
 // Keys are opaque strings (typically UUID-based paths).


### PR DESCRIPTION
Closes #136.

`LocalBlobStore.Put` staged a blob in a temp file and renamed it into place without ever flushing it. `os.Rename` is atomic only with respect to the *name* — it says nothing about whether the bytes reached durable storage. A crash right after the rename could therefore publish a truncated or garbage blob, and nothing detects it later because blobs are not checksum-verified on read.

## Changes

- **fsync before rename** — the temp file is flushed before `Close`/`Rename`. A failed fsync fails the `Put` and removes the temp file rather than publishing a blob whose contents never reached disk.
- **fsync the parent directory after the rename**, so the directory entry is durable too. Best effort: some filesystems reject fsync on a directory, and the blob contents are already safe by then.
- **ENOSPC is no longer opaque** — a full disk on the write path is tagged with a new `storage.ErrNoSpace` sentinel, and `base.HTTPStatusForError` maps it to `507 Insufficient Storage` next to the existing quota case (the "Related" note in the issue).

The fsync hook is a field on `LocalBlobStore` (defaulting to `(*os.File).Sync`) because an fsync failure cannot be provoked from a test otherwise.

## Tests

Written first, all failing before the fix:

| Test | Covers |
| --- | --- |
| `Put_SyncsBlobBeforeRename` | the blob is fsynced while the destination does not yet exist |
| `Put_SyncsParentDirAfterRename` | the parent directory is fsynced after the rename |
| `Put_SyncFailure_LeavesNoBlob` | a failed fsync fails the Put, leaving no blob and no temp file |
| `Put_DirSyncFailure_IsNotFatal` | a directory that rejects fsync does not fail the upload |
| `Put_DiskFull_ReturnsErrNoSpace` | ENOSPC surfaces as `storage.ErrNoSpace` |
| `Put_OtherWriteError_IsNotNoSpace` | other I/O errors are not mislabelled |
| `HTTPStatusForError_NoSpaceLeft` | `ErrNoSpace` maps to 507 |

`go build ./...`, `go test ./internal/...`, `golangci-lint run` and `go vet` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW