### PR TITLE
docs: refresh the advertised test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   ![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker&logoColor=white)
   ![License](https://img.shields.io/badge/License-AGPLv3-22c55e?style=flat-square)
   ![Lint](https://img.shields.io/badge/lint-golangci--lint%20v2-22c55e?style=flat-square&logo=go&logoColor=white)
-  ![Tests](https://img.shields.io/badge/tests-1857%20passing-22c55e?style=flat-square)
+  ![Tests](https://img.shields.io/badge/tests-2049%20passing-22c55e?style=flat-square)
 
 </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -437,7 +437,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
     <div style="max-width:1200px;margin:0 auto">
       <div class="stats-grid">
         <div class="sitem rev"><div class="snum" data-count="14">14</div><div class="slbl">Artifact Formats</div></div>
-        <div class="sitem rev d1"><div class="snum" style="background:linear-gradient(135deg,var(--green),var(--cyan));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text" data-count="1857">1857</div><div class="slbl">Tests Passing</div></div>
+        <div class="sitem rev d1"><div class="snum" style="background:linear-gradient(135deg,var(--green),var(--cyan));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text" data-count="2049">2049</div><div class="slbl">Tests Passing</div></div>
         <div class="sitem rev d2"><div class="snum" style="background:linear-gradient(135deg,var(--purple),var(--blue));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">100%</div><div class="slbl">Nexus API Compat</div></div>
         <div class="sitem rev d3"><div class="snum" style="background:linear-gradient(135deg,var(--amber),var(--red));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">$0</div><div class="slbl">License Fee</div></div>
       </div>


### PR DESCRIPTION
The landing page stat (`website/index.html`) and the README badge both still claimed **1857 passing tests**. Measured on `main` at 1048f44:

| Suite | Count |
| --- | --- |
| Go (`go test ./...`, top-level test functions) | 1565 |
| Frontend (`vitest`) | 484 |
| **Total** | **2049** |

Both numbers updated to 2049. No other change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW