### PR TITLE
feat(oci): OCI artifacts as a first-class repository format

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ Published on the [Terraform Registry](https://registry.terraform.io/providers/ne
 | npm | ✓ | ✓ | ✓ |
 | PyPI | ✓ | ✓ | ✓ |
 | Go modules (GOPROXY v2) | ✓ | ✓ | ✓ |
-| Docker / OCI | ✓ | ✓ | ✓ |
+| Docker | ✓ | ✓ | ✓ |
+| OCI artifacts (Helm `oci://` push, ORAS, cosign) | ✓ | ✓ | ✓ |
 | NuGet v2 / v3 | ✓ | ✓ | ✓ |
 | Helm charts | ✓ | ✓ | ✓ |
 | Cargo (Rust) | ✓ | ✓ | ✓ |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 ## What is Nexspence?
 
-Nexspence is a self-hosted artifact repository manager that supports **14 package formats**, three repository types (hosted, proxy, group), fine-grained RBAC, SSO via OIDC/LDAP, audit logging, S3-compatible storage, and a modern dark-theme web UI — all in a single binary backed by PostgreSQL. It exposes the full **Sonatype Nexus v1 REST API** at `/service/rest/v1/` for drop-in compatibility with existing CI/CD pipelines and package manager configs.
+Nexspence is a self-hosted artifact repository manager that supports **15 package formats**, three repository types (hosted, proxy, group), fine-grained RBAC, SSO via OIDC/LDAP, audit logging, S3-compatible storage, and a modern dark-theme web UI — all in a single binary backed by PostgreSQL. It exposes the full **Sonatype Nexus v1 REST API** at `/service/rest/v1/` for drop-in compatibility with existing CI/CD pipelines and package manager configs.
 
 ---
 

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -31,7 +31,7 @@ CREATE TABLE repositories (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name            TEXT NOT NULL UNIQUE,
     format          TEXT NOT NULL CHECK (format IN (
-                        'maven2', 'npm', 'docker', 'pypi',
+                        'maven2', 'npm', 'docker', 'oci', 'pypi',
                         'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan', 'conda', 'terraform'
                     )),
     type            TEXT NOT NULL CHECK (type IN ('hosted', 'proxy', 'group')),

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -12,6 +12,7 @@ const repos = [
   fixtures.repository({ id: 'r1', name: 'maven-hosted', format: 'maven2', type: 'hosted' }),
   fixtures.repository({ id: 'r2', name: 'docker-hosted', format: 'docker', type: 'hosted' }),
   fixtures.repository({ id: 'r3', name: 'raw-hosted', format: 'raw', type: 'hosted' }),
+  fixtures.repository({ id: 'r4', name: 'oci-hosted', format: 'oci', type: 'hosted' }),
 ]
 
 function renderBrowse(search = '') {
@@ -492,6 +493,33 @@ describe('BrowsePage — Docker tree', () => {
     renderBrowse('?repo=docker-hosted&cid=dc1')
     expect(await screen.findByText('Component details')).toBeInTheDocument()
     expect(await screen.findByText('Vulnerability scan')).toBeInTheDocument()
+  })
+})
+
+describe('BrowsePage — OCI tree', () => {
+  it('renders the registry tree (not the generic component list) for an oci repository', async () => {
+    server.use(
+      http.get('/api/v1/browse/repositories/:name/docker-tree', () =>
+        HttpResponse.json({
+          root: {
+            kind: 'folder', label: '', path: '', children: [
+              {
+                kind: 'folder', label: 'my-chart', path: '/my-chart', imageRef: 'my-chart', children: [
+                  {
+                    kind: 'folder', label: 'Tags', path: '/my-chart/Tags', children: [
+                      { kind: 'tag', label: '1.0.0', path: '/my-chart/Tags/1.0.0', imageRef: 'my-chart', version: '1.0.0', componentId: 'oc1' },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ),
+    )
+    renderBrowse('?repo=oci-hosted')
+    expect(await screen.findByText('my-chart')).toBeInTheDocument()
+    expect(screen.queryByText('No components in this repository')).not.toBeInTheDocument()
   })
 })
 

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -1109,7 +1109,7 @@ export default function BrowsePage() {
   }))
 
   const selectedRepo = useMemo(() => repos.find((r) => r.name === repoName), [repos, repoName])
-  const isDocker = selectedRepo?.format?.toLowerCase() === 'docker'
+  const isOciDistribution = selectedRepo?.format?.toLowerCase() === 'docker' || selectedRepo?.format?.toLowerCase() === 'oci'
   const isRaw = selectedRepo?.format?.toLowerCase() === 'raw'
 
   const { data: components, isLoading, isError, error: componentsError, refetch } = useQuery({
@@ -1120,7 +1120,7 @@ export default function BrowsePage() {
           params: { repository: repoName, limit, offset: page * limit },
         })
         .then((r) => r.data as { items: Component[]; continuationToken: string | null }),
-    enabled: !!repoName && !isDocker && !isRaw,
+    enabled: !!repoName && !isOciDistribution && !isRaw,
     retry: (failureCount, err: unknown) => {
       const status = (err as { response?: { status?: number } })?.response?.status
       if (status === 403) return false
@@ -1136,7 +1136,7 @@ export default function BrowsePage() {
     queryKey: ['dockerBrowseTree', repoName],
     queryFn: () =>
       nexspenceApi.getDockerBrowseTree(repoName).then((r) => r.data as { root: DockerTreeNode }),
-    enabled: !!repoName && isDocker,
+    enabled: !!repoName && isOciDistribution,
   })
 
   const {
@@ -1154,7 +1154,7 @@ export default function BrowsePage() {
     queryKey: ['dockerComponentDetail', dockerSelection?.componentId],
     queryFn: () =>
       nexusApi.getComponent(dockerSelection!.componentId).then((r) => r.data as DockerComponentDetail),
-    enabled: !!repoName && isDocker && !!dockerSelection?.componentId,
+    enabled: !!repoName && isOciDistribution && !!dockerSelection?.componentId,
   })
 
   const toggleTree = useCallback((p: string) => {
@@ -1184,7 +1184,7 @@ export default function BrowsePage() {
 
   // Auto-drill Docker tree: walk to leaf with matching componentId, expand ancestors, select it.
   useEffect(() => {
-    if (!highlightComponentId || !isDocker || !dockerTree?.root) return
+    if (!highlightComponentId || !isOciDistribution || !dockerTree?.root) return
     const key = `docker:${repoName}:${highlightComponentId}`
     if (drilledRef.current === key) return
     const hit = findWithAncestors(
@@ -1207,7 +1207,7 @@ export default function BrowsePage() {
         version: hit.leaf.version ?? hit.leaf.label,
       })
     }
-  }, [highlightComponentId, isDocker, dockerTree, repoName])
+  }, [highlightComponentId, isOciDistribution, dockerTree, repoName])
 
   // Auto-drill Raw tree by componentId.
   useEffect(() => {
@@ -1230,7 +1230,7 @@ export default function BrowsePage() {
 
   const subtitle = !repoName
     ? 'Select a repository to browse'
-    : isDocker || isRaw
+    : isOciDistribution || isRaw
       ? selectedRepo!.name
       : `${items.length} components loaded`
 
@@ -1246,7 +1246,7 @@ export default function BrowsePage() {
         {repoName && (
           <HoloButton
             style={{ padding: 8, lineHeight: 0 }}
-            onClick={() => isDocker ? refetchDockerTree() : isRaw ? refetchRawTree() : refetch()}
+            onClick={() => isOciDistribution ? refetchDockerTree() : isRaw ? refetchRawTree() : refetch()}
             title="Refresh"
           >
             <RefreshCw size={16} />
@@ -1283,7 +1283,7 @@ export default function BrowsePage() {
           <FolderOpen size={40} style={{ opacity: 0.3 }} />
           <p>Choose a repository above</p>
         </div>
-      ) : isDocker ? (
+      ) : isOciDistribution ? (
         dockerTreeLoading ? (
           <div style={S.empty}>Loading tree…</div>
         ) : !dockerTree?.root?.children?.length ? (

--- a/frontend/src/pages/CleanupPage.tsx
+++ b/frontend/src/pages/CleanupPage.tsx
@@ -43,7 +43,7 @@ interface PolicyForm {
   scopePath: string
 }
 
-const FORMATS = ['*', 'maven2', 'npm', 'docker', 'pypi', 'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan']
+const FORMATS = ['*', 'maven2', 'npm', 'docker', 'oci', 'pypi', 'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan']
 
 const FORMAT_COLOR: Record<string, string> = {
   maven2: '#f97316', npm: '#ef4444', docker: '#3b82f6', pypi: '#a78bfa',

--- a/frontend/src/pages/CleanupPage.tsx
+++ b/frontend/src/pages/CleanupPage.tsx
@@ -46,7 +46,7 @@ interface PolicyForm {
 const FORMATS = ['*', 'maven2', 'npm', 'docker', 'oci', 'pypi', 'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan']
 
 const FORMAT_COLOR: Record<string, string> = {
-  maven2: '#f97316', npm: '#ef4444', docker: '#3b82f6', pypi: '#a78bfa',
+  maven2: '#f97316', npm: '#ef4444', docker: '#3b82f6', oci: '#5b8def', pypi: '#a78bfa',
   go: '#06b6d4', nuget: '#8b5cf6', helm: '#0ea5e9', raw: '#6b7280',
   apt: '#f59e0b', yum: '#10b981', cargo: '#fb923c', conan: '#94a3b8',
   '*': '#6b7280',

--- a/frontend/src/pages/RepositoriesPage.test.tsx
+++ b/frontend/src/pages/RepositoriesPage.test.tsx
@@ -831,4 +831,14 @@ describe('RepositoriesPage', () => {
     await openSettingsFor('maven-hosted')
     expect(screen.queryByText('Member Repositories *')).not.toBeInTheDocument()
   })
+
+  it('offers oci as a repository format', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<RepositoriesPage />)
+    expect(await screen.findByText('maven-hosted')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /All formats/ }))
+
+    expect(screen.getByText('oci')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -59,6 +59,7 @@ const FORMAT_COLORS: Record<string, string> = {
   maven2:    '#f97316',
   npm:       '#ef4444',
   docker:    '#3b82f6',
+  oci:       '#5b8def',
   pypi:      '#a78bfa',
   go:        '#06b6d4',
   nuget:     '#8b5cf6',
@@ -156,7 +157,7 @@ export default function RepositoriesPage() {
         <Select
           options={[
             { value: '', label: 'All formats' },
-            ...['maven2','npm','docker','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform'].map(f => ({ value: f, label: f })),
+            ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform'].map(f => ({ value: f, label: f })),
           ]}
           value={formatFilter}
           onChange={setFormatFilter}
@@ -387,6 +388,7 @@ const PROXY_DEFAULTS: Record<string, string> = {
   pypi:      'https://pypi.org/',
   go:        'https://proxy.golang.org/',
   docker:    'https://registry-1.docker.io/',
+  oci:       'https://ghcr.io/',
   helm:      'https://charts.bitnami.com/bitnami/',
   nuget:     'https://api.nuget.org/v3/',
   cargo:     'https://index.crates.io/',
@@ -531,7 +533,7 @@ function CreateRepoModal({ onClose, onCreated }: {
       <div className={styles.formRow}>
         <label style={LABEL_STYLE}>Format</label>
         <Select
-          options={['maven2','npm','docker','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform'].map(f => ({ value: f, label: f }))}
+          options={['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform'].map(f => ({ value: f, label: f }))}
           value={form.format}
           onChange={handleFormatChange}
         />

--- a/frontend/src/pages/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage.test.tsx
@@ -111,6 +111,32 @@ describe('SearchPage', () => {
     expect(screen.getByText('blobs/sha256:abcdef')).toBeInTheDocument()
   })
 
+  it('renders oci digest aliases inside the expanded parent tag', async () => {
+    const user = userEvent.setup()
+    const tag = component({
+      id: 'o1', repository: 'oci-hosted', format: 'oci', name: 'mychart', version: '1.0.0', group: '',
+      assets: [{ id: 'oa1', path: 'manifests/1.0.0', fileSize: 1000, contentType: 'application/vnd.oci', lastModified: '2026-05-01T00:00:00Z' }],
+    })
+    const digest = component({
+      id: 'o2', repository: 'oci-hosted', format: 'oci', name: 'mychart', version: 'sha256:abcdef0123456789abcdef', group: '',
+      assets: [{ id: 'oa2', path: 'blobs/sha256:abcdef', fileSize: 999, contentType: 'application/octet-stream', lastModified: '2026-05-01T00:00:00Z' }],
+    })
+    server.use(
+      http.get('/service/rest/v1/search', () => HttpResponse.json({ items: [tag, digest] })),
+    )
+    renderWithProviders(<SearchPage />)
+    await user.type(screen.getByPlaceholderText('e.g. spring-core'), 'mychart')
+    await user.click(screen.getByRole('button', { name: /Search/ }))
+    await screen.findByText('mychart')
+    // Only the tag (1.0.0) is in the main list, not the sha256 alias.
+    expect(screen.getByText('1.0.0')).toBeInTheDocument()
+    expect(screen.queryByText(/sha256:abcdef0123456789/)).not.toBeInTheDocument()
+    // Expand and look for digest aliases section
+    await user.click(screen.getByTitle('Expand assets'))
+    expect(await screen.findByText('Digest aliases')).toBeInTheDocument()
+    expect(screen.getByText('blobs/sha256:abcdef')).toBeInTheDocument()
+  })
+
   it('navigates to Browse via the group Browse button', async () => {
     const user = userEvent.setup()
     server.use(

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -294,7 +294,7 @@ export default function SearchPage() {
             <Select
               options={[
                 { value: '', label: 'any' },
-                ...['maven2','npm','docker','pypi','go','nuget','helm','raw','apt','yum'].map(f => ({ value: f, label: f })),
+                ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum'].map(f => ({ value: f, label: f })),
               ]}
               value={filters.format}
               onChange={v => setFilters(f => ({ ...f, format: v }))}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -202,12 +202,14 @@ export default function SearchPage() {
 
   const allItems = useMemo(() => data?.items ?? [], [data])
 
-  // Docker digest-alias components (version = "sha256:...") are filtered from the main list
-  // but kept in a lookup map so they can appear inside the expanded view of their parent tag.
+  // OCI Distribution digest-alias components (version = "sha256:...") are filtered from the
+  // main list but kept in a lookup map so they can appear inside the expanded view of their
+  // parent tag. Both 'docker' and 'oci' formats speak the OCI Distribution protocol and get
+  // the same digest-alias component created on every manifest push.
   const dockerDigests = useMemo(() => {
     const map = new Map<string, SearchComponent[]>()
     for (const c of allItems) {
-      if (c.format === 'docker' && c.version?.startsWith('sha256:')) {
+      if ((c.format === 'docker' || c.format === 'oci') && c.version?.startsWith('sha256:')) {
         const key = `${c.repository}::${c.name}`
         const arr = map.get(key) ?? []
         arr.push(c)
@@ -218,7 +220,7 @@ export default function SearchPage() {
   }, [allItems])
 
   const items = useMemo(() =>
-    allItems.filter(c => !(c.format === 'docker' && c.version?.startsWith('sha256:')))
+    allItems.filter(c => !((c.format === 'docker' || c.format === 'oci') && c.version?.startsWith('sha256:')))
   , [allItems])
 
   const sorted = useMemo(() => {

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -92,7 +92,7 @@ const S = {
 }
 
 const FORMAT_COLORS: Record<string, string> = {
-  maven2: '#f97316', npm: '#ef4444', docker: '#3b82f6', pypi: '#a78bfa',
+  maven2: '#f97316', npm: '#ef4444', docker: '#3b82f6', oci: '#5b8def', pypi: '#a78bfa',
   go: '#06b6d4', nuget: '#8b5cf6', helm: '#0ea5e9', raw: '#6b7280', apt: '#f59e0b', yum: '#10b981',
 }
 

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -362,6 +362,28 @@ func TestDockerV2Auth_NoAuth_AnyAnonymousRepo_Returns200(t *testing.T) {
 	assert.Empty(t, w.Header().Get("WWW-Authenticate"))
 }
 
+// An oci repository serves the same /v2/ surface, so a public one must open the
+// anonymous door exactly like a public docker one.
+func TestDockerV2Auth_NoAuth_AnonymousOCIRepo_Returns200(t *testing.T) {
+	svc := newUserSvc()
+	publicRepo := &domain.Repository{
+		ID:             "r-pub-oci",
+		Name:           "public-oci",
+		Format:         domain.FormatOCI,
+		Type:           domain.TypeHosted,
+		Online:         true,
+		AllowAnonymous: true,
+	}
+	r := buildDockerV2AuthRouter(svc, publicRepo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("WWW-Authenticate"))
+}
+
 func TestDockerV2Auth_NoAuth_OnlyPrivateDockerRepo_Returns401(t *testing.T) {
 	svc := newUserSvc()
 	privateRepo := &domain.Repository{

--- a/internal/api/handlers/browse_docker.go
+++ b/internal/api/handlers/browse_docker.go
@@ -52,7 +52,7 @@ func (h *BrowseHandler) DockerTree(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
 		return
 	}
-	if !isOCIRegistryFormat(repo.Format) {
+	if !repo.Format.IsOCIRegistry() {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry format"})
 		return
 	}
@@ -112,7 +112,7 @@ func (h *BrowseHandler) PathTree(c *gin.Context) {
 	}
 
 	var paths []string
-	if isOCIRegistryFormat(repo.Format) {
+	if repo.Format.IsOCIRegistry() {
 		raw, err := h.assets.ListRawAssetPaths(ctx, repoName)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -456,10 +456,4 @@ func (h *BrowseHandler) DeleteDockerImage(c *gin.Context) {
 
 	_ = h.components.DeleteOrphans(ctx, repoName)
 	c.Status(http.StatusNoContent)
-}
-
-// isOCIRegistryFormat reports whether a repository stores its content the way the
-// OCI Distribution handler does — /manifests/... and /blobs/... paths.
-func isOCIRegistryFormat(f domain.RepoFormat) bool {
-	return f == domain.FormatDocker || f == domain.FormatOCI
 }

--- a/internal/api/handlers/browse_docker.go
+++ b/internal/api/handlers/browse_docker.go
@@ -52,8 +52,8 @@ func (h *BrowseHandler) DockerTree(c *gin.Context) {
 		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
 		return
 	}
-	if !strings.EqualFold(string(repo.Format), string(domain.FormatDocker)) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not a docker format"})
+	if !isOCIRegistryFormat(repo.Format) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry format"})
 		return
 	}
 
@@ -63,7 +63,7 @@ func (h *BrowseHandler) DockerTree(c *gin.Context) {
 		if len(repoNames) == 0 {
 			c.JSON(http.StatusOK, gin.H{
 				"repository": repoName,
-				"format":     "docker",
+				"format":     string(repo.Format),
 				"root":       &dockerBrowseNode{Kind: "folder", Label: "/", Path: "/"},
 			})
 			return
@@ -89,7 +89,7 @@ func (h *BrowseHandler) DockerTree(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"repository": repoName,
-		"format":     "docker",
+		"format":     string(repo.Format),
 		"root":       root,
 	})
 }
@@ -112,7 +112,7 @@ func (h *BrowseHandler) PathTree(c *gin.Context) {
 	}
 
 	var paths []string
-	if strings.EqualFold(string(repo.Format), "docker") {
+	if isOCIRegistryFormat(repo.Format) {
 		raw, err := h.assets.ListRawAssetPaths(ctx, repoName)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -456,4 +456,10 @@ func (h *BrowseHandler) DeleteDockerImage(c *gin.Context) {
 
 	_ = h.components.DeleteOrphans(ctx, repoName)
 	c.Status(http.StatusNoContent)
+}
+
+// isOCIRegistryFormat reports whether a repository stores its content the way the
+// OCI Distribution handler does — /manifests/... and /blobs/... paths.
+func isOCIRegistryFormat(f domain.RepoFormat) bool {
+	return f == domain.FormatDocker || f == domain.FormatOCI
 }

--- a/internal/api/handlers/browse_oci_test.go
+++ b/internal/api/handlers/browse_oci_test.go
@@ -1,0 +1,31 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// The registry browse tree is the same for both labels of the OCI protocol.
+func TestDockerTree_OCIFormatRepo_IsAccepted(t *testing.T) {
+	r, repos, _, _, _, _ := mountBrowse(t)
+	require.NoError(t, repos.Create(context.Background(), &domain.Repository{
+		ID: "r1", Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted,
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/browse/repositories/oci-hosted/docker-tree", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "an oci repository must have a browse tree")
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "oci", body["format"])
+}

--- a/internal/api/handlers/browse_oci_test.go
+++ b/internal/api/handlers/browse_oci_test.go
@@ -29,3 +29,32 @@ func TestDockerTree_OCIFormatRepo_IsAccepted(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
 	assert.Equal(t, "oci", body["format"])
 }
+
+// A component stored in an oci repository must reach the tree, not just the
+// format gate: the browse rows are the tree's only data source.
+func TestDockerTree_OCIFormatRepo_ComponentAppearsInTree(t *testing.T) {
+	r, repos, comps, _, _, _ := mountBrowse(t)
+	require.NoError(t, repos.Create(context.Background(), &domain.Repository{
+		ID: "r1", Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted,
+	}))
+	comps.DockerRowsByRepo = map[string][]domain.DockerBrowseRow{
+		"oci-hosted": {
+			{ComponentID: "c1", ImageName: "charts/nginx", Version: "1.2.3", SamplePath: "/manifests/charts/nginx/1.2.3"},
+		},
+	}
+
+	rec := do(t, r, http.MethodGet, "/api/v1/browse/repositories/oci-hosted/docker-tree", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got browseTreeResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	charts, ok := findChild(got.Root, "charts")
+	require.True(t, ok, "the oci component must appear in the browse tree")
+	nginx, ok := findChild(charts, "nginx")
+	require.True(t, ok)
+	tags, ok := findChild(nginx, "Tags")
+	require.True(t, ok)
+	leaf, ok := findChild(tags, "1.2.3")
+	require.True(t, ok)
+	assert.Equal(t, "c1", leaf.ComponentID)
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -701,7 +701,7 @@ func serveDockerV2(
 		}
 
 		if repoDef.Type == domain.TypeGroup {
-			if !isRegistryFormat(repoDef.Format) {
+			if !isOCIRegistryFormat(repoDef.Format) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
 				return
 			}
@@ -713,7 +713,7 @@ func serveDockerV2(
 			return
 		}
 
-		if !isRegistryFormat(repoDef.Format) {
+		if !isOCIRegistryFormat(repoDef.Format) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
 			return
 		}
@@ -727,6 +727,9 @@ func serveDockerV2(
 		}
 		h, ok := fmtRegistry[string(repoDef.Format)]
 		if !ok {
+			// Defensive backstop: isOCIRegistryFormat and fmtRegistry are two
+			// separate format lists that should always agree. This only fires
+			// if they drift apart; not reachable in normal operation.
 			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
 			return
 		}
@@ -734,10 +737,10 @@ func serveDockerV2(
 	}
 }
 
-// isRegistryFormat reports whether a repository speaks the OCI Distribution
+// isOCIRegistryFormat reports whether a repository speaks the OCI Distribution
 // protocol. One handler serves both labels: "docker" for container images,
 // "oci" for charts, ORAS artifacts and signatures.
-func isRegistryFormat(f domain.RepoFormat) bool {
+func isOCIRegistryFormat(f domain.RepoFormat) bool {
 	return f == domain.FormatDocker || f == domain.FormatOCI
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -701,7 +701,7 @@ func serveDockerV2(
 		}
 
 		if repoDef.Type == domain.TypeGroup {
-			if !isOCIRegistryFormat(repoDef.Format) {
+			if !repoDef.Format.IsOCIRegistry() {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
 				return
 			}
@@ -713,7 +713,7 @@ func serveDockerV2(
 			return
 		}
 
-		if !isOCIRegistryFormat(repoDef.Format) {
+		if !repoDef.Format.IsOCIRegistry() {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
 			return
 		}
@@ -727,7 +727,7 @@ func serveDockerV2(
 		}
 		h, ok := fmtRegistry[string(repoDef.Format)]
 		if !ok {
-			// Defensive backstop: isOCIRegistryFormat and fmtRegistry are two
+			// Defensive backstop: RepoFormat.IsOCIRegistry and fmtRegistry are two
 			// separate format lists that should always agree. This only fires
 			// if they drift apart; not reachable in normal operation.
 			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
@@ -735,13 +735,6 @@ func serveDockerV2(
 		}
 		h.ServeHTTP(c)
 	}
-}
-
-// isOCIRegistryFormat reports whether a repository speaks the OCI Distribution
-// protocol. One handler serves both labels: "docker" for container images,
-// "oci" for charts, ORAS artifacts and signatures.
-func isOCIRegistryFormat(f domain.RepoFormat) bool {
-	return f == domain.FormatDocker || f == domain.FormatOCI
 }
 
 // cleanupTaskAdapter adapts the cleanup repo (List) and service (RunPolicy) to the

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -27,13 +27,13 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/formats/cargo"
 	"github.com/nexspence-oss/nexspence/internal/formats/conan"
 	"github.com/nexspence-oss/nexspence/internal/formats/conda"
-	"github.com/nexspence-oss/nexspence/internal/formats/docker"
 	"github.com/nexspence-oss/nexspence/internal/formats/gomod"
 	"github.com/nexspence-oss/nexspence/internal/formats/group"
 	"github.com/nexspence-oss/nexspence/internal/formats/helm"
 	"github.com/nexspence-oss/nexspence/internal/formats/maven"
 	"github.com/nexspence-oss/nexspence/internal/formats/npm"
 	"github.com/nexspence-oss/nexspence/internal/formats/nuget"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
 	"github.com/nexspence-oss/nexspence/internal/formats/pypi"
 	"github.com/nexspence-oss/nexspence/internal/formats/raw"
 	"github.com/nexspence-oss/nexspence/internal/formats/terraform"
@@ -220,7 +220,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		"apt":       apt.New(formatDeps),
 		"terraform": terraform.New(formatDeps),
 		"yum":       yum.New(formatDeps),
-		"docker":    docker.New(formatDeps),
+		"docker":    oci.New(formatDeps),
 	}
 	// Group handler needs a reference to the registry to fan-out to members.
 	groupHandler := group.New(formatDeps, formatRegistry)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -222,6 +222,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		"yum":       yum.New(formatDeps),
 		"docker":    oci.New(formatDeps),
 	}
+	// The OCI Distribution protocol is served under two labels — same handler,
+	// different presentation (proxy defaults, UI, command hints).
+	formatRegistry["oci"] = formatRegistry["docker"]
 	// Group handler needs a reference to the registry to fan-out to members.
 	groupHandler := group.New(formatDeps, formatRegistry)
 
@@ -698,8 +701,8 @@ func serveDockerV2(
 		}
 
 		if repoDef.Type == domain.TypeGroup {
-			if string(repoDef.Format) != "docker" {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not a docker registry"})
+			if !isRegistryFormat(repoDef.Format) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
 				return
 			}
 			c.Params = gin.Params{
@@ -710,20 +713,32 @@ func serveDockerV2(
 			return
 		}
 
-		if string(repoDef.Format) != "docker" {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not a docker registry"})
+		if !isRegistryFormat(repoDef.Format) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
 			return
 		}
 
-		// Rewrite params so the docker handler sees what it expects:
+		// Rewrite params so the registry handler sees what it expects:
 		//   c.Param("repoName") = <repoName>
 		//   c.Param("path")     = /v2/<imagePath>/<endpoint>
 		c.Params = gin.Params{
 			{Key: "repoName", Value: repoName},
 			{Key: "path", Value: "/v2" + dockerPath},
 		}
-		fmtRegistry["docker"].ServeHTTP(c)
+		h, ok := fmtRegistry[string(repoDef.Format)]
+		if !ok {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "repository is not an OCI registry"})
+			return
+		}
+		h.ServeHTTP(c)
 	}
+}
+
+// isRegistryFormat reports whether a repository speaks the OCI Distribution
+// protocol. One handler serves both labels: "docker" for container images,
+// "oci" for charts, ORAS artifacts and signatures.
+func isRegistryFormat(f domain.RepoFormat) bool {
+	return f == domain.FormatDocker || f == domain.FormatOCI
 }
 
 // cleanupTaskAdapter adapts the cleanup repo (List) and service (RunPolicy) to the

--- a/internal/api/router_docker_test.go
+++ b/internal/api/router_docker_test.go
@@ -42,7 +42,7 @@ func buildDockerRouter(repos ...*domain.Repository) *gin.Engine {
 	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, zap.NewNop().Sugar())
 
 	stub := &stubDockerHandler{}
-	fmtRegistry := map[string]formats.FormatHandler{"docker": stub}
+	fmtRegistry := map[string]formats.FormatHandler{"docker": stub, "oci": stub}
 
 	dockerV2H := serveDockerV2(repoRepo, stub, fmtRegistry)
 

--- a/internal/api/router_oci_test.go
+++ b/internal/api/router_oci_test.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// An oci-format repository speaks the same /v2/ protocol as a docker one and
+// must be dispatched to the registry handler, not rejected as "not a registry".
+func TestServeDockerV2_OCIFormatRepo_IsDispatched(t *testing.T) {
+	repo := &domain.Repository{
+		Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted,
+		Online: true, AllowAnonymous: true,
+	}
+	r := buildDockerRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/oci-hosted/charts/nginx/tags/list", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code, "an oci repository must reach the registry handler")
+}
+
+func TestServeDockerV2_NonRegistryFormatRepo_IsRejected(t *testing.T) {
+	repo := &domain.Repository{
+		Name: "maven-hosted", Format: domain.FormatMaven2, Type: domain.TypeHosted,
+		Online: true, AllowAnonymous: true,
+	}
+	r := buildDockerRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/maven-hosted/some/tags/list", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/db/migrations/022_oci_format.sql
+++ b/internal/db/migrations/022_oci_format.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_format_check;
+ALTER TABLE repositories ADD CONSTRAINT repositories_format_check CHECK (format IN (
+    'maven2','npm','docker','oci','pypi','go','nuget','helm','raw',
+    'apt','yum','cargo','conan','conda','terraform'
+));
+
+-- +goose Down
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_format_check;
+ALTER TABLE repositories ADD CONSTRAINT repositories_format_check CHECK (format IN (
+    'maven2','npm','docker','pypi','go','nuget','helm','raw',
+    'apt','yum','cargo','conan','conda','terraform'
+));

--- a/internal/domain/repo_format_test.go
+++ b/internal/domain/repo_format_test.go
@@ -1,0 +1,26 @@
+package domain
+
+import "testing"
+
+func TestRepoFormat_IsOCIRegistry(t *testing.T) {
+	cases := []struct {
+		format RepoFormat
+		want   bool
+	}{
+		{FormatDocker, true},
+		{FormatOCI, true},
+		{FormatHelm, false},
+		{FormatRaw, false},
+		{FormatMaven2, false},
+		{"", false},
+		// The stored value is the canonical lowercase label; anything else is not
+		// a format this codebase writes, and the check stays strict.
+		{"Docker", false},
+		{"OCI", false},
+	}
+	for _, tc := range cases {
+		if got := tc.format.IsOCIRegistry(); got != tc.want {
+			t.Errorf("RepoFormat(%q).IsOCIRegistry() = %v, want %v", tc.format, got, tc.want)
+		}
+	}
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -19,13 +19,16 @@ const (
 	FormatMaven2 RepoFormat = "maven2"
 	FormatNPM    RepoFormat = "npm"
 	FormatDocker RepoFormat = "docker"
-	FormatPyPI   RepoFormat = "pypi"
-	FormatGo     RepoFormat = "go"
-	FormatNuGet  RepoFormat = "nuget"
-	FormatHelm   RepoFormat = "helm"
-	FormatRaw    RepoFormat = "raw"
-	FormatApt    RepoFormat = "apt"
-	FormatYum    RepoFormat = "yum"
+	// FormatOCI is the same OCI Distribution protocol as FormatDocker, labelled
+	// for charts, ORAS artifacts and signatures rather than container images.
+	FormatOCI   RepoFormat = "oci"
+	FormatPyPI  RepoFormat = "pypi"
+	FormatGo    RepoFormat = "go"
+	FormatNuGet RepoFormat = "nuget"
+	FormatHelm  RepoFormat = "helm"
+	FormatRaw   RepoFormat = "raw"
+	FormatApt   RepoFormat = "apt"
+	FormatYum   RepoFormat = "yum"
 
 	TypeHosted RepoType = "hosted"
 	TypeProxy  RepoType = "proxy"

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -35,6 +35,15 @@ const (
 	TypeGroup  RepoType = "group"
 )
 
+// IsOCIRegistry reports whether a repository of this format speaks the OCI
+// Distribution protocol — the /v2/ surface with /manifests/... and /blobs/...
+// paths. One handler serves both labels: "docker" for container images, "oci"
+// for charts, ORAS artifacts and signatures. They differ only in presentation,
+// never in protocol behavior, so every protocol-level check uses this one method.
+func (f RepoFormat) IsOCIRegistry() bool {
+	return f == FormatDocker || f == FormatOCI
+}
+
 // Repository is a hosted, proxy, or group artifact repository of a given format.
 type Repository struct {
 	ID               string         `json:"id"`

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -19,7 +19,7 @@ const (
 	FormatMaven2 RepoFormat = "maven2"
 	FormatNPM    RepoFormat = "npm"
 	FormatDocker RepoFormat = "docker"
-	// FormatOCI is the same OCI Distribution protocol as FormatDocker, labelled
+	// FormatOCI is the same OCI Distribution protocol as FormatDocker, labeled
 	// for charts, ORAS artifacts and signatures rather than container images.
 	FormatOCI   RepoFormat = "oci"
 	FormatPyPI  RepoFormat = "pypi"

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -1,4 +1,4 @@
-// Package docker implements the OCI Distribution Spec v2 (Docker registry v2 protocol).
+// Package oci implements the OCI Distribution Spec v2 (Docker registry v2 protocol).
 //
 // All endpoints under /repository/:repoName/v2/:
 //
@@ -43,8 +43,9 @@ func New(deps formats.Deps) *Handler {
 	return &Handler{deps: deps, uploads: uploadStore{deps: deps}}
 }
 
-// Name returns the format identifier.
-func (h *Handler) Name() string { return "docker" }
+// Name returns the format identifier. Dispatch happens through the router's
+// format registry, which maps both "docker" and "oci" to this handler.
+func (h *Handler) Name() string { return "oci" }
 
 func (h *Handler) ServeHTTP(c *gin.Context) {
 	p := normPath(c.Param("path"))

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -302,17 +302,27 @@ func (h *Handler) recordCachedManifestMeta(ctx context.Context, repo *domain.Rep
 	}
 	defer func() { _ = rc.Close() }()
 
-	body, err := io.ReadAll(io.LimitReader(rc, maxManifestBytes))
+	// One byte past the cap, as the push path does, so an oversized body is
+	// visible rather than silently truncated into unparsable JSON. Unlike a push
+	// there is nothing to reject here — the blob is already cached and already
+	// served — so an overflow only skips the parse.
+	body, err := io.ReadAll(io.LimitReader(rc, maxManifestBytes+1))
 	if err != nil {
 		return
 	}
-	meta, ok := parseManifestMeta(body)
-	if !ok {
-		return
+	var extra map[string]any
+	if len(body) <= maxManifestBytes {
+		if meta, ok := parseManifestMeta(body); ok {
+			extra = extraFrom(meta)
+		}
+	}
+	if extra == nil {
+		extra = make(map[string]any, 1)
 	}
 	// The source digest is written unconditionally: it is what arms the guard
-	// above, including for a manifest that yields no metadata at all.
-	extra := extraFrom(meta)
+	// above, including for a manifest that yields no metadata at all — one that
+	// is not JSON, or one too large to parse. Without it every pull would read
+	// the whole blob back from the store forever.
 	extra[extraSourceDigestKey] = asset.SHA256
 	_ = h.deps.Components.UpdateExtra(ctx, comp.ID, extra)
 }

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -18,6 +18,7 @@ package oci
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"strings"
@@ -200,12 +201,27 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 	}
 	fp := manifestPath(imageName, reference)
 	coords := base.Coords{Name: imageName, Version: reference}
+
+	// The body is buffered because it is needed twice: stored verbatim, and
+	// parsed for the artifact type. Manifests are capped at 4 MiB by the spec.
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxManifestBytes))
+	if err != nil {
+		dockerError(c, http.StatusBadRequest, "MANIFEST_INVALID", err.Error())
+		return
+	}
+
 	res, err := base.StoreArtifact(c.Request.Context(), h.deps,
 		repoName, fp, ct, coords,
-		c.Request.Body, c.Request.ContentLength)
+		bytes.NewReader(body), int64(len(body)))
 	if err != nil {
 		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
 		return
+	}
+
+	if meta, ok := parseManifestMeta(body); ok {
+		if extra := extraFrom(meta); len(extra) > 0 {
+			_ = h.deps.Components.UpdateExtra(c.Request.Context(), res.Asset.ComponentID, extra)
+		}
 	}
 
 	// Docker pulls always re-fetch the manifest by content digest after getting it by tag.

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -151,7 +151,10 @@ func (h *Handler) handleManifests(c *gin.Context, repoName, imageName, reference
 				dockerError(c, http.StatusBadGateway, "UNKNOWN", err.Error())
 				return
 			}
-			h.recordCachedManifestMeta(c.Request.Context(), repo, cachePath)
+			// Post-response work: drop cancellation (the client may already have
+			// hung up) while keeping request values, as repoproxy does for its
+			// own after-the-fact freshness update.
+			h.recordCachedManifestMeta(context.WithoutCancel(c.Request.Context()), repo, cachePath)
 			return
 		}
 		h.pullManifest(c, repoName, imageName, reference)
@@ -267,9 +270,10 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 }
 
 // recordCachedManifestMeta types a manifest that repoproxy has just written to
-// the cache. ServeGET does not expose the body, so it is read back once — a
-// component that already carries a media type is left alone, keeping revalidated
-// manifests off the blob store.
+// the cache. ServeGET does not expose the body, so it is read back once per
+// distinct manifest: the recorded source digest keeps a steady-state cache hit
+// off the blob store, while a tag re-pointed upstream re-types because the
+// cached content — and so its digest — changed.
 func (h *Handler) recordCachedManifestMeta(ctx context.Context, repo *domain.Repository, cachePath string) {
 	asset, err := h.deps.Assets.GetByPath(ctx, repo.Name, cachePath)
 	if err != nil || asset == nil {
@@ -279,7 +283,10 @@ func (h *Handler) recordCachedManifestMeta(ctx context.Context, repo *domain.Rep
 	if err != nil || comp == nil {
 		return
 	}
-	if _, typed := comp.Extra[extraMediaTypeKey]; typed {
+	// Keyed on WHICH manifest was typed, not on whether anything was typed. A
+	// re-pointed tag changes the cached blob's digest and re-types; an unchanged
+	// one skips the read even when the manifest carries no mediaType of its own.
+	if dg, ok := comp.Extra[extraSourceDigestKey].(string); ok && dg == asset.SHA256 {
 		return
 	}
 
@@ -303,9 +310,11 @@ func (h *Handler) recordCachedManifestMeta(ctx context.Context, repo *domain.Rep
 	if !ok {
 		return
 	}
-	if extra := extraFrom(meta); len(extra) > 0 {
-		_ = h.deps.Components.UpdateExtra(ctx, comp.ID, extra)
-	}
+	// The source digest is written unconditionally: it is what arms the guard
+	// above, including for a manifest that yields no metadata at all.
+	extra := extraFrom(meta)
+	extra[extraSourceDigestKey] = asset.SHA256
+	_ = h.deps.Components.UpdateExtra(ctx, comp.ID, extra)
 }
 
 func (h *Handler) deleteManifest(c *gin.Context, repoName, imageName, reference string) {

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -204,9 +204,18 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 
 	// The body is buffered because it is needed twice: stored verbatim, and
 	// parsed for the artifact type. Manifests are capped at 4 MiB by the spec.
-	body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxManifestBytes))
+	// Reading one byte past the cap is what makes an overflow visible: a reader
+	// limited to exactly the cap returns the trimmed prefix and a nil error, so
+	// an oversized manifest would be stored corrupt under a digest of bytes the
+	// client never sent.
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxManifestBytes+1))
 	if err != nil {
 		dockerError(c, http.StatusBadRequest, "MANIFEST_INVALID", err.Error())
+		return
+	}
+	if len(body) > maxManifestBytes {
+		dockerError(c, http.StatusRequestEntityTooLarge, "MANIFEST_INVALID",
+			"manifest exceeds the 4MiB limit")
 		return
 	}
 
@@ -218,10 +227,15 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 		return
 	}
 
+	// Held outside the block because the digest alias below is typed from the
+	// same metadata. Recording it is best effort throughout: the manifest is
+	// already stored and nothing in the protocol reads these keys.
+	var extra map[string]any
 	if meta, ok := parseManifestMeta(body); ok {
-		if extra := extraFrom(meta); len(extra) > 0 {
-			_ = h.deps.Components.UpdateExtra(c.Request.Context(), res.Asset.ComponentID, extra)
-		}
+		extra = extraFrom(meta)
+	}
+	if len(extra) > 0 {
+		_ = h.deps.Components.UpdateExtra(c.Request.Context(), res.Asset.ComponentID, extra)
 	}
 
 	// Docker pulls always re-fetch the manifest by content digest after getting it by tag.
@@ -230,11 +244,16 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 	digestRef := "sha256:" + res.SHA256
 	if reference != digestRef {
 		if repo, err2 := h.deps.Repos.Get(c.Request.Context(), repoName); err2 == nil && repo != nil {
-			_, _ = base.RegisterStoredBlob(c.Request.Context(), h.deps, repo,
+			alias, aerr := base.RegisterStoredBlob(c.Request.Context(), h.deps, repo,
 				manifestPath(imageName, digestRef), ct,
 				base.Coords{Name: imageName, Version: digestRef},
 				res.Asset.BlobKey,
 				res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+			// The alias carries the same metadata: the referrers API resolves a
+			// subject by digest, not by tag.
+			if aerr == nil && alias != nil && len(extra) > 0 {
+				_ = h.deps.Components.UpdateExtra(c.Request.Context(), alias.ComponentID, extra)
+			}
 		}
 	}
 

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -13,7 +13,7 @@
 //	PATCH /v2/:name/blobs/uploads/:uuid         → stream blob chunks
 //	PUT  /v2/:name/blobs/uploads/:uuid?digest=  → finalize blob upload
 //	DELETE /v2/:name/blobs/:digest              → delete blob
-package docker
+package oci
 
 import (
 	"bytes"

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -17,6 +17,7 @@ package oci
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -148,7 +149,9 @@ func (h *Handler) handleManifests(c *gin.Context, repoName, imageName, reference
 			}
 			if err := repoproxy.ServeGET(c, h.deps, repo, cachePath, upPath, coords, ct, maxAge); err != nil {
 				dockerError(c, http.StatusBadGateway, "UNKNOWN", err.Error())
+				return
 			}
+			h.recordCachedManifestMeta(c.Request.Context(), repo, cachePath)
 			return
 		}
 		h.pullManifest(c, repoName, imageName, reference)
@@ -261,6 +264,48 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 	c.Header("Docker-Content-Digest", digest)
 	c.Header("Location", "/v2/"+imageName+"/manifests/"+digest)
 	c.Status(http.StatusCreated)
+}
+
+// recordCachedManifestMeta types a manifest that repoproxy has just written to
+// the cache. ServeGET does not expose the body, so it is read back once — a
+// component that already carries a media type is left alone, keeping revalidated
+// manifests off the blob store.
+func (h *Handler) recordCachedManifestMeta(ctx context.Context, repo *domain.Repository, cachePath string) {
+	asset, err := h.deps.Assets.GetByPath(ctx, repo.Name, cachePath)
+	if err != nil || asset == nil {
+		return
+	}
+	comp, err := h.deps.Components.Get(ctx, asset.ComponentID)
+	if err != nil || comp == nil {
+		return
+	}
+	if _, typed := comp.Extra[extraMediaTypeKey]; typed {
+		return
+	}
+
+	store := h.deps.BlobStore
+	if asset.BlobStoreID != "" {
+		if bsMeta, getErr := h.deps.Blobs.GetByID(ctx, asset.BlobStoreID); getErr == nil {
+			store = base.PhysicalStore(ctx, h.deps, bsMeta)
+		}
+	}
+	rc, _, err := store.Get(ctx, asset.BlobKey)
+	if err != nil {
+		return
+	}
+	defer func() { _ = rc.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(rc, maxManifestBytes))
+	if err != nil {
+		return
+	}
+	meta, ok := parseManifestMeta(body)
+	if !ok {
+		return
+	}
+	if extra := extraFrom(meta); len(extra) > 0 {
+		_ = h.deps.Components.UpdateExtra(ctx, comp.ID, extra)
+	}
 }
 
 func (h *Handler) deleteManifest(c *gin.Context, repoName, imageName, reference string) {

--- a/internal/formats/oci/handler_extra_test.go
+++ b/internal/formats/oci/handler_extra_test.go
@@ -1,4 +1,4 @@
-package docker_test
+package oci_test
 
 import (
 	"fmt"
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
-	"github.com/nexspence-oss/nexspence/internal/formats/docker"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
 	"github.com/nexspence-oss/nexspence/internal/requestctx"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
@@ -29,7 +29,7 @@ func TestDocker_Name(t *testing.T) {
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
 	}
-	h := docker.New(d)
+	h := oci.New(d)
 	assert.Equal(t, "docker", h.Name())
 }
 
@@ -349,7 +349,7 @@ func TestDocker_ProxyManifest_Get_FallsThrough(t *testing.T) {
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
 	}
-	h := docker.New(d)
+	h := oci.New(d)
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
 		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
@@ -381,7 +381,7 @@ func TestDocker_ProxyBlob_Get_FallsThrough(t *testing.T) {
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
 	}
-	h := docker.New(d)
+	h := oci.New(d)
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
 		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
@@ -420,7 +420,7 @@ func TestDocker_ProxyBlob_Delete_Rejected(t *testing.T) {
 // engineFor wires one gin engine per Handler so a test can drive several
 // handler instances that share the same Deps — the multi-node deployment where
 // consecutive requests of one push land on different nodes.
-func engineFor(h *docker.Handler) *gin.Engine {
+func engineFor(h *oci.Handler) *gin.Engine {
 	r := gin.New()
 	r.Use(func(c *gin.Context) {
 		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
@@ -443,7 +443,7 @@ func TestDocker_BlobUpload_SpansInstances(t *testing.T) {
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
 	}
-	node1, node2 := engineFor(docker.New(d)), engineFor(docker.New(d))
+	node1, node2 := engineFor(oci.New(d)), engineFor(oci.New(d))
 
 	const first, second = "layer-part-one|", "layer-part-two"
 	dgst := digest(first + second)
@@ -511,7 +511,7 @@ func TestDocker_BlobUpload_IDsAreUnguessable(t *testing.T) {
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
 	}
-	node1, node2 := engineFor(docker.New(d)), engineFor(docker.New(d))
+	node1, node2 := engineFor(oci.New(d)), engineFor(oci.New(d))
 
 	ids := map[string]bool{}
 	for _, node := range []*gin.Engine{node1, node2, node1, node2} {

--- a/internal/formats/oci/handler_extra_test.go
+++ b/internal/formats/oci/handler_extra_test.go
@@ -30,7 +30,7 @@ func TestDocker_Name(t *testing.T) {
 		BaseURL:    "http://localhost:8080",
 	}
 	h := oci.New(d)
-	assert.Equal(t, "docker", h.Name())
+	assert.Equal(t, "oci", h.Name())
 }
 
 // ── Version check (no /v2/ prefix) ───────────────────────────

--- a/internal/formats/oci/handler_test.go
+++ b/internal/formats/oci/handler_test.go
@@ -1,4 +1,4 @@
-package docker_test
+package oci_test
 
 import (
 	"crypto/sha256"
@@ -15,7 +15,7 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/formats"
-	"github.com/nexspence-oss/nexspence/internal/formats/docker"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
 	"github.com/nexspence-oss/nexspence/internal/requestctx"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
@@ -31,7 +31,7 @@ func setup(repo *domain.Repository) *gin.Engine {
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
 	}
-	h := docker.New(d)
+	h := oci.New(d)
 	r := gin.New()
 	// Inject a user into context so requireDockerAuth passes.
 	r.Use(func(c *gin.Context) {
@@ -91,7 +91,7 @@ func setupV2Scoped(repo *domain.Repository) *gin.Engine {
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
 	}
-	h := docker.New(d)
+	h := oci.New(d)
 	r := gin.New()
 	// Credentials are only attached to /v2/ requests (as a real Docker client does).
 	r.Use(func(c *gin.Context) {
@@ -273,7 +273,7 @@ func TestDocker_BlobUpload_NoAuth_Returns401(t *testing.T) {
 		Components: testutil.NewComponentRepo(), Assets: testutil.NewAssetRepo(),
 		BlobStore: testutil.NewBlobStore(),
 	}
-	h := docker.New(d)
+	h := oci.New(d)
 	r := gin.New()
 	// No user injected — requireDockerAuth should challenge with 401
 	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })

--- a/internal/formats/oci/manifest.go
+++ b/internal/formats/oci/manifest.go
@@ -59,8 +59,12 @@ func parseManifestMeta(body []byte) (manifestMeta, bool) {
 }
 
 // extraFrom renders the metadata as component.Extra entries. Empty fields are
-// left out: Extra is merged, not replaced, so writing a blank value would erase
-// what an earlier push recorded.
+// left out so the stored map holds only keys that carry a meaning: a blank
+// oci_artifact_type would assert "this artifact has no type" rather than say
+// nothing. It is not protecting earlier data — every write path here goes
+// through base.RegisterStoredBlob → Components.Create, whose upsert does
+// SET extra = EXCLUDED.extra with an always-empty Extra, so the whole map is
+// wiped immediately before UpdateExtra merges these keys back in.
 func extraFrom(m manifestMeta) map[string]any {
 	extra := make(map[string]any, 4)
 	if m.MediaType != "" {

--- a/internal/formats/oci/manifest.go
+++ b/internal/formats/oci/manifest.go
@@ -9,6 +9,9 @@ const (
 	extraArtifactTypeKey = "oci_artifact_type"
 	extraSubjectKey      = "oci_subject"
 	extraAnnotationsKey  = "oci_annotations"
+	// extraSourceDigestKey records which manifest the other keys were derived
+	// from, so a cached copy is re-typed exactly when its content changes.
+	extraSourceDigestKey = "oci_source_digest"
 )
 
 // maxManifestBytes is the manifest size limit from the OCI Distribution Spec.

--- a/internal/formats/oci/manifest.go
+++ b/internal/formats/oci/manifest.go
@@ -1,0 +1,80 @@
+package oci
+
+import "encoding/json"
+
+// component.Extra keys holding the manifest metadata. They are what the
+// referrers API and the browse UI read; nothing in the protocol depends on them.
+const (
+	extraMediaTypeKey    = "oci_media_type"
+	extraArtifactTypeKey = "oci_artifact_type"
+	extraSubjectKey      = "oci_subject"
+	extraAnnotationsKey  = "oci_annotations"
+)
+
+// maxManifestBytes is the manifest size limit from the OCI Distribution Spec.
+// It caps how much of a push body is buffered for parsing.
+const maxManifestBytes = 4 << 20
+
+// manifestMeta is the descriptive subset of an OCI manifest the registry stores.
+type manifestMeta struct {
+	MediaType    string
+	ArtifactType string
+	Subject      string
+	Annotations  map[string]string
+}
+
+// parseManifestMeta reads the descriptive fields of a manifest. ok is false when
+// the body is not a JSON object; an image index parses fine and simply yields no
+// artifact type.
+func parseManifestMeta(body []byte) (manifestMeta, bool) {
+	var doc struct {
+		MediaType    string `json:"mediaType"`
+		ArtifactType string `json:"artifactType"`
+		Config       struct {
+			MediaType string `json:"mediaType"`
+		} `json:"config"`
+		Subject struct {
+			Digest string `json:"digest"`
+		} `json:"subject"`
+		Annotations map[string]string `json:"annotations"`
+	}
+	if json.Unmarshal(body, &doc) != nil {
+		return manifestMeta{}, false
+	}
+	artifactType := doc.ArtifactType
+	if artifactType == "" {
+		// OCI 1.0 has no artifactType field: Helm and cosign put the type in
+		// config.mediaType instead, and clients still read it from there.
+		artifactType = doc.Config.MediaType
+	}
+	return manifestMeta{
+		MediaType:    doc.MediaType,
+		ArtifactType: artifactType,
+		Subject:      doc.Subject.Digest,
+		Annotations:  doc.Annotations,
+	}, true
+}
+
+// extraFrom renders the metadata as component.Extra entries. Empty fields are
+// left out: Extra is merged, not replaced, so writing a blank value would erase
+// what an earlier push recorded.
+func extraFrom(m manifestMeta) map[string]any {
+	extra := make(map[string]any, 4)
+	if m.MediaType != "" {
+		extra[extraMediaTypeKey] = m.MediaType
+	}
+	if m.ArtifactType != "" {
+		extra[extraArtifactTypeKey] = m.ArtifactType
+	}
+	if m.Subject != "" {
+		extra[extraSubjectKey] = m.Subject
+	}
+	if len(m.Annotations) > 0 {
+		annotations := make(map[string]any, len(m.Annotations))
+		for k, v := range m.Annotations {
+			annotations[k] = v
+		}
+		extra[extraAnnotationsKey] = annotations
+	}
+	return extra
+}

--- a/internal/formats/oci/manifest_test.go
+++ b/internal/formats/oci/manifest_test.go
@@ -1,0 +1,72 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A Helm chart pushed with `helm push oci://` carries its type in
+// config.mediaType — artifactType is absent in the OCI 1.0 manifests Helm writes.
+func TestParseManifestMeta_HelmChart(t *testing.T) {
+	body := []byte(`{
+	  "schemaVersion": 2,
+	  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+	  "config": {"mediaType": "application/vnd.cncf.helm.config.v1+json", "digest": "sha256:aa", "size": 12},
+	  "layers": [{"mediaType": "application/vnd.cncf.helm.chart.content.v1.tar+gzip", "digest": "sha256:bb", "size": 34}],
+	  "annotations": {"org.opencontainers.image.title": "nginx", "org.opencontainers.image.version": "1.2.3"}
+	}`)
+
+	meta, ok := parseManifestMeta(body)
+
+	require.True(t, ok)
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", meta.MediaType)
+	assert.Equal(t, "application/vnd.cncf.helm.config.v1+json", meta.ArtifactType)
+	assert.Empty(t, meta.Subject)
+	assert.Equal(t, "1.2.3", meta.Annotations["org.opencontainers.image.version"])
+}
+
+// An ORAS artifact sets artifactType explicitly; it wins over config.mediaType.
+func TestParseManifestMeta_ORASArtifact_PrefersArtifactType(t *testing.T) {
+	body := []byte(`{
+	  "schemaVersion": 2,
+	  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+	  "artifactType": "application/vnd.wasm.content.layer.v1+wasm",
+	  "config": {"mediaType": "application/vnd.oci.empty.v1+json", "digest": "sha256:cc", "size": 2}
+	}`)
+
+	meta, ok := parseManifestMeta(body)
+
+	require.True(t, ok)
+	assert.Equal(t, "application/vnd.wasm.content.layer.v1+wasm", meta.ArtifactType)
+}
+
+// A cosign signature points at the image it signs through subject.
+func TestParseManifestMeta_SignatureCarriesSubject(t *testing.T) {
+	body := []byte(`{
+	  "schemaVersion": 2,
+	  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+	  "artifactType": "application/vnd.dev.cosign.artifact.sig.v1+json",
+	  "subject": {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": "sha256:deadbeef", "size": 7}
+	}`)
+
+	meta, ok := parseManifestMeta(body)
+
+	require.True(t, ok)
+	assert.Equal(t, "sha256:deadbeef", meta.Subject)
+}
+
+func TestParseManifestMeta_NotJSON(t *testing.T) {
+	_, ok := parseManifestMeta([]byte("not a manifest"))
+	assert.False(t, ok)
+}
+
+func TestExtraFrom_OmitsEmptyFields(t *testing.T) {
+	extra := extraFrom(manifestMeta{MediaType: "application/vnd.oci.image.manifest.v1+json"})
+
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", extra[extraMediaTypeKey])
+	assert.NotContains(t, extra, extraArtifactTypeKey, "an empty field must not overwrite a value from an earlier push")
+	assert.NotContains(t, extra, extraSubjectKey)
+	assert.NotContains(t, extra, extraAnnotationsKey)
+}

--- a/internal/formats/oci/manifest_test.go
+++ b/internal/formats/oci/manifest_test.go
@@ -70,3 +70,35 @@ func TestExtraFrom_OmitsEmptyFields(t *testing.T) {
 	assert.NotContains(t, extra, extraSubjectKey)
 	assert.NotContains(t, extra, extraAnnotationsKey)
 }
+
+// An empty annotations object must not be treated differently from a manifest
+// that omits annotations entirely: extraFrom must omit the key in both cases.
+func TestParseManifestMeta_EmptyAnnotationsOmittedFromExtra(t *testing.T) {
+	withEmptyObject := []byte(`{
+	  "schemaVersion": 2,
+	  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+	  "config": {"mediaType": "application/vnd.oci.empty.v1+json", "digest": "sha256:cc", "size": 2},
+	  "annotations": {}
+	}`)
+	withoutKey := []byte(`{
+	  "schemaVersion": 2,
+	  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+	  "config": {"mediaType": "application/vnd.oci.empty.v1+json", "digest": "sha256:cc", "size": 2}
+	}`)
+
+	metaWithEmptyObject, ok := parseManifestMeta(withEmptyObject)
+	require.True(t, ok)
+	metaWithoutKey, ok := parseManifestMeta(withoutKey)
+	require.True(t, ok)
+
+	assert.NotContains(t, extraFrom(metaWithEmptyObject), extraAnnotationsKey)
+	assert.NotContains(t, extraFrom(metaWithoutKey), extraAnnotationsKey)
+}
+
+// A body that parses as JSON but is not an object (a bare array here) is not a
+// manifest; parseManifestMeta must report ok=false rather than silently
+// returning zero-valued metadata.
+func TestParseManifestMeta_JSONArrayIsNotAManifest(t *testing.T) {
+	_, ok := parseManifestMeta([]byte(`[1,2,3]`))
+	assert.False(t, ok)
+}

--- a/internal/formats/oci/metadata_test.go
+++ b/internal/formats/oci/metadata_test.go
@@ -259,6 +259,43 @@ func pullTag(t *testing.T, r *gin.Engine, repoName, tag string) string {
 	return w.Body.String()
 }
 
+// oversizedManifest is valid JSON larger than the 4 MiB spec cap, padded with an
+// annotation. Nothing rejects it on the proxy read-back path — it is already in
+// the cache — so the metadata helper must still arm its guard on it.
+func oversizedManifest() string {
+	return `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"mediaType": "application/vnd.cncf.helm.config.v1+json", "digest": "sha256:aa", "size": 12},
+  "annotations": {"pad": "` + strings.Repeat("x", 5<<20) + `"}
+}`
+}
+
+// A cached manifest over the 4 MiB cap must not be re-read from the blob store on
+// every pull: parsing it is optional, arming the guard is not.
+func TestProxyManifest_DoesNotRereadOversizedManifest(t *testing.T) {
+	body := oversizedManifest()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	repo := &domain.Repository{
+		ID: "r6", Name: "oci-proxy", Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r, _, store := setupCounting(repo)
+
+	require.Equal(t, body, pullTag(t, r, "oci-proxy", "1.2.3"))
+	afterFirst := store.getCount()
+	require.Positive(t, afterFirst, "the counting store must actually be the one in use")
+
+	require.Equal(t, body, pullTag(t, r, "oci-proxy", "1.2.3"))
+	assert.Equal(t, afterFirst+1, store.getCount(),
+		"an oversized cached manifest must not be re-read for metadata on every pull")
+}
+
 // A mutable tag re-pointed upstream must re-type the component: the cached blob
 // now holds a different manifest, so metadata describing the old one is wrong.
 func TestProxyManifest_RetypesRepointedTag(t *testing.T) {

--- a/internal/formats/oci/metadata_test.go
+++ b/internal/formats/oci/metadata_test.go
@@ -163,3 +163,31 @@ func TestPushManifest_StoresBodyVerbatim(t *testing.T) {
 	require.Equal(t, http.StatusOK, gw.Code)
 	assert.Equal(t, helmChartManifest, gw.Body.String())
 }
+
+func TestProxyManifest_RecordsArtifactMetadata(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v2/charts/nginx/manifests/1.2.3" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_, _ = w.Write([]byte(helmChartManifest))
+	}))
+	defer upstream.Close()
+
+	repo := &domain.Repository{
+		ID: "r2", Name: "oci-proxy", Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r, d := setupWithDeps(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/oci-proxy/v2/charts/nginx/manifests/1.2.3", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "proxy should serve the upstream manifest")
+	assert.Equal(t, helmChartManifest, w.Body.String())
+
+	comp := componentOf(t, d, "oci-proxy", "charts/nginx", "1.2.3")
+	assert.Equal(t, "application/vnd.cncf.helm.config.v1+json", comp.Extra["oci_artifact_type"],
+		"a cached chart must be typed like a pushed one")
+}

--- a/internal/formats/oci/metadata_test.go
+++ b/internal/formats/oci/metadata_test.go
@@ -81,6 +81,67 @@ func TestPushManifest_RecordsArtifactMetadata(t *testing.T) {
 	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", comp.Extra["oci_media_type"])
 }
 
+// Docker clients re-fetch a manifest by digest after pulling it by tag, so the
+// digest reference gets a component of its own. Phase 2's referrers API resolves
+// a subject by digest — that component needs the same metadata as the tag.
+func TestPushManifest_TypesDigestAlias(t *testing.T) {
+	repo := &domain.Repository{
+		ID: "r1", Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true,
+	}
+	r, d := setupWithDeps(repo)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/oci-hosted/v2/charts/nginx/manifests/1.2.3", strings.NewReader(helmChartManifest))
+	req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+	req.ContentLength = int64(len(helmChartManifest))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	dgst := digest(helmChartManifest)
+	require.Equal(t, dgst, w.Header().Get("Docker-Content-Digest"))
+
+	comp := componentOf(t, d, "oci-hosted", "charts/nginx", dgst)
+	assert.Equal(t, "application/vnd.cncf.helm.config.v1+json", comp.Extra["oci_artifact_type"])
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", comp.Extra["oci_media_type"])
+}
+
+// maxManifest mirrors the unexported maxManifestBytes: the 4 MiB manifest limit
+// from the OCI Distribution Spec.
+const maxManifest = 4 << 20
+
+// A body past the limit must be rejected outright. Truncating it to the limit
+// would store a corrupt manifest and answer 201 with a digest over bytes the
+// client never pushed.
+func TestPushManifest_RejectsOversizedManifest(t *testing.T) {
+	repo := &domain.Repository{
+		ID: "r1", Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true,
+	}
+	r, d := setupWithDeps(repo)
+
+	// Exactly one byte over the limit, and valid JSON apart from its size.
+	head := `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","pad":"`
+	tail := `"}`
+	oversized := head + strings.Repeat("a", maxManifest+1-len(head)-len(tail)) + tail
+	require.Len(t, oversized, maxManifest+1)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/oci-hosted/v2/charts/big/manifests/1.0.0", strings.NewReader(oversized))
+	req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+	req.ContentLength = int64(len(oversized))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+
+	// Rejection must be total — no half-stored manifest behind the error.
+	page, err := d.Components.Search(context.Background(), domain.SearchParams{Repository: "oci-hosted", Limit: 100})
+	require.NoError(t, err)
+	assert.Empty(t, page.Items, "a rejected push must leave no component")
+
+	_, err = d.Assets.GetByPath(context.Background(), "oci-hosted", "/manifests/charts/big/1.0.0")
+	assert.Error(t, err, "a rejected push must leave no asset")
+}
+
 // The pushed bytes must survive parsing untouched — reading the body for
 // metadata must not truncate what gets stored.
 func TestPushManifest_StoresBodyVerbatim(t *testing.T) {

--- a/internal/formats/oci/metadata_test.go
+++ b/internal/formats/oci/metadata_test.go
@@ -2,9 +2,12 @@ package oci_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -190,4 +193,154 @@ func TestProxyManifest_RecordsArtifactMetadata(t *testing.T) {
 	comp := componentOf(t, d, "oci-proxy", "charts/nginx", "1.2.3")
 	assert.Equal(t, "application/vnd.cncf.helm.config.v1+json", comp.Extra["oci_artifact_type"],
 		"a cached chart must be typed like a pushed one")
+}
+
+// cosignManifest carries no top-level mediaType — the artifact type lives only in
+// config.mediaType. Real cosign signatures and older OCI 1.0 producers look like
+// this, so the "have we typed this yet?" guard cannot key on the media type.
+const cosignManifest = `{
+  "schemaVersion": 2,
+  "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "digest": "sha256:cc", "size": 12},
+  "layers": [{"mediaType": "application/vnd.dev.cosign.simplesigning.v1+json", "digest": "sha256:dd", "size": 34}]
+}`
+
+// countingStore wraps the blob store double to count Get calls, so a test can
+// observe whether the metadata helper re-reads a manifest it has already typed.
+// Embedding supplies every other BlobStore method unchanged.
+type countingStore struct {
+	*testutil.BlobStore
+	mu   sync.Mutex
+	gets int
+}
+
+func (s *countingStore) Get(ctx context.Context, key string) (io.ReadCloser, int64, error) {
+	s.mu.Lock()
+	s.gets++
+	s.mu.Unlock()
+	return s.BlobStore.Get(ctx, key)
+}
+
+func (s *countingStore) getCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gets
+}
+
+// setupCounting is setupWithDeps with a Get-counting blob store.
+func setupCounting(repo *domain.Repository) (*gin.Engine, formats.Deps, *countingStore) {
+	store := &countingStore{BlobStore: testutil.NewBlobStore()}
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  store,
+		BaseURL:    "http://localhost:8080",
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, d, store
+}
+
+// pullTag issues one proxy pull and asserts it succeeded.
+func pullTag(t *testing.T, r *gin.Engine, repoName, tag string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/"+repoName+"/v2/charts/nginx/manifests/"+tag, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "proxy pull should succeed")
+	return w.Body.String()
+}
+
+// A mutable tag re-pointed upstream must re-type the component: the cached blob
+// now holds a different manifest, so metadata describing the old one is wrong.
+func TestProxyManifest_RetypesRepointedTag(t *testing.T) {
+	var serveSecond atomic.Bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		if serveSecond.Load() {
+			_, _ = w.Write([]byte(cosignManifest))
+			return
+		}
+		_, _ = w.Write([]byte(helmChartManifest))
+	}))
+	defer upstream.Close()
+
+	// A 1ns metadata TTL forces revalidation on the second pull without sleeping:
+	// any elapsed time between the two requests already exceeds it.
+	repo := &domain.Repository{
+		ID: "r3", Name: "oci-proxy", Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL, "metadata_max_age": 0.000000001},
+	}
+	r, d := setupWithDeps(repo)
+
+	require.Equal(t, helmChartManifest, pullTag(t, r, "oci-proxy", "1.2.3"))
+	require.Equal(t, "application/vnd.cncf.helm.config.v1+json",
+		componentOf(t, d, "oci-proxy", "charts/nginx", "1.2.3").Extra["oci_artifact_type"])
+
+	serveSecond.Store(true)
+	require.Equal(t, cosignManifest, pullTag(t, r, "oci-proxy", "1.2.3"),
+		"revalidation should have replaced the cached body")
+
+	comp := componentOf(t, d, "oci-proxy", "charts/nginx", "1.2.3")
+	assert.Equal(t, "application/vnd.oci.image.config.v1+json", comp.Extra["oci_artifact_type"],
+		"a re-pointed tag must carry the NEW manifest's artifact type, not the old one")
+}
+
+// Steady state: a second pull of an unchanged manifest serves from cache and must
+// not read the blob a second time for metadata it already recorded.
+func TestProxyManifest_DoesNotRereadUnchangedManifest(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_, _ = w.Write([]byte(helmChartManifest))
+	}))
+	defer upstream.Close()
+
+	repo := &domain.Repository{
+		ID: "r4", Name: "oci-proxy", Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r, _, store := setupCounting(repo)
+
+	require.Equal(t, helmChartManifest, pullTag(t, r, "oci-proxy", "1.2.3"))
+	afterFirst := store.getCount()
+	require.Positive(t, afterFirst, "the counting store must actually be the one in use")
+
+	require.Equal(t, helmChartManifest, pullTag(t, r, "oci-proxy", "1.2.3"))
+	assert.Equal(t, afterFirst+1, store.getCount(),
+		"the second pull may read the blob once to serve it, never twice")
+}
+
+// The same steady-state guarantee for a manifest with no top-level mediaType:
+// the guard must still arm, or every pull re-reads the blob forever.
+func TestProxyManifest_DoesNotRereadManifestWithoutMediaType(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_, _ = w.Write([]byte(cosignManifest))
+	}))
+	defer upstream.Close()
+
+	repo := &domain.Repository{
+		ID: "r5", Name: "oci-proxy", Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r, d, store := setupCounting(repo)
+
+	require.Equal(t, cosignManifest, pullTag(t, r, "oci-proxy", "1.2.3"))
+	require.Equal(t, "application/vnd.oci.image.config.v1+json",
+		componentOf(t, d, "oci-proxy", "charts/nginx", "1.2.3").Extra["oci_artifact_type"],
+		"a manifest with no top-level mediaType is still typed from config.mediaType")
+	afterFirst := store.getCount()
+	require.Positive(t, afterFirst, "the counting store must actually be the one in use")
+
+	require.Equal(t, cosignManifest, pullTag(t, r, "oci-proxy", "1.2.3"))
+	assert.Equal(t, afterFirst+1, store.getCount(),
+		"a manifest without mediaType must not be re-read on every pull")
 }

--- a/internal/formats/oci/metadata_test.go
+++ b/internal/formats/oci/metadata_test.go
@@ -1,0 +1,104 @@
+package oci_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+const helmChartManifest = `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"mediaType": "application/vnd.cncf.helm.config.v1+json", "digest": "sha256:aa", "size": 12},
+  "layers": [{"mediaType": "application/vnd.cncf.helm.chart.content.v1.tar+gzip", "digest": "sha256:bb", "size": 34}],
+  "annotations": {"org.opencontainers.image.version": "1.2.3"}
+}`
+
+// setupWithDeps is setup() from handler_test.go, also handing back the deps so a
+// test can inspect what the handler stored.
+func setupWithDeps(repo *domain.Repository) (*gin.Engine, formats.Deps) {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, d
+}
+
+// componentOf finds the stored component for an image/tag pair.
+func componentOf(t *testing.T, d formats.Deps, repoName, name, version string) domain.Component {
+	t.Helper()
+	page, err := d.Components.Search(context.Background(), domain.SearchParams{Repository: repoName, Limit: 100})
+	require.NoError(t, err)
+	for _, comp := range page.Items {
+		if comp.Name == name && comp.Version == version {
+			return comp
+		}
+	}
+	t.Fatalf("no component %s:%s in %s", name, version, repoName)
+	return domain.Component{}
+}
+
+func TestPushManifest_RecordsArtifactMetadata(t *testing.T) {
+	repo := &domain.Repository{
+		ID: "r1", Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true,
+	}
+	r, d := setupWithDeps(repo)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/oci-hosted/v2/charts/nginx/manifests/1.2.3", strings.NewReader(helmChartManifest))
+	req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+	req.ContentLength = int64(len(helmChartManifest))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "manifest push should succeed")
+
+	comp := componentOf(t, d, "oci-hosted", "charts/nginx", "1.2.3")
+	assert.Equal(t, "application/vnd.cncf.helm.config.v1+json", comp.Extra["oci_artifact_type"])
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", comp.Extra["oci_media_type"])
+}
+
+// The pushed bytes must survive parsing untouched — reading the body for
+// metadata must not truncate what gets stored.
+func TestPushManifest_StoresBodyVerbatim(t *testing.T) {
+	repo := &domain.Repository{
+		ID: "r1", Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true,
+	}
+	r, _ := setupWithDeps(repo)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/oci-hosted/v2/charts/nginx/manifests/1.2.3", strings.NewReader(helmChartManifest))
+	req.ContentLength = int64(len(helmChartManifest))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	get := httptest.NewRequest(http.MethodGet, "/repository/oci-hosted/v2/charts/nginx/manifests/1.2.3", nil)
+	gw := httptest.NewRecorder()
+	r.ServeHTTP(gw, get)
+	require.Equal(t, http.StatusOK, gw.Code)
+	assert.Equal(t, helmChartManifest, gw.Body.String())
+}

--- a/internal/formats/oci/proxy_testmain_test.go
+++ b/internal/formats/oci/proxy_testmain_test.go
@@ -1,0 +1,17 @@
+package oci_test
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// TestMain installs an unguarded upstream HTTP client for this package's proxy
+// tests. Production UpstreamClient is SSRF-guarded and would block the loopback
+// httptest servers these tests use as fake upstreams.
+func TestMain(m *testing.M) {
+	repoproxy.UpstreamClient = &http.Client{}
+	os.Exit(m.Run())
+}

--- a/internal/formats/oci/uploads.go
+++ b/internal/formats/oci/uploads.go
@@ -1,4 +1,4 @@
-package docker
+package oci
 
 import (
 	"bytes"

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -36,7 +36,8 @@ type ComponentRepo interface {
 	ListByRepoNames(ctx context.Context, repoNames []string, limit int, offset int) (*domain.Page[domain.Component], error)
 	Get(ctx context.Context, id string) (*domain.Component, error)
 	Search(ctx context.Context, p domain.SearchParams) (*domain.Page[domain.Component], error)
-	// ListDockerBrowseRows returns Docker-format components with one asset path per row (for Tags vs Manifests vs Blobs).
+	// ListDockerBrowseRows returns components of both OCI Distribution formats — docker
+	// and oci — with one asset path per row (for Tags vs Manifests vs Blobs).
 	ListDockerBrowseRows(ctx context.Context, repoNames []string, maxRows int) ([]domain.DockerBrowseRow, error)
 	Create(ctx context.Context, c *domain.Component) error
 	Delete(ctx context.Context, id string) error

--- a/internal/repository/postgres/component_repo.go
+++ b/internal/repository/postgres/component_repo.go
@@ -256,7 +256,7 @@ func (r *componentRepo) ListDockerBrowseRows(ctx context.Context, repoNames []st
 		FROM components c
 		JOIN repositories rep ON rep.id = c.repository_id
 		LEFT JOIN assets a ON a.component_id = c.id
-		WHERE rep.name IN (%s) AND lower(trim(rep.format)) = 'docker'
+		WHERE rep.name IN (%s) AND lower(trim(rep.format)) IN ('docker', 'oci')
 		GROUP BY c.id, c.name, c.version
 		ORDER BY c.name, c.version
 		LIMIT $%d`, strings.Join(ph, ","), lim)

--- a/internal/repository/postgres/component_repo_integration_test.go
+++ b/internal/repository/postgres/component_repo_integration_test.go
@@ -1224,6 +1224,57 @@ func TestComponentRepo_ListDockerBrowseRows_ReturnsDockerComponents(t *testing.T
 	}
 }
 
+// An oci repository speaks the same OCI Distribution protocol as a docker one,
+// so its components must appear in the registry browse rows too.
+func TestComponentRepo_ListDockerBrowseRows_ReturnsOCIComponents(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+
+	bsRepo := NewBlobStoreRepo(pool)
+	bs := &domain.BlobStore{
+		Name:   "oci_bs_browse",
+		Type:   "local",
+		Config: map[string]any{"path": "/data/oci_browse"},
+	}
+	if err := bsRepo.Create(ctx, bs); err != nil {
+		t.Fatalf("Create blob store: %v", err)
+	}
+	rRepo := NewRepositoryRepo(pool)
+	r := &domain.Repository{
+		Name:        "oci-browse-repo",
+		Format:      domain.FormatOCI,
+		Type:        domain.TypeHosted,
+		BlobStoreID: &bs.ID,
+		Online:      true,
+	}
+	if err := rRepo.Create(ctx, r); err != nil {
+		t.Fatalf("Create oci repo: %v", err)
+	}
+
+	repo := NewComponentRepo(pool)
+	c := &domain.Component{
+		RepositoryID: r.ID,
+		Format:       "oci",
+		Name:         "charts/nginx",
+		Version:      "1.2.3",
+	}
+	if err := repo.Create(ctx, c); err != nil {
+		t.Fatalf("Create component: %v", err)
+	}
+
+	rows, err := repo.ListDockerBrowseRows(ctx, []string{"oci-browse-repo"}, 100)
+	if err != nil {
+		t.Fatalf("ListDockerBrowseRows: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row for an oci repository, got %d", len(rows))
+	}
+	if rows[0].ImageName != "charts/nginx" || rows[0].Version != "1.2.3" {
+		t.Errorf("unexpected row: %+v", rows[0])
+	}
+}
+
 func TestComponentRepo_ListDockerBrowseRows_EmptyRepoNamesReturnsNil(t *testing.T) {
 	pool := pgtest.Pool(t)
 	pgtest.Truncate(t, pool, "blob_stores", "repositories")

--- a/internal/repository/postgres/repository_repo.go
+++ b/internal/repository/postgres/repository_repo.go
@@ -169,12 +169,14 @@ func (r *repositoryRepo) ListByBlobStoreID(ctx context.Context, blobStoreID stri
 	return repos, rows.Err()
 }
 
+// HasAnyAnonymousDocker reports whether any repository on the /v2/ surface
+// (docker or oci — one protocol, two labels) allows anonymous access.
 func (r *repositoryRepo) HasAnyAnonymousDocker(ctx context.Context) (bool, error) {
 	var exists bool
 	err := r.db.QueryRow(ctx, `
 		SELECT EXISTS(
 			SELECT 1 FROM repositories
-			WHERE format = 'docker' AND allow_anonymous = true
+			WHERE format IN ('docker', 'oci') AND allow_anonymous = true
 		)`).Scan(&exists)
 	if err != nil {
 		return false, err

--- a/internal/repository/postgres/repository_repo_integration_test.go
+++ b/internal/repository/postgres/repository_repo_integration_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -631,6 +633,22 @@ func TestRepositoryRepo_HasAnyAnonymousDocker_FalseWhenOnlyNonDockerAnonymous(t 
 	if ok {
 		t.Error("HasAnyAnonymousDocker: got true for non-docker anonymous repo, want false")
 	}
+}
+
+func TestRepositoryRepo_HasAnyAnonymousDocker_OCIFormatCounts(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+	repo := NewRepositoryRepo(pool)
+
+	// An oci repo serves the same /v2/ surface, so it must open the door too.
+	r := makeRepo("rr_anon_oci", domain.FormatOCI, domain.TypeHosted, nil)
+	r.AllowAnonymous = true
+	require.NoError(t, repo.Create(ctx, r))
+
+	got, err := repo.HasAnyAnonymousDocker(ctx)
+	require.NoError(t, err)
+	assert.True(t, got, "a public oci repository must allow anonymous /v2/ access")
 }
 
 // ── ListNamesByCleanupPolicyID ────────────────────────────────────────────────

--- a/internal/service/rbac_service.go
+++ b/internal/service/rbac_service.go
@@ -41,7 +41,7 @@ func (s *RBACService) CanAccessRepo(ctx context.Context, userID string, roles []
 	checkPath := path
 	// Both labels of the OCI Distribution protocol store /manifests/... and
 	// /blobs/... paths, so both need the same normalisation before matching.
-	if repo.Format == domain.FormatDocker || repo.Format == domain.FormatOCI {
+	if repo.Format.IsOCIRegistry() {
 		checkPath = assetSamplePath(path)
 	}
 	return matchPrivileges(privs, repo.Name, checkPath, action), nil

--- a/internal/service/rbac_service.go
+++ b/internal/service/rbac_service.go
@@ -39,7 +39,9 @@ func (s *RBACService) CanAccessRepo(ctx context.Context, userID string, roles []
 		return false, err
 	}
 	checkPath := path
-	if repo.Format == domain.FormatDocker {
+	// Both labels of the OCI Distribution protocol store /manifests/... and
+	// /blobs/... paths, so both need the same normalisation before matching.
+	if repo.Format == domain.FormatDocker || repo.Format == domain.FormatOCI {
 		checkPath = assetSamplePath(path)
 	}
 	return matchPrivileges(privs, repo.Name, checkPath, action), nil

--- a/internal/service/rbac_service_test.go
+++ b/internal/service/rbac_service_test.go
@@ -187,6 +187,25 @@ func TestRBAC_CanAccessRepo_Docker_PathConversion(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestRBAC_CanAccessRepo_OCI_PathConversion(t *testing.T) {
+	// The oci format label serves the same OCI Distribution protocol as docker,
+	// so a path-restricted privilege must produce the same decision on an oci
+	// repository as it does on a docker one for the same registry path.
+	// OCI path /v2/myimage/manifests/latest → CanAccessRepo converts to /myimage/
+	privs := []repository.PrivilegeWithSelector{
+		{
+			Actions:    []string{"read"},
+			Expression: `repository == "oci-repo" && path.startsWith("/myimage/")`,
+		},
+	}
+	svc := newRBACTestSvc(privs)
+	repo := &domain.Repository{Name: "oci-repo", Format: domain.FormatOCI}
+
+	ok, err := svc.CanAccessRepo(context.Background(), "user1", nil, repo, "/v2/myimage/manifests/latest", "read")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
 // ── actionAllowed (tested via CanAccessRepo) ─────────────────
 
 func TestRBAC_ActionAllowed_EmptyActionsAllowsAll(t *testing.T) {

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -143,7 +143,8 @@ func (s *ScanService) WithCredentials(username, password string) *ScanService {
 }
 
 // Scan runs trivy against imageRef, persists the result in component.Extra["scan_result"],
-// and returns it. Only docker-format components are supported; others get a clear error.
+// and returns it. Components of the two OCI Distribution formats (docker, oci) go to
+// Trivy, a few language formats go to OSV, and anything else gets a clear error.
 func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*domain.ScanResult, error) {
 	comp, err := s.Components.Get(ctx, componentID)
 	if err != nil {
@@ -153,8 +154,12 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 		return nil, fmt.Errorf("component %s not found", componentID)
 	}
 	switch strings.ToLower(comp.Format) {
-	case "docker":
-		// falls through to Trivy path below
+	case "docker", "oci":
+		// Falls through to the Trivy path below. An oci repository holds the same
+		// content a docker one does — an ORAS artifact is an image by structure —
+		// so refusing it on its format label would be wrong. A non-image artifact
+		// (a chart, a signature) surfaces as a Trivy error instead of being
+		// refused up front, which is the more honest answer.
 	case "maven", "npm", "pypi", "cargo":
 		return s.scanOSV(ctx, comp)
 	default:

--- a/internal/service/scan_service_test.go
+++ b/internal/service/scan_service_test.go
@@ -92,6 +92,31 @@ func TestScanService_TrivyNotInstalled(t *testing.T) {
 	}
 }
 
+// An oci repository holds the same content a docker one does, so its components
+// must reach the Trivy path rather than being refused on their format label.
+func TestScanService_OCIFormat_ReachesTrivy(t *testing.T) {
+	comp := &domain.Component{
+		ID:         "comp-scan-oci",
+		Repository: "oci-hosted",
+		Format:     "oci",
+		Name:       "charts/nginx",
+		Version:    "1.2.3",
+	}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	svc := service.NewScanService(comps, "")
+	svc.TrivyBin = "/no/such/binary"
+
+	_, err := svc.Scan(context.Background(), comp.ID, "")
+	if err == nil {
+		t.Fatal("expected ErrTrivyNotInstalled")
+	}
+	if !errors.Is(err, service.ErrTrivyNotInstalled) {
+		t.Fatalf("an oci component must reach the Trivy path, got %v", err)
+	}
+}
+
 func TestScanService_ParseTrivyJSON(t *testing.T) {
 	// Inject a fake "trivy" that echoes a minimal JSON report.
 	trivyOutput := `{

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -153,7 +153,7 @@ func (r *RepoRepo) HasAnyAnonymousDocker(_ context.Context) (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, v := range r.repos {
-		if (v.Format == domain.FormatDocker || v.Format == domain.FormatOCI) && v.AllowAnonymous {
+		if v.Format.IsOCIRegistry() && v.AllowAnonymous {
 			return true, nil
 		}
 	}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -146,11 +146,14 @@ func (r *RepoRepo) ListByBlobStoreID(_ context.Context, blobStoreID string) ([]d
 	return out, nil
 }
 
+// HasAnyAnonymousDocker mirrors the production SQL, which matches
+// format IN ('docker','oci') — both labels of the OCI Distribution protocol
+// share the /v2/ surface, so either can open the anonymous door.
 func (r *RepoRepo) HasAnyAnonymousDocker(_ context.Context) (bool, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for _, v := range r.repos {
-		if string(v.Format) == "docker" && v.AllowAnonymous {
+		if (v.Format == domain.FormatDocker || v.Format == domain.FormatOCI) && v.AllowAnonymous {
 			return true, nil
 		}
 	}

--- a/website/index.html
+++ b/website/index.html
@@ -436,7 +436,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
   <div class="stats-band" role="region" aria-label="Statistics">
     <div style="max-width:1200px;margin:0 auto">
       <div class="stats-grid">
-        <div class="sitem rev"><div class="snum" data-count="14">14</div><div class="slbl">Artifact Formats</div></div>
+        <div class="sitem rev"><div class="snum" data-count="15">15</div><div class="slbl">Artifact Formats</div></div>
         <div class="sitem rev d1"><div class="snum" style="background:linear-gradient(135deg,var(--green),var(--cyan));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text" data-count="2049">2049</div><div class="slbl">Tests Passing</div></div>
         <div class="sitem rev d2"><div class="snum" style="background:linear-gradient(135deg,var(--purple),var(--blue));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">100%</div><div class="slbl">Nexus API Compat</div></div>
         <div class="sitem rev d3"><div class="snum" style="background:linear-gradient(135deg,var(--amber),var(--red));-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text">$0</div><div class="slbl">License Fee</div></div>
@@ -542,6 +542,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
       <div class="card fmcard rev d5"><div class="fmicon" style="background:rgba(71,85,105,.12);color:#94a3b8"><svg width="20" height="20" fill="none" stroke="#94a3b8" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg></div><div class="fmname">Raw</div><div class="fmproto">PUT/GET/DELETE</div><div class="fmtypes"><span class="ftag t-b">Hosted</span></div></div>
       <div class="card fmcard rev d1"><div class="fmicon" style="background:rgba(68,168,51,.12);color:#44a833"><img src="https://cdn.simpleicons.org/anaconda/44a833" width="26" height="26" alt="Conda" style="object-fit:contain"></div><div class="fmname">Conda</div><div class="fmproto">channel / repodata</div><div class="fmtypes"><span class="ftag t-b">Hosted</span><span class="ftag t-a">Proxy</span></div></div>
       <div class="card fmcard rev d2"><div class="fmicon" style="background:rgba(123,66,188,.12);color:#7b42bc"><img src="https://cdn.simpleicons.org/terraform/7b42bc" width="26" height="26" alt="Terraform" style="object-fit:contain"></div><div class="fmname">Terraform</div><div class="fmproto">Registry Mirror</div><div class="fmtypes"><span class="ftag t-b">Hosted</span><span class="ftag t-a">Proxy</span></div></div>
+      <div class="card fmcard rev d3"><div class="fmicon" style="background:rgba(91,141,239,.12);color:#5b8def"><img src="https://cdn.simpleicons.org/opencontainersinitiative/5b8def" width="26" height="26" alt="OCI" style="object-fit:contain"></div><div class="fmname">OCI</div><div class="fmproto">Distribution v2</div><div class="fmtypes"><span class="ftag t-b">Hosted</span><span class="ftag t-a">Proxy</span><span class="ftag t-p">Group</span></div></div>
     </div>
   </div>
 </section>

--- a/website/index.html
+++ b/website/index.html
@@ -6,20 +6,20 @@
 <title>Nexspence — Universal Artifact Repository Manager</title>
 <link rel="icon" type="image/png" href="/assets/favicon.png">
 <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png">
-<meta name="description" content="Free, open-source alternative to commercial artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 9 more formats in one self-hosted registry.">
+<meta name="description" content="Free, open-source alternative to commercial artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 10 more formats in one self-hosted registry.">
 <link rel="canonical" href="https://nexspence.com/">
 <meta name="theme-color" content="#070b14">
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="Nexspence">
 <meta property="og:url" content="https://nexspence.com/">
 <meta property="og:title" content="Nexspence — Universal Artifact Repository Manager">
-<meta property="og:description" content="Free, open-source alternative to commercial artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 9 more formats in one self-hosted registry.">
+<meta property="og:description" content="Free, open-source alternative to commercial artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 10 more formats in one self-hosted registry.">
 <meta property="og:image" content="https://nexspence.com/assets/og-image.jpg">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Nexspence — Universal Artifact Repository Manager">
-<meta name="twitter:description" content="Free, open-source alternative to commercial artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 9 more formats in one self-hosted registry.">
+<meta name="twitter:description" content="Free, open-source alternative to commercial artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 10 more formats in one self-hosted registry.">
 <meta name="twitter:image" content="https://nexspence.com/assets/og-image.jpg">
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <style>
@@ -394,7 +394,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
           Universal Artifact<br>
           <span class="grad">Repository Manager</span>
         </h1>
-        <p class="hero-sub rev d2">Drop-in replacement for other artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 9 more formats — in one self-hosted registry, forever free.</p>
+        <p class="hero-sub rev d2">Drop-in replacement for other artifact repository managers. Manage Maven, Docker, npm, PyPI, Helm and 10 more formats — in one self-hosted registry, forever free.</p>
         <div class="hero-actions rev d3">
           <a href="#deploy" class="btn btn-primary">
             <svg fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24" aria-hidden="true"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>

--- a/website/index.html
+++ b/website/index.html
@@ -523,7 +523,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
 <section id="formats" class="sect" aria-label="Supported formats">
   <div class="sect-wrap">
     <div class="rev" style="text-align:center;margin-bottom:36px">
-      <div class="stag" style="justify-content:center">14 Formats</div>
+      <div class="stag" style="justify-content:center">15 Formats</div>
       <h2 class="stitle">One registry for all your artifacts</h2>
       <p class="ssub" style="margin:0 auto">Every format supports Hosted, Proxy, and Group types. One URL for your entire organization.</p>
     </div>
@@ -637,7 +637,7 @@ resource <span style="color:#7dd3fc">"nexspence_repository"</span> <span style="
       <div class="rev-l">
         <div class="stag">Clean Architecture</div>
         <h2 class="stitle">Handler → Service → Repository</h2>
-        <p class="ssub" style="margin-bottom:28px">No circular imports. All DB access through mockable interfaces. Plugin-style format handlers for each of the 14 formats.</p>
+        <p class="ssub" style="margin-bottom:28px">No circular imports. All DB access through mockable interfaces. Plugin-style format handlers for each of the 15 formats.</p>
         <div style="display:flex;flex-direction:column;gap:10px">
           <div class="card" style="padding:14px 16px;display:flex;align-items:center;gap:12px"><div style="width:36px;height:36px;border-radius:8px;background:rgba(0,173,216,.12);display:flex;align-items:center;justify-content:center;font-size:.8rem;font-weight:800;font-family:'JetBrains Mono',monospace;color:#00add8;flex-shrink:0">Go</div><div><div style="font-size:.88rem;font-weight:700">Go (Golang) + Gin</div><div style="font-size:.74rem;color:var(--dim)">Backend · pgx · golang-migrate</div></div></div>
           <div class="card" style="padding:14px 16px;display:flex;align-items:center;gap:12px"><div style="width:36px;height:36px;border-radius:8px;background:rgba(97,218,251,.1);display:flex;align-items:center;justify-content:center;font-size:.72rem;font-weight:800;color:#61dafb;flex-shrink:0">Re</div><div><div style="font-size:.88rem;font-weight:700">React + TypeScript</div><div style="font-size:.74rem;color:var(--dim)">Vite · Zustand · React Query</div></div></div>


### PR DESCRIPTION
Phase 1 of five. Makes `oci` a supported repository format so `helm push oci://`, `oras push` and `cosign` are intended scenarios rather than accidents of the Docker handler.

## Approach

One protocol implementation, two format labels. `internal/formats/docker` is renamed to `internal/formats/oci` — it always was an OCI Distribution Spec v2 implementation — and the same handler *instance* is registered under both `"docker"` and `"oci"`. Protocol drift between the labels is therefore structurally impossible; they differ only in presentation (proxy default, colour, format lists). Existing docker repositories are not migrated and gain everything new for free.

## What is in this PR

**The format itself**
- `domain.FormatOCI`, registered in the format registry; `/v2/` routing dispatches on the repository's own format
- migration `022_oci_format.sql` — the `repositories.format` CHECK constraint did not list `oci`, so *no oci repository could be created at all*
- every protocol-shaped `FormatDocker` special case extended: RBAC path normalisation, the anonymous `/v2/` door, the browse tree and path tree, the browse-row SQL, vulnerability scanning
- `RepoFormat.IsOCIRegistry()` — one home for the docker-or-oci question, replacing three copies that had already started to diverge

**Artifact typing**
- a manifest parser recording `oci_media_type`, `oci_artifact_type` (with the `config.mediaType` fallback OCI 1.0, Helm and cosign rely on), `oci_subject` and annotations onto `component.Extra`
- wired into both the hosted push path and the proxy cache-fill path, so a proxied chart is typed like a pushed one
- the digest-alias component is typed too, because phase 2 resolves referrer subjects by digest

**Correctness fixes found while building**
- a manifest over 4 MiB was silently truncated and answered `201` with a digest over bytes the client never sent; it is now rejected with `413`
- a cached manifest carrying no `mediaType` was re-read from the blob store on *every* pull, forever; the guard now keys on the source digest

**UI and docs**
- `oci` in the repository, cleanup and search format lists, its colour, and a `ghcr.io` proxy default
- the registry browse tree and search digest-alias deduplication now cover oci
- format count 14 → 15 across the README and the landing page

## Out of scope (phases 2-5)

Referrers API, `_catalog`, tag pagination, cross-repo mount, group index merging for `tags/list`, artifact-type badges in the browse tree.

One deliberate deferral worth naming: a group repository still requires its members to share its exact format, so an `oci` group cannot contain `docker` members. That is how every format behaves today, not a regression — but for these two labels it is the natural adoption path, so it belongs in phase 4 alongside the group index merging.

## Verification

`go build ./...` clean; `go test ./internal/...` 1620 passed (only `TestWebhookHandler_Test_200` fails, which needs outbound networking the sandbox lacks and passes in CI); `golangci-lint run --new-from-rev=origin/main` reports zero issues; frontend 487 passed; the Postgres integration suite passes including the new browse-row and anonymous-door tests.

Every change was written test-first, and each task went through spec-compliance and code-quality review. Three of the findings in this PR came from those reviews rather than from the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW