### PR TITLE
feat(oci): referrers API for signatures, SBOMs and attestations

### DIFF
--- a/internal/db/migrations/023_oci_referrers_index.sql
+++ b/internal/db/migrations/023_oci_referrers_index.sql
@@ -1,0 +1,25 @@
+-- The referrers API filters components on extra->>'oci_subject', and on OCI
+-- every blob upload creates a component, so the table is large. cosign issues
+-- one referrers call per verify, which without this index is a sequential scan
+-- of the whole table.
+--
+-- The index is partial: only manifests that name a subject are worth indexing,
+-- which is a small fraction of the rows.
+--
+-- The predicate is deliberately "(extra->>'oci_subject') IS NOT NULL" and not
+-- the shorter "extra ? 'oci_subject'". The planner only uses a partial index
+-- when it can prove the query implies the predicate, and it has no rule that
+-- derives the jsonb "?" operator from an equality on "->>": measured against a
+-- 60k-row components table, the "?" form left the query on a sequential scan
+-- (60000 rows removed by filter) while this form is chosen as a bitmap index
+-- scan. The two select the same rows for this query — "->>" yields NULL exactly
+-- when the key is absent or its value is JSON null, and neither can equal the
+-- digest the query looks for.
+
+-- +goose Up
+CREATE INDEX IF NOT EXISTS idx_components_oci_subject
+    ON components ((extra->>'oci_subject'))
+    WHERE (extra->>'oci_subject') IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_components_oci_subject;

--- a/internal/formats/group/handler.go
+++ b/internal/formats/group/handler.go
@@ -160,10 +160,16 @@ func (h *Handler) callMember(ctx context.Context, c *gin.Context, memberName, fi
 // failing members skipped so the group survives a down upstream), and serves
 // the merged document. A merge failure degrades to the first member body —
 // never a 500 for a merge bug.
+//
+// A format implementing formats.GroupIndexStrictMerger inverts both defaults for
+// the failures it calls fatal: the member's own response is relayed instead of
+// being merged around, and a merge that fails is reported as one. See that
+// interface for why an index nobody may read as short needs it.
 func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, members []string,
 	rule *domain.RoutingRule, merger formats.GroupIndexMerger, source, requestPath string,
 ) {
 	ctx := c.Request.Context()
+	strict, isStrict := merger.(formats.GroupIndexStrictMerger)
 
 	var parts []formats.GroupIndexPart
 	var contributing []string
@@ -186,6 +192,13 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 			code = http.StatusOK
 		}
 		if code < 200 || code > 299 {
+			if isStrict && strict.GroupIndexMemberFailureIsFatal(source, code) {
+				// Relayed verbatim: the member's handler already phrased the
+				// failure in its own protocol's error shape, and re-wrapping it
+				// would cost the client the reason.
+				h.relayMemberFailure(c, memberName, rec)
+				return
+			}
 			continue
 		}
 		parts = append(parts, formats.GroupIndexPart{Member: memberName, Body: rec.Body.Bytes()})
@@ -202,11 +215,36 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 	c.Writer.Header().Set("X-Nexspence-Source", strings.Join(contributing, ","))
 	body, contentType, err := merger.MergeGroupIndex(repoDef.Name, requestPath, parts)
 	if err != nil {
+		if isStrict {
+			// A member's document that could not be merged is a member whose
+			// contribution is missing from the result, which is the same fact a
+			// fatal member failure reports.
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error": fmt.Sprintf("members of group %q could not be merged into one index, so the answer "+
+					"would be incomplete: %v", repoDef.Name, err),
+			})
+			return
+		}
 		// Degrade to the first member's document rather than failing the group.
 		c.Data(http.StatusOK, "application/octet-stream", parts[0].Body)
 		return
 	}
 	c.Data(http.StatusOK, contentType, body)
+}
+
+// relayMemberFailure passes a member's failed response through unchanged, so the
+// client reads the reason in the format's own error shape.
+func (h *Handler) relayMemberFailure(c *gin.Context, memberName string, rec *httptest.ResponseRecorder) {
+	for k, vals := range rec.Header() {
+		for _, v := range vals {
+			c.Writer.Header().Add(k, v)
+		}
+	}
+	c.Writer.Header().Set("X-Nexspence-Source", memberName)
+	c.Status(rec.Code)
+	if c.Request.Method != http.MethodHead && rec.Body.Len() > 0 {
+		_, _ = io.Copy(c.Writer, rec.Body)
+	}
 }
 
 func (h *Handler) serveWrite(c *gin.Context) {

--- a/internal/formats/group/merge_oci_test.go
+++ b/internal/formats/group/merge_oci_test.go
@@ -1,0 +1,276 @@
+package group_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+const (
+	ociCosignSigArtifactType = "application/vnd.dev.cosign.artifact.sig.v1+json"
+	ociSBOMArtifactType      = "application/spdx+json"
+	ociIndexMediaType        = "application/vnd.oci.image.index.v1+json"
+)
+
+// ociImageManifest is a plain image manifest — the subject a signature attaches to.
+const ociImageManifest = `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "digest": "sha256:aa", "size": 2},
+  "layers": [{"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "digest": "sha256:bb", "size": 9}]
+}`
+
+func ociDigest(content string) string {
+	sum := sha256.Sum256([]byte(content))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+// ociReferrerManifest points at another manifest through its subject descriptor —
+// how cosign attaches a signature. salt keeps two otherwise identical referrers
+// distinct so a test can tell a union from a deduplication.
+func ociReferrerManifest(artifactType, subjectDigest, salt string) string {
+	return fmt.Sprintf(`{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": %q,
+  "config": {"mediaType": "application/vnd.oci.empty.v1+json", "digest": "sha256:ee", "size": 2},
+  "layers": [{"mediaType": "application/octet-stream", "digest": "sha256:ff", "size": 7}],
+  "subject": {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": %q, "size": 100},
+  "annotations": {"salt": %q}
+}`, artifactType, subjectDigest, salt)
+}
+
+// hostedOCI is an online hosted OCI repository.
+func hostedOCI(name string) *domain.Repository {
+	return &domain.Repository{
+		ID: "repo-" + name, Name: name, Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true,
+	}
+}
+
+// proxyOCI is an online OCI proxy repository pointed at remote.
+func proxyOCI(name, remote string) *domain.Repository {
+	return &domain.Repository{
+		ID: "repo-" + name, Name: name, Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": remote},
+	}
+}
+
+// ociGroup is an OCI group repository over the named members, in order.
+func ociGroup(name string, members ...string) *domain.Repository {
+	ms := make([]interface{}, len(members))
+	for i, m := range members {
+		ms[i] = m
+	}
+	return &domain.Repository{
+		ID: "repo-" + name, Name: name, Format: domain.FormatOCI, Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": ms},
+	}
+}
+
+// ociGroupEngine wires the real OCI handler behind a group handler, the way the
+// router does.
+func ociGroupEngine(repos ...*domain.Repository) *gin.Engine {
+	repoRepo := testutil.NewRepoRepo(repos...)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	ociH := oci.New(d)
+	registry := map[string]formats.FormatHandler{string(domain.FormatOCI): ociH}
+	groupH := group.New(d, registry)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Request = c.Request.WithContext(requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser"))
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		ociH.ServeHTTP(c)
+	})
+	return r
+}
+
+// pushOCIManifest pushes one manifest into a member and returns its digest.
+func pushOCIManifest(t *testing.T, r *gin.Engine, repoName, imageName, reference, body string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/"+repoName+"/v2/"+imageName+"/manifests/"+reference, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "manifest push should succeed")
+	return w.Header().Get("Docker-Content-Digest")
+}
+
+// pushSignature attaches a referrer to subject in the named member and returns
+// the referrer's own digest, pushed under the cosign tag scheme.
+func pushSignature(t *testing.T, r *gin.Engine, repoName, imageName, artifactType, subject, salt string) string {
+	t.Helper()
+	body := ociReferrerManifest(artifactType, subject, salt)
+	tag := strings.Replace(subject, ":", "-", 1) + ".sig." + salt
+	return pushOCIManifest(t, r, repoName, imageName, tag, body)
+}
+
+type ociDescriptor struct {
+	MediaType    string            `json:"mediaType"`
+	Digest       string            `json:"digest"`
+	Size         int64             `json:"size"`
+	ArtifactType string            `json:"artifactType"`
+	Annotations  map[string]string `json:"annotations"`
+}
+
+type ociIndexDoc struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	MediaType     string          `json:"mediaType"`
+	Manifests     []ociDescriptor `json:"manifests"`
+}
+
+// getGroupReferrers asks the group for the referrers of subject.
+func getGroupReferrers(r *gin.Engine, groupName, imageName, subject, query string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/"+groupName+"/v2/"+imageName+"/referrers/"+subject+query, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// decodeIndex decodes a referrers response, asserting it is a 200 image index.
+func decodeIndex(t *testing.T, w *httptest.ResponseRecorder) ociIndexDoc {
+	t.Helper()
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var idx ociIndexDoc
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &idx), "response should be an image index")
+	return idx
+}
+
+func digestsOf(idx ociIndexDoc) []string {
+	out := make([]string, 0, len(idx.Manifests))
+	for _, d := range idx.Manifests {
+		out = append(out, d.Digest)
+	}
+	return out
+}
+
+// A signature pushed to the SECOND member must be visible through the group.
+// The referrers endpoint never answers 404 — an unknown subject is an empty 200 —
+// so first-non-404 fan-out would let the first member's empty index shadow every
+// member behind it and report a signed image as unsigned.
+func TestGroupMerge_OCIReferrers_SecondMemberSignatureIsFound(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	subject := pushOCIManifest(t, r, "m2", "img", "1.0.0", ociImageManifest)
+	sig := pushSignature(t, r, "m2", "img", ociCosignSigArtifactType, subject, "a")
+
+	idx := decodeIndex(t, getGroupReferrers(r, "grp", "img", subject, ""))
+	assert.Equal(t, ociIndexMediaType, idx.MediaType)
+	assert.Equal(t, []string{sig}, digestsOf(idx),
+		"the second member's signature must reach the client through the group")
+}
+
+// Referrers held by two members are unioned, and a manifest present in both is
+// named once: the dedup key is the manifest digest, not the member it came from.
+func TestGroupMerge_OCIReferrers_UnionsMembersAndDeduplicatesByDigest(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	subject := ociDigest(ociImageManifest)
+	shared := pushSignature(t, r, "m1", "img", ociCosignSigArtifactType, subject, "shared")
+	sharedAgain := pushSignature(t, r, "m2", "img", ociCosignSigArtifactType, subject, "shared")
+	require.Equal(t, shared, sharedAgain, "the same manifest bytes must have the same digest in both members")
+	onlyM2 := pushSignature(t, r, "m2", "img", ociSBOMArtifactType, subject, "m2-only")
+
+	idx := decodeIndex(t, getGroupReferrers(r, "grp", "img", subject, ""))
+	assert.Equal(t, []string{shared, onlyM2}, digestsOf(idx),
+		"both members contribute, the shared manifest is listed once, and the earlier member wins")
+}
+
+// Every member genuinely holding nothing is an empty index, never a 404 and
+// never a null list: a 404 reads as "this registry has no referrers API".
+func TestGroupMerge_OCIReferrers_AllMembersEmptyIsEmptyIndex(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	w := getGroupReferrers(r, "grp", "img", ociDigest("nothing refers to this"), "")
+	idx := decodeIndex(t, w)
+	assert.Empty(t, idx.Manifests)
+	assert.Contains(t, w.Body.String(), `"manifests":[]`, "manifests must be [] and not null")
+}
+
+// A member that could not be consulted makes the whole group answer 502. Serving
+// the other members' referrers as if they were the complete list would report a
+// possibly-incomplete answer as complete — a policy gate would read the short
+// list as "unsigned".
+func TestGroupMerge_OCIReferrers_UnconsultableMemberIsBadGatewayNotPartialList(t *testing.T) {
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	remote := closed.URL
+	closed.Close() // nothing listens on this port any more
+
+	r := ociGroupEngine(ociGroup("grp", "m1", "down"), hostedOCI("m1"), proxyOCI("down", remote))
+
+	subject := ociDigest(ociImageManifest)
+	pushSignature(t, r, "m1", "img", ociCosignSigArtifactType, subject, "a")
+
+	w := getGroupReferrers(r, "grp", "img", subject, "")
+	require.Equal(t, http.StatusBadGateway, w.Code,
+		"a member that could not be checked must not be silently dropped from the merge")
+	assert.NotContains(t, w.Body.String(), `"manifests"`,
+		"an incomplete answer must never be dressed up as an index")
+}
+
+// A rate-limited upstream told the proxy to come back later; it did not tell it
+// the subject has no referrers. The group must not merge around that either.
+func TestGroupMerge_OCIReferrers_RateLimitedMemberIsBadGateway(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer upstream.Close()
+
+	r := ociGroupEngine(ociGroup("grp", "limited", "m2"), proxyOCI("limited", upstream.URL), hostedOCI("m2"))
+
+	subject := ociDigest(ociImageManifest)
+	pushSignature(t, r, "m2", "img", ociCosignSigArtifactType, subject, "a")
+
+	w := getGroupReferrers(r, "grp", "img", subject, "")
+	require.Equal(t, http.StatusBadGateway, w.Code)
+	assert.NotContains(t, w.Body.String(), `"manifests"`)
+}
+
+// The artifactType filter must still select through the group, or a cosign query
+// would come back carrying every SBOM in every member.
+func TestGroupMerge_OCIReferrers_ArtifactTypeFilterAppliesThroughGroup(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	subject := ociDigest(ociImageManifest)
+	sbom := pushSignature(t, r, "m1", "img", ociSBOMArtifactType, subject, "sbom")
+	sig := pushSignature(t, r, "m2", "img", ociCosignSigArtifactType, subject, "sig")
+
+	idx := decodeIndex(t, getGroupReferrers(r, "grp", "img", subject,
+		"?artifactType="+url.QueryEscape(ociCosignSigArtifactType)))
+	assert.Equal(t, []string{sig}, digestsOf(idx), "only the cosign signature matches the filter")
+	assert.NotContains(t, digestsOf(idx), sbom)
+}

--- a/internal/formats/group_merge.go
+++ b/internal/formats/group_merge.go
@@ -22,3 +22,22 @@ type GroupIndexMerger interface {
 	// wins on conflict) into one document rooted at the group's URL.
 	MergeGroupIndex(groupName, path string, parts []GroupIndexPart) (body []byte, contentType string, err error)
 }
+
+// GroupIndexStrictMerger is optionally implemented alongside GroupIndexMerger by
+// formats whose merged index must never be served incomplete.
+//
+// By default the group skips a member that answered non-2xx, so one down
+// upstream cannot take the whole group with it. For most indexes a short list is
+// a degraded but honest answer. For the OCI referrers index it is not: a client
+// reads a short list as "this image carries no signature", so silently dropping
+// a member that could not be consulted turns "I could not check" into a
+// statement about the subject. A format that says so here gets the opposite
+// default — the group relays the member's failure instead of merging around it,
+// and a merge that cannot be completed is an error rather than a degradation to
+// the first member's document.
+type GroupIndexStrictMerger interface {
+	// GroupIndexMemberFailureIsFatal reports whether a member's non-2xx answer
+	// on path means "I could not check" — which must fail the whole group —
+	// rather than "I have nothing to contribute", which is skipped as usual.
+	GroupIndexMemberFailureIsFatal(path string, status int) bool
+}

--- a/internal/formats/oci/groupindex.go
+++ b/internal/formats/oci/groupindex.go
@@ -1,0 +1,113 @@
+package oci
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// The referrers index is merged across group members rather than taken from the
+// first member that answers. GET /v2/{name}/referrers/{digest} never returns
+// 404 — an unknown subject is a 200 carrying an empty index, because that is
+// what a client reads as "no signatures" — so the group's first-non-404 fan-out
+// would let member one's empty index shadow every member behind it. A signature
+// pushed to the second member would be reported as absent, which is the one
+// direction this endpoint must never fail in.
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger. A referrers request
+// is its own source: every member is asked the same question. Nothing else under
+// /v2/ is merged — a manifest or a blob is one artifact, and the first member
+// holding it is the right answer.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	rest := strings.TrimPrefix(normPath(p), "/v2/")
+	if rest == normPath(p) {
+		return "", false
+	}
+	if referrersIndex(strings.Split(rest, "/")) < 0 {
+		return "", false
+	}
+	return p, true
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger: one index carrying every
+// member's descriptors, in member order, each manifest named once.
+//
+// Descriptors are carried across as the raw JSON the member produced instead of
+// being decoded into this package's descriptor struct and re-encoded, which
+// would drop the spec fields it does not model — platform, urls, subject,
+// per-descriptor annotations this package does not read. Only the digest is
+// decoded, because that is the key a duplicate is recognized by: the same
+// manifest legitimately exists in two members, and it is the same referrer in
+// both. Anything else — the member it came from, its position, its size — would
+// either split one referrer into two entries or fuse two into one.
+//
+// The client's OCI-Filters-Applied is deliberately not reproduced here. Each
+// member applied the artifactType filter to its own answer, but a proxy member
+// forwards the filter to an upstream that may ignore it, so the group cannot
+// promise the merged list is filtered. Leaving the header off is the honest
+// reading: a client that wanted the filter re-applies it to a superset and lands
+// on the same set.
+func (h *Handler) MergeGroupIndex(_, _ string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	merged := make([]json.RawMessage, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+
+	for _, part := range parts {
+		var idx struct {
+			Manifests []json.RawMessage `json:"manifests"`
+		}
+		if err := json.Unmarshal(part.Body, &idx); err != nil {
+			// A member's answer we cannot read is a member whose referrers are
+			// missing from the result. Reported, never skipped: a short index is
+			// what a signature checker reads as "unsigned".
+			return nil, "", fmt.Errorf("member %q did not answer the referrers request with an image index: %w",
+				part.Member, err)
+		}
+		for _, raw := range idx.Manifests {
+			var desc struct {
+				Digest string `json:"digest"`
+			}
+			if err := json.Unmarshal(raw, &desc); err != nil || desc.Digest == "" {
+				return nil, "", fmt.Errorf(
+					"member %q listed a referrer with no readable digest, so its referrers cannot be merged",
+					part.Member)
+			}
+			// Member order is priority: the first member to name a manifest is
+			// the one whose descriptor is kept.
+			if _, dup := seen[desc.Digest]; dup {
+				continue
+			}
+			seen[desc.Digest] = struct{}{}
+			merged = append(merged, raw)
+		}
+	}
+
+	// Manifests is non-nil so an empty result serializes as [] and not null.
+	body, err := json.Marshal(struct {
+		SchemaVersion int               `json:"schemaVersion"`
+		MediaType     string            `json:"mediaType"`
+		Manifests     []json.RawMessage `json:"manifests"`
+	}{SchemaVersion: 2, MediaType: mediaTypeImageIndex, Manifests: merged})
+	if err != nil {
+		return nil, "", err
+	}
+	return body, mediaTypeImageIndex, nil
+}
+
+// GroupIndexMemberFailureIsFatal implements formats.GroupIndexStrictMerger.
+//
+// A member that answered anything but 2xx or 404 could not tell us what it holds
+// — a proxy whose upstream was unreachable, rate-limited or refused its
+// credentials answers 502 for exactly that reason. Merging the remaining members
+// and calling the result complete would convert "I could not check" into "this
+// subject has no referrers", which is what a policy gate reads as an unsigned
+// image. 404 is the one non-2xx that says something about the subject rather
+// than about the member, and it contributes nothing.
+func (h *Handler) GroupIndexMemberFailureIsFatal(p string, status int) bool {
+	if _, ok := h.GroupIndexSourcePath(p); !ok {
+		return false
+	}
+	return status != http.StatusNotFound
+}

--- a/internal/formats/oci/groupindex_test.go
+++ b/internal/formats/oci/groupindex_test.go
@@ -1,0 +1,172 @@
+package oci_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+)
+
+func groupMerger() *oci.Handler { return oci.New(formats.Deps{}) }
+
+// Only the referrers index is merged across members. A manifest or a blob is a
+// single artifact, and the first member holding it is the right answer.
+func TestOCI_GroupIndexSourcePath(t *testing.T) {
+	h := groupMerger()
+
+	src, ok := h.GroupIndexSourcePath("/v2/charts/nginx/referrers/" + digest("subject"))
+	assert.True(t, ok)
+	assert.Equal(t, "/v2/charts/nginx/referrers/"+digest("subject"), src,
+		"every member is asked the same question, so the source is the path itself")
+
+	_, ok = h.GroupIndexSourcePath("/v2/charts/nginx/manifests/1.0.0")
+	assert.False(t, ok)
+	_, ok = h.GroupIndexSourcePath("/v2/charts/nginx/blobs/" + digest("layer"))
+	assert.False(t, ok)
+	_, ok = h.GroupIndexSourcePath("/v2/charts/nginx/tags/list")
+	assert.False(t, ok)
+	_, ok = h.GroupIndexSourcePath("/v2/")
+	assert.False(t, ok)
+	_, ok = h.GroupIndexSourcePath("/charts/nginx/referrers/" + digest("subject"))
+	assert.False(t, ok, "a path outside /v2/ is not a referrers request")
+
+	// An image legitimately named ".../referrers" must keep its own manifests.
+	_, ok = h.GroupIndexSourcePath("/v2/lib/referrers/manifests/1.0.0")
+	assert.False(t, ok)
+}
+
+// indexWith builds one member's referrers answer from raw descriptor bodies.
+func indexWith(descs ...string) []byte {
+	body := `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[`
+	for i, d := range descs {
+		if i > 0 {
+			body += ","
+		}
+		body += d
+	}
+	return []byte(body + "]}")
+}
+
+func mergedDescriptors(t *testing.T, body []byte) []map[string]any {
+	t.Helper()
+	var idx struct {
+		SchemaVersion int              `json:"schemaVersion"`
+		MediaType     string           `json:"mediaType"`
+		Manifests     []map[string]any `json:"manifests"`
+	}
+	require.NoError(t, json.Unmarshal(body, &idx))
+	assert.Equal(t, 2, idx.SchemaVersion)
+	assert.Equal(t, "application/vnd.oci.image.index.v1+json", idx.MediaType)
+	return idx.Manifests
+}
+
+// Every member's referrers reach the merged index, in member order.
+func TestOCI_MergeGroupIndex_UnionsMembers(t *testing.T) {
+	h := groupMerger()
+	body, ct, err := h.MergeGroupIndex("grp", "/v2/img/referrers/"+digest("s"), []formats.GroupIndexPart{
+		{Member: "m1", Body: indexWith(`{"digest":"sha256:aa","size":1}`)},
+		{Member: "m2", Body: indexWith(`{"digest":"sha256:bb","size":2}`)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "application/vnd.oci.image.index.v1+json", ct)
+
+	descs := mergedDescriptors(t, body)
+	require.Len(t, descs, 2)
+	assert.Equal(t, "sha256:aa", descs[0]["digest"])
+	assert.Equal(t, "sha256:bb", descs[1]["digest"])
+}
+
+// The same manifest can legitimately sit in two members. It is the same
+// referrer, so it is named once — keyed on the manifest digest, and the earlier
+// member's descriptor is the one kept.
+func TestOCI_MergeGroupIndex_DeduplicatesByDigestEarlierMemberWins(t *testing.T) {
+	h := groupMerger()
+	body, _, err := h.MergeGroupIndex("grp", "/v2/img/referrers/"+digest("s"), []formats.GroupIndexPart{
+		{Member: "m1", Body: indexWith(`{"digest":"sha256:aa","size":1,"artifactType":"from-m1"}`)},
+		{Member: "m2", Body: indexWith(
+			`{"digest":"sha256:aa","size":1,"artifactType":"from-m2"}`,
+			`{"digest":"sha256:bb","size":2}`)},
+	})
+	require.NoError(t, err)
+
+	descs := mergedDescriptors(t, body)
+	require.Len(t, descs, 2, "the shared manifest is one referrer, not two")
+	assert.Equal(t, "sha256:aa", descs[0]["digest"])
+	assert.Equal(t, "from-m1", descs[0]["artifactType"], "member order is priority")
+	assert.Equal(t, "sha256:bb", descs[1]["digest"])
+}
+
+// Descriptors cross the merge as the bytes the member produced: re-encoding them
+// through this package's struct would drop the spec fields it does not model,
+// and a client reading platform or urls would silently lose them.
+func TestOCI_MergeGroupIndex_KeepsFieldsThisPackageDoesNotModel(t *testing.T) {
+	h := groupMerger()
+	body, _, err := h.MergeGroupIndex("grp", "/v2/img/referrers/"+digest("s"), []formats.GroupIndexPart{
+		{Member: "m1", Body: indexWith(
+			`{"digest":"sha256:aa","size":1,"platform":{"os":"linux","architecture":"arm64"},` +
+				`"urls":["https://example.test/a"]}`)},
+	})
+	require.NoError(t, err)
+
+	descs := mergedDescriptors(t, body)
+	require.Len(t, descs, 1)
+	assert.Equal(t, map[string]any{"os": "linux", "architecture": "arm64"}, descs[0]["platform"])
+	assert.Equal(t, []any{"https://example.test/a"}, descs[0]["urls"])
+}
+
+// Members with nothing to contribute merge into an empty index whose manifests
+// is [] and not null: a null breaks clients that range over the list.
+func TestOCI_MergeGroupIndex_AllEmptyIsEmptyList(t *testing.T) {
+	h := groupMerger()
+	body, _, err := h.MergeGroupIndex("grp", "/v2/img/referrers/"+digest("s"), []formats.GroupIndexPart{
+		{Member: "m1", Body: indexWith()},
+		{Member: "m2", Body: indexWith()},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"manifests":[]`)
+	assert.Empty(t, mergedDescriptors(t, body))
+}
+
+// A member body that cannot be read is a member whose referrers are missing from
+// the result. Skipping it the way the other formats skip a malformed part would
+// hand back a short index, which is what a signature checker reads as "unsigned".
+func TestOCI_MergeGroupIndex_UnreadableMemberBodyIsAnError(t *testing.T) {
+	h := groupMerger()
+	for name, part := range map[string]formats.GroupIndexPart{
+		"not json":              {Member: "m1", Body: []byte("<html>captive portal</html>")},
+		"descriptor not object": {Member: "m1", Body: indexWith(`"just a string"`)},
+		"descriptor no digest":  {Member: "m1", Body: indexWith(`{"size":1}`)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := h.MergeGroupIndex("grp", "/v2/img/referrers/"+digest("s"),
+				[]formats.GroupIndexPart{part, {Member: "m2", Body: indexWith(`{"digest":"sha256:bb"}`)}})
+			require.Error(t, err, "an unreadable member must not be silently dropped from the merge")
+		})
+	}
+}
+
+// A member that could not tell us what it holds must fail the group; 404 is the
+// one non-2xx that is a fact about the subject rather than about the member.
+func TestOCI_GroupIndexMemberFailureIsFatal(t *testing.T) {
+	h := groupMerger()
+	p := "/v2/img/referrers/" + digest("s")
+
+	assert.False(t, h.GroupIndexMemberFailureIsFatal(p, http.StatusNotFound),
+		"404 contributes nothing and is not a failure to look")
+	for _, status := range []int{
+		http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
+		http.StatusTooManyRequests, http.StatusInternalServerError,
+		http.StatusBadGateway, http.StatusServiceUnavailable,
+	} {
+		assert.True(t, h.GroupIndexMemberFailureIsFatal(p, status),
+			"%d means the member could not be consulted", status)
+	}
+
+	assert.False(t, h.GroupIndexMemberFailureIsFatal("/v2/img/manifests/1.0.0", http.StatusBadGateway),
+		"the policy belongs to the referrers index alone")
+}

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -4,6 +4,7 @@
 //
 //	GET  /v2/                                   → API version check (200 OK)
 //	GET  /v2/:name/tags/list                    → list tags
+//	GET  /v2/:name/referrers/:digest            → list manifests referring to :digest
 //	GET  /v2/:name/manifests/:reference         → pull manifest
 //	PUT  /v2/:name/manifests/:reference         → push manifest
 //	DELETE /v2/:name/manifests/:reference       → delete manifest
@@ -76,11 +77,21 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	}
 
 	// Find the endpoint keyword from the right
-	// patterns: .../tags/list | .../manifests/:ref | .../blobs/:digest | .../blobs/uploads/[uuid]
+	// patterns: .../tags/list | .../referrers/:digest | .../manifests/:ref |
+	//           .../blobs/:digest | .../blobs/uploads/[uuid]
 	switch {
 	case endsWithSegments(parts, "tags", "list"):
 		imageName := strings.Join(parts[:len(parts)-2], "/")
 		h.handleTagsList(c, repoName, imageName)
+
+	// Before manifests and blobs: the shape is <name>/referrers/<digest>, and
+	// referrersIndex only matches the keyword in that exact position, so no
+	// existing path can be re-routed by this case.
+	case referrersIndex(parts) >= 0:
+		idx := referrersIndex(parts)
+		imageName := strings.Join(parts[:idx], "/")
+		subjectDigest := strings.Join(parts[idx+1:], "/")
+		h.handleReferrers(c, repoName, imageName, subjectDigest)
 
 	case hasSegment(parts, "manifests"):
 		idx := segmentIndex(parts, "manifests")

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -353,6 +353,14 @@ func blobPath(imageName, digest string) string {
 	return "/blobs/" + imageName + "/" + digest
 }
 
+// referrersPath is the repository-relative form of a referrers request, in the
+// same shape as manifestPath and blobPath. Nothing is stored under it — the
+// index is computed per request — but a proxy failure has to be reported against
+// the path on this side, as every other repoproxy caller does.
+func referrersPath(imageName, subjectDigest string) string {
+	return "/referrers/" + imageName + "/" + subjectDigest
+}
+
 func (h *Handler) handleBlobs(c *gin.Context, repoName, imageName, digest string) {
 	repo, _ := h.deps.Repos.Get(c.Request.Context(), repoName)
 	switch c.Request.Method {
@@ -596,6 +604,20 @@ func segmentIndex(parts []string, seg string) int {
 		}
 	}
 	return -1
+}
+
+// referrersIndex reports where the "referrers" keyword sits in a split path, or
+// -1 when the path is not a referrers request. The keyword is only recognized as
+// the second-to-last segment — the spec's shape is {name}/referrers/{digest} and
+// a digest is always exactly one segment. Matching it anywhere (as the manifests
+// and blobs cases do) would let an image legitimately named ".../referrers"
+// swallow its own manifest and blob requests.
+func referrersIndex(parts []string) int {
+	idx := len(parts) - 2
+	if idx < 1 || parts[idx] != "referrers" {
+		return -1
+	}
+	return idx
 }
 
 func normPath(p string) string {

--- a/internal/formats/oci/manifest.go
+++ b/internal/formats/oci/manifest.go
@@ -18,6 +18,15 @@ const (
 // It caps how much of a push body is buffered for parsing.
 const maxManifestBytes = 4 << 20
 
+// maxReferrersBytes caps a referrers index read from an upstream registry. It is
+// deliberately larger than maxManifestBytes because the two are not the same kind
+// of object: a manifest describes one artifact and its size is bounded by its own
+// layer count, while a referrers index grows without bound in the number of
+// signatures, attestations and SBOMs ever attached to one subject. A heavily
+// attested image legitimately produces a far bigger document than any manifest,
+// and sizing the two alike would turn a normal index into a truncated one.
+const maxReferrersBytes = 16 << 20
+
 // manifestMeta is the descriptive subset of an OCI manifest the registry stores.
 type manifestMeta struct {
 	MediaType    string

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -92,10 +92,12 @@ func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDi
 	c.JSON(http.StatusOK, index)
 }
 
-// proxyReferrers forwards the request upstream. Anything other than a usable
-// upstream answer — no such endpoint, an error status, an unreachable host —
-// becomes an empty index: a client asking "is this image signed" must get a
-// definite "no referrers here" rather than a failure it cannot interpret.
+// proxyReferrers forwards the request upstream. An empty index is reserved for
+// the answers that genuinely mean "this registry holds no referrers information
+// for that subject" — 404, 405 and 501, i.e. an upstream with no referrers API.
+// Every other outcome, from an unreachable host to a 500 to a 200 whose body is
+// not an index, is a failure to look, and a failure to look must never be
+// reported as an absence: a policy gate reads an empty index as "unsigned".
 func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageName, subjectDigest string) {
 	upPath := "/v2/" + imageName + "/referrers/" + subjectDigest
 	hdr := http.Header{"Accept": []string{mediaTypeImageIndex}}
@@ -104,13 +106,23 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 	// artifactType filter would silently never be applied.
 	resp, err := repoproxy.FetchUpstreamOnce(c.Request.Context(), repo, upPath, c.Request.URL.RawQuery, hdr)
 	if err != nil {
-		emptyIndex(c)
+		// No response at all: DNS failure, refused connection, TLS error, timeout,
+		// the SSRF guard, or a proxy_config that cannot even produce a URL. The
+		// upstream URL is unknown here, so the record carries the path alone.
+		h.upstreamUnusable(c, repo, upPath, "", "UNKNOWN",
+			fmt.Sprintf("could not reach the upstream registry to list referrers: %v", err))
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	switch resp.StatusCode {
 	case http.StatusOK:
+	case http.StatusNotFound, http.StatusMethodNotAllowed, http.StatusNotImplemented:
+		// The upstream has no referrers API. That is a fact about the registry
+		// which a client can act on, and the only one that justifies an empty
+		// index: we did reach the registry and it has nothing to tell us.
+		emptyIndex(c)
+		return
 	case http.StatusUnauthorized, http.StatusForbidden:
 		// "I could not check" is not "there is nothing to check". Collapsing an
 		// upstream refusal into an empty index would let a policy gate read a
@@ -119,28 +131,39 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 		h.upstreamRefused(c, repo, upPath, upstreamURLOf(resp), resp.StatusCode)
 		return
 	default:
-		// 404 (no referrers API upstream) and every other status genuinely mean
-		// "no referrers information here", which a client can act on.
-		emptyIndex(c)
+		code := "UNKNOWN"
+		if resp.StatusCode == http.StatusTooManyRequests {
+			code = "TOOMANYREQUESTS"
+		}
+		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), code, fmt.Sprintf(
+			"upstream registry answered the referrers request with %d %s: proxy repository %q could not list "+
+				"referrers, so this is an upstream failure and not an absence of referrers",
+			resp.StatusCode, http.StatusText(resp.StatusCode), repo.Name))
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, maxReferrersBytes+1))
 	if err != nil {
-		emptyIndex(c)
+		// A body that died mid-read is a truncated list, which can only ever
+		// under-report — the same direction as the size cap below.
+		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), "UNKNOWN", fmt.Sprintf(
+			"upstream referrers index for %q could not be read whole: %v", repo.Name, err))
 		return
 	}
 	if len(body) > maxReferrersBytes {
 		// A list too large to read whole can only ever under-report referrers, so
 		// it is an error for the same reason a refusal is.
-		msg := fmt.Sprintf("upstream referrers index for %q exceeds the %d byte limit and cannot be served complete",
-			repo.Name, maxReferrersBytes)
-		repoproxy.DispatchProxyError(h.deps, repo.Name, upPath, upstreamURLOf(resp), errors.New(msg))
-		dockerError(c, http.StatusBadGateway, "TOOBIG", msg)
+		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), "TOOBIG", fmt.Sprintf(
+			"upstream referrers index for %q exceeds the %d byte limit and cannot be served complete",
+			repo.Name, maxReferrersBytes))
 		return
 	}
 	if !looksLikeIndex(body) {
-		emptyIndex(c)
+		// A 200 carrying an error page or a captive portal's HTML means we never
+		// reached a registry, so we learned nothing about this subject.
+		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), "UNKNOWN", fmt.Sprintf(
+			"upstream answered the referrers request for %q with 200 but the body is not an image index, "+
+				"so no registry was reached", repo.Name))
 		return
 	}
 	if applied := resp.Header.Get("OCI-Filters-Applied"); applied != "" {
@@ -149,19 +172,27 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 	c.Data(http.StatusOK, mediaTypeImageIndex, body)
 }
 
-// upstreamRefused relays a 401/403 from upstream as a 502 in the OCI error shape,
-// and records it on the proxy-error bus. formats.Deps carries no logger — the
-// webhook bus is the reporting channel repoproxy already uses for a failed
-// upstream fetch, so an operator sees this the same way.
+// upstreamRefused relays a 401/403 from upstream as a 502 in the OCI error shape.
 func (h *Handler) upstreamRefused(c *gin.Context, repo *domain.Repository, upPath, upstream string, status int) {
 	code := "UNAUTHORIZED"
 	if status == http.StatusForbidden {
 		code = "DENIED"
 	}
-	msg := fmt.Sprintf(
+	h.upstreamUnusable(c, repo, upPath, upstream, code, fmt.Sprintf(
 		"upstream registry refused the referrers request with %d %s: proxy repository %q could not list referrers, "+
 			"so this is a credentials problem on the proxy and not an absence of referrers",
-		status, http.StatusText(status), repo.Name)
+		status, http.StatusText(status), repo.Name))
+}
+
+// upstreamUnusable answers 502 in the OCI error shape and records the failure on
+// the proxy-error bus. formats.Deps carries no logger — the webhook bus is the
+// reporting channel repoproxy already uses for a failed upstream fetch, so an
+// operator sees this the same way.
+//
+// upPath is the upstream request path, which is what the other DispatchProxyError
+// callers pass as well: repoproxy's own cache paths are repository-relative and
+// are the path it asked upstream for.
+func (h *Handler) upstreamUnusable(c *gin.Context, repo *domain.Repository, upPath, upstream, code, msg string) {
 	repoproxy.DispatchProxyError(h.deps, repo.Name, upPath, upstream, errors.New(msg))
 	dockerError(c, http.StatusBadGateway, code, msg)
 }

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 
@@ -116,7 +117,10 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 	// The query goes as its own argument: JoinURL escapes everything it is given
 	// as a path, so a "?" glued on would reach upstream as %3F and the
 	// artifactType filter would silently never be applied.
-	resp, err := repoproxy.FetchUpstreamOnce(c.Request.Context(), repo, upPath, c.Request.URL.RawQuery, hdr)
+	//
+	// Only artifactType is forwarded; the client's pagination is dropped. See
+	// upstreamQuery.
+	resp, err := repoproxy.FetchUpstreamOnce(c.Request.Context(), repo, upPath, upstreamQuery(c), hdr)
 	if err != nil {
 		// No response at all: DNS failure, refused connection, TLS error, timeout,
 		// the SSRF guard, or a proxy_config that cannot even produce a URL. The
@@ -181,7 +185,27 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 	if applied := resp.Header.Get("OCI-Filters-Applied"); applied != "" {
 		c.Header("OCI-Filters-Applied", applied)
 	}
+	// The upstream's Link header is deliberately not copied: it points at a
+	// continuation this endpoint cannot serve, since upstreamQuery has already
+	// asked for the whole list.
 	c.Data(http.StatusOK, mediaTypeImageIndex, body)
+}
+
+// upstreamQuery is the client's query as it should reach the upstream: the
+// artifactType filter and nothing else.
+//
+// The spec's "n" and "last" are dropped on purpose. Honoring pagination would
+// mean relaying the upstream's Link: <...>; rel="next" continuation, which this
+// endpoint does not implement — so a forwarded "n" would fetch page one from a
+// paginating upstream and the client would read a truncated list as the
+// complete one. Dropping the two parameters makes the upstream answer in full,
+// which is the only answer this endpoint can pass through honestly.
+func upstreamQuery(c *gin.Context) string {
+	artifactType := c.Query("artifactType")
+	if artifactType == "" {
+		return ""
+	}
+	return url.Values{"artifactType": []string{artifactType}}.Encode()
 }
 
 // upstreamRefused relays a 401/403 from upstream as a 502 in the OCI error shape.

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -78,7 +78,16 @@ func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDi
 
 	seen := make(map[string]struct{}, len(comps))
 	for _, comp := range comps {
-		desc, ok := h.descriptorOf(ctx, repoName, imageName, comp)
+		desc, ok, err := h.descriptorOf(ctx, repoName, imageName, comp)
+		if err != nil {
+			// A referrer we failed to look up is not a referrer that is not there.
+			// Dropping it and still answering 200 would hand the client a short
+			// index — the same under-report the proxy path refuses to produce.
+			dockerError(c, http.StatusBadGateway, "UNKNOWN", fmt.Sprintf(
+				"could not read the manifest behind referrer %s:%s, so the referrers index for %q would be "+
+					"incomplete: %v", comp.Name, comp.Version, subjectDigest, err))
+			return
+		}
 		if !ok {
 			continue
 		}
@@ -275,10 +284,22 @@ func emptyIndex(c *gin.Context) {
 // descriptorOf renders one referring component as an index entry. The digest and
 // size come from the stored manifest asset, the rest from the metadata phase 1
 // recorded on the component.
-func (h *Handler) descriptorOf(ctx context.Context, repoName, imageName string, comp domain.Component) (descriptor, bool) {
+//
+// The two ways this can fail are deliberately not the same. ok is false when the
+// asset is genuinely absent — a component that outlived its manifest, which has
+// nothing to name in the index and is skipped. A non-nil error means the lookup
+// itself failed, and the caller must fail the whole request rather than serve a
+// short index: a missing entry reads to a signature checker as "not signed".
+func (h *Handler) descriptorOf(ctx context.Context, repoName, imageName string, comp domain.Component) (descriptor, bool, error) {
 	asset, err := h.deps.Assets.GetByPath(ctx, repoName, manifestPath(imageName, comp.Version))
-	if err != nil || asset == nil || asset.SHA256 == "" {
-		return descriptor{}, false
+	if errors.Is(err, repository.ErrNotFound) {
+		return descriptor{}, false, nil
+	}
+	if err != nil {
+		return descriptor{}, false, err
+	}
+	if asset == nil || asset.SHA256 == "" {
+		return descriptor{}, false, nil
 	}
 	mediaType, _ := comp.Extra[extraMediaTypeKey].(string)
 	if mediaType == "" {
@@ -291,7 +312,7 @@ func (h *Handler) descriptorOf(ctx context.Context, repoName, imageName string, 
 		Size:         asset.SizeBytes,
 		ArtifactType: artifactType,
 		Annotations:  annotationsOf(comp),
-	}, true
+	}, true, nil
 }
 
 // annotationsOf converts the stored annotation map back to string values.

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -3,6 +3,8 @@ package oci
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -106,12 +108,38 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// "I could not check" is not "there is nothing to check". Collapsing an
+		// upstream refusal into an empty index would let a policy gate read a
+		// proxy's missing or rejected credentials as proof that an image is
+		// unsigned — the one direction this endpoint must never fail in.
+		h.upstreamRefused(c, repo, upPath, upstreamURLOf(resp), resp.StatusCode)
+		return
+	default:
+		// 404 (no referrers API upstream) and every other status genuinely mean
+		// "no referrers information here", which a client can act on.
 		emptyIndex(c)
 		return
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestBytes))
-	if err != nil || !looksLikeIndex(body) {
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxReferrersBytes+1))
+	if err != nil {
+		emptyIndex(c)
+		return
+	}
+	if len(body) > maxReferrersBytes {
+		// A list too large to read whole can only ever under-report referrers, so
+		// it is an error for the same reason a refusal is.
+		msg := fmt.Sprintf("upstream referrers index for %q exceeds the %d byte limit and cannot be served complete",
+			repo.Name, maxReferrersBytes)
+		repoproxy.DispatchProxyError(h.deps, repo.Name, upPath, upstreamURLOf(resp), errors.New(msg))
+		dockerError(c, http.StatusBadGateway, "TOOBIG", msg)
+		return
+	}
+	if !looksLikeIndex(body) {
 		emptyIndex(c)
 		return
 	}
@@ -119,6 +147,33 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 		c.Header("OCI-Filters-Applied", applied)
 	}
 	c.Data(http.StatusOK, mediaTypeImageIndex, body)
+}
+
+// upstreamRefused relays a 401/403 from upstream as a 502 in the OCI error shape,
+// and records it on the proxy-error bus. formats.Deps carries no logger — the
+// webhook bus is the reporting channel repoproxy already uses for a failed
+// upstream fetch, so an operator sees this the same way.
+func (h *Handler) upstreamRefused(c *gin.Context, repo *domain.Repository, upPath, upstream string, status int) {
+	code := "UNAUTHORIZED"
+	if status == http.StatusForbidden {
+		code = "DENIED"
+	}
+	msg := fmt.Sprintf(
+		"upstream registry refused the referrers request with %d %s: proxy repository %q could not list referrers, "+
+			"so this is a credentials problem on the proxy and not an absence of referrers",
+		status, http.StatusText(status), repo.Name)
+	repoproxy.DispatchProxyError(h.deps, repo.Name, upPath, upstream, errors.New(msg))
+	dockerError(c, http.StatusBadGateway, code, msg)
+}
+
+// upstreamURLOf reports the URL actually requested, for the error record. The
+// client fills in Response.Request, but a nil guard keeps a doubled transport
+// from turning a reporting path into a panic.
+func upstreamURLOf(resp *http.Response) string {
+	if resp == nil || resp.Request == nil || resp.Request.URL == nil {
+		return ""
+	}
+	return resp.Request.URL.String()
 }
 
 // looksLikeIndex reports whether the upstream body is at least shaped like an

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -2,11 +2,14 @@ package oci
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
 )
 
 // mediaTypeImageIndex is the media type of the referrers response document.
@@ -39,9 +42,17 @@ func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDi
 	}
 	ctx := c.Request.Context()
 
-	// Non-nil so an empty result serializes as [] and not null: a null breaks
-	// clients that range over the list.
-	index := imageIndex{SchemaVersion: 2, MediaType: mediaTypeImageIndex, Manifests: []descriptor{}}
+	// A proxy repository answers from upstream. Its cache holds only the
+	// referring manifests that happen to have been pulled through it, so the
+	// local query would under-report — and an under-reported index reads to a
+	// signature checker as "this image is unsigned".
+	repo, _ := h.deps.Repos.Get(ctx, repoName)
+	if repo != nil && repo.Type == domain.TypeProxy {
+		h.proxyReferrers(c, repo, imageName, subjectDigest)
+		return
+	}
+
+	index := newIndex()
 	filter := c.Query("artifactType")
 
 	comps, err := h.deps.Components.ListOCIReferrers(ctx, []string{repoName}, imageName, subjectDigest)
@@ -77,6 +88,66 @@ func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDi
 	// Content-Type is present yet.
 	c.Header("Content-Type", mediaTypeImageIndex)
 	c.JSON(http.StatusOK, index)
+}
+
+// proxyReferrers forwards the request upstream. Anything other than a usable
+// upstream answer — no such endpoint, an error status, an unreachable host —
+// becomes an empty index: a client asking "is this image signed" must get a
+// definite "no referrers here" rather than a failure it cannot interpret.
+func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageName, subjectDigest string) {
+	upPath := "/v2/" + imageName + "/referrers/" + subjectDigest
+	hdr := http.Header{"Accept": []string{mediaTypeImageIndex}}
+	// The query goes as its own argument: JoinURL escapes everything it is given
+	// as a path, so a "?" glued on would reach upstream as %3F and the
+	// artifactType filter would silently never be applied.
+	resp, err := repoproxy.FetchUpstreamOnce(c.Request.Context(), repo, upPath, c.Request.URL.RawQuery, hdr)
+	if err != nil {
+		emptyIndex(c)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		emptyIndex(c)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestBytes))
+	if err != nil || !looksLikeIndex(body) {
+		emptyIndex(c)
+		return
+	}
+	if applied := resp.Header.Get("OCI-Filters-Applied"); applied != "" {
+		c.Header("OCI-Filters-Applied", applied)
+	}
+	c.Data(http.StatusOK, mediaTypeImageIndex, body)
+}
+
+// looksLikeIndex reports whether the upstream body is at least shaped like an
+// image index. The body is passed through byte for byte rather than re-encoded —
+// re-encoding through the local structs would drop spec fields this package does
+// not model (platform, urls, subject, top-level annotations) and corrupt valid
+// answers. So the check is deliberately shallow: it exists to stop a captive
+// portal's HTML, or an error document served with a 200, from being handed to a
+// client under an image-index content type.
+func looksLikeIndex(body []byte) bool {
+	var probe struct {
+		Manifests []json.RawMessage `json:"manifests"`
+	}
+	return json.Unmarshal(body, &probe) == nil && probe.Manifests != nil
+}
+
+// newIndex is a referrers index with no entries. Manifests is non-nil so an
+// empty result serializes as [] and not null: a null breaks clients that range
+// over the list.
+func newIndex() imageIndex {
+	return imageIndex{SchemaVersion: 2, MediaType: mediaTypeImageIndex, Manifests: []descriptor{}}
+}
+
+// emptyIndex answers with a well-formed index carrying no referrers.
+func emptyIndex(c *gin.Context) {
+	// Set before c.JSON, which only fills in application/json when no
+	// Content-Type is present yet.
+	c.Header("Content-Type", mediaTypeImageIndex)
+	c.JSON(http.StatusOK, newIndex())
 }
 
 // descriptorOf renders one referring component as an index entry. The digest and

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -42,6 +43,17 @@ type imageIndex struct {
 func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDigest string) {
 	if c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead {
 		c.Status(http.StatusMethodNotAllowed)
+		return
+	}
+	// A digest that is not a digest is a client mistake, and the client is told
+	// so. Answering the usual empty index would report a typo'd or truncated
+	// digest as "this image has no signatures" — the reading this endpoint exists
+	// to avoid producing by accident. Checked before the proxy branch: there is
+	// nothing to ask an upstream about either.
+	if !validDigest(subjectDigest) {
+		dockerError(c, http.StatusBadRequest, "DIGEST_INVALID",
+			fmt.Sprintf("%q is not a valid digest: expected <algorithm>:<hex>, e.g. sha256 followed by 64 "+
+				"lowercase hex characters", subjectDigest))
 		return
 	}
 	ctx := c.Request.Context()
@@ -122,6 +134,10 @@ func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDi
 // reported as an absence: a policy gate reads an empty index as "unsigned".
 func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageName, subjectDigest string) {
 	upPath := "/v2/" + imageName + "/referrers/" + subjectDigest
+	// What the failure record names is the path on THIS side, as every other
+	// DispatchProxyError caller does; the upstream side travels in the separate
+	// upstream argument.
+	repoPath := referrersPath(imageName, subjectDigest)
 	hdr := http.Header{"Accept": []string{mediaTypeImageIndex}}
 	// The query goes as its own argument: JoinURL escapes everything it is given
 	// as a path, so a "?" glued on would reach upstream as %3F and the
@@ -134,7 +150,7 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 		// No response at all: DNS failure, refused connection, TLS error, timeout,
 		// the SSRF guard, or a proxy_config that cannot even produce a URL. The
 		// upstream URL is unknown here, so the record carries the path alone.
-		h.upstreamUnusable(c, repo, upPath, "", "UNKNOWN",
+		h.upstreamUnusable(c, repo, repoPath, "", "UNKNOWN",
 			fmt.Sprintf("could not reach the upstream registry to list referrers: %v", err))
 		return
 	}
@@ -153,14 +169,14 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 		// upstream refusal into an empty index would let a policy gate read a
 		// proxy's missing or rejected credentials as proof that an image is
 		// unsigned — the one direction this endpoint must never fail in.
-		h.upstreamRefused(c, repo, upPath, upstreamURLOf(resp), resp.StatusCode)
+		h.upstreamRefused(c, repo, repoPath, upstreamURLOf(resp), resp.StatusCode)
 		return
 	default:
 		code := "UNKNOWN"
 		if resp.StatusCode == http.StatusTooManyRequests {
 			code = "TOOMANYREQUESTS"
 		}
-		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), code, fmt.Sprintf(
+		h.upstreamUnusable(c, repo, repoPath, upstreamURLOf(resp), code, fmt.Sprintf(
 			"upstream registry answered the referrers request with %d %s: proxy repository %q could not list "+
 				"referrers, so this is an upstream failure and not an absence of referrers",
 			resp.StatusCode, http.StatusText(resp.StatusCode), repo.Name))
@@ -171,14 +187,14 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 	if err != nil {
 		// A body that died mid-read is a truncated list, which can only ever
 		// under-report — the same direction as the size cap below.
-		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), "UNKNOWN", fmt.Sprintf(
+		h.upstreamUnusable(c, repo, repoPath, upstreamURLOf(resp), "UNKNOWN", fmt.Sprintf(
 			"upstream referrers index for %q could not be read whole: %v", repo.Name, err))
 		return
 	}
 	if len(body) > maxReferrersBytes {
 		// A list too large to read whole can only ever under-report referrers, so
 		// it is an error for the same reason a refusal is.
-		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), "TOOBIG", fmt.Sprintf(
+		h.upstreamUnusable(c, repo, repoPath, upstreamURLOf(resp), "TOOBIG", fmt.Sprintf(
 			"upstream referrers index for %q exceeds the %d byte limit and cannot be served complete",
 			repo.Name, maxReferrersBytes))
 		return
@@ -186,7 +202,7 @@ func (h *Handler) proxyReferrers(c *gin.Context, repo *domain.Repository, imageN
 	if !looksLikeIndex(body) {
 		// A 200 carrying an error page or a captive portal's HTML means we never
 		// reached a registry, so we learned nothing about this subject.
-		h.upstreamUnusable(c, repo, upPath, upstreamURLOf(resp), "UNKNOWN", fmt.Sprintf(
+		h.upstreamUnusable(c, repo, repoPath, upstreamURLOf(resp), "UNKNOWN", fmt.Sprintf(
 			"upstream answered the referrers request for %q with 200 but the body is not an image index, "+
 				"so no registry was reached", repo.Name))
 		return
@@ -218,12 +234,12 @@ func upstreamQuery(c *gin.Context) string {
 }
 
 // upstreamRefused relays a 401/403 from upstream as a 502 in the OCI error shape.
-func (h *Handler) upstreamRefused(c *gin.Context, repo *domain.Repository, upPath, upstream string, status int) {
+func (h *Handler) upstreamRefused(c *gin.Context, repo *domain.Repository, repoPath, upstream string, status int) {
 	code := "UNAUTHORIZED"
 	if status == http.StatusForbidden {
 		code = "DENIED"
 	}
-	h.upstreamUnusable(c, repo, upPath, upstream, code, fmt.Sprintf(
+	h.upstreamUnusable(c, repo, repoPath, upstream, code, fmt.Sprintf(
 		"upstream registry refused the referrers request with %d %s: proxy repository %q could not list referrers, "+
 			"so this is a credentials problem on the proxy and not an absence of referrers",
 		status, http.StatusText(status), repo.Name))
@@ -234,11 +250,10 @@ func (h *Handler) upstreamRefused(c *gin.Context, repo *domain.Repository, upPat
 // reporting channel repoproxy already uses for a failed upstream fetch, so an
 // operator sees this the same way.
 //
-// upPath is the upstream request path, which is what the other DispatchProxyError
-// callers pass as well: repoproxy's own cache paths are repository-relative and
-// are the path it asked upstream for.
-func (h *Handler) upstreamUnusable(c *gin.Context, repo *domain.Repository, upPath, upstream, code, msg string) {
-	repoproxy.DispatchProxyError(h.deps, repo.Name, upPath, upstream, errors.New(msg))
+// repoPath is the repository-relative path, the side every other
+// DispatchProxyError caller reports; upstream is the URL actually requested.
+func (h *Handler) upstreamUnusable(c *gin.Context, repo *domain.Repository, repoPath, upstream, code, msg string) {
+	repoproxy.DispatchProxyError(h.deps, repo.Name, repoPath, upstream, errors.New(msg))
 	dockerError(c, http.StatusBadGateway, code, msg)
 }
 
@@ -250,6 +265,35 @@ func upstreamURLOf(resp *http.Response) string {
 		return ""
 	}
 	return resp.Request.URL.String()
+}
+
+// digestHexLen is the encoded length each accepted digest algorithm produces.
+// sha256 is what this registry computes and stores; sha512 is admitted because
+// the browse layer already treats a "sha512:" version as a digest, and rejecting
+// a well-formed one here would turn a spec-conformant client's request into a
+// 400. Nothing wider is accepted: the point of the check is to catch a mistyped
+// or truncated digest, and an open-ended algorithm list catches nothing.
+var digestHexLen = map[string]int{"sha256": 64, "sha512": 128}
+
+// validDigest reports whether s has the shape <algorithm>:<hex>. The encoded
+// part must be lowercase hex of the algorithm's exact length — the OCI spec's
+// grammar, and what makes a truncated or mistyped digest visible.
+func validDigest(s string) bool {
+	algo, hex, ok := strings.Cut(s, ":")
+	if !ok {
+		return false
+	}
+	want, known := digestHexLen[algo]
+	if !known || len(hex) != want {
+		return false
+	}
+	for i := 0; i < len(hex); i++ {
+		ch := hex[i]
+		if (ch < '0' || ch > '9') && (ch < 'a' || ch > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 // looksLikeIndex reports whether the upstream body is at least shaped like an
@@ -328,18 +372,4 @@ func annotationsOf(comp domain.Component) map[string]string {
 		}
 	}
 	return out
-}
-
-// referrersIndex reports where the "referrers" keyword sits in a split path, or
-// -1 when the path is not a referrers request. The keyword is only recognized as
-// the second-to-last segment — the spec's shape is {name}/referrers/{digest} and
-// a digest is always exactly one segment. Matching it anywhere (as the manifests
-// and blobs cases do) would let an image legitimately named ".../referrers"
-// swallow its own manifest and blob requests.
-func referrersIndex(parts []string) int {
-	idx := len(parts) - 2
-	if idx < 1 || parts[idx] != "referrers" {
-		return -1
-	}
-	return idx
 }

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -1,0 +1,131 @@
+package oci
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// mediaTypeImageIndex is the media type of the referrers response document.
+const mediaTypeImageIndex = "application/vnd.oci.image.index.v1+json"
+
+// descriptor is one entry of the referrers image index.
+type descriptor struct {
+	MediaType    string            `json:"mediaType"`
+	Digest       string            `json:"digest"`
+	Size         int64             `json:"size"`
+	ArtifactType string            `json:"artifactType,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
+}
+
+// imageIndex is the referrers response document.
+type imageIndex struct {
+	SchemaVersion int          `json:"schemaVersion"`
+	MediaType     string       `json:"mediaType"`
+	Manifests     []descriptor `json:"manifests"`
+}
+
+// handleReferrers answers GET /v2/{name}/referrers/{digest} with an image index
+// of every manifest whose subject is that digest. An unknown digest yields an
+// empty index rather than a 404: clients read "no referrers" from the empty
+// list, and a 404 would read as "this registry has no referrers API".
+func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDigest string) {
+	if c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead {
+		c.Status(http.StatusMethodNotAllowed)
+		return
+	}
+	ctx := c.Request.Context()
+
+	// Non-nil so an empty result serializes as [] and not null: a null breaks
+	// clients that range over the list.
+	index := imageIndex{SchemaVersion: 2, MediaType: mediaTypeImageIndex, Manifests: []descriptor{}}
+	filter := c.Query("artifactType")
+
+	comps, err := h.deps.Components.ListOCIReferrers(ctx, []string{repoName}, imageName, subjectDigest)
+	if err != nil {
+		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
+		return
+	}
+
+	seen := make(map[string]struct{}, len(comps))
+	for _, comp := range comps {
+		desc, ok := h.descriptorOf(ctx, repoName, imageName, comp)
+		if !ok {
+			continue
+		}
+		// A referrer pushed by tag has both a tag component and a digest-alias
+		// component; both name the same manifest, so list it once. Recorded
+		// before the filter runs, so which copy is seen first cannot decide
+		// whether the other one slips through.
+		if _, dup := seen[desc.Digest]; dup {
+			continue
+		}
+		seen[desc.Digest] = struct{}{}
+		if filter != "" && desc.ArtifactType != filter {
+			continue
+		}
+		index.Manifests = append(index.Manifests, desc)
+	}
+
+	if filter != "" {
+		c.Header("OCI-Filters-Applied", "artifactType")
+	}
+	// Set before c.JSON, which only fills in application/json when no
+	// Content-Type is present yet.
+	c.Header("Content-Type", mediaTypeImageIndex)
+	c.JSON(http.StatusOK, index)
+}
+
+// descriptorOf renders one referring component as an index entry. The digest and
+// size come from the stored manifest asset, the rest from the metadata phase 1
+// recorded on the component.
+func (h *Handler) descriptorOf(ctx context.Context, repoName, imageName string, comp domain.Component) (descriptor, bool) {
+	asset, err := h.deps.Assets.GetByPath(ctx, repoName, manifestPath(imageName, comp.Version))
+	if err != nil || asset == nil || asset.SHA256 == "" {
+		return descriptor{}, false
+	}
+	mediaType, _ := comp.Extra[extraMediaTypeKey].(string)
+	if mediaType == "" {
+		mediaType = asset.ContentType
+	}
+	artifactType, _ := comp.Extra[extraArtifactTypeKey].(string)
+	return descriptor{
+		MediaType:    mediaType,
+		Digest:       "sha256:" + asset.SHA256,
+		Size:         asset.SizeBytes,
+		ArtifactType: artifactType,
+		Annotations:  annotationsOf(comp),
+	}, true
+}
+
+// annotationsOf converts the stored annotation map back to string values.
+func annotationsOf(comp domain.Component) map[string]string {
+	raw, _ := comp.Extra[extraAnnotationsKey].(map[string]any)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(raw))
+	for k, v := range raw {
+		if s, ok := v.(string); ok {
+			out[k] = s
+		}
+	}
+	return out
+}
+
+// referrersIndex reports where the "referrers" keyword sits in a split path, or
+// -1 when the path is not a referrers request. The keyword is only recognized as
+// the second-to-last segment — the spec's shape is {name}/referrers/{digest} and
+// a digest is always exactly one segment. Matching it anywhere (as the manifests
+// and blobs cases do) would let an image legitimately named ".../referrers"
+// swallow its own manifest and blob requests.
+func referrersIndex(parts []string) int {
+	idx := len(parts) - 2
+	if idx < 1 || parts[idx] != "referrers" {
+		return -1
+	}
+	return idx
+}

--- a/internal/formats/oci/referrers.go
+++ b/internal/formats/oci/referrers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 )
 
 // mediaTypeImageIndex is the media type of the referrers response document.
@@ -48,7 +49,18 @@ func (h *Handler) handleReferrers(c *gin.Context, repoName, imageName, subjectDi
 	// referring manifests that happen to have been pulled through it, so the
 	// local query would under-report — and an under-reported index reads to a
 	// signature checker as "this image is unsigned".
-	repo, _ := h.deps.Repos.Get(ctx, repoName)
+	//
+	// A lookup that fails is therefore not the same as one that finds nothing:
+	// swallowing the error would leave repo nil, skip the proxy branch and answer
+	// a proxy's request from its cache without ever touching the network. Only a
+	// genuine absence falls through to the local query.
+	repo, err := h.deps.Repos.Get(ctx, repoName)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		dockerError(c, http.StatusBadGateway, "UNKNOWN",
+			fmt.Sprintf("could not determine whether repository %q is a proxy, so its referrers cannot be listed: %v",
+				repoName, err))
+		return
+	}
 	if repo != nil && repo.Type == domain.TypeProxy {
 		h.proxyReferrers(c, repo, imageName, subjectDigest)
 		return

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -232,6 +232,133 @@ func TestReferrers_DoesNotSwallowImageNamedReferrers(t *testing.T) {
 	assert.Equal(t, helmChartManifest, w.Body.String())
 }
 
+// A digest that is not a digest is a client mistake, and saying so is the whole
+// point: answering an empty index would report a typo'd or truncated digest as
+// "this image has no signatures", which is the reading this endpoint must never
+// produce by accident.
+func TestReferrers_InvalidDigestIsBadRequest(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	valid := digest("something")
+	cases := map[string]string{
+		"no algorithm":        strings.TrimPrefix(valid, "sha256:"),
+		"unknown algorithm":   "md5:" + strings.Repeat("a", 32),
+		"one hex short":       "sha256:" + strings.Repeat("a", 63),
+		"one hex long":        "sha256:" + strings.Repeat("a", 65),
+		"not hex":             "sha256:" + strings.Repeat("z", 64),
+		"uppercase hex":       "sha256:" + strings.Repeat("A", 64),
+		"empty encoded part":  "sha256:",
+		"a tag, not a digest": "latest",
+	}
+	for name, bad := range cases {
+		t.Run(name, func(t *testing.T) {
+			w := doReferrers(r, "oci-hosted", "charts/nginx", bad, "")
+			require.Equal(t, http.StatusBadRequest, w.Code,
+				"a malformed digest must not read as 'no referrers'")
+			var doc ociErrors
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+			require.Len(t, doc.Errors, 1)
+			assert.Equal(t, "DIGEST_INVALID", doc.Errors[0].Code)
+			assert.NotContains(t, w.Body.String(), `"manifests"`)
+		})
+	}
+}
+
+// A well-formed digest of any algorithm the rest of the codebase recognizes is
+// answered normally — validation exists to catch a mistake, not to narrow the
+// protocol.
+func TestReferrers_WellFormedDigestsAreAccepted(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	for name, good := range map[string]string{
+		"sha256": "sha256:" + strings.Repeat("a", 64),
+		"sha512": "sha512:" + strings.Repeat("b", 128),
+	} {
+		t.Run(name, func(t *testing.T) {
+			w, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", good, "")
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Empty(t, descs)
+		})
+	}
+}
+
+// A malformed digest must be rejected before a proxy repository forwards it:
+// there is nothing to ask an upstream about.
+func TestReferrers_InvalidDigestOnProxyIsNotForwarded(t *testing.T) {
+	var reached bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached = true
+		w.Header().Set("Content-Type", ociIndexMediaType)
+		_, _ = w.Write([]byte(upstreamReferrersIndex))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w := doReferrers(r, "oci-proxy", "charts/nginx", "not-a-digest", "")
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	assert.False(t, reached, "a malformed digest must never reach the upstream")
+}
+
+// descriptorOf prefers the manifest's own mediaType and falls back to the asset's
+// stored Content-Type. Every other test pushes the two identical, so neither half
+// of that rule is actually pinned; these two push them apart.
+func TestReferrers_MediaTypePrefersManifestOverContentType(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+
+	// The manifest declares the OCI media type; it is pushed under the Docker one.
+	sig := referrerManifest(cosignSigArtifactType, subjectDigest)
+	pushManifestWithContentType(t, r, "oci-hosted", "charts/nginx", "sig", sig,
+		"application/vnd.docker.distribution.manifest.v2+json")
+
+	_, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Len(t, descs, 1)
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", descs[0].MediaType,
+		"the manifest's own mediaType wins over the Content-Type it was pushed under")
+}
+
+func TestReferrers_MediaTypeFallsBackToContentType(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+
+	// A manifest carrying no mediaType of its own — legal, and what an OCI 1.0
+	// producer emits. The only thing left to name it is the Content-Type.
+	noMediaType := fmt.Sprintf(`{
+  "schemaVersion": 2,
+  "artifactType": %q,
+  "config": {"mediaType": "application/vnd.oci.empty.v1+json", "digest": "sha256:ee", "size": 2},
+  "layers": [],
+  "subject": {"digest": %q, "size": 100}
+}`, cosignSigArtifactType, subjectDigest)
+	pushManifestWithContentType(t, r, "oci-hosted", "charts/nginx", "sig", noMediaType,
+		"application/vnd.docker.distribution.manifest.v2+json")
+
+	_, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Len(t, descs, 1)
+	assert.Equal(t, "application/vnd.docker.distribution.manifest.v2+json", descs[0].MediaType,
+		"with no mediaType in the manifest the stored Content-Type is what names it")
+}
+
+// pushManifestWithContentType pushes a manifest under a Content-Type that need
+// not match the manifest's own mediaType.
+func pushManifestWithContentType(t *testing.T, r *gin.Engine, repoName, imageName, reference, body, contentType string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/"+repoName+"/v2/"+imageName+"/manifests/"+reference, strings.NewReader(body))
+	req.Header.Set("Content-Type", contentType)
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "manifest push should succeed")
+}
+
 // An asset lookup that fails is not a referrer that does not exist. Dropping it
 // from the index and still answering 200 is the same under-report the proxy path
 // refuses to produce: the client would read a database blip as "unsigned".
@@ -667,6 +794,12 @@ func requireProxyFailure(t *testing.T, w *httptest.ResponseRecorder, disp *recor
 	require.Len(t, disp.events, 1, "the failure must be recorded for the operator, not only returned")
 	assert.Equal(t, domain.EventProxyError, disp.events[0].Event)
 	assert.Equal(t, "oci-proxy", disp.events[0].Repository)
+
+	// The payload's "path" is the repository-relative side, as every other
+	// DispatchProxyError caller reports; the upstream side has its own key. A
+	// caller that mixed the two would make "path" mean one thing per caller.
+	assert.Equal(t, "/referrers/charts/nginx/"+digest("subject"), disp.events[0].Asset["path"],
+		"the recorded path is the one the client asked for, not the upstream path")
 }
 
 // A 401 from upstream means "I could not check", which is a different fact from

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -2,6 +2,7 @@ package oci_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -443,6 +444,44 @@ func TestReferrers_ProxyTruncatedBodyIsBadGateway(t *testing.T) {
 	requireProxyFailure(t, w, disp, "UNKNOWN")
 	assert.Contains(t, w.Body.String(), "could not be read whole",
 		"the truncated-read branch is what must be exercised here, not the shape check")
+}
+
+// A repository lookup that fails must not be read as "no such repository". On a
+// proxy that silently downgrades the request to the local cache — a 200
+// under-report reached without touching the network, which is the exact failure
+// the proxy branch exists to prevent.
+func TestReferrers_RepositoryLookupErrorIsBadGateway(t *testing.T) {
+	repos := testutil.NewRepoRepo(proxyOCIRepo("r2", "oci-proxy", "http://127.0.0.1:1"))
+	d := formats.Deps{
+		Repos:      repos,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+
+	repos.Err = errors.New("connection to the database was lost")
+
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	require.Equal(t, http.StatusBadGateway, w.Code,
+		"a lookup failure is not the same fact as 'this subject has no referrers'")
+	assert.NotContains(t, w.Body.String(), `"manifests"`,
+		"a lookup failure must never be dressed up as an index")
+}
+
+// A repository that is genuinely absent is still not an error: the hosted path
+// answers an empty index for it, exactly as before.
+func TestReferrers_UnknownRepositoryStillAnswersEmptyIndex(t *testing.T) {
+	r, _ := setupWithDeps(hostedOCIRepo("r1", "oci-hosted"))
+
+	// The router accepts any repoName; the repository simply does not exist.
+	w, _, descs := getReferrers(t, r, "no-such-repo", "charts/nginx", digest("subject"), "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, descs)
 }
 
 // ─── Proxy failures the client must be able to distinguish ─────────────────

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -1,0 +1,238 @@
+package oci_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+const (
+	cosignSigArtifactType = "application/vnd.dev.cosign.artifact.sig.v1+json"
+	sbomArtifactType      = "application/spdx+json"
+	ociIndexMediaType     = "application/vnd.oci.image.index.v1+json"
+)
+
+// referrerManifest is a manifest that points at another one through its subject
+// descriptor — how cosign attaches a signature and how an SBOM attaches to a chart.
+func referrerManifest(artifactType, subjectDigest string) string {
+	return fmt.Sprintf(`{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": %q,
+  "config": {"mediaType": "application/vnd.oci.empty.v1+json", "digest": "sha256:ee", "size": 2},
+  "layers": [{"mediaType": "application/octet-stream", "digest": "sha256:ff", "size": 7}],
+  "subject": {"mediaType": "application/vnd.oci.image.manifest.v1+json", "digest": %q, "size": 100},
+  "annotations": {"org.opencontainers.image.created": "2026-08-04T00:00:00Z"}
+}`, artifactType, subjectDigest)
+}
+
+// pushManifestBody pushes one manifest and returns its digest.
+func pushManifestBody(t *testing.T, r *gin.Engine, repoName, imageName, reference, body string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/"+repoName+"/v2/"+imageName+"/manifests/"+reference, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "manifest push should succeed")
+	dgst := w.Header().Get("Docker-Content-Digest")
+	require.Equal(t, digest(body), dgst)
+	return dgst
+}
+
+// referrersIndex is the decoded referrers response.
+type referrersIndex struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	MediaType     string          `json:"mediaType"`
+	Manifests     json.RawMessage `json:"manifests"`
+}
+
+type referrersDescriptor struct {
+	MediaType    string            `json:"mediaType"`
+	Digest       string            `json:"digest"`
+	Size         int64             `json:"size"`
+	ArtifactType string            `json:"artifactType"`
+	Annotations  map[string]string `json:"annotations"`
+}
+
+// getReferrers issues GET /v2/<image>/referrers/<digest> and decodes the index.
+func getReferrers(t *testing.T, r *gin.Engine, repoName, imageName, subjectDigest, query string) (*httptest.ResponseRecorder, referrersIndex, []referrersDescriptor) {
+	t.Helper()
+	url := "/repository/" + repoName + "/v2/" + imageName + "/referrers/" + subjectDigest + query
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		return w, referrersIndex{}, nil
+	}
+	var idx referrersIndex
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &idx), "response should be an image index")
+	var descs []referrersDescriptor
+	require.NoError(t, json.Unmarshal(idx.Manifests, &descs))
+	return w, idx, descs
+}
+
+func hostedOCIRepo(id, name string) *domain.Repository {
+	return &domain.Repository{
+		ID: id, Name: name, Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true,
+	}
+}
+
+// A cosign signature attached to a pushed image must be discoverable through the
+// referrers API of the repository that holds it.
+func TestReferrers_FindsSignatureBySubjectDigest(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+
+	sig := referrerManifest(cosignSigArtifactType, subjectDigest)
+	sigTag := strings.Replace(subjectDigest, ":", "-", 1) + ".sig"
+	sigDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", sigTag, sig)
+
+	w, idx, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, ociIndexMediaType, w.Header().Get("Content-Type"))
+	assert.Equal(t, 2, idx.SchemaVersion)
+	assert.Equal(t, ociIndexMediaType, idx.MediaType)
+
+	require.Len(t, descs, 1, "exactly one referrer")
+	got := descs[0]
+	assert.Equal(t, cosignSigArtifactType, got.ArtifactType)
+	assert.Equal(t, sigDigest, got.Digest, "the descriptor names the referrer's own manifest")
+	assert.Equal(t, int64(len(sig)), got.Size)
+	assert.Positive(t, got.Size)
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", got.MediaType)
+	assert.Equal(t, "2026-08-04T00:00:00Z", got.Annotations["org.opencontainers.image.created"])
+}
+
+// An unknown subject yields an empty index, never a 404: a 404 reads as "this
+// registry has no referrers API" and sends cosign down a fallback path.
+func TestReferrers_UnknownSubjectIsEmptyIndexNotNotFound(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	unknown := digest("nothing was ever pushed under this digest")
+	w, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", unknown, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, descs)
+
+	// A JSON null for manifests breaks clients that range over the list, so the
+	// exact serialization matters, not just the decoded value.
+	assert.JSONEq(t,
+		`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`,
+		w.Body.String())
+	assert.Contains(t, w.Body.String(), `"manifests":[]`, "manifests must be [] and not null")
+	assert.NotContains(t, w.Body.String(), `"manifests":null`)
+}
+
+// artifactType selects one kind of referrer and must be announced back to the
+// client, so it can tell a filtered answer from a complete one.
+func TestReferrers_FiltersByArtifactType(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+
+	sig := referrerManifest(cosignSigArtifactType, subjectDigest)
+	sigDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "sig", sig)
+	sbom := referrerManifest(sbomArtifactType, subjectDigest)
+	sbomDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "sbom", sbom)
+	require.NotEqual(t, sigDigest, sbomDigest)
+
+	// Unfiltered: both, and no filter header.
+	w, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, descs, 2)
+	assert.Empty(t, w.Header().Get("OCI-Filters-Applied"),
+		"an unfiltered answer must not claim a filter was applied")
+
+	// Filtered: only the signature, and the header says so. The value is escaped
+	// as a real client escapes it — a raw "+" in a query string decodes to a
+	// space, and every media type here contains one.
+	w2, _, filtered := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest,
+		"?artifactType="+url.QueryEscape(cosignSigArtifactType))
+	require.Equal(t, http.StatusOK, w2.Code)
+	require.Len(t, filtered, 1)
+	assert.Equal(t, cosignSigArtifactType, filtered[0].ArtifactType)
+	assert.Equal(t, sigDigest, filtered[0].Digest)
+	assert.Equal(t, "artifactType", w2.Header().Get("OCI-Filters-Applied"))
+
+	// A filter nothing matches is still an empty index, not the unfiltered list.
+	w3, _, none := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest,
+		"?artifactType="+url.QueryEscape("application/vnd.example.nothing"))
+	require.Equal(t, http.StatusOK, w3.Code)
+	assert.Empty(t, none)
+	assert.Equal(t, "artifactType", w3.Header().Get("OCI-Filters-Applied"))
+}
+
+// A manifest pushed by tag also gets a digest-alias component, and phase 1 puts
+// the same oci_subject on both. The index must name the manifest once.
+func TestReferrers_DeduplicatesTagAndDigestAlias(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, d := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+	sig := referrerManifest(cosignSigArtifactType, subjectDigest)
+	sigTag := strings.Replace(subjectDigest, ":", "-", 1) + ".sig"
+	sigDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", sigTag, sig)
+
+	// Both components really exist and both really carry the subject — otherwise
+	// this test would pass without any deduplication at all.
+	requireSubject(t, d, "oci-hosted", "charts/nginx", sigTag, subjectDigest)
+	requireSubject(t, d, "oci-hosted", "charts/nginx", sigDigest, subjectDigest)
+
+	w, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, descs, 1, "the tag component and its digest alias are one manifest")
+	assert.Equal(t, sigDigest, descs[0].Digest)
+}
+
+// requireSubject asserts the stored component carries oci_subject.
+func requireSubject(t *testing.T, d formats.Deps, repoName, name, version, subjectDigest string) {
+	t.Helper()
+	comp := componentOf(t, d, repoName, name, version)
+	require.Equal(t, subjectDigest, comp.Extra["oci_subject"],
+		"component %s:%s should carry the subject", name, version)
+}
+
+// The referrers dispatch must not swallow requests for an image whose own name
+// ends in "referrers": /v2/lib/referrers/manifests/1.0.0 is a manifest push.
+func TestReferrers_DoesNotSwallowImageNamedReferrers(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	pushManifestBody(t, r, "oci-hosted", "lib/referrers", "1.0.0", helmChartManifest)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/oci-hosted/v2/lib/referrers/manifests/1.0.0", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "a manifest GET under such a name must still route to manifests")
+	assert.Equal(t, helmChartManifest, w.Body.String())
+}
+
+// Only GET (and HEAD, which gin serves through the same handler) reads referrers;
+// a write verb is not part of the API.
+func TestReferrers_RejectsNonGET(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/oci-hosted/v2/charts/nginx/referrers/"+digest("x"), strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -324,6 +324,51 @@ func TestReferrers_ProxyForwardsArtifactTypeFilter(t *testing.T) {
 		"the upstream's filter announcement must reach the client")
 }
 
+// This endpoint does not implement pagination: it never relays the spec's
+// Link: <...>; rel="next" continuation. Forwarding the client's "n" would
+// therefore fetch page one from a paginating upstream and hand the client a
+// truncated list it would read as complete — the under-report this whole
+// endpoint is built to avoid. "n" and "last" are dropped so the upstream
+// answers in full; only artifactType goes through.
+func TestReferrers_ProxyDropsPaginationItCannotHonor(t *testing.T) {
+	var gotQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", ociIndexMediaType)
+		w.Header().Set("Link", `</v2/charts/nginx/referrers/sha256:abc?n=1&last=x>; rel="next"`)
+		_, _ = w.Write([]byte(upstreamReferrersIndex))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"),
+		"?n=1&artifactType="+url.QueryEscape(cosignSigArtifactType)+"&last=sha256:abc")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "artifactType="+url.QueryEscape(cosignSigArtifactType), gotQuery,
+		"only artifactType may reach the upstream; n and last would truncate the list")
+	require.Len(t, descs, 1)
+	assert.Empty(t, w.Header().Get("Link"),
+		"a continuation this endpoint cannot serve must not be advertised to the client")
+}
+
+// A request with no artifactType sends no query at all.
+func TestReferrers_ProxyDropsPaginationWithoutFilter(t *testing.T) {
+	gotQuery := "unset"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", ociIndexMediaType)
+		_, _ = w.Write([]byte(upstreamReferrersIndex))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w, _, _ := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "?n=10&last=sha256:abc")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, gotQuery, "pagination alone must leave nothing to forward")
+}
+
 // An upstream with no referrers API answers 404. That is not an error to relay:
 // a client asking "is this signed" needs a definite empty answer.
 func TestReferrers_ProxyUpstreamWithoutEndpointIsEmptyIndex(t *testing.T) {

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -15,6 +16,9 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
 const (
@@ -347,6 +351,167 @@ func TestReferrers_ProxyUnreachableUpstreamIsEmptyIndex(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code)
 	assert.Empty(t, descs)
 	assert.JSONEq(t, emptyIndexJSON, w.Body.String())
+}
+
+// ─── Proxy failures the client must be able to distinguish ─────────────────
+
+// recordingDispatcher captures the proxy_error events the handler emits — the
+// only reporting channel a format handler has (formats.Deps carries no logger).
+type recordingDispatcher struct {
+	events []domain.WebhookPayload
+}
+
+func (r *recordingDispatcher) Dispatch(p domain.WebhookPayload) { r.events = append(r.events, p) }
+
+// setupWithWebhooks is setupWithDeps with a webhook dispatcher installed, so a
+// test can assert the operator-facing record of an upstream failure.
+func setupWithWebhooks(repo *domain.Repository, disp domain.WebhookDispatcher) *gin.Engine {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+		Webhooks:   disp,
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+// ociErrors is the OCI error document shape.
+type ociErrors struct {
+	Errors []struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+// requireUpstreamAuthRelayed asserts the response is a 502 naming the upstream
+// refusal, and that an empty index was NOT what the client got.
+func requireUpstreamAuthRelayed(t *testing.T, w *httptest.ResponseRecorder, wantCode string, wantStatus int) {
+	t.Helper()
+	require.Equal(t, http.StatusBadGateway, w.Code,
+		"an upstream refusal is not the same fact as 'this subject has no referrers'")
+	assert.NotContains(t, w.Body.String(), `"manifests"`,
+		"a refusal must never be dressed up as an index")
+	var doc ociErrors
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc), "response should be an OCI error document")
+	require.Len(t, doc.Errors, 1)
+	assert.Equal(t, wantCode, doc.Errors[0].Code)
+	assert.Contains(t, doc.Errors[0].Message, strconv.Itoa(wantStatus),
+		"the message must name the upstream status so an operator can see it is a credentials problem")
+}
+
+// A 401 from upstream means "I could not check", which is a different fact from
+// "there is nothing to check". Reporting it as an empty index would let a policy
+// gate read a misconfigured proxy as proof that an image is unsigned.
+func TestReferrers_ProxyUpstream401IsBadGatewayNotEmptyIndex(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer upstream.Close()
+
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", upstream.URL), disp)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/oci-proxy/v2/charts/nginx/referrers/"+digest("subject"), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	requireUpstreamAuthRelayed(t, w, "UNAUTHORIZED", http.StatusUnauthorized)
+	require.Len(t, disp.events, 1, "the failure must be recorded for the operator, not only returned")
+	assert.Equal(t, domain.EventProxyError, disp.events[0].Event)
+	assert.Equal(t, "oci-proxy", disp.events[0].Repository)
+}
+
+// A 403 is the same class of fact as a 401 — the proxy was not allowed to look —
+// and carries the OCI code for a denied request.
+func TestReferrers_ProxyUpstream403IsBadGatewayNotEmptyIndex(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer upstream.Close()
+
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", upstream.URL), disp)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/oci-proxy/v2/charts/nginx/referrers/"+digest("subject"), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	requireUpstreamAuthRelayed(t, w, "DENIED", http.StatusForbidden)
+	require.Len(t, disp.events, 1)
+	assert.Equal(t, domain.EventProxyError, disp.events[0].Event)
+}
+
+// An index too large to read is a truncated list, and a truncated list read as
+// complete is the same unsafe direction as the auth case: it can only ever
+// under-report referrers. It must be an error, never a short answer.
+func TestReferrers_ProxyOversizedUpstreamIndexIsBadGateway(t *testing.T) {
+	// A single valid descriptor padded past the cap: a legitimately huge index,
+	// not garbage, so the size limit is what is under test and nothing else.
+	huge := `{"schemaVersion":2,"mediaType":"` + ociIndexMediaType + `","manifests":[` +
+		`{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + upstreamSigDigest +
+		`","size":419,"annotations":{"pad":"` + strings.Repeat("x", 17<<20) + `"}}]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", ociIndexMediaType)
+		_, _ = w.Write([]byte(huge))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/oci-proxy/v2/charts/nginx/referrers/"+digest("subject"), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadGateway, w.Code,
+		"a list too large to read whole must not be served as if it were complete")
+	assert.NotContains(t, w.Body.String(), `"manifests":[]`)
+}
+
+// A 200 carrying something that is not an index — a captive portal's HTML, an
+// error page — is no referrers information, which is a fact a client can act on.
+func TestReferrers_ProxyNonIndexBodyIsEmptyIndex(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body>Sign in to your network</body></html>`))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, descs)
+	assert.JSONEq(t, emptyIndexJSON, w.Body.String())
+	assert.Equal(t, ociIndexMediaType, w.Header().Get("Content-Type"),
+		"upstream HTML must never reach the client under an index content type")
+}
+
+// A 500 from upstream is not an auth failure and keeps the specified behavior.
+func TestReferrers_ProxyUpstreamServerErrorIsEmptyIndex(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, descs)
 }
 
 // Only GET (and HEAD, which gin serves through the same handler) reads referrers;

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -224,6 +224,131 @@ func TestReferrers_DoesNotSwallowImageNamedReferrers(t *testing.T) {
 	assert.Equal(t, helmChartManifest, w.Body.String())
 }
 
+// ─── Proxy repositories ────────────────────────────────────────────────────
+
+// proxyOCIRepo is an OCI proxy repository pointed at the given upstream base.
+func proxyOCIRepo(id, name, remote string) *domain.Repository {
+	return &domain.Repository{
+		ID: id, Name: name, Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": remote},
+	}
+}
+
+// upstreamSigDigest is the digest an upstream registry reports for the signature
+// attached to the subject — a manifest this proxy has never cached.
+const upstreamSigDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+// upstreamReferrersIndex is what a real upstream returns from its referrers API.
+const upstreamReferrersIndex = `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "size": 419,
+      "artifactType": "application/vnd.dev.cosign.artifact.sig.v1+json",
+      "annotations": {"org.opencontainers.image.created": "2026-08-01T00:00:00Z"}
+    }
+  ]
+}`
+
+const emptyIndexJSON = `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[]}`
+
+// A proxy repository must answer from the upstream, not from whichever referring
+// manifests happen to sit in its cache: an under-reported index reads to cosign
+// as "this image is unsigned", which is worse than no answer at all.
+func TestReferrers_ProxyForwardsUpstreamIndex(t *testing.T) {
+	subject := digest("an image manifest that lives upstream")
+	var gotPath, gotQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotQuery = r.URL.Path, r.URL.RawQuery
+		if r.URL.Path != "/v2/charts/nginx/referrers/"+subject {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", ociIndexMediaType)
+		_, _ = w.Write([]byte(upstreamReferrersIndex))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w, idx, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", subject, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "/v2/charts/nginx/referrers/"+subject, gotPath,
+		"the upstream referrers endpoint must be asked, unescaped")
+	assert.Empty(t, gotQuery)
+	assert.Equal(t, ociIndexMediaType, w.Header().Get("Content-Type"))
+	assert.Equal(t, ociIndexMediaType, idx.MediaType)
+	require.Len(t, descs, 1, "the upstream's referrer must reach the client")
+	assert.Equal(t, upstreamSigDigest, descs[0].Digest)
+	assert.Equal(t, cosignSigArtifactType, descs[0].ArtifactType)
+	assert.JSONEq(t, upstreamReferrersIndex, w.Body.String(), "the index is passed through verbatim")
+}
+
+// artifactType must reach the upstream, and the upstream's OCI-Filters-Applied
+// must reach the client: without the header a client cannot tell a filtered list
+// from a complete one, and the filter itself would silently be ignored.
+func TestReferrers_ProxyForwardsArtifactTypeFilter(t *testing.T) {
+	subject := digest("an image manifest that lives upstream")
+	var gotQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", ociIndexMediaType)
+		if r.URL.Query().Get("artifactType") == cosignSigArtifactType {
+			w.Header().Set("OCI-Filters-Applied", "artifactType")
+			_, _ = w.Write([]byte(upstreamReferrersIndex))
+			return
+		}
+		_, _ = w.Write([]byte(emptyIndexJSON))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", subject,
+		"?artifactType="+url.QueryEscape(cosignSigArtifactType))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "artifactType="+url.QueryEscape(cosignSigArtifactType), gotQuery,
+		"the filter must reach the upstream unmangled")
+	require.Len(t, descs, 1)
+	assert.Equal(t, "artifactType", w.Header().Get("OCI-Filters-Applied"),
+		"the upstream's filter announcement must reach the client")
+}
+
+// An upstream with no referrers API answers 404. That is not an error to relay:
+// a client asking "is this signed" needs a definite empty answer.
+func TestReferrers_ProxyUpstreamWithoutEndpointIsEmptyIndex(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, descs)
+	assert.JSONEq(t, emptyIndexJSON, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"manifests":[]`, "manifests must be [] and not null")
+}
+
+// An unreachable upstream must not become a 500: a signature-checking client
+// cannot interpret a proxy's connectivity failure, so it gets an empty index.
+func TestReferrers_ProxyUnreachableUpstreamIsEmptyIndex(t *testing.T) {
+	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	remote := closed.URL
+	closed.Close() // nothing listens on this port any more
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", remote))
+
+	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, descs)
+	assert.JSONEq(t, emptyIndexJSON, w.Body.String())
+}
+
 // Only GET (and HEAD, which gin serves through the same handler) reads referrers;
 // a write verb is not part of the API.
 func TestReferrers_RejectsNonGET(t *testing.T) {

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -3,6 +3,8 @@ package oci_test
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -338,19 +340,109 @@ func TestReferrers_ProxyUpstreamWithoutEndpointIsEmptyIndex(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"manifests":[]`, "manifests must be [] and not null")
 }
 
-// An unreachable upstream must not become a 500: a signature-checking client
-// cannot interpret a proxy's connectivity failure, so it gets an empty index.
-func TestReferrers_ProxyUnreachableUpstreamIsEmptyIndex(t *testing.T) {
+// An upstream that does not implement the endpoint may say so with 405 or 501
+// as well as 404. Those three are the only statuses that mean "no referrers
+// information here" rather than "I could not look".
+func TestReferrers_ProxyUpstreamMethodNotAllowedAndNotImplementedAreEmptyIndex(t *testing.T) {
+	for _, status := range []int{http.StatusMethodNotAllowed, http.StatusNotImplemented} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(status)
+			}))
+			defer upstream.Close()
+
+			r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+			w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
+			require.Equal(t, http.StatusOK, w.Code)
+			assert.Empty(t, descs)
+			assert.JSONEq(t, emptyIndexJSON, w.Body.String())
+		})
+	}
+}
+
+// An unreachable upstream is "I could not check", not "there is nothing to
+// check": answering an empty index would let a policy gate read a DNS failure,
+// a refused connection or a TLS error as proof that an image is unsigned.
+func TestReferrers_ProxyUnreachableUpstreamIsBadGateway(t *testing.T) {
 	closed := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
 	remote := closed.URL
 	closed.Close() // nothing listens on this port any more
 
-	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", remote))
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", remote), disp)
 
-	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
-	require.Equal(t, http.StatusOK, w.Code)
-	assert.Empty(t, descs)
-	assert.JSONEq(t, emptyIndexJSON, w.Body.String())
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	requireProxyFailure(t, w, disp, "UNKNOWN")
+}
+
+// A misconfigured proxy_config never reaches the network at all, and that is
+// the same fact as an unreachable host: not an absence of referrers.
+func TestReferrers_ProxyMisconfiguredRemoteURLIsBadGateway(t *testing.T) {
+	repo := &domain.Repository{
+		ID: "r2", Name: "oci-proxy", Format: domain.FormatOCI, Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{}, // no remote_url: RemoteURL fails before any fetch
+	}
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(repo, disp)
+
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	requireProxyFailure(t, w, disp, "UNKNOWN")
+}
+
+// A rate-limited upstream told us to come back later; it did not tell us the
+// subject has no referrers.
+func TestReferrers_ProxyUpstreamTooManyRequestsIsBadGateway(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer upstream.Close()
+
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", upstream.URL), disp)
+
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	requireProxyFailure(t, w, disp, "TOOMANYREQUESTS")
+}
+
+// A 503 is an upstream that is temporarily broken, which is a failure to look
+// and must never be flattened into "nothing to find".
+func TestReferrers_ProxyUpstreamUnavailableIsBadGateway(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer upstream.Close()
+
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", upstream.URL), disp)
+
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	requireProxyFailure(t, w, disp, "UNKNOWN")
+}
+
+// A body that dies mid-read is a truncated list, which can only under-report.
+func TestReferrers_ProxyTruncatedBodyIsBadGateway(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", ociIndexMediaType)
+		// A Content-Length longer than what is written, then a hang-up: the read
+		// fails with an unexpected EOF part way through the index.
+		w.Header().Set("Content-Length", strconv.Itoa(len(upstreamReferrersIndex)+512))
+		_, _ = w.Write([]byte(upstreamReferrersIndex[:40]))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		panic(http.ErrAbortHandler) // drop the connection mid-body
+	}))
+	defer upstream.Close()
+	upstream.Config.ErrorLog = quietLogger()
+
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", upstream.URL), disp)
+
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	requireProxyFailure(t, w, disp, "UNKNOWN")
+	assert.Contains(t, w.Body.String(), "could not be read whole",
+		"the truncated-read branch is what must be exercised here, not the shape check")
 }
 
 // ─── Proxy failures the client must be able to distinguish ─────────────────
@@ -408,6 +500,39 @@ func requireUpstreamAuthRelayed(t *testing.T, w *httptest.ResponseRecorder, want
 	assert.Equal(t, wantCode, doc.Errors[0].Code)
 	assert.Contains(t, doc.Errors[0].Message, strconv.Itoa(wantStatus),
 		"the message must name the upstream status so an operator can see it is a credentials problem")
+}
+
+// doReferrers issues the referrers GET without decoding the body, for the cases
+// where the answer is expected not to be an index at all.
+func doReferrers(r *gin.Engine, repoName, imageName, subjectDigest, query string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/"+repoName+"/v2/"+imageName+"/referrers/"+subjectDigest+query, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// quietLogger keeps a deliberately aborted upstream handler from writing a panic
+// trace to the test output; the abort is the fixture, not a failure.
+func quietLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+// requireProxyFailure asserts the client got a 502 in the OCI error shape rather
+// than an index, and that the operator got a proxy_error event for it. "I could
+// not check" must never be reported as "there is nothing to check".
+func requireProxyFailure(t *testing.T, w *httptest.ResponseRecorder, disp *recordingDispatcher, wantCode string) {
+	t.Helper()
+	require.Equal(t, http.StatusBadGateway, w.Code,
+		"a failure to reach a usable upstream answer is not the same fact as 'this subject has no referrers'")
+	assert.NotContains(t, w.Body.String(), `"manifests"`,
+		"a failure must never be dressed up as an index")
+	var doc ociErrors
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc), "response should be an OCI error document")
+	require.Len(t, doc.Errors, 1)
+	assert.Equal(t, wantCode, doc.Errors[0].Code)
+	assert.NotEmpty(t, doc.Errors[0].Message)
+	require.Len(t, disp.events, 1, "the failure must be recorded for the operator, not only returned")
+	assert.Equal(t, domain.EventProxyError, disp.events[0].Event)
+	assert.Equal(t, "oci-proxy", disp.events[0].Repository)
 }
 
 // A 401 from upstream means "I could not check", which is a different fact from
@@ -482,36 +607,36 @@ func TestReferrers_ProxyOversizedUpstreamIndexIsBadGateway(t *testing.T) {
 }
 
 // A 200 carrying something that is not an index — a captive portal's HTML, an
-// error page — is no referrers information, which is a fact a client can act on.
-func TestReferrers_ProxyNonIndexBodyIsEmptyIndex(t *testing.T) {
+// error page — means we never reached a registry, so we know nothing about this
+// subject's referrers and must not claim it has none.
+func TestReferrers_ProxyNonIndexBodyIsBadGateway(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		_, _ = w.Write([]byte(`<html><body>Sign in to your network</body></html>`))
 	}))
 	defer upstream.Close()
 
-	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", upstream.URL), disp)
 
-	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
-	require.Equal(t, http.StatusOK, w.Code)
-	assert.Empty(t, descs)
-	assert.JSONEq(t, emptyIndexJSON, w.Body.String())
-	assert.Equal(t, ociIndexMediaType, w.Header().Get("Content-Type"),
-		"upstream HTML must never reach the client under an index content type")
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	requireProxyFailure(t, w, disp, "UNKNOWN")
+	assert.NotContains(t, w.Body.String(), "Sign in to your network",
+		"upstream HTML must never reach the client")
 }
 
-// A 500 from upstream is not an auth failure and keeps the specified behavior.
-func TestReferrers_ProxyUpstreamServerErrorIsEmptyIndex(t *testing.T) {
+// A 500 from upstream is a failure to look, not an answer.
+func TestReferrers_ProxyUpstreamServerErrorIsBadGateway(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer upstream.Close()
 
-	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+	disp := &recordingDispatcher{}
+	r := setupWithWebhooks(proxyOCIRepo("r2", "oci-proxy", upstream.URL), disp)
 
-	w, _, descs := getReferrers(t, r, "oci-proxy", "charts/nginx", digest("subject"), "")
-	require.Equal(t, http.StatusOK, w.Code)
-	assert.Empty(t, descs)
+	w := doReferrers(r, "oci-proxy", "charts/nginx", digest("subject"), "")
+	requireProxyFailure(t, w, disp, "UNKNOWN")
 }
 
 // Only GET (and HEAD, which gin serves through the same handler) reads referrers;

--- a/internal/formats/oci/referrers_test.go
+++ b/internal/formats/oci/referrers_test.go
@@ -1,6 +1,7 @@
 package oci_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -229,6 +230,55 @@ func TestReferrers_DoesNotSwallowImageNamedReferrers(t *testing.T) {
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code, "a manifest GET under such a name must still route to manifests")
 	assert.Equal(t, helmChartManifest, w.Body.String())
+}
+
+// An asset lookup that fails is not a referrer that does not exist. Dropping it
+// from the index and still answering 200 is the same under-report the proxy path
+// refuses to produce: the client would read a database blip as "unsigned".
+func TestReferrers_AssetLookupErrorIsBadGateway(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, d := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+	pushManifestBody(t, r, "oci-hosted", "charts/nginx", "sig",
+		referrerManifest(cosignSigArtifactType, subjectDigest))
+
+	// The referrer is really there — without this the test would pass on an
+	// empty result rather than on the error branch.
+	w, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, descs, 1)
+
+	assets, ok := d.Assets.(*testutil.AssetRepo)
+	require.True(t, ok)
+	assets.GetByPathErr = errors.New("connection to the database was lost")
+
+	w2 := doReferrers(r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Equal(t, http.StatusBadGateway, w2.Code,
+		"a lookup that failed is not a referrer that does not exist")
+	assert.NotContains(t, w2.Body.String(), `"manifests"`,
+		"a lookup failure must never be dressed up as an index")
+}
+
+// A referrer whose manifest asset is genuinely gone is still skipped: the
+// component outlived its asset, and there is nothing to name in the index.
+func TestReferrers_MissingAssetIsSkippedNotAnError(t *testing.T) {
+	repo := hostedOCIRepo("r1", "oci-hosted")
+	r, d := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+	pushManifestBody(t, r, "oci-hosted", "charts/nginx", "sig",
+		referrerManifest(cosignSigArtifactType, subjectDigest))
+
+	// A component pointing at a manifest path that was never stored.
+	require.NoError(t, d.Components.Create(context.Background(), &domain.Component{
+		RepositoryID: "r1", Repository: "oci-hosted", Format: "oci", Name: "charts/nginx", Version: "vanished",
+		Extra: map[string]any{"oci_subject": subjectDigest},
+	}))
+
+	w, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Len(t, descs, 1, "the referrer with an asset is listed; the one without is skipped")
 }
 
 // ─── Proxy repositories ────────────────────────────────────────────────────

--- a/internal/formats/repoproxy/coverage_extra_test.go
+++ b/internal/formats/repoproxy/coverage_extra_test.go
@@ -3,6 +3,7 @@ package repoproxy
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -98,5 +99,35 @@ func TestBuildProxyClient_Modes(t *testing.T) {
 	// no_proxy honored (client still builds)
 	if _, err := buildProxyClient(proxySettings{httpProxy: "http://127.0.0.1:3128", noProxy: "example.com"}); err != nil {
 		t.Fatalf("no_proxy client: %v", err)
+	}
+}
+
+// A Docker Hub pull needs a Bearer token scoped to the repository, and the scope
+// is derived from the request path when the 401 challenge does not carry one. The
+// splitter recognized only "blobs" and "manifests", so a referrers request
+// yielded an empty scope, no token was fetched, and the request was retried
+// anonymously — which Hub answers with another 401. That reads at the referrers
+// endpoint as an upstream refusal for a repository the proxy can otherwise pull.
+func TestScopeFromRegistryV2URL_Endpoints(t *testing.T) {
+	cases := map[string]string{
+		"/v2/library/nginx/manifests/latest":     "repository:library/nginx:pull",
+		"/v2/library/nginx/blobs/sha256:abc":     "repository:library/nginx:pull",
+		"/v2/library/nginx/referrers/sha256:abc": "repository:library/nginx:pull",
+		"/v2/nginx/referrers/sha256:abc":         "repository:nginx:pull",
+		"/v2/Library/NGINX/referrers/sha256:abc": "repository:library/nginx:pull",
+		// No endpoint keyword at all, and the keyword in first position (which
+		// would leave an empty repository name): neither yields a scope.
+		"/v2/library/nginx/tags/list":            "",
+		"/v2/referrers/sha256:abc":               "",
+		"/v1/library/nginx/referrers/sha256:abc": "",
+	}
+	for path, want := range cases {
+		u, err := url.Parse("https://registry-1.docker.io" + path)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		if got := scopeFromRegistryV2URL(u); got != want {
+			t.Errorf("scopeFromRegistryV2URL(%s) = %q, want %q", path, got, want)
+		}
 	}
 }

--- a/internal/formats/repoproxy/docker_registry_token.go
+++ b/internal/formats/repoproxy/docker_registry_token.go
@@ -57,7 +57,14 @@ func parseDockerBearerChallenge(h http.Header) (realm, service, scope string, ok
 	return "", "", "", false
 }
 
-// scopeFromRegistryV2URL builds "repository:<name>:pull" from a registry URL path /v2/<name>/manifests/... or /v2/<name>/blobs/...
+// scopeFromRegistryV2URL builds "repository:<name>:pull" from a registry URL
+// path /v2/<name>/manifests/..., /v2/<name>/blobs/... or
+// /v2/<name>/referrers/....
+//
+// referrers belongs here for the same reason the other two do: without a scope
+// no Bearer token is fetched and the request is retried anonymously, which Hub
+// answers with another 401 — and at the referrers endpoint that reads as an
+// upstream refusal for a repository the proxy can otherwise pull.
 func scopeFromRegistryV2URL(u *url.URL) string {
 	p := u.Path
 	if !strings.HasPrefix(p, "/v2/") {
@@ -70,7 +77,7 @@ func scopeFromRegistryV2URL(u *url.URL) string {
 	parts := strings.Split(rest, "/")
 	split := -1
 	for i, seg := range parts {
-		if seg == "blobs" || seg == "manifests" {
+		if seg == "blobs" || seg == "manifests" || seg == "referrers" {
 			split = i
 			break
 		}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -586,7 +586,14 @@ func storeOriginal(ctx context.Context, c *gin.Context, d formats.Deps, repo *do
 // Exported because format handlers that talk upstream outside ServeGET — the OCI
 // referrers endpoint, for one — must report a failure the same way; formats.Deps
 // carries no logger, so this bus is the only operator-facing channel they have.
-func DispatchProxyError(d formats.Deps, repoName, repoRelativePath, upstream string, cause error) {
+//
+// path is the path on THIS side: the repository-relative path the client asked
+// for, which for a cached artifact is also its asset path and cache key. It is
+// not the upstream path — the upstream side of the request is the separate
+// upstream argument, which carries the full URL actually requested. Every caller
+// must pass the same side, or the payload's "path" key would mean one thing per
+// caller and be unreadable to whoever consumes the webhook.
+func DispatchProxyError(d formats.Deps, repoName, path, upstream string, cause error) {
 	if d.Webhooks == nil {
 		return
 	}
@@ -595,7 +602,7 @@ func DispatchProxyError(d formats.Deps, repoName, repoRelativePath, upstream str
 		Timestamp:  time.Now(),
 		Repository: repoName,
 		Asset: map[string]any{
-			"path":     repoRelativePath,
+			"path":     path,
 			"upstream": upstream,
 			"error":    cause.Error(),
 		},

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -237,6 +237,32 @@ func serveCachedAsset(c *gin.Context, d formats.Deps, asset *domain.Asset, rc io
 	c.DataFromReader(http.StatusOK, asset.SizeBytes, asset.ContentType, rc, nil)
 }
 
+// FetchUpstreamOnce performs a single upstream GET and returns the raw response
+// without caching anything. It exists for computed registry endpoints — the
+// referrers API, the catalog — whose responses are generated per request and are
+// not artifacts, so the blob-backed cache in ServeGET does not apply.
+//
+// upstreamPath is the repository-relative path; rawQuery is the already-encoded
+// query string (without the leading "?") and must be passed separately, because
+// JoinURL percent-escapes whatever it is handed as a path — a "?" glued on would
+// arrive upstream as %3F, i.e. part of the digest, not a filter.
+//
+// The caller must close the response body.
+func FetchUpstreamOnce(ctx context.Context, repo *domain.Repository, upstreamPath, rawQuery string, hdr http.Header) (*http.Response, error) {
+	baseRemote, err := RemoteURL(repo)
+	if err != nil {
+		return nil, err
+	}
+	upstream, err := JoinURL(baseRemote, upstreamPath)
+	if err != nil {
+		return nil, err
+	}
+	if rawQuery != "" {
+		upstream += "?" + rawQuery
+	}
+	return fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), http.MethodGet, upstream, baseRemote, hdr)
+}
+
 // ServeGET serves a cached asset or fetches upstream, streaming to the client
 // and persisting to the blob store on success. repo must be TypeProxy.
 // upstreamPath, when non-empty, is used only for the upstream URL (e.g. npm scoped metadata);

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -367,7 +367,7 @@ func fetchAndCache(c *gin.Context, d formats.Deps, repo *domain.Repository,
 
 	resp, err := fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), upstreamMethod, upstream, baseRemote, upHdr)
 	if err != nil {
-		dispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
+		DispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch failed: " + err.Error()})
 		return nil
 	}
@@ -430,7 +430,7 @@ func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository,
 	resp, err := fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), http.MethodGet, upstream, baseRemote, upHdr)
 	if err != nil {
 		// Upstream unreachable → serve stale cache so metadata consumers keep working.
-		dispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
+		DispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
 		serveCachedAsset(c, d, asset, rc, rewrite)
 		return nil
 	}
@@ -452,7 +452,7 @@ func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository,
 	default:
 		// Any other status (404/410/5xx): don't discard a good cache on a transient
 		// upstream hiccup — serve stale and record the anomaly.
-		dispatchProxyError(d, repo.Name, repoRelativePath, upstream,
+		DispatchProxyError(d, repo.Name, repoRelativePath, upstream,
 			fmt.Errorf("revalidation returned status %d", resp.StatusCode))
 		serveCachedAsset(c, d, asset, rc, rewrite)
 		return nil
@@ -581,9 +581,12 @@ func storeOriginal(ctx context.Context, c *gin.Context, d formats.Deps, repo *do
 	return nil
 }
 
-// dispatchProxyError records an upstream fetch/revalidation failure via the
+// DispatchProxyError records an upstream fetch/revalidation failure via the
 // webhook bus (the package's proxy-error reporting channel), if configured.
-func dispatchProxyError(d formats.Deps, repoName, repoRelativePath, upstream string, cause error) {
+// Exported because format handlers that talk upstream outside ServeGET — the OCI
+// referrers endpoint, for one — must report a failure the same way; formats.Deps
+// carries no logger, so this bus is the only operator-facing channel they have.
+func DispatchProxyError(d formats.Deps, repoName, repoRelativePath, upstream string, cause error) {
 	if d.Webhooks == nil {
 		return
 	}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -47,6 +47,10 @@ type ComponentRepo interface {
 	SetTags(ctx context.Context, id string, tags []string) error
 	// DeleteOrphans removes components in repoName that have no remaining assets.
 	DeleteOrphans(ctx context.Context, repoName string) error
+	// ListOCIReferrers returns components whose stored manifest metadata names
+	// subjectDigest as its subject — the referrers of that manifest. imageName
+	// restricts the search to one repository path; empty means any.
+	ListOCIReferrers(ctx context.Context, repoNames []string, imageName, subjectDigest string) ([]domain.Component, error)
 }
 
 // AssetRepo manages artifact file records.

--- a/internal/repository/postgres/component_repo.go
+++ b/internal/repository/postgres/component_repo.go
@@ -277,6 +277,52 @@ func (r *componentRepo) ListDockerBrowseRows(ctx context.Context, repoNames []st
 	return out, rows.Err()
 }
 
+// ListOCIReferrers returns components whose stored manifest metadata names
+// subjectDigest as its subject. imageName restricts the search to one
+// repository path (the "name" segment of /v2/{name}/...); empty means any.
+func (r *componentRepo) ListOCIReferrers(ctx context.Context, repoNames []string, imageName, subjectDigest string) ([]domain.Component, error) {
+	if len(repoNames) == 0 {
+		return nil, nil
+	}
+	ph := make([]string, len(repoNames))
+	args := make([]any, 0, len(repoNames)+2)
+	for i, n := range repoNames {
+		ph[i] = fmt.Sprintf("$%d", i+1)
+		args = append(args, n)
+	}
+	digestPos := len(args) + 1
+	args = append(args, subjectDigest)
+	q := fmt.Sprintf(`
+		SELECT c.id, c.repository_id, rep.name, c.format,
+		       c.group_id, c.name, c.version, c.tags,
+		       c.extra, c.last_downloaded, c.download_count, c.created_at
+		FROM components c
+		JOIN repositories rep ON rep.id = c.repository_id
+		WHERE rep.name IN (%s) AND c.extra->>'oci_subject' = $%d`, strings.Join(ph, ","), digestPos)
+	if imageName != "" {
+		namePos := len(args) + 1
+		args = append(args, imageName)
+		q += fmt.Sprintf(" AND c.name = $%d", namePos)
+	}
+	q += " ORDER BY c.name, c.version"
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []domain.Component
+	for rows.Next() {
+		c, err := scanComponent(rows)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, *c)
+	}
+	return items, rows.Err()
+}
+
 func (r *componentRepo) DeleteOrphans(ctx context.Context, repoName string) error {
 	_, err := r.db.Exec(ctx, `
 		DELETE FROM components c

--- a/internal/repository/postgres/component_repo_integration_test.go
+++ b/internal/repository/postgres/component_repo_integration_test.go
@@ -1488,3 +1488,106 @@ func TestComponentRepo_ListOCIReferrers_FiltersBySubjectDigest(t *testing.T) {
 		t.Errorf("expected 0 referrers for unmatched digest, got %d: %+v", len(none), none)
 	}
 }
+
+// The referrers handler always passes a non-empty imageName — /v2/{name}/... —
+// so the "AND c.name = $N" clause and the placeholder arithmetic that positions
+// it after the repository names and the digest are what production actually
+// runs. Covered here against real SQL, not only against the in-memory mock.
+func TestComponentRepo_ListOCIReferrers_FiltersByImageName(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+
+	p1 := makeCompParent(t, ctx, "referrers_name_r1")
+	p2 := makeCompParent(t, ctx, "referrers_name_r2")
+	repo := NewComponentRepo(pool)
+
+	subjectDigest := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+	// The referrer we want: right image name, right subject.
+	wanted := &domain.Component{
+		RepositoryID: p1.RepositoryID,
+		Format:       "oci",
+		Name:         "charts/nginx",
+		Version:      "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		Extra:        map[string]any{"oci_subject": subjectDigest},
+	}
+	if err := repo.Create(ctx, wanted); err != nil {
+		t.Fatalf("Create wanted: %v", err)
+	}
+
+	// The same subject digest under a different image name. Digests are global,
+	// so this row really can exist; naming it would leak another image's
+	// signature into this image's index.
+	otherName := &domain.Component{
+		RepositoryID: p1.RepositoryID,
+		Format:       "oci",
+		Name:         "charts/redis",
+		Version:      "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+		Extra:        map[string]any{"oci_subject": subjectDigest},
+	}
+	if err := repo.Create(ctx, otherName); err != nil {
+		t.Fatalf("Create otherName: %v", err)
+	}
+
+	// The right image name in a repository that was not asked for, so the name
+	// filter cannot be mistaken for the repository filter.
+	otherRepo := &domain.Component{
+		RepositoryID: p2.RepositoryID,
+		Format:       "oci",
+		Name:         "charts/nginx",
+		Version:      "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+		Extra:        map[string]any{"oci_subject": subjectDigest},
+	}
+	if err := repo.Create(ctx, otherRepo); err != nil {
+		t.Fatalf("Create otherRepo: %v", err)
+	}
+
+	// A prefix of the wanted name must not match: the clause is equality.
+	prefixName := &domain.Component{
+		RepositoryID: p1.RepositoryID,
+		Format:       "oci",
+		Name:         "charts/nginx-extra",
+		Version:      "sha256:5555555555555555555555555555555555555555555555555555555555555555",
+		Extra:        map[string]any{"oci_subject": subjectDigest},
+	}
+	if err := repo.Create(ctx, prefixName); err != nil {
+		t.Fatalf("Create prefixName: %v", err)
+	}
+
+	got, err := repo.ListOCIReferrers(ctx, []string{p1.RepoName}, "charts/nginx", subjectDigest)
+	if err != nil {
+		t.Fatalf("ListOCIReferrers(imageName): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly the charts/nginx referrer in repo1, got %d: %+v", len(got), got)
+	}
+	if got[0].ID != wanted.ID {
+		t.Errorf("expected %s (charts/nginx), got %s (%s)", wanted.ID, got[0].ID, got[0].Name)
+	}
+
+	// Two repository names push the digest and image-name placeholders one
+	// position further along; the arithmetic must still line up.
+	gotBoth, err := repo.ListOCIReferrers(ctx, []string{p1.RepoName, p2.RepoName}, "charts/nginx", subjectDigest)
+	if err != nil {
+		t.Fatalf("ListOCIReferrers(both repos, imageName): %v", err)
+	}
+	if len(gotBoth) != 2 {
+		t.Fatalf("expected both charts/nginx referrers across the two repos, got %d: %+v", len(gotBoth), gotBoth)
+	}
+	for _, c := range gotBoth {
+		if c.Name != "charts/nginx" {
+			t.Errorf("image-name filter leaked %q into the result", c.Name)
+		}
+	}
+
+	// An image name nothing was pushed under returns no rows, even though the
+	// subject digest itself matches four components.
+	none, err := repo.ListOCIReferrers(ctx, []string{p1.RepoName, p2.RepoName}, "charts/absent", subjectDigest)
+	if err != nil {
+		t.Fatalf("ListOCIReferrers(absent imageName): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("expected 0 referrers for an unused image name, got %d: %+v", len(none), none)
+	}
+}

--- a/internal/repository/postgres/component_repo_integration_test.go
+++ b/internal/repository/postgres/component_repo_integration_test.go
@@ -1405,3 +1405,86 @@ func TestComponentRepo_DeleteOrphans_EmptyRepoIsNoOp(t *testing.T) {
 		t.Fatalf("DeleteOrphans on empty repo: %v", err)
 	}
 }
+
+// ── ListOCIReferrers ─────────────────────────────────────────────────────────
+
+func TestComponentRepo_ListOCIReferrers_FiltersBySubjectDigest(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+
+	p1 := makeCompParent(t, ctx, "referrers_r1")
+	p2 := makeCompParent(t, ctx, "referrers_r2")
+	repo := NewComponentRepo(pool)
+
+	subjectDigest := "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+	// repo1: one referrer of subjectDigest ...
+	referrer1 := &domain.Component{
+		RepositoryID: p1.RepositoryID,
+		Format:       "oci",
+		Name:         "signed-image",
+		Version:      "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+		Extra:        map[string]any{"oci_subject": subjectDigest},
+	}
+	if err := repo.Create(ctx, referrer1); err != nil {
+		t.Fatalf("Create referrer1: %v", err)
+	}
+
+	// ... and one unrelated component with no oci_subject at all.
+	unrelated := &domain.Component{
+		RepositoryID: p1.RepositoryID,
+		Format:       "oci",
+		Name:         "plain-image",
+		Version:      "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+	}
+	if err := repo.Create(ctx, unrelated); err != nil {
+		t.Fatalf("Create unrelated: %v", err)
+	}
+
+	// repo2: another referrer of the same subjectDigest.
+	referrer2 := &domain.Component{
+		RepositoryID: p2.RepositoryID,
+		Format:       "oci",
+		Name:         "sbom",
+		Version:      "sha256:4444444444444444444444444444444444444444444444444444444444444444",
+		Extra:        map[string]any{"oci_subject": subjectDigest},
+	}
+	if err := repo.Create(ctx, referrer2); err != nil {
+		t.Fatalf("Create referrer2: %v", err)
+	}
+
+	// Querying repo1 alone returns only referrer1.
+	got, err := repo.ListOCIReferrers(ctx, []string{p1.RepoName}, "", subjectDigest)
+	if err != nil {
+		t.Fatalf("ListOCIReferrers(repo1): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 referrer in repo1, got %d: %+v", len(got), got)
+	}
+	if got[0].ID != referrer1.ID {
+		t.Errorf("expected referrer1 (%s), got %s (%s)", referrer1.ID, got[0].ID, got[0].Name)
+	}
+
+	// Querying both repo names returns both referrers.
+	gotBoth, err := repo.ListOCIReferrers(ctx, []string{p1.RepoName, p2.RepoName}, "", subjectDigest)
+	if err != nil {
+		t.Fatalf("ListOCIReferrers(both repos): %v", err)
+	}
+	if len(gotBoth) != 2 {
+		t.Fatalf("expected 2 referrers across both repos, got %d: %+v", len(gotBoth), gotBoth)
+	}
+	ids := map[string]bool{gotBoth[0].ID: true, gotBoth[1].ID: true}
+	if !ids[referrer1.ID] || !ids[referrer2.ID] {
+		t.Errorf("expected both referrer1 and referrer2, got %+v", gotBoth)
+	}
+
+	// A digest nothing points at returns no rows.
+	none, err := repo.ListOCIReferrers(ctx, []string{p1.RepoName, p2.RepoName}, "", "sha256:deadbeef")
+	if err != nil {
+		t.Fatalf("ListOCIReferrers(no match): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("expected 0 referrers for unmatched digest, got %d: %+v", len(none), none)
+	}
+}

--- a/internal/repository/postgres/component_repo_referrers_plan_integration_test.go
+++ b/internal/repository/postgres/component_repo_referrers_plan_integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
+)
+
+// An index the planner declines to use is not an index. The first form of
+// migration 023 was partial on "extra ? 'oci_subject'", which Postgres cannot
+// discharge from the equality this query applies, so the query stayed on a
+// sequential scan of the whole components table with the index in place. This
+// asserts the plan, not just the index's existence.
+func TestComponentRepo_ListOCIReferrers_UsesSubjectIndex(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+
+	p := makeCompParent(t, ctx, "explain_scratch")
+
+	// On OCI every blob upload creates a component, and they all sit under the
+	// image they belong to, so the image name is NOT selective: one busy image
+	// owns most of the rows. Only the subject digest is.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO components (repository_id, format, name, version, extra)
+		SELECT $1, 'oci',
+		       CASE WHEN i % 10 = 0 THEN 'charts/other' || (i % 200) ELSE 'charts/nginx' END,
+		       'sha256:' || lpad(i::text, 64, '0'),
+		       CASE WHEN i % 20 = 0
+		            THEN jsonb_build_object('oci_subject', 'sha256:' || lpad((i/20)::text, 64, 'a'))
+		            ELSE '{}'::jsonb END
+		FROM generate_series(1, 60000) i`, p.RepositoryID); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `ANALYZE components`); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	var idxdef string
+	if err := pool.QueryRow(ctx,
+		`SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_components_oci_subject'`).Scan(&idxdef); err != nil {
+		t.Fatalf("migration 023 did not create the index: %v", err)
+	}
+	t.Log("INDEX: " + idxdef)
+
+	// The exact query ListOCIReferrers builds for a non-empty imageName.
+	q := `EXPLAIN (ANALYZE, BUFFERS)
+		SELECT c.id, c.repository_id, rep.name, c.format,
+		       c.group_id, c.name, c.version, c.tags,
+		       c.extra, c.last_downloaded, c.download_count, c.created_at
+		FROM components c
+		JOIN repositories rep ON rep.id = c.repository_id
+		WHERE rep.name IN ($1) AND c.extra->>'oci_subject' = $2 AND c.name = $3
+		ORDER BY c.name, c.version`
+
+	rows, err := pool.Query(ctx, q, p.RepoName,
+		"sha256:"+fmt.Sprintf("%064s", "aaa"), "charts/nginx")
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer rows.Close()
+	var plan []string
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		plan = append(plan, line)
+		t.Log(line)
+	}
+	joined := strings.Join(plan, "\n")
+	if !strings.Contains(joined, "idx_components_oci_subject") {
+		t.Errorf("the referrers query does not use idx_components_oci_subject:\n%s", joined)
+	}
+	if strings.Contains(joined, "Seq Scan on components") {
+		t.Errorf("the referrers query still sequentially scans components:\n%s", joined)
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -523,6 +523,10 @@ type AssetRepo struct {
 	RawRowsByRepo map[string][]domain.RawBrowseAsset
 	RawBrowseErr  error // when non-nil, ListRawBrowseAssets returns it (500-branch seam)
 	BrowseErr     error // when non-nil, ListByRepoAndPath/ListPathsByRepo/ListRawAssetPaths return it (500-branch seam)
+	// GetByPathErr, when non-nil, makes GetByPath return it. Separate from Err so
+	// a test can tell a lookup that failed from a path that does not exist —
+	// callers that must not treat the two alike need exactly that distinction.
+	GetByPathErr error
 	// DownloadIncrements records aggregated counts passed to IncrementDownloads.
 	DownloadIncrements map[string]int64
 }
@@ -555,6 +559,9 @@ func (a *AssetRepo) Get(_ context.Context, id string) (*domain.Asset, error) {
 func (a *AssetRepo) GetByPath(_ context.Context, repoName, path string) (*domain.Asset, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.GetByPathErr != nil {
+		return nil, a.GetByPathErr
+	}
 	v, ok := a.assets[repoName+":"+path]
 	if !ok {
 		return nil, repository.ErrNotFound

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -383,6 +383,45 @@ func (c *ComponentRepo) ListDockerBrowseRows(_ context.Context, names []string, 
 	return out, nil
 }
 
+// ListOCIReferrers mirrors the SQL: filter by repository name (IN repoNames),
+// by extra["oci_subject"] == subjectDigest, and by name == imageName when
+// imageName is non-empty.
+func (c *ComponentRepo) ListOCIReferrers(_ context.Context, repoNames []string, imageName, subjectDigest string) ([]domain.Component, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.Err != nil {
+		return nil, c.Err
+	}
+	if len(repoNames) == 0 {
+		return nil, nil
+	}
+	allow := make(map[string]struct{}, len(repoNames))
+	for _, n := range repoNames {
+		allow[n] = struct{}{}
+	}
+	var items []domain.Component
+	for _, v := range c.components {
+		if _, ok := allow[v.Repository]; !ok {
+			continue
+		}
+		subj, _ := v.Extra["oci_subject"].(string)
+		if subj != subjectDigest {
+			continue
+		}
+		if imageName != "" && v.Name != imageName {
+			continue
+		}
+		items = append(items, *v)
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Name != items[j].Name {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].Version < items[j].Version
+	})
+	return items, nil
+}
+
 func (c *ComponentRepo) Create(_ context.Context, comp *domain.Component) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()


### PR DESCRIPTION
Phase 2 of five, on top of v1.26.0. Adds `GET /v2/{name}/referrers/{digest}` — how cosign discovers signatures, and how SBOMs and in-toto attestations are found for an image or a chart.

Phase 1 already recorded `oci_subject` on every pushed and every proxy-cached manifest, so this is mostly a query, an index document, and a great deal of care about one question.

## The question this PR is really about

**"I could not check" must never be reported as "there is nothing to check."** A client asking whether an image is signed reads an empty index as *unsigned*, and a policy gate then rejects a valid image — or, worse, a permissive policy passes content whose signatures were never actually checked. Every design decision below follows from that.

| Situation | Answer |
| --- | --- |
| Subject has no referrers | `200`, empty index (never `404`, never JSON `null`) |
| Upstream returns 404 / 405 / 501 — no such endpoint | `200`, empty index |
| Upstream returns 401 / 403 | `502` + `proxy_error` event — a credentials problem, not an unsigned image |
| Upstream unreachable, 429, 5xx, body unreadable or not an index | `502` + event |
| Upstream index too large to read whole | `502` — a truncated list served as complete is the same lie |
| A group member cannot be consulted | `502` — the group refuses to serve a partial list as complete |
| Repository or asset lookup fails | `502` — not a quietly shortened index |

## What is in this PR

- **The query** — `ComponentRepo.ListOCIReferrers`, matching `extra->>'oci_subject'`, with a partial index behind it (migration `023`). The index predicate had to be `(extra->>'oci_subject') IS NOT NULL` rather than `extra ? 'oci_subject'`: the planner cannot discharge the latter from a `->>` equality and went back to a sequential scan. There is a test asserting the query plan, because an index the planner declines to use is not an index.
- **The endpoint** — an OCI image index with `?artifactType=` filtering and `OCI-Filters-Applied`. A referrer that exists as both a tag component and a digest alias is listed once; an invalid digest is `400 DIGEST_INVALID`.
- **Proxy repositories** forward upstream through a new non-caching `repoproxy.FetchUpstreamOnce` — the referrers list is computed per request, not a stored artifact. The upstream body is passed through byte for byte so spec fields this package does not model (`platform`, `urls`, `subject`) survive. Pagination parameters we cannot honour are not forwarded, so an upstream never returns us a truncated page we would relay as complete.
- **Group repositories** merge across members instead of shadowing them. This one was a regression the review caught: the group handler returns the first non-404 member response, and referrers never returns 404, so the first member always won and a signature in the second was invisible. Worse than an unimplemented feature — before this branch the group answered 404, which is exactly what makes cosign fall back to the tag scheme, and that fallback works. The fix implements `GroupIndexMerger` for referrers and adds a `GroupIndexStrictMerger` seam so a member that cannot be consulted makes the whole group answer `502` rather than a quietly partial list.

## Also fixed on the way

`JoinURL` percent-escapes a query string glued onto a path, which would have silently dropped the `artifactType` filter on every proxied request. The Docker Hub token scope parser did not recognise `referrers` URLs. Promotion and deletion interactions with referrers are documented as follow-ups rather than fixed here.

## Verification

`go test ./internal/...` 1680 passing (only `TestWebhookHandler_Test_200` fails, which needs outbound networking the sandbox lacks and passes in CI); integration suite green including the query-plan test; `golangci-lint run --new-from-rev=origin/main` zero issues.

Written test-first throughout. The review found four things worth naming: the group regression above, the query-string escaping, the unusable index predicate, and five failure paths that still reported an empty index. All are fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW