### PR TITLE
fix(helm): resolve every index URL shape when proxying a nested repository

### DIFF
--- a/internal/formats/helm/handler.go
+++ b/internal/formats/helm/handler.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"regexp"
 	"strings"
 	"time"
 
@@ -51,10 +52,13 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			return
 		}
 		// The request path may be nested (charts/mychart-1.2.3.tgz), so the component
-		// coordinates come from the filename, never from the path.
-		coords := base.Coords{Name: path.Base(p)}
-		if strings.HasSuffix(p, ".tgz") {
-			chartName, version := splitChartFilename(path.Base(p))
+		// coordinates come from the filename, never from the path. Helm fetches a
+		// "<chart>.tgz.prov" signature alongside each chart; file that under the
+		// chart's own coordinates instead of as a component in its own right.
+		filename := strings.TrimSuffix(path.Base(p), ".prov")
+		coords := base.Coords{Name: filename}
+		if strings.HasSuffix(filename, ".tgz") {
+			chartName, version := splitChartFilename(filename)
 			coords = base.Coords{Name: chartName, Version: version}
 		}
 		// Chart tarballs are immutable (index.yaml — the mutable index — is
@@ -302,11 +306,22 @@ func normPath(p string) string {
 	return path.Clean("/" + strings.TrimPrefix(p, "/"))
 }
 
+// chartVersionRe matches the "-<version>" tail of a chart archive name, right-anchored
+// on a SemVer-shaped version. Splitting at the last dash instead would cut a
+// prerelease in half: "cert-manager-v1.13.0-beta.0" is version "v1.13.0-beta.0", not
+// name "cert-manager-v1.13.0" at version "beta.0".
+var chartVersionRe = regexp.MustCompile(
+	`-(v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)$`)
+
 // splitChartFilename splits a chart archive filename ("mychart-1.2.3.tgz") into its
-// chart name and version at the last dash. A filename with no usable dash keeps the
-// whole stem as the name and gets the placeholder version "0.0.0".
+// chart name and version. Charts whose version is not SemVer-shaped fall back to a
+// split at the last dash; a filename with no usable dash keeps the whole stem as the
+// name and gets the placeholder version "0.0.0".
 func splitChartFilename(filename string) (chartName, version string) {
 	stem := strings.TrimSuffix(filename, ".tgz")
+	if m := chartVersionRe.FindStringSubmatchIndex(stem); m != nil {
+		return stem[:m[0]], stem[m[2]:m[3]]
+	}
 	if lastDash := strings.LastIndex(stem, "-"); lastDash > 0 {
 		return stem[:lastDash], stem[lastDash+1:]
 	}
@@ -314,42 +329,98 @@ func splitChartFilename(filename string) (chartName, version string) {
 }
 
 // rewriteChartURL maps one `urls` entry of an upstream index.yaml onto this proxy.
-// Entries come in three shapes:
+//
+// Helm resolves each entry as a URL reference against the repository URL (see
+// helm.sh/helm/v3/pkg/repo.ResolveReferenceURL), so an entry takes one of four shapes:
 //
 //  1. a repository-relative path of any depth ("charts/mychart-1.2.3.tgz") — kept
 //     whole, because the download handler forwards the request path upstream verbatim;
-//  2. an absolute URL under the configured remote — the remote prefix is stripped and
-//     the remainder is treated as case 1;
-//  3. an absolute URL on some other host (charts published to GitHub releases, say) —
-//     returned untouched. We cannot express it as a path under this proxy, so the
-//     client fetches it directly. That skips the cache, but it beats handing back a
-//     proxy path that would 404.
+//  2. an absolute URL under the configured remote — the remote's own path prefix is
+//     stripped and the remainder is treated as case 1;
+//  3. an absolute URL we cannot serve: another host (charts published to GitHub
+//     releases, say), a sibling subtree of the same host, or any URL carrying a query;
+//  4. a root-relative path ("/charts/mychart-1.2.3.tgz"), which resolves against the
+//     HOST root and NOT the remote's path prefix — case 2 when it happens to land
+//     inside the proxied subtree, case 3 otherwise.
 //
-// localBase must end in "/" and remoteBase must not.
+// Whatever falls to case 3 is handed back as the absolute upstream URL it resolves to,
+// unchanged when the entry was already absolute. Such an artifact cannot be expressed
+// as a path under this proxy, so the client fetches it directly: that skips the cache
+// and needs egress, but it beats a proxy path that would 404 or, worse, quietly serve
+// a different artifact.
+//
+// localBase must end in "/"; remoteBase is the repository's remote_url.
 func rewriteChartURL(rawURL, remoteBase, localBase string) string {
-	rel := rawURL
-
-	u, err := url.Parse(rawURL)
+	remote, err := url.Parse(remoteBase)
+	if err != nil {
+		return rawURL
+	}
+	ref, err := url.Parse(rawURL)
 	if err != nil {
 		return rawURL // unparsable: leave it for the client to deal with
 	}
-	if u.Host != "" { // absolute (or protocol-relative) URL
-		remote, err := url.Parse(remoteBase)
-		if err != nil {
+
+	// Resolve the reference the way Helm does: against the remote URL with a trailing
+	// slash, so a relative entry lands beside index.yaml rather than beside the
+	// remote's last path segment, and a root-relative entry lands at the host root.
+	resolveBase := *remote
+	resolveBase.Path = strings.TrimSuffix(remote.Path, "/") + "/"
+	resolveBase.RawPath = ""
+	abs := resolveBase.ResolveReference(ref)
+
+	// unproxyable hands the client the upstream URL. An entry that was already
+	// absolute goes back byte for byte rather than as a re-serialized copy.
+	unproxyable := func() string {
+		if ref.Scheme != "" || ref.Host != "" {
 			return rawURL
 		}
-		// Compare hosts only: an index served over https regularly lists http URLs
-		// (and the reverse), and that is still the same upstream repository.
-		if !strings.EqualFold(u.Host, remote.Host) {
-			return rawURL // case 3
-		}
-		remotePath := strings.TrimSuffix(remote.Path, "/")
-		if remotePath != "" && u.Path != remotePath && !strings.HasPrefix(u.Path, remotePath+"/") {
-			return rawURL // same host but outside the proxied subtree — case 3
-		}
-		rel = strings.TrimPrefix(u.Path, remotePath)
+		return abs.String()
 	}
 
-	rel = strings.TrimPrefix(path.Clean("/"+strings.TrimPrefix(rel, "/")), "/")
-	return localBase + rel
+	// A query cannot survive the round trip: the download path forwards only the
+	// request path upstream, so a signed or tokenized URL would be re-fetched
+	// unsigned and rejected. Send the client to the original instead.
+	if abs.RawQuery != "" || abs.ForceQuery {
+		return unproxyable()
+	}
+	if !sameUpstreamHost(abs, remote) {
+		return unproxyable()
+	}
+
+	// Compare cleaned paths, so a ".." segment cannot slip past the subtree check and
+	// only afterwards collapse into a path pointing at a different upstream file.
+	remotePath := path.Clean("/" + strings.Trim(remote.Path, "/"))
+	absPath := path.Clean("/" + strings.TrimPrefix(abs.Path, "/"))
+	if remotePath != "/" {
+		if absPath != remotePath && !strings.HasPrefix(absPath, remotePath+"/") {
+			return unproxyable()
+		}
+		absPath = strings.TrimPrefix(absPath, remotePath)
+	}
+	return localBase + strings.TrimPrefix(absPath, "/")
+}
+
+// sameUpstreamHost reports whether two URLs address the same upstream host. The
+// scheme itself is ignored — an index served over https routinely lists http URLs and
+// the reverse — but each scheme's default port is normalized away first, so an entry
+// on "host:443" and a remote of bare "host" are recognized as one upstream.
+func sameUpstreamHost(a, b *url.URL) bool {
+	return normalizedHost(a, b.Scheme) == normalizedHost(b, a.Scheme)
+}
+
+// normalizedHost lowercases u's host and drops the port when it is the default for
+// u's scheme. fallbackScheme supplies the scheme for a protocol-relative reference.
+func normalizedHost(u *url.URL, fallbackScheme string) string {
+	scheme := strings.ToLower(u.Scheme)
+	if scheme == "" {
+		scheme = strings.ToLower(fallbackScheme)
+	}
+	host := strings.ToLower(u.Host)
+	switch scheme {
+	case "http":
+		return strings.TrimSuffix(host, ":80")
+	case "https":
+		return strings.TrimSuffix(host, ":443")
+	}
+	return host
 }

--- a/internal/formats/helm/handler.go
+++ b/internal/formats/helm/handler.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 	"time"
@@ -49,7 +50,13 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			h.fetchAndRewriteHelmIndex(c, repo)
 			return
 		}
-		coords := base.Coords{Name: strings.TrimSuffix(strings.TrimPrefix(p, "/"), ".tgz")}
+		// The request path may be nested (charts/mychart-1.2.3.tgz), so the component
+		// coordinates come from the filename, never from the path.
+		coords := base.Coords{Name: path.Base(p)}
+		if strings.HasSuffix(p, ".tgz") {
+			chartName, version := splitChartFilename(path.Base(p))
+			coords = base.Coords{Name: chartName, Version: version}
+		}
 		// Chart tarballs are immutable (index.yaml — the mutable index — is
 		// fetched-and-rewritten above, not cached through here).
 		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar", 0); err != nil {
@@ -169,16 +176,7 @@ func (h *Handler) handleUpload(c *gin.Context, repoName, pathFilename string) {
 		}
 	}
 
-	// Parse name-version from filename: "mychart-1.2.3.tgz"
-	base2 := strings.TrimSuffix(filename, ".tgz")
-	lastDash := strings.LastIndex(base2, "-")
-	if lastDash > 0 {
-		chartName = base2[:lastDash]
-		version = base2[lastDash+1:]
-	} else {
-		chartName = base2
-		version = "0.0.0"
-	}
+	chartName, version = splitChartFilename(filename)
 
 	filePath := "/" + filename
 	coords := base.Coords{Name: chartName, Version: version}
@@ -278,7 +276,7 @@ func (h *Handler) fetchAndRewriteHelmIndex(c *gin.Context, repo *domain.Reposito
 				if urls, ok := chart["urls"].([]any); ok {
 					for i, u := range urls {
 						if us, ok := u.(string); ok {
-							urls[i] = localBase + path.Base(us)
+							urls[i] = rewriteChartURL(us, remoteBase, localBase)
 						}
 					}
 					chart["urls"] = urls
@@ -302,4 +300,56 @@ func (h *Handler) fetchAndRewriteHelmIndex(c *gin.Context, repo *domain.Reposito
 
 func normPath(p string) string {
 	return path.Clean("/" + strings.TrimPrefix(p, "/"))
+}
+
+// splitChartFilename splits a chart archive filename ("mychart-1.2.3.tgz") into its
+// chart name and version at the last dash. A filename with no usable dash keeps the
+// whole stem as the name and gets the placeholder version "0.0.0".
+func splitChartFilename(filename string) (chartName, version string) {
+	stem := strings.TrimSuffix(filename, ".tgz")
+	if lastDash := strings.LastIndex(stem, "-"); lastDash > 0 {
+		return stem[:lastDash], stem[lastDash+1:]
+	}
+	return stem, "0.0.0"
+}
+
+// rewriteChartURL maps one `urls` entry of an upstream index.yaml onto this proxy.
+// Entries come in three shapes:
+//
+//  1. a repository-relative path of any depth ("charts/mychart-1.2.3.tgz") — kept
+//     whole, because the download handler forwards the request path upstream verbatim;
+//  2. an absolute URL under the configured remote — the remote prefix is stripped and
+//     the remainder is treated as case 1;
+//  3. an absolute URL on some other host (charts published to GitHub releases, say) —
+//     returned untouched. We cannot express it as a path under this proxy, so the
+//     client fetches it directly. That skips the cache, but it beats handing back a
+//     proxy path that would 404.
+//
+// localBase must end in "/" and remoteBase must not.
+func rewriteChartURL(rawURL, remoteBase, localBase string) string {
+	rel := rawURL
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL // unparsable: leave it for the client to deal with
+	}
+	if u.Host != "" { // absolute (or protocol-relative) URL
+		remote, err := url.Parse(remoteBase)
+		if err != nil {
+			return rawURL
+		}
+		// Compare hosts only: an index served over https regularly lists http URLs
+		// (and the reverse), and that is still the same upstream repository.
+		if !strings.EqualFold(u.Host, remote.Host) {
+			return rawURL // case 3
+		}
+		remotePath := strings.TrimSuffix(remote.Path, "/")
+		if remotePath != "" && u.Path != remotePath && !strings.HasPrefix(u.Path, remotePath+"/") {
+			return rawURL // same host but outside the proxied subtree — case 3
+		}
+		rel = strings.TrimPrefix(u.Path, remotePath)
+	}
+
+	rel = strings.TrimPrefix(path.Clean("/"+strings.TrimPrefix(rel, "/")), "/")
+	return localBase + rel
 }

--- a/internal/formats/helm/handler_test.go
+++ b/internal/formats/helm/handler_test.go
@@ -161,22 +161,24 @@ func TestHelm_GetNotFound(t *testing.T) {
 }
 
 func TestHelm_ProxyIndexYaml_RewritesURLs(t *testing.T) {
-	// Mock upstream helm repository
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// Mock upstream helm repository. Its index spells the chart URL out in full
+	// against its own host, the way public repositories (Bitnami, …) do.
+	var upstream *httptest.Server
+	upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/index.yaml" {
 			http.NotFound(w, r)
 			return
 		}
 		w.Header().Set("Content-Type", "application/yaml")
-		fmt.Fprint(w, `apiVersion: v1
+		fmt.Fprintf(w, `apiVersion: v1
 entries:
   nginx:
   - name: nginx
     version: "15.0.0"
     urls:
-    - https://charts.bitnami.com/bitnami/nginx-15.0.0.tgz
+    - %s/nginx-15.0.0.tgz
 generated: "2024-01-01T00:00:00Z"
-`)
+`, upstream.URL)
 	}))
 	defer upstream.Close()
 
@@ -195,7 +197,7 @@ generated: "2024-01-01T00:00:00Z"
 	body := w.Body.String()
 	assert.Contains(t, body, "http://localhost:8080/repository/helm-proxy/nginx-15.0.0.tgz",
 		"chart URL should be rewritten to local proxy")
-	assert.NotContains(t, body, "charts.bitnami.com",
+	assert.NotContains(t, body, upstream.URL,
 		"upstream URL must not appear in rewritten index")
 }
 

--- a/internal/formats/helm/proxy_subpath_test.go
+++ b/internal/formats/helm/proxy_subpath_test.go
@@ -1,0 +1,220 @@
+package helm_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/helm"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+const testBaseURL = "http://localhost:8080"
+
+// setupProxy builds a helm proxy repository pointing at remoteURL and returns the
+// engine plus the in-memory component repo so tests can assert what got cached.
+func setupProxy(t *testing.T, repoName, remoteURL string) (*gin.Engine, *testutil.ComponentRepo) {
+	t.Helper()
+	comps := testutil.NewComponentRepo()
+	repo := &domain.Repository{
+		ID: repoName, Name: repoName, Format: "helm",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": remoteURL},
+	}
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    testBaseURL,
+	}
+	h := helm.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps
+}
+
+// nestedUpstream serves an index.yaml whose single entry URL is entryURL, plus the
+// chart tarball at tgzPath.
+func nestedUpstream(t *testing.T, entryURL, tgzPath, body string) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.yaml":
+			url := entryURL
+			// "%s" in entryURL is filled with the server's own base URL so tests can
+			// express absolute-under-remote entries.
+			if strings.Contains(url, "%s") {
+				url = strings.ReplaceAll(url, "%s", srv.URL)
+			}
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("apiVersion: v1\n" +
+				"entries:\n" +
+				"  ingress-nginx:\n" +
+				"  - name: ingress-nginx\n" +
+				"    version: \"4.11.2\"\n" +
+				"    urls:\n" +
+				"    - " + url + "\n" +
+				"generated: \"2024-01-01T00:00:00Z\"\n"))
+		case tgzPath:
+			w.Header().Set("Content-Type", "application/x-tar")
+			_, _ = w.Write([]byte(body))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+// firstChartURL fetches index.yaml through the proxy and returns the single
+// rewritten chart URL the helm client would follow.
+func firstChartURL(t *testing.T, r *gin.Engine, repoName string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/repository/"+repoName+"/index.yaml", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "index.yaml body: %s", w.Body.String())
+
+	var index struct {
+		Entries map[string][]struct {
+			URLs []string `yaml:"urls"`
+		} `yaml:"entries"`
+	}
+	require.NoError(t, yaml.Unmarshal(w.Body.Bytes(), &index))
+	require.Len(t, index.Entries, 1)
+	for _, versions := range index.Entries {
+		require.Len(t, versions, 1)
+		require.Len(t, versions[0].URLs, 1)
+		return versions[0].URLs[0]
+	}
+	return ""
+}
+
+// TestHelm_Proxy_NestedChartURL_RoundTrip is the reported case (#139): the upstream
+// index points at charts/<name>-<version>.tgz, a path below the repository root.
+// The download path is taken from the rewritten index, not hand-built, so this
+// proves the whole round trip closes.
+func TestHelm_Proxy_NestedChartURL_RoundTrip(t *testing.T) {
+	upstream := nestedUpstream(t, "charts/ingress-nginx-4.11.2.tgz",
+		"/charts/ingress-nginx-4.11.2.tgz", "nested-chart-bytes")
+	defer upstream.Close()
+
+	r, _ := setupProxy(t, "helm-nested", upstream.URL)
+
+	chartURL := firstChartURL(t, r, "helm-nested")
+	assert.Equal(t, testBaseURL+"/repository/helm-nested/charts/ingress-nginx-4.11.2.tgz", chartURL,
+		"the upstream subdirectory must survive the rewrite")
+
+	req := httptest.NewRequest(http.MethodGet, strings.TrimPrefix(chartURL, testBaseURL), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "nested-chart-bytes", w.Body.String())
+}
+
+// TestHelm_Proxy_FlatChartURL_RoundTrip is the regression guard: a flat upstream
+// (no subdirectory) must keep working exactly as before.
+func TestHelm_Proxy_FlatChartURL_RoundTrip(t *testing.T) {
+	upstream := nestedUpstream(t, "ingress-nginx-4.11.2.tgz",
+		"/ingress-nginx-4.11.2.tgz", "flat-chart-bytes")
+	defer upstream.Close()
+
+	r, _ := setupProxy(t, "helm-flat", upstream.URL)
+
+	chartURL := firstChartURL(t, r, "helm-flat")
+	assert.Equal(t, testBaseURL+"/repository/helm-flat/ingress-nginx-4.11.2.tgz", chartURL)
+
+	req := httptest.NewRequest(http.MethodGet, strings.TrimPrefix(chartURL, testBaseURL), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "flat-chart-bytes", w.Body.String())
+}
+
+// TestHelm_Proxy_AbsoluteURLUnderRemote_RoundTrip covers an index that spells its
+// URLs out in full against the configured remote: the remote prefix is stripped and
+// the remainder — subdirectory included — becomes the proxy path.
+func TestHelm_Proxy_AbsoluteURLUnderRemote_RoundTrip(t *testing.T) {
+	upstream := nestedUpstream(t, "%s/charts/ingress-nginx-4.11.2.tgz",
+		"/charts/ingress-nginx-4.11.2.tgz", "absolute-chart-bytes")
+	defer upstream.Close()
+
+	r, _ := setupProxy(t, "helm-abs", upstream.URL)
+
+	chartURL := firstChartURL(t, r, "helm-abs")
+	assert.Equal(t, testBaseURL+"/repository/helm-abs/charts/ingress-nginx-4.11.2.tgz", chartURL)
+
+	req := httptest.NewRequest(http.MethodGet, strings.TrimPrefix(chartURL, testBaseURL), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "absolute-chart-bytes", w.Body.String())
+}
+
+// TestHelm_Proxy_AbsoluteURLForeignHost_LeftAlone covers charts published elsewhere
+// (typically GitHub releases). We cannot express those as a path under this proxy,
+// so the URL must survive untouched and the client fetches it directly.
+func TestHelm_Proxy_AbsoluteURLForeignHost_LeftAlone(t *testing.T) {
+	const foreign = "https://github.com/kubernetes/ingress-nginx/releases/download/helm-chart-4.11.2/ingress-nginx-4.11.2.tgz"
+	upstream := nestedUpstream(t, foreign, "/unused.tgz", "unused")
+	defer upstream.Close()
+
+	r, _ := setupProxy(t, "helm-foreign", upstream.URL)
+
+	assert.Equal(t, foreign, firstChartURL(t, r, "helm-foreign"),
+		"a chart on another host cannot be proxied and must not be rewritten")
+}
+
+// TestHelm_Proxy_NestedPath_NoTraversal guards the nested download path against
+// escaping the configured remote: normPath resolves ".." before the path is ever
+// forwarded upstream, so a traversal attempt lands back inside the remote subtree.
+func TestHelm_Proxy_NestedPath_NoTraversal(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+
+	r, _ := setupProxy(t, "helm-trav", upstream.URL+"/base")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/helm-trav/charts/../../../../etc/passwd", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, "/base/etc/passwd", gotPath,
+		"the remote base prefix must survive a traversal attempt")
+}
+
+// TestHelm_Proxy_NestedChart_CachedCoords verifies the cached component carries the
+// chart name and version parsed from the filename, not the request path.
+func TestHelm_Proxy_NestedChart_CachedCoords(t *testing.T) {
+	upstream := nestedUpstream(t, "charts/ingress-nginx-4.11.2.tgz",
+		"/charts/ingress-nginx-4.11.2.tgz", "nested-chart-bytes")
+	defer upstream.Close()
+
+	r, comps := setupProxy(t, "helm-coords", upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/helm-coords/charts/ingress-nginx-4.11.2.tgz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	page, err := comps.List(req.Context(), "helm-coords", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "ingress-nginx", page.Items[0].Name)
+	assert.Equal(t, "4.11.2", page.Items[0].Version)
+}

--- a/internal/formats/helm/proxy_subpath_test.go
+++ b/internal/formats/helm/proxy_subpath_test.go
@@ -175,9 +175,114 @@ func TestHelm_Proxy_AbsoluteURLForeignHost_LeftAlone(t *testing.T) {
 		"a chart on another host cannot be proxied and must not be rewritten")
 }
 
-// TestHelm_Proxy_NestedPath_NoTraversal guards the nested download path against
-// escaping the configured remote: normPath resolves ".." before the path is ever
-// forwarded upstream, so a traversal attempt lands back inside the remote subtree.
+// prefixedUpstream serves a repository rooted at /charts-repo, i.e. a remote whose
+// URL carries a path prefix. index.yaml lists two entries: one inside the prefixed
+// subtree and one outside it.
+func prefixedUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/charts-repo/index.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			_, _ = w.Write([]byte("apiVersion: v1\n" +
+				"entries:\n" +
+				"  inside:\n" +
+				"  - name: inside\n" +
+				"    version: \"1.0.0\"\n" +
+				"    urls:\n" +
+				"    - " + srv.URL + "/charts-repo/charts/inside-1.0.0.tgz\n" +
+				"  outside:\n" +
+				"  - name: outside\n" +
+				"    version: \"1.0.0\"\n" +
+				"    urls:\n" +
+				"    - " + srv.URL + "/other-repo/outside-1.0.0.tgz\n" +
+				"generated: \"2024-01-01T00:00:00Z\"\n"))
+		case "/charts-repo/charts/inside-1.0.0.tgz":
+			w.Header().Set("Content-Type", "application/x-tar")
+			_, _ = w.Write([]byte("inside-chart-bytes"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+// TestHelm_Proxy_RemoteWithPathPrefix covers a remote_url that has its own path
+// prefix: an entry inside that subtree is proxied with the prefix stripped, and one
+// outside it is handed to the client untouched.
+func TestHelm_Proxy_RemoteWithPathPrefix(t *testing.T) {
+	upstream := prefixedUpstream(t)
+	defer upstream.Close()
+
+	r, _ := setupProxy(t, "helm-prefix", upstream.URL+"/charts-repo")
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/helm-prefix/index.yaml", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var index struct {
+		Entries map[string][]struct {
+			URLs []string `yaml:"urls"`
+		} `yaml:"entries"`
+	}
+	require.NoError(t, yaml.Unmarshal(w.Body.Bytes(), &index))
+
+	inside := index.Entries["inside"][0].URLs[0]
+	assert.Equal(t, testBaseURL+"/repository/helm-prefix/charts/inside-1.0.0.tgz", inside,
+		"the remote's own path prefix must be stripped, the rest kept")
+	assert.Equal(t, upstream.URL+"/other-repo/outside-1.0.0.tgz",
+		index.Entries["outside"][0].URLs[0],
+		"a URL outside the proxied subtree is not ours to rewrite")
+
+	req = httptest.NewRequest(http.MethodGet, strings.TrimPrefix(inside, testBaseURL), nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "inside-chart-bytes", w.Body.String())
+}
+
+// TestHelm_Proxy_ProvenanceFile_SharesChartCoords verifies the ".prov" signature
+// Helm fetches alongside a chart is filed under the chart's own coordinates rather
+// than registering a junk component of its own.
+func TestHelm_Proxy_ProvenanceFile_SharesChartCoords(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/charts/ingress-nginx-4.11.2.tgz":
+			_, _ = w.Write([]byte("chart"))
+		case "/charts/ingress-nginx-4.11.2.tgz.prov":
+			_, _ = w.Write([]byte("signature"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	r, comps := setupProxy(t, "helm-prov", upstream.URL)
+
+	for _, p := range []string{
+		"/repository/helm-prov/charts/ingress-nginx-4.11.2.tgz",
+		"/repository/helm-prov/charts/ingress-nginx-4.11.2.tgz.prov",
+	} {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "%s body: %s", p, w.Body.String())
+	}
+
+	page, err := comps.List(t.Context(), "helm-prov", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1, "the provenance file must not register its own component")
+	assert.Equal(t, "ingress-nginx", page.Items[0].Name)
+	assert.Equal(t, "4.11.2", page.Items[0].Version)
+}
+
+// TestHelm_Proxy_NestedPath_NoTraversal is a standing guard on the pre-existing
+// normPath: it resolves ".." before the request path is forwarded upstream, so a
+// traversal attempt lands back inside the remote subtree. This held before the
+// nested-path fix too — ServeGET already received the full request path — and the
+// test exists to keep it that way now that nested paths are routinely in play.
 func TestHelm_Proxy_NestedPath_NoTraversal(t *testing.T) {
 	var gotPath string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/formats/helm/rewrite_internal_test.go
+++ b/internal/formats/helm/rewrite_internal_test.go
@@ -1,0 +1,219 @@
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRewriteChartURL covers every shape an index.yaml `urls` entry can take.
+// An httptest upstream always carries an explicit port and no path prefix, so the
+// port-normalization and remote-path-prefix branches are only reachable here.
+func TestRewriteChartURL(t *testing.T) {
+	const local = "http://nexus.local/repository/charts/"
+
+	tests := []struct {
+		name       string
+		remoteBase string
+		url        string
+		want       string
+	}{
+		// ── Case 1: repository-relative ──────────────────────────────
+		{
+			name:       "relative nested path keeps its directory",
+			remoteBase: "https://charts.example.com",
+			url:        "charts/ingress-nginx-4.11.2.tgz",
+			want:       local + "charts/ingress-nginx-4.11.2.tgz",
+		},
+		{
+			name:       "relative flat path",
+			remoteBase: "https://charts.example.com",
+			url:        "ingress-nginx-4.11.2.tgz",
+			want:       local + "ingress-nginx-4.11.2.tgz",
+		},
+		{
+			name:       "relative dot-slash prefix is cleaned",
+			remoteBase: "https://charts.example.com",
+			url:        "./charts/x-1.0.0.tgz",
+			want:       local + "charts/x-1.0.0.tgz",
+		},
+
+		// ── Case 2: absolute under the remote ────────────────────────
+		{
+			name:       "absolute under remote root",
+			remoteBase: "https://charts.example.com",
+			url:        "https://charts.example.com/charts/x-1.0.0.tgz",
+			want:       local + "charts/x-1.0.0.tgz",
+		},
+		{
+			name:       "absolute under remote with path prefix",
+			remoteBase: "https://charts.example.com/charts-repo",
+			url:        "https://charts.example.com/charts-repo/charts/x-1.0.0.tgz",
+			want:       local + "charts/x-1.0.0.tgz",
+		},
+		{
+			name:       "scheme mismatch is still the same upstream",
+			remoteBase: "https://charts.example.com",
+			url:        "http://charts.example.com/x-1.0.0.tgz",
+			want:       local + "x-1.0.0.tgz",
+		},
+
+		// ── Default-port normalization ───────────────────────────────
+		{
+			name:       "explicit https default port matches bare remote host",
+			remoteBase: "https://charts.example.com",
+			url:        "https://charts.example.com:443/x-1.0.0.tgz",
+			want:       local + "x-1.0.0.tgz",
+		},
+		{
+			name:       "explicit http default port matches bare remote host",
+			remoteBase: "http://charts.example.com",
+			url:        "http://charts.example.com:80/x-1.0.0.tgz",
+			want:       local + "x-1.0.0.tgz",
+		},
+		{
+			name:       "bare host matches remote carrying the default port",
+			remoteBase: "https://charts.example.com:443",
+			url:        "https://charts.example.com/x-1.0.0.tgz",
+			want:       local + "x-1.0.0.tgz",
+		},
+		{
+			name:       "host comparison is case-insensitive",
+			remoteBase: "https://Charts.Example.com",
+			url:        "https://charts.example.com/x-1.0.0.tgz",
+			want:       local + "x-1.0.0.tgz",
+		},
+		{
+			name:       "a non-default port is a different upstream",
+			remoteBase: "https://charts.example.com",
+			url:        "https://charts.example.com:8443/x-1.0.0.tgz",
+			want:       "https://charts.example.com:8443/x-1.0.0.tgz",
+		},
+
+		// ── Case 3: unproxyable, handed back absolute ────────────────
+		{
+			name:       "absolute URL on another host is left alone",
+			remoteBase: "https://charts.example.com",
+			url:        "https://github.com/o/r/releases/download/v1/x-1.0.0.tgz",
+			want:       "https://github.com/o/r/releases/download/v1/x-1.0.0.tgz",
+		},
+		{
+			name:       "same host but outside the proxied subtree",
+			remoteBase: "https://charts.example.com/charts-repo",
+			url:        "https://charts.example.com/other-repo/x-1.0.0.tgz",
+			want:       "https://charts.example.com/other-repo/x-1.0.0.tgz",
+		},
+		{
+			// The subtree check must run on the cleaned path. Comparing the raw one
+			// would see the "/base/" prefix, strip it, and only then collapse the
+			// "..", silently proxying a different upstream file.
+			name:       "dot-dot escaping the subtree is not proxied",
+			remoteBase: "https://charts.example.com/base",
+			url:        "https://charts.example.com/base/../secret/x-1.0.0.tgz",
+			want:       "https://charts.example.com/base/../secret/x-1.0.0.tgz",
+		},
+
+		// ── Case 4: root-relative, resolved against the HOST root ────
+		{
+			name:       "root-relative under the remote prefix",
+			remoteBase: "https://charts.example.com/base",
+			url:        "/base/charts/x-1.0.0.tgz",
+			want:       local + "charts/x-1.0.0.tgz",
+		},
+		{
+			name:       "root-relative outside the remote prefix resolves upstream",
+			remoteBase: "https://charts.example.com/base",
+			url:        "/charts/x-1.0.0.tgz",
+			want:       "https://charts.example.com/charts/x-1.0.0.tgz",
+		},
+		{
+			name:       "root-relative with no remote prefix is proxied",
+			remoteBase: "https://charts.example.com",
+			url:        "/charts/x-1.0.0.tgz",
+			want:       local + "charts/x-1.0.0.tgz",
+		},
+
+		// ── Query strings cannot be forwarded upstream ───────────────
+		{
+			name:       "absolute signed URL is handed to the client",
+			remoteBase: "https://charts.example.com",
+			url:        "https://charts.example.com/x-1.0.0.tgz?sig=abc123",
+			want:       "https://charts.example.com/x-1.0.0.tgz?sig=abc123",
+		},
+		{
+			name:       "relative signed URL resolves to the upstream original",
+			remoteBase: "https://charts.example.com",
+			url:        "charts/x-1.0.0.tgz?sig=abc123",
+			want:       "https://charts.example.com/charts/x-1.0.0.tgz?sig=abc123",
+		},
+		{
+			name:       "empty but forced query still counts as a query",
+			remoteBase: "https://charts.example.com",
+			url:        "https://charts.example.com/x-1.0.0.tgz?",
+			want:       "https://charts.example.com/x-1.0.0.tgz?",
+		},
+
+		// ── Degenerate input ─────────────────────────────────────────
+		{
+			name:       "oci scheme is not something we can serve over HTTP",
+			remoteBase: "https://charts.example.com",
+			url:        "oci://registry.example.com/charts/x",
+			want:       "oci://registry.example.com/charts/x",
+		},
+		{
+			name:       "unparsable entry is left for the client",
+			remoteBase: "https://charts.example.com",
+			url:        "%zz-1.0.0.tgz",
+			want:       "%zz-1.0.0.tgz",
+		},
+		{
+			name:       "unparsable remote leaves every entry alone",
+			remoteBase: "http://[::1",
+			url:        "charts/x-1.0.0.tgz",
+			want:       "charts/x-1.0.0.tgz",
+		},
+		{
+			// A remote_url saved without a scheme parses as a bare path. Nothing
+			// upstream will work, but the rewrite must not panic or leak the
+			// pseudo-host into the proxy path.
+			name:       "schemeless remote still yields a sane proxy path",
+			remoteBase: "charts.example.com",
+			url:        "charts/x-1.0.0.tgz",
+			want:       local + "charts/x-1.0.0.tgz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, rewriteChartURL(tt.url, tt.remoteBase, local))
+		})
+	}
+}
+
+func TestSplitChartFilename(t *testing.T) {
+	tests := []struct {
+		filename string
+		name     string
+		version  string
+	}{
+		{"ingress-nginx-4.11.2.tgz", "ingress-nginx", "4.11.2"},
+		{"nginx-15.0.0.tgz", "nginx", "15.0.0"},
+		{"nfs-helm1-0.1.1.tgz", "nfs-helm1", "0.1.1"},
+		// SemVer prerelease and build metadata must not be split at their dashes.
+		{"cert-manager-v1.13.0-beta.0.tgz", "cert-manager", "v1.13.0-beta.0"},
+		{"foo-1.2.3-rc.1.tgz", "foo", "1.2.3-rc.1"},
+		{"foo-1.2.3+build.5.tgz", "foo", "1.2.3+build.5"},
+		{"my-2.0-chart-1.0.0.tgz", "my-2.0-chart", "1.0.0"},
+		// Fallback: nothing SemVer-shaped, split at the last dash as before.
+		{"foo-1.0.tgz", "foo", "1.0"},
+		{"chart.tgz", "chart", "0.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			gotName, gotVersion := splitChartFilename(tt.filename)
+			assert.Equal(t, tt.name, gotName, "chart name")
+			assert.Equal(t, tt.version, gotVersion, "version")
+		})
+	}
+}


### PR DESCRIPTION
Closes #139.

A Helm repository whose `index.yaml` lists charts in a subdirectory could not be proxied at all:

```yaml
urls:
  - charts/ingress-nginx-4.11.2.tgz
```

`fetchAndRewriteHelmIndex` rewrote that with `path.Base`, so the client was handed `<proxy>/<repo>/ingress-nginx-4.11.2.tgz`, which the proxy then fetched from `<remote>/ingress-nginx-4.11.2.tgz` — a path that does not exist upstream. Only flat repositories worked.

## The fix

`rewriteChartURL` now resolves every entry the way Helm's own `repo.ResolveReferenceURL` does — `url.ResolveReference` against the remote with a trailing slash — instead of matching strings, and then decides:

| Index entry | Result |
| --- | --- |
| `charts/x-1.0.tgz` (relative, any depth) | proxy path preserving the whole path |
| `/charts/x-1.0.tgz` (root-relative) | resolved against the host root, then proxied if it lands inside the remote's subtree |
| `https://remote/charts/x-1.0.tgz` (absolute, same upstream) | prefix stripped, proxied |
| absolute on a foreign host, or anything outside the remote's subtree | left as the absolute upstream URL |
| any URL carrying a query string (presigned, tokened) | absolute upstream URL — a proxy path could never carry the signature |

The rule for the last two rows: **whatever we cannot proxy is handed back as the absolute upstream URL it resolves to**, so a client with egress still succeeds. Returning a relative entry untouched would have left the client resolving it against the *proxy's* base, which is the same failure in a different disguise.

Host matching is scheme-agnostic (an https index routinely lists http URLs for the same upstream) but normalises the default port, so `https://host:443/…` against remote `https://host` stays proxied — sending that client direct would break exactly the airgapped deployments a proxy exists for. Paths are cleaned before the subtree comparison, so `…/base/../secret/x.tgz` is recognised as outside the subtree rather than silently re-rooted.

## Also in this PR

- **Cached charts were filed under nonsense coordinates.** The proxy download path derived the component name from the whole request path, so a nested chart became `charts/ingress-nginx-4.11.2` with no version. It now parses name and version from the filename, sharing the helper with the upload path.
- **`.prov` sidecars** no longer register a junk second component — a chart and its provenance signature share one component with distinct assets.
- **SemVer prereleases split correctly**: `cert-manager-v1.13.0-beta.0.tgz` was becoming name `cert-manager-v1.13.0`, version `beta.0`. The version match is right-anchored now, with the old last-dash split kept as the fallback so non-SemVer uploads are byte-identical.

## Tests

Written test-first; the helm package goes from 26 to 64 tests. The round-trip test takes the URL out of the *rewritten* index and requests exactly that path against an upstream that serves only the nested location and 404s everything else — hand-constructing the download path would not have proven anything.

Review found four things after the first round, all fixed here: root-relative URLs were mis-resolved and collapsed onto the same proxy path as their absolute form; the subtree guard compared an un-normalised path; default-port hosts were treated as foreign, which was a real regression for airgapped users; and two branches of the new function were covered by nothing, because every test built its remote from an `httptest` URL that has no path component.

`golangci-lint run --new-from-rev=origin/main` reports zero issues; the full suite is 1723 passing (only the sandbox-networking webhook test fails locally, and it passes in CI).

A sibling of this bug in the conda proxy is filed separately as #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW