### PR TITLE
fix: stop deleting blobs another asset still needs, and three more data-loss paths

### DIFF
--- a/internal/api/handlers/browse_delete_test.go
+++ b/internal/api/handlers/browse_delete_test.go
@@ -1,0 +1,226 @@
+package handlers_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nexspence-oss/nexspence/internal/api/handlers"
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/storage"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// captureDispatcher records the webhook payloads a delete produces.
+type captureDispatcher struct{ events []domain.WebhookPayload }
+
+func (d *captureDispatcher) Dispatch(p domain.WebhookPayload) { d.events = append(d.events, p) }
+
+// deletedPaths lists the asset paths reported as deleted.
+func (d *captureDispatcher) deletedPaths() []string {
+	var out []string
+	for _, e := range d.events {
+		if e.Event != domain.EventArtifactDeleted {
+			continue
+		}
+		if p, ok := e.Asset["path"].(string); ok {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// secondaryStoreID is the blob store the test repository's assets live on — a
+// store that is NOT the handler's default.
+const secondaryStoreID = "bs-secondary"
+
+// mountBrowseOnSecondaryStore wires a BrowseHandler whose default store is an
+// in-memory double, while the repository's assets live on a second, real store
+// resolved through the blob store registry. Any delete that reaches the default
+// store is deleting from the wrong place.
+//
+// Returns the engine, the asset repo, the DEFAULT store (which must stay
+// untouched), the SECONDARY store (where the bytes really are), and the webhook
+// dispatcher.
+func mountBrowseOnSecondaryStore(t *testing.T) (
+	*gin.Engine, *testutil.RepoRepo, *testutil.AssetRepo, *testutil.BlobStore, *storage.LocalBlobStore, *captureDispatcher,
+) {
+	t.Helper()
+	repos := testutil.NewRepoRepo()
+	comps := testutil.NewComponentRepo()
+	assets := testutil.NewAssetRepo()
+
+	dir := t.TempDir()
+	secondary, err := storage.NewLocalBlobStore(dir)
+	require.NoError(t, err)
+	blobs := testutil.NewBlobStoreRepo(&domain.BlobStore{
+		ID: secondaryStoreID, Name: "secondary", Type: "local",
+		Config: map[string]any{"path": dir},
+	})
+
+	defaultStore := testutil.NewBlobStore()
+	hooks := &captureDispatcher{}
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar())
+	h := handlers.NewBrowseHandler(formats.Deps{
+		Repos:      repos,
+		Components: comps,
+		Assets:     assets,
+		Blobs:      blobs,
+		BlobStore:  defaultStore,
+		Registry:   storage.NewRegistry(defaultStore),
+		Webhooks:   hooks,
+	}, rbacSvc)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("userID", "admin")
+		c.Set("roles", []string{"nx-admin"})
+		c.Next()
+	})
+	r.DELETE("/api/v1/browse/repositories/:name/path", h.DeleteByPath)
+	r.DELETE("/api/v1/browse/repositories/:name/docker-tag", h.DeleteDockerTag)
+	r.DELETE("/api/v1/browse/repositories/:name/docker-image", h.DeleteDockerImage)
+	seedRepo(t, repos, &domain.Repository{
+		ID: "d1", Name: "docker-host", Format: domain.FormatDocker, Type: domain.TypeHosted,
+		BlobStoreID: strPtr(secondaryStoreID),
+	})
+	return r, repos, assets, defaultStore, secondary, hooks
+}
+
+func strPtr(s string) *string { return &s }
+
+// putSecondary writes a blob to the secondary store.
+func putSecondary(t *testing.T, s *storage.LocalBlobStore, key, content string) {
+	t.Helper()
+	require.NoError(t, s.Put(context.Background(), key, testutil.MakeReader(content), int64(len(content))))
+}
+
+// existsSecondary reports whether the secondary store still holds a blob.
+func existsSecondary(t *testing.T, s *storage.LocalBlobStore, key string) bool {
+	t.Helper()
+	ok, err := s.Exists(context.Background(), key)
+	require.NoError(t, err)
+	return ok
+}
+
+// seedTaggedImage stores a manifest naming one config and one layer blob, plus
+// the three asset records, all on the secondary store.
+func seedTaggedImage(t *testing.T, assets *testutil.AssetRepo, secondary *storage.LocalBlobStore) {
+	t.Helper()
+	ctx := context.Background()
+	putSecondary(t, secondary, "blob-manifest", `{"config":{"digest":"sha256:cfg"},"layers":[{"digest":"sha256:layer1"}]}`)
+	putSecondary(t, secondary, "blob-cfg", "c")
+	putSecondary(t, secondary, "blob-layer1", "l")
+
+	for _, a := range []*domain.Asset{
+		{Repository: "docker-host", Path: "/manifests/da/python/3.12", BlobKey: "blob-manifest",
+			SHA256: "tagsha", BlobStoreID: secondaryStoreID, SizeBytes: 70},
+		{Repository: "docker-host", Path: "/blobs/da/python/sha256:cfg", BlobKey: "blob-cfg",
+			BlobStoreID: secondaryStoreID, SizeBytes: 1},
+		{Repository: "docker-host", Path: "/blobs/da/python/sha256:layer1", BlobKey: "blob-layer1",
+			BlobStoreID: secondaryStoreID, SizeBytes: 1},
+	} {
+		require.NoError(t, assets.Create(ctx, a))
+	}
+}
+
+// A repository whose assets live on a non-default blob store must have its bytes
+// deleted from THAT store. The manifest also has to be read back from it, or the
+// config and layer digests come back empty and none of the layer blobs are ever
+// swept.
+func TestBrowse_DeleteDockerTag_DeletesFromTheAssetsOwnStore(t *testing.T) {
+	r, _, assets, defaultStore, secondary, hooks := mountBrowseOnSecondaryStore(t)
+	seedTaggedImage(t, assets, secondary)
+
+	rec := do(t, r, http.MethodDelete,
+		"/api/v1/browse/repositories/docker-host/docker-tag?image=da/python&ref=3.12", nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	assert.False(t, existsSecondary(t, secondary, "blob-manifest"), "manifest blob must be gone from its own store")
+	assert.False(t, existsSecondary(t, secondary, "blob-cfg"), "config blob must be gone from its own store")
+	assert.False(t, existsSecondary(t, secondary, "blob-layer1"), "layer blob must be gone from its own store")
+	assert.Empty(t, defaultStore.Deleted, "nothing may be deleted from the default store")
+
+	assert.ElementsMatch(t, []string{
+		"/manifests/da/python/3.12",
+		"/blobs/da/python/sha256:cfg",
+		"/blobs/da/python/sha256:layer1",
+	}, hooks.deletedPaths(), "every deleted artifact is reported on the webhook bus")
+}
+
+// Deleting a whole image must clear its manifests and blobs from the store that
+// holds them.
+func TestBrowse_DeleteDockerImage_DeletesFromTheAssetsOwnStore(t *testing.T) {
+	r, _, assets, defaultStore, secondary, hooks := mountBrowseOnSecondaryStore(t)
+	seedTaggedImage(t, assets, secondary)
+
+	rec := do(t, r, http.MethodDelete,
+		"/api/v1/browse/repositories/docker-host/docker-image?image=da/python", nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	assert.False(t, existsSecondary(t, secondary, "blob-manifest"))
+	assert.False(t, existsSecondary(t, secondary, "blob-cfg"))
+	assert.False(t, existsSecondary(t, secondary, "blob-layer1"))
+	assert.Empty(t, defaultStore.Deleted, "nothing may be deleted from the default store")
+	assert.Len(t, hooks.deletedPaths(), 3)
+}
+
+// Deleting by path prefix removes the bytes too, from the store that holds them.
+func TestBrowse_DeleteByPath_DeletesFromTheAssetsOwnStore(t *testing.T) {
+	r, _, assets, defaultStore, secondary, hooks := mountBrowseOnSecondaryStore(t)
+	seedTaggedImage(t, assets, secondary)
+
+	rec := do(t, r, http.MethodDelete,
+		"/api/v1/browse/repositories/docker-host/path?path=/blobs/da/python/", nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	assert.False(t, existsSecondary(t, secondary, "blob-cfg"))
+	assert.False(t, existsSecondary(t, secondary, "blob-layer1"))
+	assert.True(t, existsSecondary(t, secondary, "blob-manifest"), "a path outside the prefix is untouched")
+	assert.Empty(t, defaultStore.Deleted, "nothing may be deleted from the default store")
+	assert.ElementsMatch(t, []string{
+		"/blobs/da/python/sha256:cfg",
+		"/blobs/da/python/sha256:layer1",
+	}, hooks.deletedPaths())
+}
+
+// A tag and its digest alias are two records of ONE manifest on ONE blob. Both
+// records go, and the shared blob goes with the last of them — the order of the
+// two deletions no longer matters, but the outcome must not change.
+func TestBrowse_DeleteDockerTag_RemovesBothRecordsAndTheSharedBlob(t *testing.T) {
+	r, _, assets, _, secondary, _ := mountBrowseOnSecondaryStore(t)
+	ctx := context.Background()
+
+	putSecondary(t, secondary, "blob-manifest", `{"config":{"digest":"sha256:cfg"},"layers":[]}`)
+	putSecondary(t, secondary, "blob-cfg", "c")
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		Repository: "docker-host", Path: "/manifests/da/python/3.12", BlobKey: "blob-manifest",
+		SHA256: "abc123", BlobStoreID: secondaryStoreID, SizeBytes: 46,
+	}))
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		Repository: "docker-host", Path: "/manifests/da/python/sha256:abc123", BlobKey: "blob-manifest",
+		SHA256: "abc123", BlobStoreID: secondaryStoreID, SizeBytes: 46,
+	}))
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		Repository: "docker-host", Path: "/blobs/da/python/sha256:cfg", BlobKey: "blob-cfg",
+		BlobStoreID: secondaryStoreID, SizeBytes: 1,
+	}))
+
+	rec := do(t, r, http.MethodDelete,
+		"/api/v1/browse/repositories/docker-host/docker-tag?image=da/python&ref=3.12", nil)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	_, err := assets.GetByPath(ctx, "docker-host", "/manifests/da/python/3.12")
+	assert.Error(t, err, "the tag record is gone")
+	_, err = assets.GetByPath(ctx, "docker-host", "/manifests/da/python/sha256:abc123")
+	assert.Error(t, err, "the digest alias record is gone with it")
+	assert.False(t, existsSecondary(t, secondary, "blob-manifest"), "and the blob both shared is gone")
+	assert.False(t, existsSecondary(t, secondary, "blob-cfg"), "the config blob it referenced too")
+}

--- a/internal/api/handlers/browse_docker.go
+++ b/internal/api/handlers/browse_docker.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -10,25 +11,25 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
 	"github.com/nexspence-oss/nexspence/internal/formats/base"
-	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 )
 
 // BrowseHandler serves Nexspence-native browse APIs.
 type BrowseHandler struct {
-	repos      repository.RepositoryRepo
-	components repository.ComponentRepo
-	assets     repository.AssetRepo
-	blobs      repository.BlobStoreRepo
-	blobStore  storage.BlobStore
-	rbac       *service.RBACService
+	deps formats.Deps
+	rbac *service.RBACService
 }
 
-// NewBrowseHandler constructs a BrowseHandler from the repositories, blob store, and RBAC service it needs.
-func NewBrowseHandler(repos repository.RepositoryRepo, components repository.ComponentRepo, assets repository.AssetRepo, blobs repository.BlobStoreRepo, blobStore storage.BlobStore, rbac *service.RBACService) *BrowseHandler {
-	return &BrowseHandler{repos: repos, components: components, assets: assets, blobs: blobs, blobStore: blobStore, rbac: rbac}
+// NewBrowseHandler constructs a BrowseHandler over the same formats.Deps the
+// format handlers are built from. Deleting through the browse API removes the
+// same artifacts the registry API removes, so it has to see storage the same
+// way: the blob store registry that resolves an asset's own store, and the
+// webhook bus that reports a deletion.
+func NewBrowseHandler(deps formats.Deps, rbac *service.RBACService) *BrowseHandler {
+	return &BrowseHandler{deps: deps, rbac: rbac}
 }
 
 // dockerBrowseNode is a Nexus-style folder or leaf in the Docker browse tree.
@@ -47,7 +48,7 @@ func (h *BrowseHandler) DockerTree(c *gin.Context) {
 	repoName := c.Param("name")
 	ctx := c.Request.Context()
 
-	repo, err := h.repos.Get(ctx, repoName)
+	repo, err := h.deps.Repos.Get(ctx, repoName)
 	if err != nil || repo == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
 		return
@@ -70,7 +71,7 @@ func (h *BrowseHandler) DockerTree(c *gin.Context) {
 		}
 	}
 
-	rows, err := h.components.ListDockerBrowseRows(ctx, repoNames, 3000)
+	rows, err := h.deps.Components.ListDockerBrowseRows(ctx, repoNames, 3000)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -105,7 +106,7 @@ func (h *BrowseHandler) PathTree(c *gin.Context) {
 	q := c.Query("q")
 	ctx := c.Request.Context()
 
-	repo, err := h.repos.Get(ctx, repoName)
+	repo, err := h.deps.Repos.Get(ctx, repoName)
 	if err != nil || repo == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
 		return
@@ -113,7 +114,7 @@ func (h *BrowseHandler) PathTree(c *gin.Context) {
 
 	var paths []string
 	if repo.Format.IsOCIRegistry() {
-		raw, err := h.assets.ListRawAssetPaths(ctx, repoName)
+		raw, err := h.deps.Assets.ListRawAssetPaths(ctx, repoName)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -121,7 +122,7 @@ func (h *BrowseHandler) PathTree(c *gin.Context) {
 		paths = dockerImageDirs(raw, q)
 	} else {
 		var err error
-		paths, err = h.assets.ListPathsByRepo(ctx, repoName, q)
+		paths, err = h.deps.Assets.ListPathsByRepo(ctx, repoName, q)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -284,9 +285,22 @@ func sortBrowseChildren(n *dockerBrowseNode) {
 	}
 }
 
+// assetStore returns the physical blob store that actually holds an asset's
+// bytes. A repository can be pinned to a blob store of its own, and reading or
+// deleting through the default store then addresses a store the asset was never
+// written to: the delete silently misses and the read comes back empty.
+func (h *BrowseHandler) assetStore(ctx context.Context, asset *domain.Asset) storage.BlobStore {
+	if asset != nil && asset.BlobStoreID != "" {
+		if bsMeta, err := h.deps.Blobs.GetByID(ctx, asset.BlobStoreID); err == nil {
+			return base.PhysicalStore(ctx, h.deps, bsMeta)
+		}
+	}
+	return h.deps.BlobStore
+}
+
 // DeleteByPath handles DELETE /api/v1/browse/repositories/:name/path
 // Query param: path=<prefix> (required). Deletes all assets whose path starts with
-// the prefix, then removes orphan components. Blobs are cleaned by the GC scheduler.
+// the prefix, then removes orphan components.
 func (h *BrowseHandler) DeleteByPath(c *gin.Context) {
 	repoName := c.Param("name")
 	pathPrefix := c.Query("path")
@@ -296,20 +310,18 @@ func (h *BrowseHandler) DeleteByPath(c *gin.Context) {
 	}
 
 	ctx := c.Request.Context()
-	assets, err := h.assets.ListByRepoAndPath(ctx, repoName, pathPrefix)
+	assets, err := h.deps.Assets.ListByRepoAndPath(ctx, repoName, pathPrefix)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	for _, a := range assets {
-		if err := h.assets.Delete(ctx, a.ID); err != nil {
+		if err := base.DeleteArtifact(ctx, h.deps, repoName, a.Path); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
-		asset := a
-		_ = base.DecrementBlobStoreUsage(ctx, h.blobs, &asset)
 	}
-	if err := h.components.DeleteOrphans(ctx, repoName); err != nil {
+	if err := h.deps.Components.DeleteOrphans(ctx, repoName); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -332,38 +344,40 @@ func (h *BrowseHandler) DeleteDockerTag(c *gin.Context) {
 
 	// 1. Load the tag manifest asset and read its content.
 	tagPath := "/manifests/" + imageName + "/" + ref
-	tagAsset, err := h.assets.GetByPath(ctx, repoName, tagPath)
+	tagAsset, err := h.deps.Assets.GetByPath(ctx, repoName, tagPath)
 	if err != nil || tagAsset == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "manifest not found"})
 		return
 	}
 
-	deletedDigests := parseManifestDigests(h.blobStore.Get(ctx, tagAsset.BlobKey))
+	// Read through the store that holds this asset: a repository on its own blob
+	// store keeps its manifests there, and reading the default store would return
+	// nothing — leaving deletedDigests empty and the layers below never swept.
+	deletedDigests := parseManifestDigests(h.assetStore(ctx, tagAsset).Get(ctx, tagAsset.BlobKey))
 
-	// 2. Delete tag manifest asset record and its digest alias.
-	// Both share the same physical blob — delete it once after removing both records.
-	manifestBlobKey := tagAsset.BlobKey
-	if err := h.assets.Delete(ctx, tagAsset.ID); err == nil {
-		_ = base.DecrementBlobStoreUsage(ctx, h.blobs, tagAsset)
+	// 2. Delete the tag manifest record and its digest alias — two records of one
+	// manifest on one blob. DeleteArtifact keeps a blob alive while another asset
+	// still references it, so the shared blob goes with whichever record is
+	// deleted last and the order of these two no longer matters.
+	if err := base.DeleteArtifact(ctx, h.deps, repoName, tagPath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
 	}
-
 	digestAliasPath := "/manifests/" + imageName + "/sha256:" + tagAsset.SHA256
 	if digestAliasPath != tagPath {
-		if aliasAsset, aerr := h.assets.GetByPath(ctx, repoName, digestAliasPath); aerr == nil && aliasAsset != nil {
-			if err := h.assets.Delete(ctx, aliasAsset.ID); err == nil {
-				_ = base.DecrementBlobStoreUsage(ctx, h.blobs, aliasAsset)
-			}
+		if err := base.DeleteArtifact(ctx, h.deps, repoName, digestAliasPath); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
 		}
 	}
-	// Physical manifest blob: safe to delete now that both asset records are gone.
-	_ = h.blobStore.Delete(ctx, manifestBlobKey)
 
 	// 3. Collect digests still referenced by remaining manifests of this image.
 	//    This correctly handles shared layers between tags (e.g. latest and 3.15-rc share base layers).
 	stillUsed := make(map[string]struct{})
-	remaining, _ := h.assets.ListByRepoAndPath(ctx, repoName, "/manifests/"+imageName+"/")
-	for _, ra := range remaining {
-		for _, d := range parseManifestDigests(h.blobStore.Get(ctx, ra.BlobKey)) {
+	remaining, _ := h.deps.Assets.ListByRepoAndPath(ctx, repoName, "/manifests/"+imageName+"/")
+	for i := range remaining {
+		ra := remaining[i]
+		for _, d := range parseManifestDigests(h.assetStore(ctx, &ra).Get(ctx, ra.BlobKey)) {
 			stillUsed[d] = struct{}{}
 		}
 	}
@@ -373,19 +387,14 @@ func (h *BrowseHandler) DeleteDockerTag(c *gin.Context) {
 		if _, inUse := stillUsed[digest]; inUse {
 			continue
 		}
-		blobPath := "/blobs/" + imageName + "/" + digest
-		blobAsset, berr := h.assets.GetByPath(ctx, repoName, blobPath)
-		if berr != nil || blobAsset == nil {
-			continue
-		}
-		_ = h.blobStore.Delete(ctx, blobAsset.BlobKey)
-		if err := h.assets.Delete(ctx, blobAsset.ID); err == nil {
-			_ = base.DecrementBlobStoreUsage(ctx, h.blobs, blobAsset)
+		if err := base.DeleteArtifact(ctx, h.deps, repoName, "/blobs/"+imageName+"/"+digest); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
 		}
 	}
 
 	// 5. Remove orphaned component records.
-	_ = h.components.DeleteOrphans(ctx, repoName)
+	_ = h.deps.Components.DeleteOrphans(ctx, repoName)
 
 	c.Status(http.StatusNoContent)
 }
@@ -434,26 +443,18 @@ func (h *BrowseHandler) DeleteDockerImage(c *gin.Context) {
 	ctx := c.Request.Context()
 	prefix := imageName + "/"
 
-	// Delete all manifest blobs and asset records.
-	manifests, _ := h.assets.ListByRepoAndPath(ctx, repoName, "/manifests/"+prefix)
-	for _, a := range manifests {
-		_ = h.blobStore.Delete(ctx, a.BlobKey)
-		if err := h.assets.Delete(ctx, a.ID); err == nil {
-			asset := a
-			_ = base.DecrementBlobStoreUsage(ctx, h.blobs, &asset)
+	// Delete all manifest records, then all layer/config blob records. Each goes
+	// through DeleteArtifact, so the bytes are removed from the store that holds
+	// them and the deletion is reported like any other.
+	manifests, _ := h.deps.Assets.ListByRepoAndPath(ctx, repoName, "/manifests/"+prefix)
+	blobs, _ := h.deps.Assets.ListByRepoAndPath(ctx, repoName, "/blobs/"+prefix)
+	for _, a := range append(manifests, blobs...) {
+		if err := base.DeleteArtifact(ctx, h.deps, repoName, a.Path); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
 		}
 	}
 
-	// Delete all layer/config blobs and asset records.
-	blobs, _ := h.assets.ListByRepoAndPath(ctx, repoName, "/blobs/"+prefix)
-	for _, a := range blobs {
-		_ = h.blobStore.Delete(ctx, a.BlobKey)
-		if err := h.assets.Delete(ctx, a.ID); err == nil {
-			asset := a
-			_ = base.DecrementBlobStoreUsage(ctx, h.blobs, &asset)
-		}
-	}
-
-	_ = h.components.DeleteOrphans(ctx, repoName)
+	_ = h.deps.Components.DeleteOrphans(ctx, repoName)
 	c.Status(http.StatusNoContent)
 }

--- a/internal/api/handlers/browse_docker_test.go
+++ b/internal/api/handlers/browse_docker_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
@@ -28,7 +29,13 @@ func mountBrowse(t *testing.T) (*gin.Engine, *testutil.RepoRepo, *testutil.Compo
 	blobs := testutil.NewBlobStoreRepo()
 	store := testutil.NewBlobStore()
 	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar())
-	h := handlers.NewBrowseHandler(repos, comps, assets, blobs, store, rbacSvc)
+	h := handlers.NewBrowseHandler(formats.Deps{
+		Repos:      repos,
+		Components: comps,
+		Assets:     assets,
+		Blobs:      blobs,
+		BlobStore:  store,
+	}, rbacSvc)
 
 	r := gin.New()
 	r.Use(func(c *gin.Context) {

--- a/internal/api/handlers/browse_raw.go
+++ b/internal/api/handlers/browse_raw.go
@@ -27,7 +27,7 @@ func (h *BrowseHandler) RawTree(c *gin.Context) {
 	repoName := c.Param("name")
 	ctx := c.Request.Context()
 
-	repo, err := h.repos.Get(ctx, repoName)
+	repo, err := h.deps.Repos.Get(ctx, repoName)
 	if err != nil || repo == nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
 		return
@@ -50,7 +50,7 @@ func (h *BrowseHandler) RawTree(c *gin.Context) {
 		}
 	}
 
-	rows, err := h.assets.ListRawBrowseAssets(ctx, repoNames)
+	rows, err := h.deps.Assets.ListRawBrowseAssets(ctx, repoNames)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -235,7 +235,10 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	userH := handlers.NewUserHandler(userSvc)
 	blobH := handlers.NewBlobStoreHandler(blobRepo).WithUsageDeps(repoRepo, assetRepo).WithRegistry(blobRegistry).WithGC(gcSvc)
 	componentH := handlers.NewComponentHandler(componentRepo, assetRepo, repoRepo, cfg.HTTP.BaseURL).WithRBAC(rbacSvc)
-	browseH := handlers.NewBrowseHandler(repoRepo, componentRepo, assetRepo, blobRepo, localBlob, rbacSvc)
+	// The same Deps the format handlers get: a browse delete removes the same
+	// artifacts a registry delete does, from the same stores, with the same
+	// webhook.
+	browseH := handlers.NewBrowseHandler(formatDeps, rbacSvc)
 	cleanupH := handlers.NewCleanupHandler(cleanupRepo, repoRepo, cleanupSvc)
 	auditH := handlers.NewAuditHandler(auditRepo)
 	scanSvc := service.NewScanService(componentRepo, cfg.HTTP.BaseURL).

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -265,11 +265,25 @@ func DeleteArtifact(ctx context.Context, d formats.Deps, repoName, filePath stri
 	if delStore == nil {
 		delStore = d.BlobStore
 	}
-	_ = delStore.Delete(ctx, asset.BlobKey)
+	// One blob can carry several assets: an OCI manifest push registers the tag
+	// path and the digest-alias path on the same blob key, and a client that
+	// deletes one still pulls the other. Deleting the bytes here would leave the
+	// survivor — and the referrers index built from it — advertising content that
+	// is gone. A count that cannot be read keeps the blob: an orphan is reclaimed
+	// by the blob GC, whereas bytes deleted under a live asset are lost.
+	others, cerr := d.Assets.CountByBlobKey(ctx, asset.BlobKey, asset.ID)
+	if cerr == nil && others == 0 {
+		_ = delStore.Delete(ctx, asset.BlobKey)
+	}
 	if err := d.Assets.Delete(ctx, asset.ID); err != nil {
 		return err
 	}
 	metrics.ArtifactsDeleted.Add(1)
+	// Decremented whether or not the bytes went away, because the counter is
+	// incremented once per registered asset — the alias registration in
+	// RegisterStoredBlob adds size a second time for the same blob. Skipping the
+	// decrement for a surviving blob would leave that second size on the store
+	// forever and walk it into a false quota rejection.
 	_ = DecrementBlobStoreUsage(ctx, d.Blobs, asset)
 	if d.Webhooks != nil {
 		d.Webhooks.Dispatch(domain.WebhookPayload{

--- a/internal/formats/base/store_test.go
+++ b/internal/formats/base/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -240,6 +241,56 @@ func TestDeleteArtifact_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.False(t, blobStore.Has(key))
+}
+
+// An OCI manifest push registers two assets on ONE blob: the tag path and the
+// digest-alias path. Deleting either one — DELETE by the tag cosign signs under,
+// for instance — must not destroy the bytes the other one still points at, or
+// the surviving asset (and the referrers index built from it) advertises content
+// that is gone.
+func TestDeleteArtifact_KeepsBlobWhileAnotherAssetReferencesIt(t *testing.T) {
+	repo := testutil.SimpleRepo("aliasrepo", "oci")
+	d, blobStore, _, _ := deps(repo)
+
+	ctx := context.Background()
+	content := `{"schemaVersion":2}`
+	tagPath := "/manifests/app/1.0"
+	res, err := base.StoreArtifact(ctx, d,
+		"aliasrepo", tagPath, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "1.0"},
+		strings.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+
+	// The digest alias: a second asset record on the SAME blob key.
+	digestPath := "/manifests/app/sha256:" + res.SHA256
+	_, err = base.RegisterStoredBlob(ctx, d, repo,
+		digestPath, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "sha256:" + res.SHA256},
+		res.Asset.BlobKey, res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+	require.NoError(t, err)
+
+	key := base.BlobKey("aliasrepo", tagPath)
+	require.True(t, blobStore.Has(key))
+
+	// Delete by tag: the alias still needs the bytes.
+	require.NoError(t, base.DeleteArtifact(ctx, d, "aliasrepo", tagPath))
+	assert.True(t, blobStore.Has(key), "blob is still referenced by the digest alias")
+
+	rc, asset, err := base.FetchArtifact(ctx, d, "aliasrepo", digestPath)
+	require.NoError(t, err, "the surviving asset must still serve its content")
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, content, string(body))
+	assert.Equal(t, res.SHA256, asset.SHA256)
+
+	// The tag itself is gone.
+	_, _, err = base.FetchArtifact(ctx, d, "aliasrepo", tagPath)
+	require.Error(t, err)
+
+	// Delete the last asset on the blob: now the bytes go.
+	require.NoError(t, base.DeleteArtifact(ctx, d, "aliasrepo", digestPath))
+	assert.False(t, blobStore.Has(key), "no asset references the blob any more")
 }
 
 func TestDeleteArtifact_Idempotent(t *testing.T) {

--- a/internal/formats/conda/conda_extra_test.go
+++ b/internal/formats/conda/conda_extra_test.go
@@ -392,7 +392,10 @@ func TestConda_Proxy_Package_Fetch(t *testing.T) {
 // ─── rewriteCondaURLs: urls array (packages.conda) ───────────────
 
 func TestConda_ProxyRepodata_RewritesUrlsArray(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	// The entry is absolute under the configured channel — a URL on a foreign host is
+	// deliberately left alone, and is covered in proxy_subpath_test.go.
+	var upstream *httptest.Server
+	upstream = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		doc := map[string]any{
 			"info":     map[string]any{"subdir": "linux-64"},
@@ -401,7 +404,7 @@ func TestConda_ProxyRepodata_RewritesUrlsArray(t *testing.T) {
 				"numpy-1.24.0-py311_0.conda": map[string]any{
 					"name":    "numpy",
 					"version": "1.24.0",
-					"urls":    []any{"https://conda.anaconda.org/defaults/linux-64/numpy-1.24.0-py311_0.conda"},
+					"urls":    []any{upstream.URL + "/linux-64/numpy-1.24.0-py311_0.conda"},
 				},
 			},
 		}

--- a/internal/formats/conda/handler.go
+++ b/internal/formats/conda/handler.go
@@ -205,7 +205,9 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 
 	// Package binary: cache via repoproxy. Conda packages are immutable
 	// (repodata.json — the mutable index — is handled by proxyRepodata above).
-	coords := base.Coords{Name: filename, Group: platform}
+	// A repodata.json entry may point below the subdir, so filename can carry a
+	// directory; the component is named after the package file alone.
+	coords := base.Coords{Name: path.Base(filename), Group: platform}
 	if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/x-tar", 0); err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 	}
@@ -243,35 +245,11 @@ func (h *Handler) proxyRepodata(c *gin.Context, repo *domain.Repository, repoNam
 		return
 	}
 
-	localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repoName + "/" + platform + "/"
-	rewriteCondaURLs(doc, localBase)
+	// The proxy base is the CHANNEL root, not the subdir: an entry may name a sibling
+	// subdir, and rewritePackageURL resolves each one against the subdir it came from.
+	localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repoName + "/"
+	rewriteCondaURLs(doc, remoteBase, platform, localBase)
 
 	data, _ := json.Marshal(doc)
 	c.Data(http.StatusOK, "application/json", data)
-}
-
-// rewriteCondaURLs rewrites "url" and "urls" fields inside "packages" and "packages.conda"
-// so downloads route through this proxy.
-func rewriteCondaURLs(doc map[string]any, localBase string) {
-	for _, key := range []string{"packages", "packages.conda"} {
-		pkgs, _ := doc[key].(map[string]any)
-		for filename, v := range pkgs {
-			entry, ok := v.(map[string]any)
-			if !ok {
-				continue
-			}
-			if u, ok := entry["url"].(string); ok {
-				entry["url"] = localBase + path.Base(u)
-			}
-			if urls, ok := entry["urls"].([]any); ok {
-				for i, u := range urls {
-					if s, ok := u.(string); ok {
-						urls[i] = localBase + path.Base(s)
-					}
-				}
-				entry["urls"] = urls
-			}
-			doc[key].(map[string]any)[filename] = entry
-		}
-	}
 }

--- a/internal/formats/conda/proxy_subpath_test.go
+++ b/internal/formats/conda/proxy_subpath_test.go
@@ -1,0 +1,286 @@
+package conda_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/conda"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+const condaBaseURL = "http://localhost:8080"
+
+// subpathProxy builds a conda proxy repository pointing at remoteURL.
+func subpathProxy(t *testing.T, repoName, remoteURL string) (*gin.Engine, *testutil.ComponentRepo) {
+	t.Helper()
+	comps := testutil.NewComponentRepo()
+	repo := &domain.Repository{
+		ID: repoName, Name: repoName, Format: "conda",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": remoteURL},
+	}
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    condaBaseURL,
+	}
+	h := conda.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps
+}
+
+const condaPkgFile = "numpy-1.24.0-py311_0.tar.bz2"
+
+// subdirUpstream serves repodata.json at repodataPath whose single "packages" entry
+// carries entryURL, and serves the package bytes ONLY at pkgPath. Everything else
+// 404s, so a rewrite that loses or invents a path segment cannot pass.
+// A "%s" in entryURL is replaced with the server's own base URL.
+func subdirUpstream(t *testing.T, repodataPath, entryURL, pkgPath, body string) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case repodataPath:
+			u := strings.ReplaceAll(entryURL, "%s", srv.URL)
+			doc := map[string]any{
+				"info": map[string]any{"subdir": "linux-64"},
+				"packages": map[string]any{
+					condaPkgFile: map[string]any{
+						"name":    "numpy",
+						"version": "1.24.0",
+						"url":     u,
+					},
+				},
+				"packages.conda": map[string]any{},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(doc)
+		case pkgPath:
+			w.Header().Set("Content-Type", "application/x-tar")
+			_, _ = w.Write([]byte(body))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv
+}
+
+// firstPackageURL fetches repodata.json through the proxy and returns the rewritten
+// download URL a conda client would follow.
+func firstPackageURL(t *testing.T, r *gin.Engine, repoName, platform string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/"+repoName+"/"+platform+"/repodata.json", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "repodata.json body: %s", w.Body.String())
+
+	var doc struct {
+		Packages map[string]struct {
+			URL string `json:"url"`
+		} `json:"packages"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+	entry, ok := doc.Packages[condaPkgFile]
+	require.True(t, ok, "package entry missing from rewritten repodata.json")
+	return entry.URL
+}
+
+// fetchThrough requests exactly the URL the rewritten index handed the client.
+func fetchThrough(t *testing.T, r *gin.Engine, pkgURL string) *httptest.ResponseRecorder {
+	t.Helper()
+	require.True(t, strings.HasPrefix(pkgURL, condaBaseURL),
+		"expected a proxy URL, got %s", pkgURL)
+	req := httptest.NewRequest(http.MethodGet, strings.TrimPrefix(pkgURL, condaBaseURL), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// TestConda_Proxy_NestedPackageURL_RoundTrip is the reported case (#142): the
+// upstream repodata.json points at a package stored below the subdir directory.
+// path.Base dropped "pkgs/", so the client asked for a path that does not exist
+// upstream. The download path comes out of the rewritten document, so this proves
+// the whole round trip closes.
+func TestConda_Proxy_NestedPackageURL_RoundTrip(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		"pkgs/"+condaPkgFile, "/linux-64/pkgs/"+condaPkgFile, "nested-package-bytes")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-nested", upstream.URL)
+
+	pkgURL := firstPackageURL(t, r, "conda-nested", "linux-64")
+	assert.Equal(t, condaBaseURL+"/repository/conda-nested/linux-64/pkgs/"+condaPkgFile, pkgURL,
+		"the upstream subdirectory must survive the rewrite")
+
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "nested-package-bytes", w.Body.String())
+}
+
+// TestConda_Proxy_FlatPackageURL_RoundTrip is the regression guard: the ordinary
+// channel layout, where the package sits beside repodata.json, must be unchanged.
+func TestConda_Proxy_FlatPackageURL_RoundTrip(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		condaPkgFile, "/linux-64/"+condaPkgFile, "flat-package-bytes")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-flat", upstream.URL)
+
+	pkgURL := firstPackageURL(t, r, "conda-flat", "linux-64")
+	assert.Equal(t, condaBaseURL+"/repository/conda-flat/linux-64/"+condaPkgFile, pkgURL)
+
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "flat-package-bytes", w.Body.String())
+}
+
+// TestConda_Proxy_AbsoluteURLUnderRemote_RoundTrip covers a repodata.json that
+// spells its URLs out in full against the configured channel: the channel prefix is
+// stripped and the remainder — subdirectory included — becomes the proxy path.
+func TestConda_Proxy_AbsoluteURLUnderRemote_RoundTrip(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		"%s/linux-64/pkgs/"+condaPkgFile, "/linux-64/pkgs/"+condaPkgFile, "absolute-package-bytes")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-abs", upstream.URL)
+
+	pkgURL := firstPackageURL(t, r, "conda-abs", "linux-64")
+	assert.Equal(t, condaBaseURL+"/repository/conda-abs/linux-64/pkgs/"+condaPkgFile, pkgURL)
+
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "absolute-package-bytes", w.Body.String())
+}
+
+// TestConda_Proxy_RootRelativeURL_RoundTrip covers an entry that starts with "/".
+// It resolves against the HOST root, not the channel's path prefix, and is proxied
+// only because it happens to land back inside the channel subtree.
+func TestConda_Proxy_RootRelativeURL_RoundTrip(t *testing.T) {
+	upstream := subdirUpstream(t, "/channel/linux-64/repodata.json",
+		"/channel/linux-64/pkgs/"+condaPkgFile, "/channel/linux-64/pkgs/"+condaPkgFile,
+		"root-relative-package-bytes")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-rootrel", upstream.URL+"/channel")
+
+	pkgURL := firstPackageURL(t, r, "conda-rootrel", "linux-64")
+	assert.Equal(t, condaBaseURL+"/repository/conda-rootrel/linux-64/pkgs/"+condaPkgFile, pkgURL)
+
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "root-relative-package-bytes", w.Body.String())
+}
+
+// TestConda_Proxy_ForeignHostURL_LeftAlone covers a channel whose repodata.json
+// points at a CDN. We cannot express that as a path under this proxy — forwarding it
+// would 404 upstream — so the absolute URL must survive untouched.
+func TestConda_Proxy_ForeignHostURL_LeftAlone(t *testing.T) {
+	const foreign = "https://conda.anaconda.org/conda-forge/linux-64/" + condaPkgFile
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		foreign, "/unused", "unused")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-foreign", upstream.URL)
+
+	assert.Equal(t, foreign, firstPackageURL(t, r, "conda-foreign", "linux-64"),
+		"a package on another host cannot be proxied and must not be rewritten")
+}
+
+// TestConda_Proxy_SameHostOutsideChannel_LeftAlone covers a channel served under a
+// path prefix whose repodata.json points at a sibling channel on the same host. That
+// is outside the proxied subtree, so it cannot be expressed as a path here either.
+func TestConda_Proxy_SameHostOutsideChannel_LeftAlone(t *testing.T) {
+	upstream := subdirUpstream(t, "/channel/linux-64/repodata.json",
+		"%s/other-channel/linux-64/"+condaPkgFile, "/unused", "unused")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-outside", upstream.URL+"/channel")
+
+	assert.Equal(t, upstream.URL+"/other-channel/linux-64/"+condaPkgFile,
+		firstPackageURL(t, r, "conda-outside", "linux-64"),
+		"a URL outside the proxied channel is not ours to rewrite")
+}
+
+// TestConda_Proxy_CrossSubdirURL_RoundTrip covers an entry pointing at a sibling
+// subdir of the same channel ("../noarch/..."). The proxy path is rooted at the
+// channel, not at the subdir, so this stays proxyable.
+func TestConda_Proxy_CrossSubdirURL_RoundTrip(t *testing.T) {
+	const noarchFile = "mypackage-0.1.0-py_0.conda"
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		"../noarch/"+noarchFile, "/noarch/"+noarchFile, "noarch-package-bytes")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-cross", upstream.URL)
+
+	pkgURL := firstPackageURL(t, r, "conda-cross", "linux-64")
+	assert.Equal(t, condaBaseURL+"/repository/conda-cross/noarch/"+noarchFile, pkgURL)
+
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "noarch-package-bytes", w.Body.String())
+}
+
+// TestConda_Proxy_ChannelRootURL_LeftAlone covers an entry resolving to the channel
+// root itself. Every conda request path is "/<subdir>/<file>", so a single-segment
+// path has no proxy URL that would route: hand the client the upstream original
+// instead of a proxy URL that answers 400.
+func TestConda_Proxy_ChannelRootURL_LeftAlone(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		"../"+condaPkgFile, "/unused", "unused")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-root", upstream.URL)
+
+	assert.Equal(t, upstream.URL+"/"+condaPkgFile,
+		firstPackageURL(t, r, "conda-root", "linux-64"),
+		"a channel-root URL has no routable proxy path")
+}
+
+// TestConda_Proxy_QueryString_LeftAlone covers a signed URL. The download branch
+// forwards only the request path upstream, so a rewritten copy would be re-fetched
+// without its signature and rejected.
+func TestConda_Proxy_QueryString_LeftAlone(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		"%s/linux-64/"+condaPkgFile+"?token=abc", "/unused", "unused")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-query", upstream.URL)
+
+	assert.Equal(t, upstream.URL+"/linux-64/"+condaPkgFile+"?token=abc",
+		firstPackageURL(t, r, "conda-query", "linux-64"),
+		"a signed URL cannot survive the round trip")
+}
+
+// TestConda_Proxy_NestedPackage_CachedCoords verifies the cached component is named
+// after the package file, not after the subdirectory path it was fetched from.
+func TestConda_Proxy_NestedPackage_CachedCoords(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		"pkgs/"+condaPkgFile, "/linux-64/pkgs/"+condaPkgFile, "nested-package-bytes")
+	defer upstream.Close()
+
+	r, comps := subpathProxy(t, "conda-coords", upstream.URL)
+
+	pkgURL := firstPackageURL(t, r, "conda-coords", "linux-64")
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	page, err := comps.List(t.Context(), "conda-coords", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, condaPkgFile, page.Items[0].Name,
+		"the component name must not carry the subdirectory")
+}

--- a/internal/formats/conda/rewrite.go
+++ b/internal/formats/conda/rewrite.go
@@ -123,6 +123,14 @@ func rewritePackageURL(rawURL, remoteBase, platform, localBase string) string {
 	return localBase + rel
 }
 
+// sameUpstreamHost and normalizedHost below are, for now, twins of helm's. The two
+// rewriters around them are NOT interchangeable — conda resolves against the subdir
+// and proxies from the channel root, helm does both at the repository root — so only
+// these two leaves are shared logic. They are duplicated rather than lifted into
+// repoproxy because that move would have to change helm in the same commit, and this
+// change is scoped to the conda package; lifting them is worth doing once a third
+// format needs them.
+//
 // sameUpstreamHost reports whether two URLs address the same upstream host. The
 // scheme itself is ignored — an index served over https routinely lists http URLs and
 // the reverse — but each scheme's default port is normalized away first, so an entry

--- a/internal/formats/conda/rewrite.go
+++ b/internal/formats/conda/rewrite.go
@@ -1,0 +1,149 @@
+package conda
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+// rewriteCondaURLs rewrites the "url" and "urls" fields inside "packages" and
+// "packages.conda" of an upstream repodata.json so downloads route through this proxy.
+//
+// platform is the subdir the document was fetched from, i.e. the document lives at
+// "<remoteBase>/<platform>/repodata.json" and its relative URLs resolve against
+// "<remoteBase>/<platform>/". localBase is this proxy's CHANNEL root
+// ("…/repository/<repo>/") and must end in "/", because an entry may name a sibling
+// subdir and the proxy path has to be able to say so.
+func rewriteCondaURLs(doc map[string]any, remoteBase, platform, localBase string) {
+	for _, key := range []string{"packages", "packages.conda"} {
+		pkgs, _ := doc[key].(map[string]any)
+		for filename, v := range pkgs {
+			entry, ok := v.(map[string]any)
+			if !ok {
+				continue
+			}
+			if u, ok := entry["url"].(string); ok {
+				entry["url"] = rewritePackageURL(u, remoteBase, platform, localBase)
+			}
+			if urls, ok := entry["urls"].([]any); ok {
+				for i, u := range urls {
+					if s, ok := u.(string); ok {
+						urls[i] = rewritePackageURL(s, remoteBase, platform, localBase)
+					}
+				}
+				entry["urls"] = urls
+			}
+			pkgs[filename] = entry
+		}
+	}
+}
+
+// rewritePackageURL maps one repodata.json download URL onto this proxy.
+//
+// The URL is resolved as a reference against the directory holding repodata.json —
+// "<remoteBase>/<platform>/" — the way any client resolving the document would, rather
+// than pattern-matched. That leaves five shapes:
+//
+//  1. a relative path of any depth ("pkgs/numpy-1.24.0-py311_0.tar.bz2") — kept whole
+//     under its subdir, because the download branch forwards the request path upstream
+//     verbatim;
+//  2. an absolute URL under the configured channel — the channel's own path prefix is
+//     stripped and the remainder is treated as case 1;
+//  3. a root-relative path ("/channel/linux-64/x.conda"), which resolves against the
+//     HOST root and NOT the channel's path prefix — case 2 when it happens to land
+//     inside the proxied channel, case 4 otherwise;
+//  4. an absolute URL we cannot serve: another host (a CDN, the common case that
+//     motivated this), a sibling subtree of the same host, or any URL carrying a query,
+//     which the download branch would drop and so re-fetch unsigned;
+//  5. a URL inside the channel but not under a subdir ("<channel>/x.tar.bz2"). Unlike
+//     Helm, whose repository is flat, every conda request path is "/<subdir>/<file>",
+//     so a single-segment path has no proxy URL that would route at all — it is case 4.
+//
+// Whatever falls to case 4 is handed back as the absolute upstream URL it resolves to,
+// unchanged when the entry was already absolute. Such a package cannot be expressed as
+// a path under this proxy, so the client fetches it directly: that skips the cache and
+// needs egress, but it beats a proxy path that would 404 or, worse, quietly serve a
+// different package.
+//
+// Note that unlike a Helm index, resolution is rooted at the DOCUMENT (the subdir),
+// while the proxy path is rooted at the CHANNEL — an entry may legitimately name a
+// sibling subdir, e.g. "../noarch/mypackage-0.1.0-py_0.conda".
+func rewritePackageURL(rawURL, remoteBase, platform, localBase string) string {
+	remote, err := url.Parse(remoteBase)
+	if err != nil {
+		return rawURL
+	}
+	ref, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL // unparsable: leave it for the client to deal with
+	}
+
+	// Resolve against the directory repodata.json itself lives in, with a trailing
+	// slash, so a bare filename lands beside the index and a root-relative entry lands
+	// at the host root.
+	resolveBase := *remote
+	resolveBase.Path = strings.TrimSuffix(remote.Path, "/") + "/" + platform + "/"
+	resolveBase.RawPath = ""
+	abs := resolveBase.ResolveReference(ref)
+
+	// unproxyable hands the client the upstream URL. An entry that was already
+	// absolute goes back byte for byte rather than as a re-serialized copy.
+	unproxyable := func() string {
+		if ref.Scheme != "" || ref.Host != "" {
+			return rawURL
+		}
+		return abs.String()
+	}
+
+	// A query cannot survive the round trip: the download branch forwards only the
+	// request path upstream, so a signed or tokenized URL would be re-fetched unsigned
+	// and rejected. Send the client to the original instead.
+	if abs.RawQuery != "" || abs.ForceQuery {
+		return unproxyable()
+	}
+	if !sameUpstreamHost(abs, remote) {
+		return unproxyable()
+	}
+
+	// Compare cleaned paths, so a ".." segment cannot slip past the subtree check and
+	// only afterwards collapse into a path pointing at a different upstream file.
+	remotePath := path.Clean("/" + strings.Trim(remote.Path, "/"))
+	absPath := path.Clean("/" + strings.TrimPrefix(abs.Path, "/"))
+	if remotePath != "/" {
+		if absPath != remotePath && !strings.HasPrefix(absPath, remotePath+"/") {
+			return unproxyable()
+		}
+		absPath = strings.TrimPrefix(absPath, remotePath)
+	}
+	rel := strings.TrimPrefix(absPath, "/")
+	// Case 5: the conda routes only accept "/<subdir>/<file>".
+	if !strings.Contains(rel, "/") {
+		return unproxyable()
+	}
+	return localBase + rel
+}
+
+// sameUpstreamHost reports whether two URLs address the same upstream host. The
+// scheme itself is ignored — an index served over https routinely lists http URLs and
+// the reverse — but each scheme's default port is normalized away first, so an entry
+// on "host:443" and a remote of bare "host" are recognized as one upstream.
+func sameUpstreamHost(a, b *url.URL) bool {
+	return normalizedHost(a, b.Scheme) == normalizedHost(b, a.Scheme)
+}
+
+// normalizedHost lowercases u's host and drops the port when it is the default for
+// u's scheme. fallbackScheme supplies the scheme for a protocol-relative reference.
+func normalizedHost(u *url.URL, fallbackScheme string) string {
+	scheme := strings.ToLower(u.Scheme)
+	if scheme == "" {
+		scheme = strings.ToLower(fallbackScheme)
+	}
+	host := strings.ToLower(u.Host)
+	switch scheme {
+	case "http":
+		return strings.TrimSuffix(host, ":80")
+	case "https":
+		return strings.TrimSuffix(host, ":443")
+	}
+	return host
+}

--- a/internal/formats/oci/referrers_delete_test.go
+++ b/internal/formats/oci/referrers_delete_test.go
@@ -1,0 +1,124 @@
+package oci_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deleteManifest issues DELETE /v2/<image>/manifests/<reference>.
+func deleteManifest(t *testing.T, r *gin.Engine, repoName, imageName, reference string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodDelete,
+		"/repository/"+repoName+"/v2/"+imageName+"/manifests/"+reference, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// getManifest issues GET /v2/<image>/manifests/<reference>.
+func getManifest(t *testing.T, r *gin.Engine, repoName, imageName, reference string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/"+repoName+"/v2/"+imageName+"/manifests/"+reference, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// pushSignature attaches a cosign-shaped signature to subjectDigest under the
+// tag cosign uses, and returns (tag, digest) of the signature manifest.
+func pushSignature(t *testing.T, r *gin.Engine, repoName, imageName, subjectDigest string) (string, string) {
+	t.Helper()
+	sig := referrerManifest(cosignSigArtifactType, subjectDigest)
+	sigTag := strings.Replace(subjectDigest, ":", "-", 1) + ".sig"
+	return sigTag, pushManifestBody(t, r, repoName, imageName, sigTag, sig)
+}
+
+// A referrer is listed for as long as one of its manifest records is stored, so
+// removing it from a subject's index means removing the manifest — both the tag
+// it was pushed under and the digest record clients pull it by.
+func TestReferrers_DeletingTheReferrerRemovesItFromTheIndex(t *testing.T) {
+	repo := hostedOCIRepo("r-del-1", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+	sigTag, sigDigest := pushSignature(t, r, "oci-hosted", "charts/nginx", subjectDigest)
+
+	_, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Len(t, descs, 1, "the signature is listed before it is deleted")
+
+	require.Equal(t, http.StatusAccepted, deleteManifest(t, r, "oci-hosted", "charts/nginx", sigTag).Code)
+	require.Equal(t, http.StatusAccepted, deleteManifest(t, r, "oci-hosted", "charts/nginx", sigDigest).Code)
+
+	_, _, descs = getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	assert.Empty(t, descs, "a deleted signature is no longer a referrer of its subject")
+
+	assert.Equal(t, http.StatusNotFound,
+		getManifest(t, r, "oci-hosted", "charts/nginx", sigDigest).Code,
+		"the signature manifest itself is gone")
+}
+
+// A manifest push stores two records of one manifest — the tag and the digest
+// clients re-fetch by — and DELETE names one record, not the manifest. So
+// deleting the tag a signature was pushed under leaves the signature stored,
+// pullable by digest, and listed as a referrer. That is the OCI reading of a tag
+// delete, and it is also why the underlying blob must survive the first delete:
+// an index entry whose content had been destroyed would advertise a signature no
+// client could fetch.
+func TestReferrers_DeletingOnlyTheReferrerTagLeavesTheSignatureStored(t *testing.T) {
+	repo := hostedOCIRepo("r-del-2", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+	sigTag, sigDigest := pushSignature(t, r, "oci-hosted", "charts/nginx", subjectDigest)
+
+	require.Equal(t, http.StatusAccepted, deleteManifest(t, r, "oci-hosted", "charts/nginx", sigTag).Code)
+
+	assert.Equal(t, http.StatusNotFound,
+		getManifest(t, r, "oci-hosted", "charts/nginx", sigTag).Code,
+		"the tag is gone")
+
+	byDigest := getManifest(t, r, "oci-hosted", "charts/nginx", sigDigest)
+	require.Equal(t, http.StatusOK, byDigest.Code, "the manifest is still stored under its digest")
+	assert.Equal(t, referrerManifest(cosignSigArtifactType, subjectDigest), byDigest.Body.String(),
+		"and its bytes are intact — the blob is shared with the deleted tag record")
+
+	_, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	require.Len(t, descs, 1, "a stored signature is still a referrer")
+	assert.Equal(t, sigDigest, descs[0].Digest)
+}
+
+// Deleting the SUBJECT leaves its referrers listed. A signature is an artifact
+// of its own that outlives the image it describes, and the index answers a
+// question about a digest, not about a manifest this registry still holds — a
+// client asking about a digest that was never here gets the same shape of
+// answer.
+func TestReferrers_DeletingTheSubjectLeavesItsReferrersListed(t *testing.T) {
+	repo := hostedOCIRepo("r-del-3", "oci-hosted")
+	r, _ := setupWithDeps(repo)
+
+	subjectDigest := pushManifestBody(t, r, "oci-hosted", "charts/nginx", "1.2.3", helmChartManifest)
+	sigTag, sigDigest := pushSignature(t, r, "oci-hosted", "charts/nginx", subjectDigest)
+
+	// Delete the image whole: the tag and the digest record of the same manifest.
+	require.Equal(t, http.StatusAccepted, deleteManifest(t, r, "oci-hosted", "charts/nginx", "1.2.3").Code)
+	require.Equal(t, http.StatusAccepted, deleteManifest(t, r, "oci-hosted", "charts/nginx", subjectDigest).Code)
+	require.Equal(t, http.StatusNotFound,
+		getManifest(t, r, "oci-hosted", "charts/nginx", subjectDigest).Code,
+		"the subject manifest is gone")
+
+	w, _, descs := getReferrers(t, r, "oci-hosted", "charts/nginx", subjectDigest, "")
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, descs, 1, "the signature is still stored and still names that subject")
+	assert.Equal(t, sigDigest, descs[0].Digest)
+	assert.Equal(t, cosignSigArtifactType, descs[0].ArtifactType)
+
+	// The signature is still pullable, which is what makes listing it honest.
+	assert.Equal(t, http.StatusOK, getManifest(t, r, "oci-hosted", "charts/nginx", sigTag).Code)
+}

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -282,6 +282,7 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 		Name:         comp.Name,
 		Version:      comp.Version,
 		Tags:         comp.Tags,
+		Extra:        promotedExtra(comp.Extra),
 	}
 	if err := s.componentRepo.Create(ctx, newComp); err != nil {
 		return fmt.Errorf("upsert component in target: %w", err)
@@ -335,6 +336,34 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 		})
 	}
 	return nil
+}
+
+// promotedExtra is the source component's metadata as the promoted copy should
+// carry it. The keys describe the content, and the copy is that content byte for
+// byte, so they stay true in the target repository. The OCI ones have to travel
+// in particular: a signature manifest is found through Extra["oci_subject"], so
+// a copy without it is a signature the target repository's referrers API can
+// never list.
+//
+// scan_result is the one key left behind. It records a scan run against the
+// SOURCE repository's image reference, and the scan rows the promotion gate
+// actually reads are keyed by component ID and are not copied either — so
+// carrying it would report a scan of this copy that was never run.
+func promotedExtra(extra map[string]any) map[string]any {
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(extra))
+	for k, v := range extra {
+		if k == "scan_result" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // resolveStore returns the physical BlobStore for a given blobStoreID pointer.

--- a/internal/service/promotion_service_test.go
+++ b/internal/service/promotion_service_test.go
@@ -358,5 +358,104 @@ func TestPromotionService_PathFilter(t *testing.T) {
 	})
 }
 
+// A component's Extra is what the OCI layer reads to answer the referrers API:
+// a signature manifest is found through Extra["oci_subject"]. Promoting one to
+// another repository without its Extra lands a signature the target repository
+// can never list, so the promoted copy carries the metadata over.
+func TestPromotionService_CopiesComponentExtra(t *testing.T) {
+	svc, promoRepo, compRepo, assetRepo, blobStore, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	fromRepo := testutil.SimpleRepo("oci-staging", "oci")
+	toRepo := testutil.SimpleRepo("oci-production", "oci")
+	repoRepo.Create(ctx, fromRepo)
+	repoRepo.Create(ctx, toRepo)
+
+	subject := "sha256:" + strings.Repeat("a", 64)
+	comp := &domain.Component{
+		ID:           "comp-sig-1",
+		RepositoryID: fromRepo.ID,
+		Repository:   fromRepo.Name,
+		Format:       "oci",
+		Name:         "charts/nginx",
+		Version:      strings.Replace(subject, ":", "-", 1) + ".sig",
+		Extra: map[string]any{
+			"oci_subject":       subject,
+			"oci_artifact_type": "application/vnd.dev.cosign.artifact.sig.v1+json",
+			"oci_media_type":    "application/vnd.oci.image.manifest.v1+json",
+			"oci_annotations":   map[string]any{"org.opencontainers.image.created": "2026-08-04T00:00:00Z"},
+			// Deliberately not promoted: see below.
+			"scan_result": map[string]any{"imageRef": "localhost/oci-staging/charts/nginx", "status": "ok"},
+		},
+	}
+	compRepo.AddComponent(comp)
+
+	blobKey := "oci-staging:signature-manifest"
+	if err := blobStore.PutBytes(ctx, blobKey, []byte(`{"schemaVersion":2}`)); err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+	assetRepo.Create(ctx, &domain.Asset{
+		ComponentID:  comp.ID,
+		RepositoryID: fromRepo.ID,
+		Repository:   fromRepo.Name,
+		Path:         "/manifests/charts/nginx/" + comp.Version,
+		BlobKey:      blobKey,
+		SizeBytes:    19,
+		ContentType:  "application/vnd.oci.image.manifest.v1+json",
+	})
+
+	rule := &domain.PromotionRule{
+		Name:     "oci-auto",
+		FromRepo: "oci-staging",
+		ToRepo:   "oci-production",
+	}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	results, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != domain.PromotionCompleted {
+		t.Fatalf("promotion did not complete: %+v", results)
+	}
+
+	page, err := compRepo.ListByRepoNames(ctx, []string{"oci-production"}, 100, 0)
+	if err != nil {
+		t.Fatalf("ListByRepoNames: %v", err)
+	}
+	if len(page.Items) != 1 {
+		t.Fatalf("expected 1 promoted component, got %d", len(page.Items))
+	}
+	promoted := page.Items[0]
+	if got := promoted.Extra["oci_subject"]; got != subject {
+		t.Errorf("promoted component lost oci_subject: got %v want %s", got, subject)
+	}
+	if got := promoted.Extra["oci_artifact_type"]; got != "application/vnd.dev.cosign.artifact.sig.v1+json" {
+		t.Errorf("promoted component lost oci_artifact_type: got %v", got)
+	}
+	if got := promoted.Extra["oci_media_type"]; got != "application/vnd.oci.image.manifest.v1+json" {
+		t.Errorf("promoted component lost oci_media_type: got %v", got)
+	}
+	ann, ok := promoted.Extra["oci_annotations"].(map[string]any)
+	if !ok || ann["org.opencontainers.image.created"] != "2026-08-04T00:00:00Z" {
+		t.Errorf("promoted component lost oci_annotations: got %v", promoted.Extra["oci_annotations"])
+	}
+
+	// A scan result is a record of a scan run against the SOURCE repository's
+	// image reference, and the scan rows the promotion gate reads are not copied
+	// either, so it does not travel: the promoted copy has not been scanned.
+	if got, ok := promoted.Extra["scan_result"]; ok {
+		t.Errorf("scan_result must not be promoted: got %v", got)
+	}
+
+	// The copy is its own map: mutating the source afterwards must not reach it.
+	comp.Extra["oci_subject"] = "sha256:" + strings.Repeat("b", 64)
+	if got := promoted.Extra["oci_subject"]; got != subject {
+		t.Errorf("promoted component shares the source map: got %v", got)
+	}
+}
+
 // Ensure time package is used (referenced in domain types).
 var _ = time.Now

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -667,7 +667,10 @@ func (a *AssetRepo) Delete(_ context.Context, id string) error {
 		return nil
 	}
 	delete(a.byID, id)
-	delete(a.assets, asset.RepositoryID+":"+asset.Path)
+	// Keyed the same way Create keys it — by repository NAME. Keying the removal
+	// off RepositoryID left the path index pointing at a deleted asset, so
+	// GetByPath kept resolving it.
+	delete(a.assets, asset.Repository+":"+asset.Path)
 	return nil
 }
 func (a *AssetRepo) IncrementDownloads(_ context.Context, counts map[string]int64) error {
@@ -818,8 +821,23 @@ func (a *AssetRepo) ListRawBrowseAssets(_ context.Context, names []string) ([]do
 	return out, nil
 }
 
-func (a *AssetRepo) CountByBlobKey(_ context.Context, _, _ string) (int, error) {
-	return 0, nil
+// CountByBlobKey mirrors the postgres query: how many assets reference blobKey,
+// not counting the one being excluded. DeleteArtifact reads it to decide whether
+// the physical blob is still needed, so a stub answer would make that decision
+// untestable.
+func (a *AssetRepo) CountByBlobKey(_ context.Context, blobKey, excludeID string) (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.Err != nil {
+		return 0, a.Err
+	}
+	n := 0
+	for _, v := range a.byID {
+		if v.BlobKey == blobKey && v.ID != excludeID {
+			n++
+		}
+	}
+	return n, nil
 }
 
 func (a *AssetRepo) ListRawAssetPaths(_ context.Context, repoName string) ([]string, error) {


### PR DESCRIPTION
Everything deferred from the phase-2 review, plus #142.

Closes #142.

## 1. Deleting one asset destroyed a blob another asset still pointed at

Every manifest push registers **two** assets on the **same blob key** — one under the tag, one under `sha256:<digest>` — because clients re-fetch by digest after pulling by tag. `base.DeleteArtifact` deleted the physical blob unconditionally, so `DELETE .../manifests/sha256-<hex>.sig` — the tag cosign pushes a signature under — removed the bytes while the digest record survived and kept pointing at them.

`AssetRepo.CountByBlobKey` existed for exactly this, was covered by integration tests, and had **zero production callers**. It has one now. A count that *errors* keeps the blob: an orphan is reclaimable by GC, bytes deleted under a live asset are not.

Two test doubles were lying about this, which is why nothing caught it: `testutil.AssetRepo.CountByBlobKey` was a stub returning `0`, and its `Delete` keyed the path index off a different field than `Create`, so deleted assets kept resolving.

## 2. The UI delete path deleted from the wrong blob store

`DeleteDockerTag`, `DeleteDockerImage` and `DeleteByPath` used the handler's default blob store directly and never resolved the asset's own. On a repository backed by a non-default store that meant: the manifest blob deleted from the wrong store (real bytes orphaned), the manifest then unreadable, so `parseManifestDigests` returned nothing and **no layer blob was ever cleaned**. No `artifact.deleted` webhook either, and no metric — deleting through the UI was silent while deleting through `/v2/` notified.

All three now delegate per-asset deletion to `base.DeleteArtifact`, keeping the logic that is genuinely theirs (parsing config and layer digests, the still-referenced set, `DeleteOrphans`). `BrowseHandler` takes `formats.Deps` so it sees storage the way the format handlers do — the old hand-picked subset is what let the two paths drift.

## 3. Promotion dropped component metadata

The promoted copy was built without `Extra`, so promoting a signature lost `oci_subject` and the target repository's referrers index did not list it. Every key travels now except `scan_result`, which records a scan of the *source* repository's image reference and would otherwise claim a scan of the promoted copy that never ran.

## 4. Deletion semantics of referrers, pinned

Three tests now document what deletion actually does, and one of them corrected my own assumption: because a push stores two records, deleting the signature *by tag* does **not** remove it from the index — it stays pullable by digest, with intact bytes, and stays listed. Removing it requires deleting both records. Deleting a subject leaves its referrers listed; they are independent artifacts.

## 5. conda re-rooted upstream package URLs onto the proxy (#142)

The same bug fixed for Helm in #143: `rewriteCondaURLs` rewrote every `url` as `localBase + path.Base(u)`, discarding the path and checking no host, so a CDN or mirror URL was silently re-rooted onto this proxy, which then fetched a path that does not exist. It now resolves each entry the way the client would and hands back an absolute upstream URL for anything it cannot address.

conda differs from helm in one way that matters: entries resolve against the **subdir** (`<remote>/<platform>/repodata.json`) while the proxy's URL space is rooted at the **channel**, so `../noarch/x.conda` is still proxyable, and a URL resolving to the channel root is not — conda has no single-segment route.

## Verification

`go test ./internal/...` 1742 passing (only the sandbox-networking webhook test fails locally, and it passes in CI); integration suite 401 passing; frontend 487 passing; `golangci-lint run --new-from-rev=origin/main` zero issues.

Written test-first throughout, each test aimed at the specific defect rather than at the refactor — the store-resolution tests use a real `LocalBlobStore` for the repository and assert the handler's default store is never touched.

Two things found and not fixed here: conda's `current_repodata.json` and `repodata.json.zst` are not special-cased, so their URLs are never rewritten *and* they are cached as if immutable; and `used_bytes` is incremented per registered asset rather than per stored blob, so an alias pair transiently overstates a store's usage. Both deserve their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW