### PR TITLE
feat(oci): catalog, tag pagination and cross-repository blob mounts

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -194,6 +194,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	go dlCounter.Start(context.Background(), 10*time.Second)
 
 	// ── Format handlers ───────────────────────────────────────
+	// Built before the format handlers because they take Deps by value: a
+	// handler constructed without the checker would keep a nil copy of it.
+	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, log)
 	formatDeps := formats.Deps{
 		Repos:        repoRepo,
 		Components:   componentRepo,
@@ -205,6 +208,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		Webhooks:     webhookSvc,
 		Downloads:    dlCounter,
 		RoutingRules: rrRepo,
+		RBAC:         rbacSvc,
 	}
 	formatRegistry := map[string]formats.FormatHandler{
 		"raw":       raw.New(formatDeps),
@@ -230,7 +234,6 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 
 	// ── Handlers ──────────────────────────────────────────────
 	authH := handlers.NewAuthHandler(userSvc, log).WithConfig(*cfg)
-	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, log)
 	repoH := handlers.NewRepositoryHandler(repoSvc, rbacSvc)
 	userH := handlers.NewUserHandler(userSvc)
 	blobH := handlers.NewBlobStoreHandler(blobRepo).WithUsageDeps(repoRepo, assetRepo).WithRegistry(blobRegistry).WithGC(gcSvc)

--- a/internal/formats/deps.go
+++ b/internal/formats/deps.go
@@ -1,6 +1,8 @@
 package formats
 
 import (
+	"context"
+
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/storage"
@@ -21,4 +23,24 @@ type Deps struct {
 	Downloads domain.DownloadCounter
 	// RoutingRules is optional — nil disables routing rule enforcement in group repos.
 	RoutingRules repository.RoutingRuleRepo
+	// RBAC is optional — nil disables caller-privilege checks a handler makes on
+	// its own behalf. It does not disable RBACMiddleware, which guards the
+	// request itself; this is for the paths a handler reaches that the request
+	// URL does not name, such as a blob mount's client-supplied source.
+	RBAC RBACChecker
+}
+
+// RBACChecker answers whether a caller may act on a path in a repository.
+//
+// It is declared here, as the subset of *service.RBACService a format handler
+// needs, rather than imported from internal/service: that package already
+// imports internal/formats/base, which imports this one, so depending on it the
+// other way would close a cycle.
+type RBACChecker interface {
+	// CanAccessRepo mirrors service.RBACService.CanAccessRepo. action is one of
+	// "read", "browse", "write", "delete"; path is the repository-relative asset
+	// path, which the implementation normalizes for OCI repositories so it is
+	// compared the way content selectors are written.
+	CanAccessRepo(ctx context.Context, userID string, roles []string,
+		repo *domain.Repository, path, action string) (bool, error)
 }

--- a/internal/formats/oci/catalog.go
+++ b/internal/formats/oci/catalog.go
@@ -1,0 +1,65 @@
+package oci
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/gin-gonic/gin"
+)
+
+// The catalog endpoint, GET /v2/<repoName>/_catalog.
+//
+// What it lists: the image names inside <repoName> — "library/ubuntu",
+// "charts/nginx" — and not Nexspence repository names. Each Nexspence
+// repository is its own registry namespace: a client talking to
+// <host>/v2/<repoName>/library/ubuntu sees the repository name
+// <repoName>/library/ubuntu, and <repoName> is fixed by the URL it connected
+// to. So the set the catalog enumerates is the same set of names
+// /v2/<repoName>/<image>/tags/list is addressed by, which is what
+// handleTagsList reports back as "name".
+//
+// What counts as one of those names is a stored manifest, not a stored
+// component. Every blob upload registers a component of its own — a layer, and
+// an upload abandoned before its manifest — so a catalog read off components
+// lists things no client can pull. Two more component-level details would
+// corrupt it the same way, and are the reason the query does not go near that
+// table: the component search matches names with a substring ILIKE, so
+// "charts/nginx" would drag in "charts/nginx-extra", and a manifest pushed by
+// tag registers a second digest-alias component, so every image would arrive
+// duplicated. Manifest assets have neither problem: the image name is a literal
+// segment of the asset path, and the distinct is exact.
+
+func (h *Handler) handleCatalog(c *gin.Context, repoName string) {
+	if c.Request.Method != http.MethodGet {
+		c.Status(http.StatusMethodNotAllowed)
+		return
+	}
+
+	// A proxy repository answers from its cache and never forwards. Upstreams
+	// almost universally restrict _catalog — Docker Hub, GHCR and ECR all refuse
+	// it — so forwarding would turn the endpoint into a 502 for the ordinary
+	// case. And an upstream that did answer would have this proxy claim a
+	// catalog of images it does not hold: the honest answer for a proxy is what
+	// it can serve right now, which is what it has cached. Nothing branches on
+	// the repository type below for exactly that reason.
+	names, err := h.deps.Assets.ListOCIImageNames(c.Request.Context(), []string{repoName})
+	if err != nil {
+		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
+		return
+	}
+	// Sorted here rather than in SQL: the ?last= cursor is resolved by comparing
+	// Go strings, and a database ORDER BY sorts under the server's collation,
+	// which for anything but C orders punctuation differently. A list ordered one
+	// way and searched the other makes the cursor skip entries.
+	sort.Strings(names)
+
+	params := parsePageParams(c)
+	page, more := paginate(names, params)
+	setNextLink(c, params, page, more)
+	if page == nil {
+		// An empty catalog must serialize as [] and not null: a null breaks
+		// clients that range over the list.
+		page = []string{}
+	}
+	c.JSON(http.StatusOK, gin.H{"repositories": page})
+}

--- a/internal/formats/oci/catalog_test.go
+++ b/internal/formats/oci/catalog_test.go
@@ -1,0 +1,244 @@
+package oci_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// ── Helpers ───────────────────────────────────────────────────
+
+// getCatalog issues a _catalog request and decodes the repository names plus the
+// raw Link header, the same shape getTags uses for the tag list.
+func getCatalog(t *testing.T, r *gin.Engine, target string) (repos []string, link string) {
+	t.Helper()
+	w := doCatalog(r, target)
+	require.Equal(t, http.StatusOK, w.Code, "GET %s: %s", target, w.Body.String())
+	var body struct {
+		Repositories []string `json:"repositories"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return body.Repositories, w.Header().Get("Link")
+}
+
+func doCatalog(r *gin.Engine, target string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ── What the catalog lists ────────────────────────────────────
+
+// Each Nexspence repository is its own registry namespace, so the catalog of
+// <repoName> is the set of image names inside it — the same names tags/list is
+// addressed by.
+func TestCatalog_ListsEveryImageNameOnceSorted(t *testing.T) {
+	repo := testutil.SimpleRepo("cat1", "docker")
+	r, _ := setupWithDeps(repo)
+
+	// library/ubuntu carries two tags, which is what would duplicate a name
+	// derived naively from components: every tag is its own component row, and a
+	// manifest push registers a second digest-alias component on top of that.
+	pushTags(t, r, "cat1", "library/ubuntu", "latest", "22.04")
+	pushTags(t, r, "cat1", "charts/nginx", "1.2.3")
+	// A sibling whose name contains another image's name in full: the component
+	// search matches names with a substring ILIKE, so anything built on it would
+	// fuse the two.
+	pushTags(t, r, "cat1", "charts/nginx-extra", "1.0.0")
+
+	repos, link := getCatalog(t, r, "/repository/cat1/v2/_catalog")
+	assert.Equal(t, []string{"charts/nginx", "charts/nginx-extra", "library/ubuntu"}, repos)
+	assert.Empty(t, link, "nothing was truncated, so there is no next page")
+}
+
+// Every blob upload registers a component of its own, so a catalog built from
+// components lists junk: layer names, and images whose upload was abandoned
+// before the manifest. Only an image with a manifest can be pulled, and only
+// that is a repository name in the OCI sense.
+func TestCatalog_OmitsImagesWithBlobsButNoManifest(t *testing.T) {
+	repo := testutil.SimpleRepo("cat2", "docker")
+	r, _ := setupWithDeps(repo)
+
+	pushTags(t, r, "cat2", "library/ubuntu", "latest")
+	// A blob pushed under an image whose manifest never followed.
+	pushBlob(t, r, "cat2", "aborted/upload", "layer bytes that never got a manifest")
+	// And a layer pushed under an image that does have a manifest — the same
+	// image name, so it must not appear twice either.
+	pushBlob(t, r, "cat2", "library/ubuntu", "a layer of the real image")
+
+	repos, _ := getCatalog(t, r, "/repository/cat2/v2/_catalog")
+	assert.Equal(t, []string{"library/ubuntu"}, repos,
+		"only images that have a manifest are pullable, so only those are repository names")
+	assert.NotContains(t, repos, "aborted/upload")
+}
+
+// An image whose manifests have all been deleted leaves its blobs behind until
+// the next cleanup run, but nothing that can be pulled: tags/list is empty and
+// every manifest reference 404s. Listing it would be a promise the registry
+// cannot keep, so it drops out of the catalog with its last manifest.
+func TestCatalog_DropsImagesWhoseManifestsWereAllDeleted(t *testing.T) {
+	repo := testutil.SimpleRepo("cat8", "docker")
+	r, _ := setupWithDeps(repo)
+
+	pushTags(t, r, "cat8", "library/ubuntu", "latest")
+	pushTags(t, r, "cat8", "charts/nginx", "1.2.3")
+	// The layer stays behind after the manifests go.
+	pushBlob(t, r, "cat8", "library/ubuntu", "a layer that outlives its manifest")
+
+	// Both references the tagged push registered: the tag and the digest alias.
+	for _, ref := range []string{"latest", digest(pagingManifest)} {
+		req := httptest.NewRequest(http.MethodDelete,
+			"/repository/cat8/v2/library/ubuntu/manifests/"+ref, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusAccepted, w.Code, "delete %s: %s", ref, w.Body.String())
+	}
+
+	repos, _ := getCatalog(t, r, "/repository/cat8/v2/_catalog")
+	assert.Equal(t, []string{"charts/nginx"}, repos,
+		"an image with no manifest left cannot be pulled, so it is no longer a repository name")
+}
+
+// ── The spec's paging shape ───────────────────────────────────
+
+func TestCatalog_PaginatesWithLinkHeader(t *testing.T) {
+	repo := testutil.SimpleRepo("cat3", "docker")
+	r, _ := setupWithDeps(repo)
+	for _, img := range []string{"img/e", "img/a", "img/d", "img/b", "img/c"} {
+		pushTags(t, r, "cat3", img, "1.0")
+	}
+
+	repos, link := getCatalog(t, r, "/repository/cat3/v2/_catalog?n=2")
+	assert.Equal(t, []string{"img/a", "img/b"}, repos, "first page must be the lexically first two names")
+
+	u := parseNextLink(t, link)
+	assert.Equal(t, "/repository/cat3/v2/_catalog", u.Path, "the link must keep the client's path form")
+	assert.Equal(t, "2", u.Query().Get("n"))
+	assert.Equal(t, "img/b", u.Query().Get("last"), "cursor must name the last entry of this page")
+
+	repos2, link2 := getCatalog(t, r, u.String())
+	assert.Equal(t, []string{"img/c", "img/d"}, repos2)
+
+	repos3, link3 := getCatalog(t, r, parseNextLink(t, link2).String())
+	assert.Equal(t, []string{"img/e"}, repos3)
+	assert.Empty(t, link3, "the final page must carry no Link header")
+}
+
+func TestCatalog_LastWithoutNReturnsTheRemainder(t *testing.T) {
+	repo := testutil.SimpleRepo("cat4", "docker")
+	r, _ := setupWithDeps(repo)
+	for _, img := range []string{"img/a", "img/b", "img/c"} {
+		pushTags(t, r, "cat4", img, "1.0")
+	}
+
+	repos, link := getCatalog(t, r, "/repository/cat4/v2/_catalog?last=img/a")
+	assert.Equal(t, []string{"img/b", "img/c"}, repos)
+	assert.Empty(t, link)
+}
+
+// ── The empty repository ──────────────────────────────────────
+
+// An empty catalog must serialize as [] and not null: a null breaks clients that
+// range over the list.
+func TestCatalog_EmptyRepositoryIsAnEmptyArray(t *testing.T) {
+	repo := testutil.SimpleRepo("cat5", "docker")
+	r, _ := setupWithDeps(repo)
+
+	w := doCatalog(r, "/repository/cat5/v2/_catalog")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.JSONEq(t, `{"repositories":[]}`, w.Body.String())
+	assert.NotContains(t, w.Body.String(), "null")
+}
+
+// ── Proxy repositories ────────────────────────────────────────
+
+// A proxy answers the catalog from what it has cached and never forwards. Docker
+// Hub, GHCR and almost every other upstream refuse _catalog outright, so
+// forwarding would turn the endpoint into a 502 for the common case; and an
+// upstream that did answer would have the proxy claim a catalog of images it
+// cannot serve without first fetching them.
+func TestCatalog_ProxyAnswersFromCacheWithoutAskingUpstream(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		mu.Lock()
+		paths = append(paths, req.URL.Path)
+		mu.Unlock()
+		if req.URL.Path != "/v2/library/ubuntu/manifests/latest" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_, _ = w.Write([]byte(helmChartManifest))
+	}))
+	defer upstream.Close()
+
+	r, _ := setupWithDeps(proxyOCIRepo("r2", "oci-proxy", upstream.URL))
+
+	// Pull one manifest through the proxy so the cache holds exactly one image.
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/oci-proxy/v2/library/ubuntu/manifests/latest", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "the proxy pull must succeed: %s", w.Body.String())
+
+	mu.Lock()
+	paths = nil
+	mu.Unlock()
+
+	repos, _ := getCatalog(t, r, "/repository/oci-proxy/v2/_catalog")
+	assert.Equal(t, []string{"library/ubuntu"}, repos,
+		"a proxy lists what it has cached")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, paths, "the catalog request must never reach the upstream, got %v", paths)
+}
+
+// ── Method and shape ──────────────────────────────────────────
+
+func TestCatalog_RejectsNonGET(t *testing.T) {
+	repo := testutil.SimpleRepo("cat6", "docker")
+	r, _ := setupWithDeps(repo)
+
+	for _, method := range []string{http.MethodPut, http.MethodDelete, http.MethodPost} {
+		req := httptest.NewRequest(method, "/repository/cat6/v2/_catalog", strings.NewReader(""))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code, "%s _catalog", method)
+	}
+}
+
+// The short path form a Docker client uses must reach the same endpoint, and its
+// Link header must stay on /v2/ (issue #47).
+func TestCatalog_ShortPathForm(t *testing.T) {
+	repo := testutil.SimpleRepo("cat7", "docker")
+	r := setupV2Scoped(repo)
+	for _, img := range []string{"img/a", "img/b"} {
+		req := httptest.NewRequest(http.MethodPut,
+			fmt.Sprintf("/v2/cat7/%s/manifests/1.0", img), strings.NewReader(pagingManifest))
+		req.ContentLength = int64(len(pagingManifest))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	}
+
+	repos, link := getCatalog(t, r, "/v2/cat7/_catalog?n=1")
+	assert.Equal(t, []string{"img/a"}, repos)
+	u := parseNextLink(t, link)
+	assert.Equal(t, "/v2/cat7/_catalog", u.Path)
+
+	rest, _ := getCatalog(t, r, u.String())
+	assert.Equal(t, []string{"img/b"}, rest)
+}

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -12,6 +12,7 @@
 //	GET  /v2/:name/blobs/:digest                → pull blob (content-addressable)
 //	HEAD /v2/:name/blobs/:digest                → blob exists check
 //	POST /v2/:name/blobs/uploads/               → initiate blob upload
+//	POST /v2/:name/blobs/uploads/?mount=&from=  → mount an existing blob
 //	PATCH /v2/:name/blobs/uploads/:uuid         → stream blob chunks
 //	PUT  /v2/:name/blobs/uploads/:uuid?digest=  → finalize blob upload
 //	DELETE /v2/:name/blobs/:digest              → delete blob
@@ -525,12 +526,19 @@ func (h *Handler) handleBlobUploads(c *gin.Context, repoName, imageName, uuid st
 	}
 }
 
-func (h *Handler) initiateUpload(c *gin.Context, _, _ string) {
+func (h *Handler) initiateUpload(c *gin.Context, repoName, imageName string) {
 	if !requireDockerAuth(c) {
 		return
 	}
-	// Cross-repo mount shortcut: ?mount=<digest>&from=<repo>
-	// We ignore mount for now and always start a fresh upload
+	// Cross-repository blob mount: ?mount=<digest>&from=<name>. When it cannot be
+	// served the request falls through to a normal upload session, which the spec
+	// explicitly allows and which costs the client only the bandwidth it would
+	// have spent anyway.
+	if dgst, from := c.Query("mount"), c.Query("from"); dgst != "" && from != "" {
+		if h.mountBlob(c, repoName, imageName, dgst, from) {
+			return
+		}
+	}
 	uuid, err := h.uploads.create(c.Request.Context())
 	if err != nil {
 		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
@@ -546,6 +554,141 @@ func (h *Handler) initiateUpload(c *gin.Context, _, _ string) {
 	c.Header("Docker-Upload-UUID", uuid)
 	c.Header("Range", "0-0")
 	c.Status(http.StatusAccepted)
+}
+
+// mountBlob serves POST .../blobs/uploads/?mount=<digest>&from=<name> by
+// registering a second asset over the bytes the source already stores. It
+// reports whether it answered the request; false means "start a normal upload".
+//
+// Mounting is the digest-alias registration pushManifest does after a tagged
+// push, with the image name changing instead of the reference.
+//
+// Access control: `from` is client-supplied, and the only authorization this
+// request has passed is RBACMiddleware's check of the repository and path in the
+// URL. The source is therefore resolved strictly inside repoName — the very
+// repository that check covered — so no mount can read out of a repository (or,
+// since format is a property of the repository, a format) the caller was not
+// authorized against.
+//
+// What that does NOT cover is a content selector narrower than the repository:
+// a privilege of the form `repository == "R" && path.startsWith("/library/")`
+// authorizes the POST by its own path while the mount source is a different
+// path in R. Closing it needs the caller's privileges, and a format handler has
+// none — formats.Deps carries no RBACService and requestctx carries only the
+// user's id and name, not their roles or selectors. Plumbing either through is a
+// change to every format handler's contract, not to this endpoint, so the gap is
+// recorded here rather than papered over with a check that checks nothing.
+func (h *Handler) mountBlob(c *gin.Context, repoName, imageName, dgst, from string) bool {
+	// The digest lands in an asset path, so a value that is not a digest is not
+	// a lookup key — it is someone else's path.
+	if !validDigest(dgst) {
+		return false
+	}
+	ctx := c.Request.Context()
+	repo, err := h.deps.Repos.Get(ctx, repoName)
+	if err != nil || repo == nil {
+		return false
+	}
+
+	for _, sourceImage := range mountSourceImages(repoName, from) {
+		if sourceImage == imageName {
+			continue // mounting an image onto itself has nothing to alias
+		}
+		src, err := h.deps.Assets.GetByPath(ctx, repoName, blobPath(sourceImage, dgst))
+		if err != nil || src == nil {
+			continue
+		}
+		// An asset row outlives its bytes: a manual blob delete or a GC pass can
+		// leave the record behind. Answering 201 off one of those would hand the
+		// client a layer that 404s on pull, and the client — told the registry
+		// already has it — would never upload the copy it still holds.
+		storeName, present := h.locateBlob(ctx, src)
+		if !present {
+			continue
+		}
+		blobStoreID := src.BlobStoreID
+		if storeName == "" {
+			// The store the source names could not be resolved, so let the
+			// registration fall back to the repository's own default, exactly as
+			// a fetch of that asset would.
+			blobStoreID = ""
+		}
+		if _, err := base.RegisterStoredBlob(ctx, h.deps, repo,
+			blobPath(imageName, dgst), "application/octet-stream",
+			base.Coords{Name: imageName, Version: dgst},
+			src.BlobKey, src.SHA256, src.SHA1, src.MD5, src.SizeBytes,
+			blobStoreID, storeName); err != nil {
+			return false
+		}
+		c.Header("Docker-Content-Digest", dgst)
+		c.Header("Location", blobLocation(c, imageName, dgst))
+		c.Status(http.StatusCreated)
+		return true
+	}
+	return false
+}
+
+// mountSourceImages returns the image names inside repoName that a client's
+// `from` value can name.
+//
+// A client composes `from` as the repository name it pushed the source under
+// minus the registry host — reference.Path of the source reference — so its
+// spelling follows whichever URL shape the push used:
+//
+//	host/<repo>/<image>             → from=<repo>/<image>
+//	host/repository/<repo>/<image>  → from=repository/<repo>/<image>
+//	<repo>.<baseDomain>/<image>     → from=<image>
+//
+// The last one is bare because the subdomain connector rewrites only the path;
+// the query string the client built never sees the repository name. Every form
+// therefore resolves inside the repository the request was already authorized
+// against, and a `from` naming any other Nexspence repository resolves to
+// nothing — see the access-control note on mountBlob.
+//
+// The two readings of "<repo>/<image>" are both returned because they are
+// genuinely ambiguous: an image may legitimately be named after the repository
+// it lives in. The digest pins the content either way, so whichever exists wins.
+func mountSourceImages(repoName, from string) []string {
+	from = strings.Trim(from, "/")
+	if from == "" {
+		return nil
+	}
+	images := []string{from}
+	for _, prefix := range []string{repoName + "/", "repository/" + repoName + "/"} {
+		if rest := strings.TrimPrefix(from, prefix); rest != from && rest != "" {
+			images = append(images, rest)
+		}
+	}
+	return images
+}
+
+// locateBlob reports whether an asset's bytes are really in the store, and
+// returns the name of the store holding them (empty when the asset names no
+// store, or names one that no longer resolves).
+func (h *Handler) locateBlob(ctx context.Context, asset *domain.Asset) (storeName string, present bool) {
+	store := h.deps.BlobStore
+	if asset.BlobStoreID != "" {
+		if meta, err := h.deps.Blobs.GetByID(ctx, asset.BlobStoreID); err == nil && meta != nil {
+			store = base.PhysicalStore(ctx, h.deps, meta)
+			storeName = meta.Name
+		}
+	}
+	exists, err := store.Exists(ctx, asset.BlobKey)
+	if err != nil || !exists {
+		return "", false
+	}
+	return storeName, true
+}
+
+// blobLocation is the URL of a stored blob under the same /v2/ prefix — and the
+// same short or long path form — the client authenticated against. A hardcoded
+// /repository/... URL sent the follow-up request to a different auth surface and
+// returned 401 (issue #47).
+func blobLocation(c *gin.Context, imageName, digest string) string {
+	if i := strings.Index(c.Request.URL.Path, "/blobs/"); i >= 0 {
+		return c.Request.URL.Path[:i] + "/blobs/" + digest
+	}
+	return "/v2/" + imageName + "/blobs/" + digest
 }
 
 func (h *Handler) patchUpload(c *gin.Context, _, _, uuid string) {
@@ -608,12 +751,7 @@ func (h *Handler) finalizeUpload(c *gin.Context, repoName, imageName, uuid strin
 	h.uploads.remove(ctx, uuid)
 
 	c.Header("Docker-Content-Digest", digest)
-	// Point at the stored blob under the same /v2/ prefix the client used.
-	blobLoc := "/v2/" + imageName + "/blobs/" + digest
-	if i := strings.Index(c.Request.URL.Path, "/blobs/"); i >= 0 {
-		blobLoc = c.Request.URL.Path[:i] + "/blobs/" + digest
-	}
-	c.Header("Location", blobLoc)
+	c.Header("Location", blobLocation(c, imageName, digest))
 	c.Header("Content-Range", fmt.Sprintf("0-%d", len(data)-1))
 	c.Status(http.StatusCreated)
 }

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -121,23 +122,71 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 
 // ─── Tags ──────────────────────────────────────────────────────────────────
 
+// searchPageSize is how many components one tag-list search asks for. It is not
+// a cap on the answer: the component search clamps a Limit above 500 back down
+// to 50 (see internal/repository/postgres/component_repo.go), so raising it
+// would silently return FEWER tags. The list is assembled by paging over the
+// search with a growing offset instead, which keeps a repository with more tags
+// than one search page fully enumerable.
+const searchPageSize = 500
+
 func (h *Handler) handleTagsList(c *gin.Context, repoName, imageName string) {
 	if c.Request.Method != http.MethodGet {
 		c.Status(http.StatusMethodNotAllowed)
 		return
 	}
-	page, err := h.deps.Components.Search(c.Request.Context(), domain.SearchParams{
-		Repository: repoName, Name: imageName, Limit: 500,
-	})
+	tags, err := h.collectTags(c.Request.Context(), repoName, imageName)
 	if err != nil {
 		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
 		return
 	}
-	tags := make([]string, 0, len(page.Items))
-	for _, comp := range page.Items {
-		tags = append(tags, comp.Version)
+	// The spec requires the tag list sorted; the search orders by (name,
+	// version) across every image in the repository, which is not the same
+	// thing, and an unsorted list would make the ?last= cursor meaningless.
+	sort.Strings(tags)
+
+	params := parsePageParams(c)
+	page, more := paginate(tags, params)
+	setNextLink(c, params, page, more)
+	if page == nil {
+		page = []string{}
 	}
-	c.JSON(http.StatusOK, gin.H{"name": imageName, "tags": tags})
+	c.JSON(http.StatusOK, gin.H{"name": imageName, "tags": page})
+}
+
+// collectTags returns every tag of one image, paging over the component search
+// until it is exhausted. The loop terminates because a continuation token is
+// only handed back for a full page, and each round advances the offset by one
+// full page.
+func (h *Handler) collectTags(ctx context.Context, repoName, imageName string) ([]string, error) {
+	var tags []string
+	for offset := 0; ; offset += searchPageSize {
+		page, err := h.deps.Components.Search(ctx, domain.SearchParams{
+			Repository: repoName, Name: imageName, Limit: searchPageSize, Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, comp := range page.Items {
+			// The search matches the name with a substring ILIKE, so a sibling
+			// image whose name merely contains this one would otherwise donate
+			// its tags to this list.
+			if comp.Name != imageName {
+				continue
+			}
+			// A manifest pushed by tag also registers an alias under its content
+			// digest so a pull by digest resolves (see pushManifest). Those are
+			// references, not tags, and the spec's tag grammar has no ':', so
+			// the digest form is what identifies them.
+			if strings.Contains(comp.Version, ":") {
+				continue
+			}
+			tags = append(tags, comp.Version)
+		}
+		if page.ContinuationToken == nil || len(page.Items) == 0 {
+			return tags, nil
+		}
+	}
 }
 
 // ─── Manifests ─────────────────────────────────────────────────────────────

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -563,21 +563,24 @@ func (h *Handler) initiateUpload(c *gin.Context, repoName, imageName string) {
 // Mounting is the digest-alias registration pushManifest does after a tagged
 // push, with the image name changing instead of the reference.
 //
-// Access control: `from` is client-supplied, and the only authorization this
-// request has passed is RBACMiddleware's check of the repository and path in the
-// URL. The source is therefore resolved strictly inside repoName — the very
-// repository that check covered — so no mount can read out of a repository (or,
-// since format is a property of the repository, a format) the caller was not
-// authorized against.
+// Access control: `from` is client-supplied and names a path RBACMiddleware
+// never saw — it checked the repository and path of the request URL, which is
+// the mount's target, not its source. Two things close that.
 //
-// What that does NOT cover is a content selector narrower than the repository:
-// a privilege of the form `repository == "R" && path.startsWith("/library/")`
-// authorizes the POST by its own path while the mount source is a different
-// path in R. Closing it needs the caller's privileges, and a format handler has
-// none — formats.Deps carries no RBACService and requestctx carries only the
-// user's id and name, not their roles or selectors. Plumbing either through is a
-// change to every format handler's contract, not to this endpoint, so the gap is
-// recorded here rather than papered over with a check that checks nothing.
+// The source is resolved strictly inside repoName, so no mount reads out of a
+// repository — or, since format is a property of the repository, a format — the
+// request was not authorized against at all.
+//
+// Within repoName, callerMayRead puts the source path through the same check a
+// direct blob GET would face, which is what makes a content selector narrower
+// than the repository (`repository == "R" && path.startsWith("/public/")`) hold
+// here too. Without it a selector would stop a pull but not a mount, and anyone
+// holding the digest could copy the blob into a path they can read and pull it
+// from there.
+//
+// A refused mount falls through to a normal upload session rather than 403: the
+// fallback is spec-legal, costs the client only bandwidth it was going to spend,
+// and does not disclose whether that digest is in the registry.
 func (h *Handler) mountBlob(c *gin.Context, repoName, imageName, dgst, from string) bool {
 	// The digest lands in an asset path, so a value that is not a digest is not
 	// a lookup key — it is someone else's path.
@@ -594,8 +597,14 @@ func (h *Handler) mountBlob(c *gin.Context, repoName, imageName, dgst, from stri
 		if sourceImage == imageName {
 			continue // mounting an image onto itself has nothing to alias
 		}
-		src, err := h.deps.Assets.GetByPath(ctx, repoName, blobPath(sourceImage, dgst))
+		sourcePath := blobPath(sourceImage, dgst)
+		src, err := h.deps.Assets.GetByPath(ctx, repoName, sourcePath)
 		if err != nil || src == nil {
+			continue
+		}
+		// Nothing about the source is acted on before the caller is shown to be
+		// allowed to read it.
+		if !h.callerMayRead(c, repo, sourcePath) {
 			continue
 		}
 		// An asset row outlives its bytes: a manual blob delete or a GC pass can
@@ -626,6 +635,29 @@ func (h *Handler) mountBlob(c *gin.Context, repoName, imageName, dgst, from stri
 		return true
 	}
 	return false
+}
+
+// callerMayRead asks of an asset path the question a direct GET of that path
+// would ask: may this caller read it, in this repository?
+//
+// The path handed over is the stored asset path, the same one FilterAssets
+// checks, so CanAccessRepo normalizes it through assetSamplePath and the
+// comparison happens against the form content selectors are written in.
+//
+// The caller's identity comes off the gin context, where OptionalAuth and
+// RBACMiddleware leave it — the route browse_docker.go takes to the same values.
+// An error is a denial: an access check that could not be completed has not
+// granted anything.
+func (h *Handler) callerMayRead(c *gin.Context, repo *domain.Repository, assetPath string) bool {
+	if h.deps.RBAC == nil {
+		return true
+	}
+	userID, _ := c.Get("userID")
+	roles, _ := c.Get("roles")
+	uid, _ := userID.(string)
+	roleList, _ := roles.([]string)
+	ok, err := h.deps.RBAC.CanAccessRepo(c.Request.Context(), uid, roleList, repo, assetPath, "read")
+	return err == nil && ok
 }
 
 // mountSourceImages returns the image names inside repoName that a client's

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -3,6 +3,7 @@
 // All endpoints under /repository/:repoName/v2/:
 //
 //	GET  /v2/                                   → API version check (200 OK)
+//	GET  /v2/_catalog                           → list the image names in the repository
 //	GET  /v2/:name/tags/list                    → list tags
 //	GET  /v2/:name/referrers/:digest            → list manifests referring to :digest
 //	GET  /v2/:name/manifests/:reference         → pull manifest
@@ -66,6 +67,18 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	rest := strings.TrimPrefix(p, "/v2/")
 	if rest == p { // no /v2/ prefix
 		c.Status(http.StatusNotFound)
+		return
+	}
+
+	// The catalog is the one endpoint with no image name in front of it, so it is
+	// matched before the split below rejects a single-segment path. Matching the
+	// whole rest rather than a keyword segment keeps it unambiguous: "_catalog"
+	// is not a legal image name — the OCI grammar starts every path component
+	// with an alphanumeric — so no image can be shadowed by this case, and an
+	// image whose name merely ends in "_catalog" still has its own endpoint
+	// segment behind it and never reaches here.
+	if rest == "_catalog" {
+		h.handleCatalog(c, repoName)
 		return
 	}
 

--- a/internal/formats/oci/mount_test.go
+++ b/internal/formats/oci/mount_test.go
@@ -12,12 +12,15 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/formats"
 	"github.com/nexspence-oss/nexspence/internal/formats/base"
 	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
@@ -29,6 +32,13 @@ import (
 // repository name whose spelling depends on which of the two the client pushed
 // against, so both have to be exercised against the same stored state.
 func mountDeps(repos ...*domain.Repository) (long, short *gin.Engine, d formats.Deps, store *testutil.BlobStore) {
+	return mountDepsRBAC(nil, repos...)
+}
+
+// mountDepsRBAC is mountDeps with a privilege checker wired in, and with the
+// caller's identity put on the gin context the way OptionalAuth and
+// RBACMiddleware leave it for the handler chain.
+func mountDepsRBAC(rbac formats.RBACChecker, repos ...*domain.Repository) (long, short *gin.Engine, d formats.Deps, store *testutil.BlobStore) {
 	store = testutil.NewBlobStore()
 	d = formats.Deps{
 		Repos:      testutil.NewRepoRepo(repos...),
@@ -37,12 +47,17 @@ func mountDeps(repos ...*domain.Repository) (long, short *gin.Engine, d formats.
 		Assets:     testutil.NewAssetRepo(),
 		BlobStore:  store,
 		BaseURL:    "http://localhost:8080",
+		RBAC:       rbac,
 	}
 	h := oci.New(d)
 
 	auth := func(c *gin.Context) {
 		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
 		c.Request = c.Request.WithContext(ctx)
+		// Deliberately not "nx-admin": an admin short-circuits every check in
+		// CanAccessRepo, which would make the selector tests prove nothing.
+		c.Set("userID", "test-user-id")
+		c.Set("roles", []string{"nx-developer"})
 		c.Next()
 	}
 
@@ -271,6 +286,89 @@ func TestMount_FromAnotherNexspenceRepository_IsRefused(t *testing.T) {
 
 	_, err := d.Assets.GetByPath(context.Background(), "mnt8", "/blobs/library/ubuntu/"+dgst)
 	assert.Error(t, err, "nothing may be registered in the target repository from a source outside it")
+}
+
+// rbacRepoStub hands back one fixed privilege set, as the postgres RBACRepo
+// would for a user holding those grants. The real *service.RBACService is driven
+// on top of it so these tests exercise the actual selector evaluation and the
+// actual OCI path normalisation, not a stand-in for them.
+type rbacRepoStub struct {
+	privs []repository.PrivilegeWithSelector
+}
+
+func (s rbacRepoStub) GetUserPrivilegesWithSelectors(context.Context, string) ([]repository.PrivilegeWithSelector, error) {
+	return s.privs, nil
+}
+
+// publicOnlyRBAC grants the caller everything under /public/ in repoName, and
+// nothing anywhere else.
+func publicOnlyRBAC(repoName string) formats.RBACChecker {
+	return service.NewRBACService(rbacRepoStub{privs: []repository.PrivilegeWithSelector{{
+		Actions:    []string{"read", "browse", "write"},
+		Expression: `repository == "` + repoName + `" && path.startsWith("/public/")`,
+	}}}, nil, zap.NewNop().Sugar())
+}
+
+// The security case. A content selector that stops a pull but not a mount is not
+// a control at all: anyone holding the digest — and digests travel in manifests,
+// build logs and CI output — could copy the blob into a path they can read and
+// pull it from there.
+func TestMount_SourceOutsideTheCallersSelector_IsRefusedWithoutRegistering(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt12", "docker")
+	r, _, d, _ := mountDepsRBAC(publicOnlyRBAC("mnt12"), repo)
+
+	const layer = "a layer only /private/ may read"
+	dgst := pushBlob(t, r, "mnt12", "private/secret-image", layer)
+
+	w := postMount(r, "/repository/mnt12/v2/public/app/blobs/uploads/", dgst, "private/secret-image")
+
+	// 202 rather than 403: the fallback is spec-legal, costs the client only the
+	// bandwidth it was going to spend, and — unlike a 403 — says nothing about
+	// whether that digest is in the registry at all.
+	assert.Equal(t, http.StatusAccepted, w.Code,
+		"an unreadable source falls back to a normal upload; a 403 would confirm the blob is here")
+
+	// The status alone proves nothing — a missing blob produces the same 202.
+	// What must be true is that nothing was registered.
+	_, err := d.Assets.GetByPath(context.Background(), "mnt12", "/blobs/public/app/"+dgst)
+	assert.Error(t, err, "no asset may be registered from a source the caller cannot read")
+}
+
+// The mirror: the same caller, the same registry, a source its selector allows.
+// Without this the test above would also pass on an implementation that simply
+// refuses every mount.
+func TestMount_SourceInsideTheCallersSelector_Mounts(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt13", "docker")
+	r, _, d, _ := mountDepsRBAC(publicOnlyRBAC("mnt13"), repo)
+
+	const layer = "a layer the caller may read"
+	dgst := pushBlob(t, r, "mnt13", "public/base", layer)
+
+	w := postMount(r, "/repository/mnt13/v2/public/app/blobs/uploads/", dgst, "public/base")
+	require.Equal(t, http.StatusCreated, w.Code,
+		"the selector allows /public/, so this mount must still be served: %s", w.Body.String())
+
+	dst, err := d.Assets.GetByPath(context.Background(), "mnt13", "/blobs/public/app/"+dgst)
+	require.NoError(t, err)
+	src, err := d.Assets.GetByPath(context.Background(), "mnt13", "/blobs/public/base/"+dgst)
+	require.NoError(t, err)
+	assert.Equal(t, src.BlobKey, dst.BlobKey)
+}
+
+// The dependency is optional, like Webhooks and Downloads: a handler built
+// without it keeps working. This is what lets every other test in the package
+// construct formats.Deps by hand.
+func TestMount_NilRBAC_StillMounts(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt14", "docker")
+	r, _, d, _ := mountDepsRBAC(nil, repo)
+	require.Nil(t, d.RBAC, "this test is only meaningful with no checker wired in")
+
+	const layer = "no checker configured"
+	dgst := pushBlob(t, r, "mnt14", "private/secret-image", layer)
+
+	w := postMount(r, "/repository/mnt14/v2/public/app/blobs/uploads/", dgst, "private/secret-image")
+	assert.Equal(t, http.StatusCreated, w.Code,
+		"a nil checker must mean 'not configured', not 'deny everything': %s", w.Body.String())
 }
 
 // A registry-wide GC or a manual blob deletion can leave an asset row whose

--- a/internal/formats/oci/mount_test.go
+++ b/internal/formats/oci/mount_test.go
@@ -1,0 +1,356 @@
+package oci_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// ── Helpers ───────────────────────────────────────────────────
+
+// mountDeps builds one handler over several repositories and returns both URL
+// shapes production serves it under: the long /repository/<repo>/v2/... form and
+// the short /v2/<repo>/... form. A mount names its source with a client-side
+// repository name whose spelling depends on which of the two the client pushed
+// against, so both have to be exercised against the same stored state.
+func mountDeps(repos ...*domain.Repository) (long, short *gin.Engine, d formats.Deps, store *testutil.BlobStore) {
+	store = testutil.NewBlobStore()
+	d = formats.Deps{
+		Repos:      testutil.NewRepoRepo(repos...),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  store,
+		BaseURL:    "http://localhost:8080",
+	}
+	h := oci.New(d)
+
+	auth := func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+
+	long = gin.New()
+	long.Use(auth)
+	long.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+
+	short = gin.New()
+	short.Use(auth)
+	short.Any("/v2/:repoName/*dockerpath", func(c *gin.Context) {
+		c.Params = gin.Params{
+			{Key: "repoName", Value: c.Param("repoName")},
+			{Key: "path", Value: "/v2" + c.Param("dockerpath")},
+		}
+		h.ServeHTTP(c)
+	})
+	return long, short, d, store
+}
+
+// postMount issues the mount request itself: POST to the target image's upload
+// endpoint carrying ?mount=&from=.
+func postMount(r *gin.Engine, uploadsURL, dgst, from string) *httptest.ResponseRecorder {
+	target := fmt.Sprintf("%s?mount=%s&from=%s", uploadsURL, dgst, from)
+	req := httptest.NewRequest(http.MethodPost, target, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func blobStoreKeys(t *testing.T, store *testutil.BlobStore) []string {
+	t.Helper()
+	keys, err := store.ListKeys(context.Background())
+	require.NoError(t, err)
+	sort.Strings(keys)
+	return keys
+}
+
+func usedBytes(t *testing.T, d formats.Deps) int64 {
+	t.Helper()
+	bs, err := d.Blobs.Get(context.Background(), "default")
+	require.NoError(t, err)
+	return bs.UsedBytes
+}
+
+// ── The happy path ────────────────────────────────────────────
+
+// The point of a mount is that the client sends no bytes at all: the registry
+// answers the POST with the finished blob instead of an upload session.
+func TestMount_ExistingBlob_Returns201AndOpensNoUploadSession(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt1", "docker")
+	r, _, _, store := mountDeps(repo)
+
+	const layer = "a layer shared by two images"
+	dgst := pushBlob(t, r, "mnt1", "library/alpine", layer)
+	before := blobStoreKeys(t, store)
+
+	w := postMount(r, "/repository/mnt1/v2/library/ubuntu/blobs/uploads/", dgst, "library/alpine")
+	require.Equal(t, http.StatusCreated, w.Code, "a mount that can be served returns 201, not 202: %s", w.Body.String())
+	assert.Equal(t, "/repository/mnt1/v2/library/ubuntu/blobs/"+dgst, w.Header().Get("Location"),
+		"Location names the mounted blob under the same /v2/ prefix the client authenticated against")
+	assert.Equal(t, dgst, w.Header().Get("Docker-Content-Digest"))
+
+	// A 201 with an upload session behind it would leak a staged blob per mount;
+	// sessions live under the _uploads/ prefix in the blob store.
+	after := blobStoreKeys(t, store)
+	assert.Equal(t, before, after, "a mount stores nothing new — no upload session, no second copy")
+	for _, k := range after {
+		assert.False(t, strings.HasPrefix(k, "_uploads/"), "no upload session may be created by a mount, found %q", k)
+	}
+}
+
+// A mounted layer must be pullable from the target image, and must be the very
+// same stored object: the blob key is what proves the bytes were not copied.
+func TestMount_MountedBlobIsPullableAndSharesTheSourceBlobKey(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt2", "docker")
+	r, _, d, _ := mountDeps(repo)
+
+	const layer = "bytes that must never be uploaded twice"
+	dgst := pushBlob(t, r, "mnt2", "library/alpine", layer)
+
+	w := postMount(r, "/repository/mnt2/v2/library/ubuntu/blobs/uploads/", dgst, "library/alpine")
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/mnt2/v2/library/ubuntu/blobs/"+dgst, nil)
+	pull := httptest.NewRecorder()
+	r.ServeHTTP(pull, req)
+	require.Equal(t, http.StatusOK, pull.Code, "the mounted blob must be pullable from the target image")
+	assert.Equal(t, layer, pull.Body.String())
+
+	ctx := context.Background()
+	src, err := d.Assets.GetByPath(ctx, "mnt2", "/blobs/library/alpine/"+dgst)
+	require.NoError(t, err)
+	dst, err := d.Assets.GetByPath(ctx, "mnt2", "/blobs/library/ubuntu/"+dgst)
+	require.NoError(t, err, "the mount registers an asset under the target image")
+
+	assert.Equal(t, src.BlobKey, dst.BlobKey,
+		"the mounted asset points at the source's stored object; a different key means the bytes were duplicated")
+	assert.NotEqual(t, base.BlobKey("mnt2", "/blobs/library/ubuntu/"+dgst), dst.BlobKey,
+		"a mount must not claim a key of its own — that key holds nothing")
+	assert.Equal(t, src.SizeBytes, dst.SizeBytes)
+	assert.Equal(t, src.SHA256, dst.SHA256)
+	assert.Equal(t, src.SHA1, dst.SHA1)
+	assert.Equal(t, src.MD5, dst.MD5)
+	assert.Equal(t, src.BlobStoreID, dst.BlobStoreID,
+		"the alias has to name the store the bytes actually live in, or the pull looks in the wrong place")
+}
+
+// ── The `from` spellings a real client sends ──────────────────
+
+// docker sets from=reference.Path(sourceRef) — everything after the registry
+// host. Pushing against the short path form (host/<repo>/<image>) that is
+// "<repo>/<image>", so the Nexspence repository arrives inside the value.
+func TestMount_ShortPathForm_FromCarriesTheNexspenceRepository(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt3", "docker")
+	long, short, _, _ := mountDeps(repo)
+
+	const layer = "short-path layer"
+	dgst := pushBlob(t, long, "mnt3", "library/alpine", layer)
+
+	w := postMount(short, "/v2/mnt3/library/ubuntu/blobs/uploads/", dgst, "mnt3/library/alpine")
+	require.Equal(t, http.StatusCreated, w.Code,
+		"from=<repo>/<image> is what docker push against /v2/<repo>/<image> sends: %s", w.Body.String())
+	assert.Equal(t, "/v2/mnt3/library/ubuntu/blobs/"+dgst, w.Header().Get("Location"))
+}
+
+// Against the long path form (host/repository/<repo>/<image>) the same rule
+// yields "repository/<repo>/<image>".
+func TestMount_LongPathForm_FromCarriesTheRepositoryPrefix(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt4", "docker")
+	r, _, _, _ := mountDeps(repo)
+
+	const layer = "long-path layer"
+	dgst := pushBlob(t, r, "mnt4", "library/alpine", layer)
+
+	w := postMount(r, "/repository/mnt4/v2/library/ubuntu/blobs/uploads/", dgst, "repository/mnt4/library/alpine")
+	require.Equal(t, http.StatusCreated, w.Code,
+		"from=repository/<repo>/<image> is what the long path form yields: %s", w.Body.String())
+}
+
+// An image whose own name begins with the repository name must still be
+// mountable by its bare name: the subdomain connector rewrites only the path,
+// so `from` arrives without any repository prefix at all.
+func TestMount_BareImageNameThatShadowsTheRepositoryPrefix(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt5", "docker")
+	r, _, _, _ := mountDeps(repo)
+
+	const layer = "layer of an awkwardly named image"
+	dgst := pushBlob(t, r, "mnt5", "mnt5/alpine", layer)
+
+	// "mnt5/alpine" reads as both <repo>/alpine and as the literal image name.
+	w := postMount(r, "/repository/mnt5/v2/library/ubuntu/blobs/uploads/", dgst, "mnt5/alpine")
+	require.Equal(t, http.StatusCreated, w.Code,
+		"the literal image name must be tried too, not only the repository-stripped reading: %s", w.Body.String())
+}
+
+// ── Fallbacks ─────────────────────────────────────────────────
+
+// The spec lets a registry decline any mount; declining costs the client only
+// bandwidth, so every case that cannot be served safely lands here.
+func TestMount_UnknownSourceBlob_FallsBackToAWorkingUploadSession(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt6", "docker")
+	r, _, _, _ := mountDeps(repo)
+
+	const layer = "never pushed anywhere yet"
+	dgst := digest(layer)
+
+	w := postMount(r, "/repository/mnt6/v2/library/ubuntu/blobs/uploads/", dgst, "library/alpine")
+	require.Equal(t, http.StatusAccepted, w.Code, "an unmountable blob falls back to a normal upload")
+	loc := w.Header().Get("Location")
+	require.NotEmpty(t, loc, "the fallback must hand back a fresh session to PATCH into")
+	require.NotEmpty(t, w.Header().Get("Docker-Upload-UUID"))
+
+	// And that session has to actually work end to end.
+	patch := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader(layer))
+	patch.ContentLength = int64(len(layer))
+	wp := httptest.NewRecorder()
+	r.ServeHTTP(wp, patch)
+	require.Equal(t, http.StatusAccepted, wp.Code)
+
+	put := httptest.NewRequest(http.MethodPut, loc+"?digest="+dgst, nil)
+	wput := httptest.NewRecorder()
+	r.ServeHTTP(wput, put)
+	require.Equal(t, http.StatusCreated, wput.Code, wput.Body.String())
+
+	get := httptest.NewRequest(http.MethodGet, "/repository/mnt6/v2/library/ubuntu/blobs/"+dgst, nil)
+	wg := httptest.NewRecorder()
+	r.ServeHTTP(wg, get)
+	require.Equal(t, http.StatusOK, wg.Code)
+	assert.Equal(t, layer, wg.Body.String())
+}
+
+// A malformed digest is not a blob name; it must not be handed to a path lookup.
+func TestMount_MalformedDigest_FallsBack(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt7", "docker")
+	r, _, _, _ := mountDeps(repo)
+	pushBlob(t, r, "mnt7", "library/alpine", "a layer")
+
+	for _, bad := range []string{"sha256:deadbeef", "../../etc/passwd", "notadigest"} {
+		w := postMount(r, "/repository/mnt7/v2/library/ubuntu/blobs/uploads/", bad, "library/alpine")
+		assert.Equal(t, http.StatusAccepted, w.Code, "mount=%q must not be treated as a digest", bad)
+	}
+}
+
+// ── The access boundary ───────────────────────────────────────
+
+// RBACMiddleware authorizes the request against the repository in the URL, and
+// the handler never sees the caller's privileges. So the mount source must stay
+// inside that repository: naming another Nexspence repository — even one that
+// really holds the blob — must not read out of it.
+func TestMount_FromAnotherNexspenceRepository_IsRefused(t *testing.T) {
+	target := testutil.SimpleRepo("mnt8", "docker")
+	secret := testutil.SimpleRepo("secret", "docker")
+	r, _, d, _ := mountDeps(target, secret)
+
+	const layer = "a layer the caller was never authorized to read"
+	dgst := pushBlob(t, r, "secret", "library/alpine", layer)
+
+	for _, from := range []string{
+		"secret/library/alpine",
+		"repository/secret/library/alpine",
+	} {
+		w := postMount(r, "/repository/mnt8/v2/library/ubuntu/blobs/uploads/", dgst, from)
+		assert.Equal(t, http.StatusAccepted, w.Code,
+			"from=%q names a repository the request was not authorized against; it must not mount", from)
+	}
+
+	_, err := d.Assets.GetByPath(context.Background(), "mnt8", "/blobs/library/ubuntu/"+dgst)
+	assert.Error(t, err, "nothing may be registered in the target repository from a source outside it")
+}
+
+// A registry-wide GC or a manual blob deletion can leave an asset row whose
+// bytes are gone. Mounting off it would hand the client a 201 for a layer that
+// 404s on pull, and the client would never upload the bytes it still has.
+func TestMount_SourceAssetWithMissingBlob_FallsBackInsteadOfPromisingABrokenLayer(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt9", "docker")
+	r, _, d, store := mountDeps(repo)
+
+	const layer = "bytes about to vanish from the store"
+	dgst := pushBlob(t, r, "mnt9", "library/alpine", layer)
+
+	ctx := context.Background()
+	src, err := d.Assets.GetByPath(ctx, "mnt9", "/blobs/library/alpine/"+dgst)
+	require.NoError(t, err)
+	require.NoError(t, store.Delete(ctx, src.BlobKey))
+
+	w := postMount(r, "/repository/mnt9/v2/library/ubuntu/blobs/uploads/", dgst, "library/alpine")
+	assert.Equal(t, http.StatusAccepted, w.Code,
+		"the source asset survives but its bytes do not, so the mount cannot be honored")
+
+	_, err = d.Assets.GetByPath(ctx, "mnt9", "/blobs/library/ubuntu/"+dgst)
+	assert.Error(t, err, "no asset may point at a blob key that holds nothing")
+}
+
+// ── Usage accounting ──────────────────────────────────────────
+
+// The bytes are already on disk, so a mount writes none. The used_bytes counter
+// follows the convention RegisterStoredBlob already sets everywhere else — one
+// increment per registered asset, exactly as the manifest digest alias does
+// (issue #146). Deletion decrements per asset unconditionally, so skipping the
+// increment here would drive the counter permanently negative.
+func TestMount_WritesNoBytesAndCountsUsageOncePerAsset(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt10", "docker")
+	r, _, d, store := mountDeps(repo)
+
+	const layer = "a layer worth counting exactly once"
+	dgst := pushBlob(t, r, "mnt10", "library/alpine", layer)
+
+	keysBefore := blobStoreKeys(t, store)
+	physicalBefore, err := store.UsedBytes(context.Background())
+	require.NoError(t, err)
+	countedBefore := usedBytes(t, d)
+
+	w := postMount(r, "/repository/mnt10/v2/library/ubuntu/blobs/uploads/", dgst, "library/alpine")
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+
+	assert.Equal(t, keysBefore, blobStoreKeys(t, store), "a mount writes no object")
+	physicalAfter, err := store.UsedBytes(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, physicalBefore, physicalAfter, "a mount adds no bytes to the store")
+
+	assert.Equal(t, countedBefore+int64(len(layer)), usedBytes(t, d),
+		"one asset, one increment — the same convention the manifest digest alias follows (#146)")
+}
+
+// Mounting makes two images depend on one stored object, so deleting either one
+// must not take the bytes out from under the other (#144). The counter comes
+// back down with each asset, matching the per-asset increment above.
+func TestMount_DeletingTheSourceLeavesTheMountedBlobPullable(t *testing.T) {
+	repo := testutil.SimpleRepo("mnt11", "docker")
+	r, _, d, _ := mountDeps(repo)
+
+	const layer = "one object, two images"
+	dgst := pushBlob(t, r, "mnt11", "library/alpine", layer)
+	w := postMount(r, "/repository/mnt11/v2/library/ubuntu/blobs/uploads/", dgst, "library/alpine")
+	require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+	counted := usedBytes(t, d)
+
+	del := httptest.NewRequest(http.MethodDelete, "/repository/mnt11/v2/library/alpine/blobs/"+dgst, nil)
+	wd := httptest.NewRecorder()
+	r.ServeHTTP(wd, del)
+	require.Equal(t, http.StatusAccepted, wd.Code)
+
+	get := httptest.NewRequest(http.MethodGet, "/repository/mnt11/v2/library/ubuntu/blobs/"+dgst, nil)
+	wg := httptest.NewRecorder()
+	r.ServeHTTP(wg, get)
+	require.Equal(t, http.StatusOK, wg.Code, "the mounted image still needs the bytes the source registered")
+	assert.Equal(t, layer, wg.Body.String())
+
+	assert.Equal(t, counted-int64(len(layer)), usedBytes(t, d),
+		"the deleted asset gives back exactly the size its registration added")
+}

--- a/internal/formats/oci/pagination.go
+++ b/internal/formats/oci/pagination.go
@@ -1,0 +1,88 @@
+package oci
+
+import (
+	"net/url"
+	"sort"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Pagination for the OCI Distribution list endpoints. The spec gives
+// GET /v2/<name>/tags/list and GET /v2/_catalog the same shape:
+//
+//	?n=<count>&last=<entry>  → at most n entries, sorted, starting after last
+//	Link: <...?n=10&last=v1.9>; rel="next"   when the answer was truncated
+//
+// Everything here is deliberately free of any knowledge of tags vs repository
+// names so the catalog endpoint can reuse it unchanged.
+
+// pageParams are the ?n= / ?last= arguments of a list request.
+type pageParams struct {
+	// n is the maximum number of entries to return; 0 means "no limit", which
+	// is what both an absent n and a non-positive one are treated as. The spec
+	// lets a registry reject a malformed n with 400, but returning the full
+	// list is the friendlier reading and matches what clients that omit n
+	// already get.
+	n int
+	// last is the cursor: only entries strictly greater than it are returned.
+	last string
+}
+
+// parsePageParams reads the pagination arguments off a request.
+func parsePageParams(c *gin.Context) pageParams {
+	p := pageParams{last: c.Query("last")}
+	if raw := c.Query("n"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			p.n = n
+		}
+	}
+	return p
+}
+
+// paginate cuts one page out of a sorted, ascending list of entries. It returns
+// the page and whether entries remain after it.
+//
+// Entries equal to the cursor are skipped, not just the first one, so a list
+// that somehow holds duplicates still advances: every page ends on a strictly
+// larger entry than the cursor that produced it, which is what makes a client
+// following the Link headers terminate.
+func paginate(entries []string, p pageParams) (page []string, more bool) {
+	// sort.SearchStrings finds the first entry >= last; the cursor is exclusive,
+	// so skip the run equal to it as well.
+	start := 0
+	if p.last != "" {
+		start = sort.SearchStrings(entries, p.last)
+		for start < len(entries) && entries[start] <= p.last {
+			start++
+		}
+	}
+	rest := entries[start:]
+	if p.n <= 0 || len(rest) <= p.n {
+		return rest, false
+	}
+	return rest[:p.n], true
+}
+
+// nextLink renders the RFC 8288 Link header value naming the next page of the
+// list the request asked for. The URL is built from the request's own path so
+// the client stays on the /v2/ form it used: a Docker client on the short path
+// only sends its credentials to /v2/, and a long-path link would drop it onto
+// an unauthenticated surface (the same trap as issue #47).
+func nextLink(c *gin.Context, n int, last string) string {
+	q := url.Values{}
+	q.Set("n", strconv.Itoa(n))
+	q.Set("last", last)
+	// EscapedPath keeps a name that needed escaping escaped, and Encode escapes
+	// the cursor, so a tag holding a '+' or a space survives the round trip.
+	return "<" + c.Request.URL.EscapedPath() + "?" + q.Encode() + `>; rel="next"`
+}
+
+// setNextLink attaches the Link header for a truncated page. Nothing is set for
+// a complete answer — the absence of the header is what tells a client to stop.
+func setNextLink(c *gin.Context, p pageParams, page []string, more bool) {
+	if !more || len(page) == 0 {
+		return
+	}
+	c.Header("Link", nextLink(c, p.n, page[len(page)-1]))
+}

--- a/internal/formats/oci/pagination_test.go
+++ b/internal/formats/oci/pagination_test.go
@@ -1,0 +1,309 @@
+package oci_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// ── Helpers ───────────────────────────────────────────────────
+
+const pagingManifest = `{"schemaVersion":2,"mediaType":"application/vnd.docker.distribution.manifest.v2+json"}`
+
+// pushTags pushes the same manifest body under each tag, which is what a client
+// re-tagging one image does.
+func pushTags(t *testing.T, r *gin.Engine, repoName, imageName string, tags ...string) {
+	t.Helper()
+	for _, tag := range tags {
+		req := httptest.NewRequest(http.MethodPut,
+			fmt.Sprintf("/repository/%s/v2/%s/manifests/%s", repoName, imageName, url.PathEscape(tag)),
+			strings.NewReader(pagingManifest))
+		req.ContentLength = int64(len(pagingManifest))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, "push tag %q: %s", tag, w.Body.String())
+	}
+}
+
+// getTags issues a tags/list request and decodes the tag names plus the raw Link header.
+func getTags(t *testing.T, r *gin.Engine, target string) (tags []string, link string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "GET %s: %s", target, w.Body.String())
+	var body struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return body.Tags, w.Header().Get("Link")
+}
+
+// parseNextLink splits a `</path?query>; rel="next"` header into the URL it names.
+func parseNextLink(t *testing.T, link string) *url.URL {
+	t.Helper()
+	require.NotEmpty(t, link, "Link header expected")
+	require.True(t, strings.HasSuffix(link, `>; rel="next"`),
+		`Link must be formatted <url>; rel="next", got %q`, link)
+	raw := strings.TrimSuffix(strings.TrimPrefix(link, "<"), `>; rel="next"`)
+	require.True(t, strings.HasPrefix(link, "<"), "Link must start with '<', got %q", link)
+	u, err := url.Parse(raw)
+	require.NoError(t, err, "Link URL must parse: %q", raw)
+	return u
+}
+
+// ── The spec's paging shape ───────────────────────────────────
+
+func TestTagsList_FirstPageIsSortedAndLinksToNext(t *testing.T) {
+	repo := testutil.SimpleRepo("pag1", "docker")
+	r, _ := setupWithDeps(repo)
+	pushTags(t, r, "pag1", "myapp", "v1.2", "v1.0", "v2.0", "v1.10", "v1.1")
+
+	tags, link := getTags(t, r, "/repository/pag1/v2/myapp/tags/list?n=2")
+	assert.Equal(t, []string{"v1.0", "v1.1"}, tags, "first page must be the lexically first two tags")
+
+	u := parseNextLink(t, link)
+	assert.Equal(t, "2", u.Query().Get("n"))
+	assert.Equal(t, "v1.1", u.Query().Get("last"), "cursor must name the last tag of this page")
+}
+
+func TestTagsList_FollowingLinksReachesTheEnd(t *testing.T) {
+	repo := testutil.SimpleRepo("pag2", "docker")
+	r, _ := setupWithDeps(repo)
+	pushTags(t, r, "pag2", "myapp", "v1.0", "v1.1", "v1.2", "v1.3", "v1.4")
+
+	tags, link := getTags(t, r, "/repository/pag2/v2/myapp/tags/list?n=2")
+	require.Equal(t, []string{"v1.0", "v1.1"}, tags)
+
+	tags2, link2 := getTags(t, r, parseNextLink(t, link).String())
+	assert.Equal(t, []string{"v1.2", "v1.3"}, tags2)
+
+	tags3, link3 := getTags(t, r, parseNextLink(t, link2).String())
+	assert.Equal(t, []string{"v1.4"}, tags3)
+	assert.Empty(t, link3, "the final page must carry no Link header")
+}
+
+func TestTagsList_NoLimitReturnsEverything(t *testing.T) {
+	repo := testutil.SimpleRepo("pag3", "docker")
+	r, _ := setupWithDeps(repo)
+	all := []string{"v1.0", "v1.1", "v1.2", "v1.3", "v1.4"}
+	pushTags(t, r, "pag3", "myapp", all...)
+
+	for _, target := range []string{
+		"/repository/pag3/v2/myapp/tags/list",
+		"/repository/pag3/v2/myapp/tags/list?n=0",
+	} {
+		tags, link := getTags(t, r, target)
+		assert.Equal(t, all, tags, "GET %s must return every tag", target)
+		assert.Empty(t, link, "GET %s must carry no Link header", target)
+	}
+}
+
+func TestTagsList_LastWithoutNReturnsTheRemainder(t *testing.T) {
+	repo := testutil.SimpleRepo("pag4", "docker")
+	r, _ := setupWithDeps(repo)
+	pushTags(t, r, "pag4", "myapp", "v1.0", "v1.1", "v1.2", "v1.3", "v1.4")
+
+	tags, link := getTags(t, r, "/repository/pag4/v2/myapp/tags/list?last=v1.2")
+	assert.Equal(t, []string{"v1.3", "v1.4"}, tags)
+	assert.Empty(t, link)
+}
+
+func TestTagsList_NBiggerThanTagCount(t *testing.T) {
+	repo := testutil.SimpleRepo("pag5", "docker")
+	r, _ := setupWithDeps(repo)
+	all := []string{"v1.0", "v1.1", "v1.2"}
+	pushTags(t, r, "pag5", "myapp", all...)
+
+	tags, link := getTags(t, r, "/repository/pag5/v2/myapp/tags/list?n=50")
+	assert.Equal(t, all, tags)
+	assert.Empty(t, link, "nothing was truncated, so there is no next page")
+}
+
+// TestTagsList_LinkKeepsTheClientsPathForm covers both mounts a Docker client can
+// reach: the long /repository/<repo>/v2/... form and the short /v2/<repo>/... one
+// that setupV2Scoped mimics. A client on the short path must not be handed a
+// long-path link — it only sends its credentials to /v2/ (issue #47).
+func TestTagsList_LinkKeepsTheClientsPathForm(t *testing.T) {
+	t.Run("long form", func(t *testing.T) {
+		repo := testutil.SimpleRepo("pag6", "docker")
+		r, _ := setupWithDeps(repo)
+		pushTags(t, r, "pag6", "myapp", "v1.0", "v1.1", "v1.2")
+
+		_, link := getTags(t, r, "/repository/pag6/v2/myapp/tags/list?n=1")
+		assert.Equal(t, "/repository/pag6/v2/myapp/tags/list", parseNextLink(t, link).Path)
+	})
+
+	t.Run("short form", func(t *testing.T) {
+		repo := testutil.SimpleRepo("pag6s", "docker")
+		r := setupV2Scoped(repo)
+		for _, tag := range []string{"v1.0", "v1.1", "v1.2"} {
+			req := httptest.NewRequest(http.MethodPut, "/v2/pag6s/myapp/manifests/"+tag,
+				strings.NewReader(pagingManifest))
+			req.ContentLength = int64(len(pagingManifest))
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+			require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+		}
+
+		_, link := getTags(t, r, "/v2/pag6s/myapp/tags/list?n=1")
+		u := parseNextLink(t, link)
+		assert.Equal(t, "/v2/pag6s/myapp/tags/list", u.Path)
+
+		// The link must be servable as-is.
+		tags2, _ := getTags(t, r, u.String())
+		assert.Equal(t, []string{"v1.1"}, tags2)
+	})
+}
+
+// A tag containing a character that has to be escaped in a query string must
+// survive the round trip through the Link header.
+func TestTagsList_CursorSurvivesEscaping(t *testing.T) {
+	repo := testutil.SimpleRepo("pag7", "docker")
+	r, d := setupWithDeps(repo)
+	// Written straight to the store: the odd characters are about the query
+	// string, not about what a push URL accepts.
+	seedTags(t, d, "pag7", "myapp", "v1+a", "v1 b", "v1&c", "v2")
+
+	tags, link := getTags(t, r, "/repository/pag7/v2/myapp/tags/list?n=3")
+	require.Equal(t, []string{"v1 b", "v1&c", "v1+a"}, tags)
+
+	u := parseNextLink(t, link)
+	assert.Equal(t, "v1+a", u.Query().Get("last"), "cursor must decode back to the exact tag")
+
+	rest, link2 := getTags(t, r, u.String())
+	assert.Equal(t, []string{"v2"}, rest)
+	assert.Empty(t, link2)
+}
+
+// ── The 500-row search cap ────────────────────────────────────
+
+// TestTagsList_PagesPastTheSearchCap proves a repository with more tags than the
+// component search will return in one call is still fully enumerable by following
+// links. The search is wrapped in cappedSearch, which reproduces the SQL clamp.
+func TestTagsList_PagesPastTheSearchCap(t *testing.T) {
+	repo := testutil.SimpleRepo("pag8", "docker")
+	comps := &cappedSearch{ComponentRepo: testutil.NewComponentRepo()}
+	r := setupWithComponents(repo, comps)
+
+	const total = 600
+	want := make([]string, 0, total)
+	for i := 0; i < total; i++ {
+		tag := fmt.Sprintf("v%04d", i)
+		want = append(want, tag)
+		require.NoError(t, comps.Create(context.Background(), &domain.Component{
+			RepositoryID: repo.ID, Repository: repo.Name, Format: "docker",
+			Name: "myapp", Version: tag,
+		}))
+	}
+	sort.Strings(want)
+
+	// One shot, no n: every tag, past the cap.
+	all, link := getTags(t, r, "/repository/pag8/v2/myapp/tags/list")
+	require.Len(t, all, total, "an uncapped listing must enumerate all %d tags", total)
+	assert.Equal(t, want, all, "an uncapped listing must enumerate all %d tags", total)
+	assert.Empty(t, link)
+
+	// And page by page: 7 pages of 100 (the last one short) must cover the same set.
+	var got []string
+	target := "/repository/pag8/v2/myapp/tags/list?n=100"
+	for pages := 0; ; pages++ {
+		require.Less(t, pages, 20, "following links must terminate")
+		page, l := getTags(t, r, target)
+		got = append(got, page...)
+		if l == "" {
+			break
+		}
+		target = parseNextLink(t, l).String()
+	}
+	assert.Equal(t, want, got, "paging must enumerate every tag exactly once")
+}
+
+// cappedSearch reproduces the component search's storage semantics on top of the
+// in-memory mock, whose own Search ignores Limit/Offset entirely: the SQL
+// implementation (internal/repository/postgres/component_repo.go) clamps a Limit
+// above 500 back down to 50, filters the name with a substring ILIKE, orders by
+// (name, version) and hands back a continuation token when more rows remain.
+type cappedSearch struct {
+	*testutil.ComponentRepo
+}
+
+func (c *cappedSearch) Search(ctx context.Context, p domain.SearchParams) (*domain.Page[domain.Component], error) {
+	page, err := c.ListByRepoNames(ctx, []string{p.Repository}, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]domain.Component, 0, len(page.Items))
+	for _, comp := range page.Items {
+		if p.Name != "" && !strings.Contains(strings.ToLower(comp.Name), strings.ToLower(p.Name)) {
+			continue
+		}
+		items = append(items, comp)
+	}
+	limit := p.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	if p.Offset >= len(items) {
+		return &domain.Page[domain.Component]{Items: nil}, nil
+	}
+	items = items[p.Offset:]
+	var token *string
+	if len(items) > limit {
+		items = items[:limit]
+		next := fmt.Sprintf("%d", p.Offset+limit)
+		token = &next
+	}
+	return &domain.Page[domain.Component]{Items: items, ContinuationToken: token}, nil
+}
+
+// setupWithComponents is setupWithDeps with a caller-supplied component repo.
+func setupWithComponents(repo *domain.Repository, comps repository.ComponentRepo) *gin.Engine {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+// seedTags writes components straight to the store, for tag names a push URL
+// cannot carry.
+func seedTags(t *testing.T, d formats.Deps, repoName, imageName string, tags ...string) {
+	t.Helper()
+	for _, tag := range tags {
+		require.NoError(t, d.Components.Create(context.Background(), &domain.Component{
+			RepositoryID: "repo-" + repoName, Repository: repoName, Format: "docker",
+			Name: imageName, Version: tag,
+		}))
+	}
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -107,6 +107,12 @@ type AssetRepo interface {
 	CountByBlobKey(ctx context.Context, blobKey, excludeID string) (int, error)
 	// ListRawBrowseAssets returns all assets for the given raw-format repos with metadata for tree building.
 	ListRawBrowseAssets(ctx context.Context, repoNames []string) ([]domain.RawBrowseAsset, error)
+	// ListOCIImageNames returns the distinct image names held by the given OCI
+	// Distribution repositories — the <name> of a stored
+	// /manifests/<name>/<reference> asset. Only images that have a manifest are
+	// named: a blob carries no image the client can pull. The order is
+	// unspecified; the caller sorts.
+	ListOCIImageNames(ctx context.Context, repoNames []string) ([]string, error)
 }
 
 // ContentSelectorRepo manages content selector definitions (privilege-scoped paths).

--- a/internal/repository/postgres/asset_repo.go
+++ b/internal/repository/postgres/asset_repo.go
@@ -563,6 +563,62 @@ func (r *assetRepo) ListRawBrowseAssets(ctx context.Context, repoNames []string)
 	return out, rows.Err()
 }
 
+// ListOCIImageNames returns the distinct image names the given OCI Distribution
+// repositories hold. It answers GET /v2/<repo>/_catalog.
+//
+// The order is unspecified: the catalog has to be sorted the way Go compares
+// strings, because that is what the ?last= cursor is resolved against, and a
+// database ORDER BY sorts under the server's collation — which for anything but
+// C places "img-a" and "img/a" differently. The caller sorts.
+//
+// The names are cut out of the manifest asset paths — /manifests/<name>/<ref> —
+// rather than read off components.name, because a component row is not evidence
+// of a pullable image: every blob upload registers one, so the components table
+// carries a row per layer and per abandoned upload as well. Joining components
+// to their manifest assets would answer the same question, but this way the
+// answer is one column from one table.
+//
+// The DISTINCT is done in SQL on purpose. The alternative — ListByRepoAndPath
+// with a "/manifests/" prefix and the reduction in Go — ships one full asset row
+// per manifest, which for a registry holding tags and per-manifest digest
+// aliases is a few hundred thousand rows to produce a few thousand names.
+//
+// The scan is bounded by repository, which idx_assets_repo_path (repository_id,
+// path) serves. The LIKE is redundant with the pattern below — it is the pattern
+// that decides what is a manifest — and is there so the planner drops the blob
+// rows, the bulk of the table, before the regexp runs on them.
+func (r *assetRepo) ListOCIImageNames(ctx context.Context, repoNames []string) ([]string, error) {
+	if len(repoNames) == 0 {
+		return nil, nil
+	}
+	// The reference is the last segment and never contains a slash — a tag has
+	// no '/' in the OCI grammar and a digest is <algorithm>:<hex> — so the greedy
+	// group is exactly the image name, however many segments it has.
+	rows, err := r.db.Query(ctx,
+		`SELECT DISTINCT image FROM (
+		     SELECT substring(a.path from '^/manifests/(.+)/[^/]+$') AS image
+		     FROM assets a
+		     JOIN repositories rep ON rep.id = a.repository_id
+		     WHERE rep.name = ANY($1) AND a.path LIKE '/manifests/%'
+		 ) named
+		 WHERE image IS NOT NULL AND image <> ''`,
+		repoNames,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out = append(out, name)
+	}
+	return out, rows.Err()
+}
+
 func (r *assetRepo) ListByRepoAndPath(ctx context.Context, repoName, pathPrefix string) ([]domain.Asset, error) {
 	var q string
 	var args []any

--- a/internal/repository/postgres/asset_repo_queries_integration_test.go
+++ b/internal/repository/postgres/asset_repo_queries_integration_test.go
@@ -1298,3 +1298,116 @@ func TestAssetRepoQueries_ListByComponentIDs_EmptyInput_ReturnsEmptyMap(t *testi
 		t.Errorf("expected empty map for empty input, got %d keys", len(byID))
 	}
 }
+
+// ── ListOCIImageNames ─────────────────────────────────────────────────────────
+
+// The catalog endpoint is built on this query, so what it must never do is name
+// something a client cannot pull: a layer, or an image whose upload was
+// abandoned before its manifest. Both leave assets behind under /blobs/.
+func TestAssetRepoQueries_ListOCIImageNames_OnlyImagesWithManifests(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "oci_names")
+	repo := NewAssetRepo(pool)
+
+	const dgst = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	paths := []string{
+		// One image under two tags plus the digest alias every tagged push
+		// registers: three assets, one name.
+		"/manifests/library/ubuntu/latest",
+		"/manifests/library/ubuntu/22.04",
+		"/manifests/library/ubuntu/" + dgst,
+		// A single-segment image name, and a sibling whose name contains
+		// another's in full.
+		"/manifests/myapp/1.0",
+		"/manifests/charts/nginx/1.2.3",
+		"/manifests/charts/nginx-extra/1.0.0",
+		// Blobs name nothing: a layer of an image that is listed, and one of an
+		// upload that never got a manifest.
+		"/blobs/library/ubuntu/" + dgst,
+		"/blobs/aborted/upload/" + dgst,
+	}
+	for _, path := range paths {
+		if err := repo.Create(ctx, makeAsset(p, path)); err != nil {
+			t.Fatalf("Create %q: %v", path, err)
+		}
+	}
+
+	got, err := repo.ListOCIImageNames(ctx, []string{p.RepoName})
+	if err != nil {
+		t.Fatalf("ListOCIImageNames: %v", err)
+	}
+	sort.Strings(got)
+	want := []string{"charts/nginx", "charts/nginx-extra", "library/ubuntu", "myapp"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("name[%d]: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// Each repository is its own registry namespace, so one repository's images must
+// never appear in another's catalog.
+func TestAssetRepoQueries_ListOCIImageNames_ScopedToTheNamedRepositories(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p1 := makeAssetParent(t, ctx, "oci_scope1")
+	p2 := makeAssetParent(t, ctx, "oci_scope2")
+	repo := NewAssetRepo(pool)
+
+	if err := repo.Create(ctx, makeAsset(p1, "/manifests/only/in-one/1.0")); err != nil {
+		t.Fatalf("Create in repo 1: %v", err)
+	}
+	if err := repo.Create(ctx, makeAsset(p2, "/manifests/only/in-two/1.0")); err != nil {
+		t.Fatalf("Create in repo 2: %v", err)
+	}
+
+	got, err := repo.ListOCIImageNames(ctx, []string{p1.RepoName})
+	if err != nil {
+		t.Fatalf("ListOCIImageNames(repo1): %v", err)
+	}
+	if len(got) != 1 || got[0] != "only/in-one" {
+		t.Fatalf("repo1 must list only its own image, got %v", got)
+	}
+
+	both, err := repo.ListOCIImageNames(ctx, []string{p1.RepoName, p2.RepoName})
+	if err != nil {
+		t.Fatalf("ListOCIImageNames(both): %v", err)
+	}
+	sort.Strings(both)
+	if len(both) != 2 || both[0] != "only/in-one" || both[1] != "only/in-two" {
+		t.Fatalf("both repositories must contribute, got %v", both)
+	}
+}
+
+func TestAssetRepoQueries_ListOCIImageNames_EmptyInputs(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "oci_empty")
+	repo := NewAssetRepo(pool)
+
+	none, err := repo.ListOCIImageNames(ctx, []string{p.RepoName})
+	if err != nil {
+		t.Fatalf("ListOCIImageNames(empty repo): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("an empty repository holds no images, got %v", none)
+	}
+
+	noRepos, err := repo.ListOCIImageNames(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListOCIImageNames(no repos): %v", err)
+	}
+	if len(noRepos) != 0 {
+		t.Errorf("no repositories means no images, got %v", noRepos)
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -821,6 +821,48 @@ func (a *AssetRepo) ListRawBrowseAssets(_ context.Context, names []string) ([]do
 	return out, nil
 }
 
+// ListOCIImageNames mirrors the SQL: the distinct <name> of every
+// /manifests/<name>/<reference> asset in the named repositories, unordered.
+// Assets stored under any other prefix — every blob — name no image.
+func (a *AssetRepo) ListOCIImageNames(_ context.Context, repoNames []string) ([]string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.BrowseErr != nil {
+		return nil, a.BrowseErr
+	}
+	if len(repoNames) == 0 {
+		return nil, nil
+	}
+	allow := make(map[string]struct{}, len(repoNames))
+	for _, n := range repoNames {
+		allow[n] = struct{}{}
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, asset := range a.byID {
+		if _, ok := allow[asset.Repository]; !ok {
+			continue
+		}
+		rest, ok := strings.CutPrefix(asset.Path, "/manifests/")
+		if !ok {
+			continue
+		}
+		// The reference is the last segment, exactly as the SQL regexp's greedy
+		// group leaves it: a path with no reference names no image.
+		idx := strings.LastIndex(rest, "/")
+		if idx <= 0 {
+			continue
+		}
+		name := rest[:idx]
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
+	return out, nil
+}
+
 // CountByBlobKey mirrors the postgres query: how many assets reference blobKey,
 // not counting the one being excluded. DeleteArtifact reads it to decide whether
 // the physical blob is still needed, so a stub answer would make that decision


### PR DESCRIPTION
Phase 3 of five, on top of v1.27.0. Closes the remaining protocol gaps against the OCI Distribution Spec.

## Tag pagination

`tags/list` had a hard `Limit: 500` and returned whatever order the search produced, with nothing telling the client the list was cut. It now supports `?n=` / `?last=` with a `Link: <…>; rel="next"` header, sorted as the spec requires, and the link is built in the same path form the client used — a client on the short `/v2/<repo>/…` path is not handed a long-path link.

The 500 cap is gone rather than raised. Raising it would not have worked: the component search clamps `limit > 500` back to **50**, so a bigger number returns fewer rows. The handler pages over the search instead, and a test walks a 600-tag repository to prove it is fully enumerable.

**Two defects surfaced while testing this, both fixed:**
- The search matches names with `ILIKE '%name%'`, so `myapp`'s tag list included `notmyapp`'s tags.
- A manifest push registers a digest-alias component, and those `sha256:…` references were being served as *tags*. The spec's tag grammar has no `:`, so nothing real is lost by excluding them.

## Catalog

`GET /v2/<repo>/_catalog`, paginated with the same helpers. Since each Nexspence repository is its own registry namespace, it lists the image names **inside** that repository — the same strings `tags/list` is addressed by.

A name qualifies when a *manifest* exists for it, not when a component does: every blob upload registers a component, so the naive query would list layers and abandoned uploads. It reads distinct image names out of manifest asset paths in SQL rather than shipping one row per tag-and-alias to be reduced in Go. An image whose manifests were all deleted drops out, which is right — `tags/list` is empty for it and every reference 404s.

Proxy repositories answer from what they have cached and do **not** forward upstream: upstreams almost universally restrict `_catalog`, and a proxy claiming an upstream's whole catalog would be a lie about what it can serve.

## Cross-repository blob mounts

`POST …/blobs/uploads/?mount=<digest>&from=<name>` was ignored, so clients re-uploaded layers the registry already had. It now registers a new asset against the existing blob key.

`from` is the source reference minus the host, so its spelling depends on the path form the client used — long, short, or the subdomain connector, which rewrites only the path and so leaves `from` bare. All three spellings are resolved, plus the ambiguous `R/alpine` case where an image is named after its repository; the digest pins the content either way. Anything unresolvable falls back to a normal upload session, which the spec permits and which costs the client only bandwidth.

**Access control.** A mount is a read of the source, so it goes through the same check a direct blob GET would. That check did not exist in the handler at first — `formats.Deps` carried no RBAC — and shipping without it would have meant a content selector that stops a pull but not a mount: anyone with a digest could mount a blob out of a restricted path into one they control and then pull it legitimately. `formats.Deps` now carries an optional `RBAC` checker (interface declared in `internal/formats`, so the dependency stays one-directional and `*service.RBACService` satisfies it unchanged). A refused mount falls back to an upload session rather than 403 — a 403 would answer "yes, that digest is here, you just cannot have it".

Wiring that up exposed a hazard worth naming: `formats.Deps` is passed **by value** into all fourteen format handlers, and `rbacSvc` was constructed after `formatDeps` was assembled. Setting the field afterwards would have left every handler holding a nil copy and looked like it worked.

Also handled: a source asset whose blob is missing from the store falls back instead of promising a broken layer; a self-mount is skipped; mounts into proxy repositories are refused as mutations.

## Verification

`go test ./internal/...` 1775 passing (only the sandbox-networking webhook test fails locally; it passes in CI); integration suite green including the new catalog query; `golangci-lint run --new-from-rev=origin/main` zero issues. The OCI package went from 119 to 142 tests.

## Known and deferred

- A group repository answers `_catalog` with the **first member's** catalog rather than the union — the same shadowing that referrers had. That is phase 4, which merges group indexes for `tags/list` and `_catalog`.
- RBAC on `_catalog` is all-or-nothing per request; there is no per-image filtering. A path-restricted selector gets 403 on the endpoint rather than a filtered list, which is blunt but not leaky — except for a selector whose path clause is a prefix of `/_catalog` (`path.startsWith("/_")`), which would receive every image name. Worth an operator note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW