### PR TITLE
feat(oci): merge tag lists and catalogs across group members

### DIFF
--- a/internal/formats/group/handler.go
+++ b/internal/formats/group/handler.go
@@ -141,11 +141,23 @@ func (h *Handler) eligibleMember(ctx context.Context, memberName string, groupDe
 	return memberRepo
 }
 
-// callMember invokes a member's format handler on a cloned request/recorder.
+// callMember invokes a member's format handler on a cloned request/recorder,
+// asking the question the client asked.
 func (h *Handler) callMember(ctx context.Context, c *gin.Context, memberName, filePath string, handler formats.FormatHandler) *httptest.ResponseRecorder {
+	return h.callMemberWithQuery(ctx, c, memberName, filePath, c.Request.URL.RawQuery, handler)
+}
+
+// callMemberWithQuery is callMember with the member's query spelled out, so a
+// merged index can ask members something the client did not ask literally — see
+// formats.GroupIndexPaginator for why a paginated index must.
+func (h *Handler) callMemberWithQuery(ctx context.Context, c *gin.Context, memberName, filePath, rawQuery string,
+	handler formats.FormatHandler,
+) *httptest.ResponseRecorder {
 	rec := httptest.NewRecorder()
 	sub, _ := gin.CreateTestContext(rec)
 	sub.Request = c.Request.Clone(ctx)
+	// Clone deep-copies the URL, so the client's own request is untouched.
+	sub.Request.URL.RawQuery = rawQuery
 	sub.Params = gin.Params{
 		{Key: "repoName", Value: memberName},
 		{Key: "path", Value: filePath},
@@ -170,6 +182,15 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 ) {
 	ctx := c.Request.Context()
 	strict, isStrict := merger.(formats.GroupIndexStrictMerger)
+	pager, isPager := merger.(formats.GroupIndexPaginator)
+
+	// A paginated index is asked of members without the client's paging
+	// arguments: a member that truncated its own contribution would put the
+	// entries past its cut out of reach of every later page.
+	memberQuery := c.Request.URL.RawQuery
+	if isPager {
+		memberQuery = pager.GroupIndexMemberQuery(source, memberQuery)
+	}
 
 	var parts []formats.GroupIndexPart
 	var contributing []string
@@ -186,7 +207,7 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 			continue
 		}
 
-		rec := h.callMember(ctx, c, memberName, source, handler)
+		rec := h.callMemberWithQuery(ctx, c, memberName, source, memberQuery, handler)
 		code := rec.Code
 		if code == 0 {
 			code = http.StatusOK
@@ -214,6 +235,11 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 
 	c.Writer.Header().Set("X-Nexspence-Source", strings.Join(contributing, ","))
 	body, contentType, err := merger.MergeGroupIndex(repoDef.Name, requestPath, parts)
+	if err == nil && isPager {
+		// Paged after the merge, so the page and the cursor that walks it are
+		// both cut out of the order the client is being served.
+		body, err = pager.PageGroupIndex(c, requestPath, body)
+	}
 	if err != nil {
 		if isStrict {
 			// A member's document that could not be merged is a member whose

--- a/internal/formats/group/merge_oci_test.go
+++ b/internal/formats/group/merge_oci_test.go
@@ -1,9 +1,11 @@
 package group_test
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -87,6 +89,13 @@ func ociGroup(name string, members ...string) *domain.Repository {
 // ociGroupEngine wires the real OCI handler behind a group handler, the way the
 // router does.
 func ociGroupEngine(repos ...*domain.Repository) *gin.Engine {
+	return ociGroupEngineWithDeps(nil, repos...)
+}
+
+// ociGroupEngineWithDeps is ociGroupEngine with a hook that may swap a
+// dependency for a decorated one, which is how a test makes ONE member fail
+// while the others answer normally — the mocks' error seams are per-process.
+func ociGroupEngineWithDeps(customize func(*formats.Deps), repos ...*domain.Repository) *gin.Engine {
 	repoRepo := testutil.NewRepoRepo(repos...)
 	d := formats.Deps{
 		Repos:      repoRepo,
@@ -95,6 +104,9 @@ func ociGroupEngine(repos ...*domain.Repository) *gin.Engine {
 		Assets:     testutil.NewAssetRepo(),
 		BlobStore:  testutil.NewBlobStore(),
 		BaseURL:    "http://localhost:8080",
+	}
+	if customize != nil {
+		customize(&d)
 	}
 	ociH := oci.New(d)
 	registry := map[string]formats.FormatHandler{string(domain.FormatOCI): ociH}
@@ -258,6 +270,207 @@ func TestGroupMerge_OCIReferrers_RateLimitedMemberIsBadGateway(t *testing.T) {
 	w := getGroupReferrers(r, "grp", "img", subject, "")
 	require.Equal(t, http.StatusBadGateway, w.Code)
 	assert.NotContains(t, w.Body.String(), `"manifests"`)
+}
+
+// ── tags/list ──────────────────────────────────────────────────────────────
+
+type ociTagList struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+// getGroupTags asks the group for one image's tag list.
+func getGroupTags(r *gin.Engine, groupName, imageName, query string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/"+groupName+"/v2/"+imageName+"/tags/list"+query, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func decodeTags(t *testing.T, w *httptest.ResponseRecorder) ociTagList {
+	t.Helper()
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var doc ociTagList
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc), "response should be a tag list")
+	return doc
+}
+
+// One image's tags are spread over two members — the ordinary result of
+// promoting v1 to a release repository while v2 is still in a staging one. The
+// group must list both: first-non-404 fan-out answers with member one's list
+// alone, and a tag list is read as the set of versions that exist.
+func TestGroupMerge_OCITags_UnionsMembersSortedUnderTheImageName(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	pushOCIManifest(t, r, "m1", "library/ubuntu", "v3", ociImageManifest)
+	pushOCIManifest(t, r, "m1", "library/ubuntu", "v1", ociImageManifest)
+	pushOCIManifest(t, r, "m2", "library/ubuntu", "v2", ociImageManifest)
+
+	doc := decodeTags(t, getGroupTags(r, "grp", "library/ubuntu", ""))
+	assert.Equal(t, "library/ubuntu", doc.Name,
+		"the merged list names the image, which is what the client addressed")
+	assert.Equal(t, []string{"v1", "v2", "v3"}, doc.Tags,
+		"every member's tags reach the client, sorted")
+}
+
+// The same tag in two members is one tag. A registry that listed it twice would
+// break a client that counts versions, and the spec's ?last= cursor assumes a
+// strictly ascending list.
+func TestGroupMerge_OCITags_TagInBothMembersIsListedOnce(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	pushOCIManifest(t, r, "m1", "img", "1.0.0", ociImageManifest)
+	pushOCIManifest(t, r, "m2", "img", "1.0.0", ociImageManifest)
+	pushOCIManifest(t, r, "m2", "img", "2.0.0", ociImageManifest)
+
+	doc := decodeTags(t, getGroupTags(r, "grp", "img", ""))
+	assert.Equal(t, []string{"1.0.0", "2.0.0"}, doc.Tags, "the shared tag is one tag")
+}
+
+// An image no member holds is an empty list, never a null one: a null breaks
+// clients that range over the tags, and the single-repository answer is an empty
+// 200 too, so the group must not invent a 404 the client would read as "no such
+// registry".
+func TestGroupMerge_OCITags_NoMemberHoldsTheImageIsEmptyList(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	w := getGroupTags(r, "grp", "img", "")
+	doc := decodeTags(t, w)
+	assert.Equal(t, "img", doc.Name)
+	assert.Empty(t, doc.Tags)
+	assert.Contains(t, w.Body.String(), `"tags":[]`, "tags must be [] and not null in the bytes")
+}
+
+// Paging is applied to the MERGED list, not to each member's own. A member asked
+// for its first n tags contributes a truncated list, and the tags past its cut
+// are then unreachable through every page of the group: no cursor the client can
+// send brings them back. So the members are asked for their complete lists and
+// the group cuts the page out of the union — which is also what makes the Link
+// header's cursor mean the same thing on the next request.
+func TestGroupMerge_OCITags_PagesTheMergedUnionNotEachMember(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	for _, tag := range []string{"a", "b", "c"} {
+		pushOCIManifest(t, r, "m1", "img", tag, ociImageManifest)
+	}
+	pushOCIManifest(t, r, "m2", "img", "d", ociImageManifest)
+
+	w := getGroupTags(r, "grp", "img", "?n=2")
+	doc := decodeTags(t, w)
+	assert.Equal(t, []string{"a", "b"}, doc.Tags, "the first page of the union")
+	assert.Equal(t, `</repository/grp/v2/img/tags/list?last=b&n=2>; rel="next"`, w.Header().Get("Link"),
+		"the cursor names an entry of the merged list, on the group's own URL")
+
+	// Following the link must reach "c" — the tag a per-member page would have
+	// cut off, and the one no later request could recover.
+	next := decodeTags(t, getGroupTags(r, "grp", "img", "?n=2&last=b"))
+	assert.Equal(t, []string{"c", "d"}, next.Tags)
+}
+
+// A complete answer carries no Link header: its absence is what tells a client
+// to stop paging.
+func TestGroupMerge_OCITags_CompletePageHasNoLinkHeader(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	pushOCIManifest(t, r, "m1", "img", "a", ociImageManifest)
+	pushOCIManifest(t, r, "m2", "img", "b", ociImageManifest)
+
+	w := getGroupTags(r, "grp", "img", "?n=10")
+	assert.Equal(t, []string{"a", "b"}, decodeTags(t, w).Tags)
+	assert.Empty(t, w.Header().Get("Link"), "nothing was truncated")
+}
+
+// failingComponents fails the tag search for one member and answers normally for
+// every other, which is what a group hitting one broken member looks like.
+type failingComponents struct {
+	*testutil.ComponentRepo
+	repo string
+	err  error
+}
+
+func (f *failingComponents) Search(ctx context.Context, p domain.SearchParams) (*domain.Page[domain.Component], error) {
+	if p.Repository == f.repo {
+		return nil, f.err
+	}
+	return f.ComponentRepo.Search(ctx, p)
+}
+
+// A member that could not be consulted fails the whole group. On this endpoint a
+// member with nothing to contribute answers 200 with an empty list, so a non-2xx
+// is never "I hold no tags" — it is "I could not look". Serving the remaining
+// members' tags as the answer would hand a retention job a short list, and the
+// tags missing from it are the ones it deletes.
+func TestGroupMerge_OCITags_UnconsultableMemberIsBadGatewayNotAShortList(t *testing.T) {
+	r := ociGroupEngineWithDeps(func(d *formats.Deps) {
+		d.Components = &failingComponents{
+			ComponentRepo: d.Components.(*testutil.ComponentRepo),
+			repo:          "broken",
+			err:           errors.New("component store unreachable"),
+		}
+	}, ociGroup("grp", "m1", "broken"), hostedOCI("m1"), hostedOCI("broken"))
+
+	pushOCIManifest(t, r, "m1", "img", "1.0.0", ociImageManifest)
+
+	w := getGroupTags(r, "grp", "img", "")
+	require.NotEqual(t, http.StatusOK, w.Code,
+		"a member that could not be checked must not be silently dropped from the list")
+	assert.NotContains(t, w.Body.String(), `"tags"`,
+		"an incomplete list must never be dressed up as a tag list")
+}
+
+// Merging the LIST must not move the pull. A tag held by both members resolves
+// to the earlier member's manifest, exactly as it did before the list was
+// merged: the union answers "which versions exist", and the manifest request
+// behind it still answers "whose".
+func TestGroupMerge_OCITags_MergedListDoesNotChangeWhichMemberServesThePull(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	first := pushOCIManifest(t, r, "m1", "img", "1.0.0", ociImageManifest)
+	second := pushOCIManifest(t, r, "m2", "img", "1.0.0",
+		ociReferrerManifest(ociSBOMArtifactType, ociDigest("other"), "m2"))
+	require.NotEqual(t, first, second, "the two members must hold different bytes under the tag")
+
+	assert.Equal(t, []string{"1.0.0"}, decodeTags(t, getGroupTags(r, "grp", "img", "")).Tags)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/grp/v2/img/manifests/1.0.0", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, first, w.Header().Get("Docker-Content-Digest"), "the earlier member still wins the pull")
+	assert.Equal(t, "m1", w.Header().Get("X-Nexspence-Source"))
+}
+
+// A member of another format is not a member of this group's protocol at all:
+// the group skips it before it is ever called, so it neither contributes to nor
+// breaks the merge. Same for an offline member — which is the one gap in the
+// "never answer with a list one entry short" policy, because a member skipped by
+// configuration is skipped silently.
+func TestGroupMerge_OCITags_ForeignFormatAndOfflineMembersAreSkipped(t *testing.T) {
+	maven := &domain.Repository{
+		ID: "repo-mvn", Name: "mvn", Format: domain.FormatMaven2, Type: domain.TypeHosted, Online: true,
+	}
+	offline := hostedOCI("dark")
+	offline.Online = false
+
+	r := ociGroupEngine(ociGroup("grp", "mvn", "m1", "dark"), maven, hostedOCI("m1"), offline)
+	pushOCIManifest(t, r, "m1", "img", "1.0.0", ociImageManifest)
+
+	doc := decodeTags(t, getGroupTags(r, "grp", "img", ""))
+	assert.Equal(t, []string{"1.0.0"}, doc.Tags,
+		"the OCI member still answers; the foreign and offline members are not consulted")
+}
+
+// HEAD is not a tag-list method. The members say so with a 405, and the strict
+// policy relays it rather than turning it into "no such image".
+func TestGroupMerge_OCITags_HeadIsRelayedAsMethodNotAllowed(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+	pushOCIManifest(t, r, "m1", "img", "1.0.0", ociImageManifest)
+
+	req := httptest.NewRequest(http.MethodHead, "/repository/grp/v2/img/tags/list", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
 // The artifactType filter must still select through the group, or a cosign query

--- a/internal/formats/group/merge_oci_test.go
+++ b/internal/formats/group/merge_oci_test.go
@@ -473,6 +473,112 @@ func TestGroupMerge_OCITags_HeadIsRelayedAsMethodNotAllowed(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
+// ── _catalog ───────────────────────────────────────────────────────────────
+
+// getGroupCatalog asks the group for the image names it holds.
+func getGroupCatalog(r *gin.Engine, groupName, query string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, "/repository/"+groupName+"/v2/_catalog"+query, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func decodeCatalog(t *testing.T, w *httptest.ResponseRecorder) []string {
+	t.Helper()
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	var doc struct {
+		Repositories []string `json:"repositories"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc), "response should be a catalog")
+	return doc.Repositories
+}
+
+// The catalog of a group is the set of image names a client can pull from it,
+// which is the union of its members'. Answering with the first member's alone
+// hides every image that lives only further down the member list.
+func TestGroupMerge_OCICatalog_UnionsMembersDeduplicatedSorted(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	pushOCIManifest(t, r, "m1", "library/ubuntu", "22.04", ociImageManifest)
+	pushOCIManifest(t, r, "m1", "charts/nginx", "1.2.3", ociImageManifest)
+	// The same image in both members is one image name, not two.
+	pushOCIManifest(t, r, "m2", "charts/nginx", "1.3.0", ociImageManifest)
+	pushOCIManifest(t, r, "m2", "apps/api", "2.0.0", ociImageManifest)
+
+	repos := decodeCatalog(t, getGroupCatalog(r, "grp", ""))
+	assert.Equal(t, []string{"apps/api", "charts/nginx", "library/ubuntu"}, repos,
+		"every member's image names, deduplicated and sorted")
+}
+
+// A group whose members hold nothing is an empty catalog, not a 404 and not a
+// null list — the same document a hosted repository with no images returns.
+func TestGroupMerge_OCICatalog_EmptyMembersIsEmptyList(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	w := getGroupCatalog(r, "grp", "")
+	assert.Empty(t, decodeCatalog(t, w))
+	assert.Contains(t, w.Body.String(), `"repositories":[]`,
+		"repositories must be [] and not null in the bytes")
+}
+
+// The catalog pages the merged union for the same reason the tag list does: a
+// member that paged its own catalog would put the names past its cut out of
+// reach of every page the client can ask for.
+func TestGroupMerge_OCICatalog_PagesTheMergedUnionNotEachMember(t *testing.T) {
+	r := ociGroupEngine(ociGroup("grp", "m1", "m2"), hostedOCI("m1"), hostedOCI("m2"))
+
+	for _, img := range []string{"img/a", "img/b", "img/c"} {
+		pushOCIManifest(t, r, "m1", img, "1.0.0", ociImageManifest)
+	}
+	pushOCIManifest(t, r, "m2", "img/d", "1.0.0", ociImageManifest)
+
+	w := getGroupCatalog(r, "grp", "?n=2")
+	assert.Equal(t, []string{"img/a", "img/b"}, decodeCatalog(t, w))
+	assert.Equal(t, `</repository/grp/v2/_catalog?last=img%2Fb&n=2>; rel="next"`, w.Header().Get("Link"),
+		"the cursor names an entry of the merged catalog, on the group's own URL")
+
+	next := decodeCatalog(t, getGroupCatalog(r, "grp", "?n=2&last=img%2Fb"))
+	assert.Equal(t, []string{"img/c", "img/d"}, next)
+}
+
+// failingImageNames fails the catalog query for one member and answers normally
+// for every other.
+type failingImageNames struct {
+	*testutil.AssetRepo
+	repo string
+	err  error
+}
+
+func (f *failingImageNames) ListOCIImageNames(ctx context.Context, repoNames []string) ([]string, error) {
+	for _, n := range repoNames {
+		if n == f.repo {
+			return nil, f.err
+		}
+	}
+	return f.AssetRepo.ListOCIImageNames(ctx, repoNames)
+}
+
+// A member that could not be consulted fails the whole group. A catalog is what
+// a mirroring or retention job enumerates, and the names missing from a short
+// one are the images it does not copy — or does delete.
+func TestGroupMerge_OCICatalog_UnconsultableMemberIsAnErrorNotAShortCatalog(t *testing.T) {
+	r := ociGroupEngineWithDeps(func(d *formats.Deps) {
+		d.Assets = &failingImageNames{
+			AssetRepo: d.Assets.(*testutil.AssetRepo),
+			repo:      "broken",
+			err:       errors.New("asset store unreachable"),
+		}
+	}, ociGroup("grp", "m1", "broken"), hostedOCI("m1"), hostedOCI("broken"))
+
+	pushOCIManifest(t, r, "m1", "library/ubuntu", "22.04", ociImageManifest)
+
+	w := getGroupCatalog(r, "grp", "")
+	require.NotEqual(t, http.StatusOK, w.Code,
+		"a member that could not be checked must not be silently dropped from the catalog")
+	assert.NotContains(t, w.Body.String(), `"repositories"`,
+		"an incomplete catalog must never be dressed up as one")
+}
+
 // The artifactType filter must still select through the group, or a cosign query
 // would come back carrying every SBOM in every member.
 func TestGroupMerge_OCIReferrers_ArtifactTypeFilterAppliesThroughGroup(t *testing.T) {

--- a/internal/formats/group_merge.go
+++ b/internal/formats/group_merge.go
@@ -1,5 +1,7 @@
 package formats
 
+import "github.com/gin-gonic/gin"
+
 // GroupIndexPart is one member's successful index response, in member order.
 type GroupIndexPart struct {
 	Member string // member repo name — used to rewrite member URLs to the group
@@ -40,4 +42,27 @@ type GroupIndexStrictMerger interface {
 	// on path means "I could not check" — which must fail the whole group —
 	// rather than "I have nothing to contribute", which is skipped as usual.
 	GroupIndexMemberFailureIsFatal(path string, status int) bool
+}
+
+// GroupIndexPaginator is optionally implemented alongside GroupIndexMerger by
+// formats whose index endpoints are paginated.
+//
+// Paging a member and paging the merge are different answers. A member asked for
+// its first n entries contributes a truncated list, and the entries past its own
+// cut are then unreachable through every page of the group: the cursor the
+// client sends back names an entry of the merged list, which each member resolves
+// against its own. So the group asks members for their COMPLETE documents and
+// cuts the client's page out of the merged one, where the order the cursor refers
+// to is the order the client was served.
+type GroupIndexPaginator interface {
+	// GroupIndexMemberQuery returns the raw query members are asked with,
+	// given the raw query the client sent. It is where a paginated index drops
+	// the paging arguments — and where an index that is filtered rather than
+	// paged keeps them, since a filter narrows a member's answer without
+	// hiding anything the merge would have to reach past.
+	GroupIndexMemberQuery(path, clientQuery string) string
+	// PageGroupIndex cuts the page the client asked for out of the merged
+	// document and sets whatever cursor header the format's protocol uses on
+	// c. Returning merged unchanged is what an unpaginated path does.
+	PageGroupIndex(c *gin.Context, path string, merged []byte) ([]byte, error)
 }

--- a/internal/formats/oci/groupindex.go
+++ b/internal/formats/oci/groupindex.go
@@ -4,36 +4,87 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"sort"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
 )
 
-// The referrers index is merged across group members rather than taken from the
-// first member that answers. GET /v2/{name}/referrers/{digest} never returns
-// 404 — an unknown subject is a 200 carrying an empty index, because that is
-// what a client reads as "no signatures" — so the group's first-non-404 fan-out
-// would let member one's empty index shadow every member behind it. A signature
-// pushed to the second member would be reported as absent, which is the one
-// direction this endpoint must never fail in.
+// Two OCI documents are merged across group members rather than taken from the
+// first member that answers: the referrers index and the tag list. Both are
+// aggregations, and both answer "I hold nothing" with a 200 carrying an empty
+// list rather than a 404 — so the group's first-non-404 fan-out would let member
+// one's empty document shadow every member behind it. A signature pushed to the
+// second member would be reported as absent, and a tag promoted into the second
+// member would be reported as unpublished.
+//
+// Nothing else under /v2/ is merged. A manifest or a blob is one artifact, and
+// the first member holding it is the right answer.
 
-// GroupIndexSourcePath implements formats.GroupIndexMerger. A referrers request
-// is its own source: every member is asked the same question. Nothing else under
-// /v2/ is merged — a manifest or a blob is one artifact, and the first member
-// holding it is the right answer.
-func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
-	rest := strings.TrimPrefix(normPath(p), "/v2/")
-	if rest == normPath(p) {
-		return "", false
+// ociIndexKind is which of the merged documents a request path asks for.
+type ociIndexKind int
+
+const (
+	indexNone ociIndexKind = iota
+	indexReferrers
+	indexTags
+)
+
+// jsonListContentType is what gin's c.JSON writes, which is what a client gets
+// from a single repository. The merged document keeps the same content type so a
+// group is indistinguishable from a hosted repository on the wire.
+const jsonListContentType = "application/json; charset=utf-8"
+
+// groupIndexKind classifies a request path, returning the image name for a tag
+// list. The classification mirrors ServeHTTP's routing exactly — a path is
+// mergeable as the document the member handler would have produced for it, never
+// as some other one.
+func groupIndexKind(p string) (kind ociIndexKind, imageName string) {
+	norm := normPath(p)
+	rest := strings.TrimPrefix(norm, "/v2/")
+	if rest == norm {
+		return indexNone, ""
 	}
-	if referrersIndex(strings.Split(rest, "/")) < 0 {
+	parts := strings.Split(rest, "/")
+	if len(parts) < 2 {
+		return indexNone, ""
+	}
+	switch {
+	case endsWithSegments(parts, "tags", "list"):
+		return indexTags, strings.Join(parts[:len(parts)-2], "/")
+	case referrersIndex(parts) >= 0:
+		return indexReferrers, ""
+	}
+	return indexNone, ""
+}
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger. Each of the merged
+// documents is its own source: every member is asked the same question.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if kind, _ := groupIndexKind(p); kind == indexNone {
 		return "", false
 	}
 	return p, true
 }
 
-// MergeGroupIndex implements formats.GroupIndexMerger: one index carrying every
-// member's descriptors, in member order, each manifest named once.
+// MergeGroupIndex implements formats.GroupIndexMerger, dispatching on the shape
+// of the document the path asks for.
+func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	switch kind, imageName := groupIndexKind(p); kind {
+	case indexReferrers:
+		return mergeReferrers(parts)
+	case indexTags:
+		return mergeTagLists(imageName, parts)
+	default:
+		return nil, "", fmt.Errorf("path %q is not a mergeable OCI index", p)
+	}
+}
+
+// mergeReferrers builds one index carrying every member's descriptors, in member
+// order, each manifest named once.
 //
 // Descriptors are carried across as the raw JSON the member produced instead of
 // being decoded into this package's descriptor struct and re-encoded, which
@@ -50,7 +101,7 @@ func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
 // promise the merged list is filtered. Leaving the header off is the honest
 // reading: a client that wanted the filter re-applies it to a superset and lands
 // on the same set.
-func (h *Handler) MergeGroupIndex(_, _ string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+func mergeReferrers(parts []formats.GroupIndexPart) ([]byte, string, error) {
 	merged := make([]json.RawMessage, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
 
@@ -96,18 +147,136 @@ func (h *Handler) MergeGroupIndex(_, _ string, parts []formats.GroupIndexPart) (
 	return body, mediaTypeImageIndex, nil
 }
 
+// mergeTagLists builds the union of the members' tags for one image.
+//
+// Member order is not priority here and cannot be: a tag is a name, not a
+// document, so the same tag in two members contributes one entry and there is
+// nothing to choose between them. Which manifest that tag resolves to IS a
+// choice, and it stays where it belongs — a manifest request is not merged, so
+// the earlier member still wins the pull.
+//
+// The name is taken from the requested path rather than from a member's answer:
+// it is the name the client addressed, and it is the name every later request
+// against this group has to use.
+func mergeTagLists(imageName string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	tags, err := mergeStringLists(parts, "tag", func(doc *mergedLists) []string { return doc.Tags })
+	if err != nil {
+		return nil, "", err
+	}
+	body, err := json.Marshal(struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}{Name: imageName, Tags: tags})
+	if err != nil {
+		return nil, "", err
+	}
+	return body, jsonListContentType, nil
+}
+
+// mergedLists is the shape of the merged list documents; each merge reads its
+// own field out of it.
+type mergedLists struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+// mergeStringLists unions one field of every member's document, sorted and
+// deduplicated. The result is never nil, so an empty merge serializes as [] and
+// not null — a null breaks clients that range over the list.
+func mergeStringLists(parts []formats.GroupIndexPart, kind string, pick func(*mergedLists) []string) ([]string, error) {
+	merged := []string{}
+	seen := make(map[string]struct{}, len(parts))
+	for _, part := range parts {
+		var doc mergedLists
+		if err := json.Unmarshal(part.Body, &doc); err != nil {
+			// Same rule as the referrers merge: a member whose answer cannot be
+			// read is a member missing from the result, and a list one entry
+			// short is indistinguishable from a complete one.
+			return nil, fmt.Errorf("member %q did not answer with a %s list: %w", part.Member, kind, err)
+		}
+		for _, entry := range pick(&doc) {
+			if _, dup := seen[entry]; dup {
+				continue
+			}
+			seen[entry] = struct{}{}
+			merged = append(merged, entry)
+		}
+	}
+	sort.Strings(merged)
+	return merged, nil
+}
+
 // GroupIndexMemberFailureIsFatal implements formats.GroupIndexStrictMerger.
 //
 // A member that answered anything but 2xx or 404 could not tell us what it holds
 // — a proxy whose upstream was unreachable, rate-limited or refused its
 // credentials answers 502 for exactly that reason. Merging the remaining members
-// and calling the result complete would convert "I could not check" into "this
-// subject has no referrers", which is what a policy gate reads as an unsigned
-// image. 404 is the one non-2xx that says something about the subject rather
-// than about the member, and it contributes nothing.
+// and calling the result complete would convert "I could not check" into a
+// statement about the content: no referrers, so the image is unsigned; no such
+// tag, so that version was never published. Signature gates and retention jobs
+// act on both, and a list one entry short reads exactly like a complete one.
+//
+// This is affordable because neither endpoint consults an upstream: a proxy
+// member answers both from what it has cached, so a non-2xx here is a local
+// fault rather than the ordinary flakiness of somebody else's registry. 404
+// stays the one non-2xx that says something about the request rather than about
+// the member, and it contributes nothing.
 func (h *Handler) GroupIndexMemberFailureIsFatal(p string, status int) bool {
 	if _, ok := h.GroupIndexSourcePath(p); !ok {
 		return false
 	}
 	return status != http.StatusNotFound
+}
+
+// GroupIndexMemberQuery implements formats.GroupIndexPaginator: members are
+// asked for their complete lists, and the group pages the merge.
+//
+// Only the paging arguments are dropped. The referrers index is filtered rather
+// than paged, and its artifactType must reach the members — a filter narrows
+// what a member answers without putting anything the merge needs out of reach.
+func (h *Handler) GroupIndexMemberQuery(p, clientQuery string) string {
+	if kind, _ := groupIndexKind(p); kind != indexTags {
+		return clientQuery
+	}
+	q, err := url.ParseQuery(clientQuery)
+	if err != nil {
+		// A query we cannot parse is one we cannot strip the paging arguments
+		// out of, and asking members for a page is the one thing this function
+		// exists to prevent.
+		return ""
+	}
+	q.Del("n")
+	q.Del("last")
+	return q.Encode()
+}
+
+// PageGroupIndex implements formats.GroupIndexPaginator: the client's ?n=/?last=
+// are applied to the merged list, and the Link header is built from the group's
+// own URL, so the cursor a client sends back names an entry of the list it was
+// actually served.
+func (h *Handler) PageGroupIndex(c *gin.Context, p string, merged []byte) ([]byte, error) {
+	if kind, _ := groupIndexKind(p); kind != indexTags {
+		return merged, nil
+	}
+	var doc mergedLists
+	if err := json.Unmarshal(merged, &doc); err != nil {
+		return nil, fmt.Errorf("the merged tag list could not be paginated: %w", err)
+	}
+	return json.Marshal(struct {
+		Name string   `json:"name"`
+		Tags []string `json:"tags"`
+	}{Name: doc.Name, Tags: pageMergedList(c, doc.Tags)})
+}
+
+// pageMergedList cuts the requested page out of a merged list and sets the Link
+// header for a truncated one, exactly as the single-repository endpoints do —
+// the page is a page of the same sorted list either way.
+func pageMergedList(c *gin.Context, entries []string) []string {
+	params := parsePageParams(c)
+	page, more := paginate(entries, params)
+	setNextLink(c, params, page, more)
+	if page == nil {
+		page = []string{}
+	}
+	return page
 }

--- a/internal/formats/oci/groupindex.go
+++ b/internal/formats/oci/groupindex.go
@@ -13,13 +13,14 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/formats"
 )
 
-// Two OCI documents are merged across group members rather than taken from the
-// first member that answers: the referrers index and the tag list. Both are
-// aggregations, and both answer "I hold nothing" with a 200 carrying an empty
-// list rather than a 404 — so the group's first-non-404 fan-out would let member
-// one's empty document shadow every member behind it. A signature pushed to the
-// second member would be reported as absent, and a tag promoted into the second
-// member would be reported as unpublished.
+// Three OCI documents are merged across group members rather than taken from the
+// first member that answers: the referrers index, the tag list and the catalog.
+// All three are aggregations, and all three answer "I hold nothing" with a 200
+// carrying an empty list rather than a 404 — so the group's first-non-404 fan-out
+// would let member one's empty document shadow every member behind it. A
+// signature pushed to the second member would be reported as absent, a tag
+// promoted into the second member as unpublished, and an image that lives only
+// in the second member as not present in the registry at all.
 //
 // Nothing else under /v2/ is merged. A manifest or a blob is one artifact, and
 // the first member holding it is the right answer.
@@ -31,7 +32,12 @@ const (
 	indexNone ociIndexKind = iota
 	indexReferrers
 	indexTags
+	indexCatalog
 )
+
+// paginated reports whether the document takes the spec's ?n=/?last= arguments.
+// The referrers index does not: it is filtered, not paged.
+func (k ociIndexKind) paginated() bool { return k == indexTags || k == indexCatalog }
 
 // jsonListContentType is what gin's c.JSON writes, which is what a client gets
 // from a single repository. The merged document keeps the same content type so a
@@ -47,6 +53,12 @@ func groupIndexKind(p string) (kind ociIndexKind, imageName string) {
 	rest := strings.TrimPrefix(norm, "/v2/")
 	if rest == norm {
 		return indexNone, ""
+	}
+	// Matched whole, exactly as ServeHTTP matches it: "_catalog" is not a legal
+	// image name, so no image is shadowed, and an image name merely ending in
+	// "_catalog" still has its own endpoint segment behind it.
+	if rest == "_catalog" {
+		return indexCatalog, ""
 	}
 	parts := strings.Split(rest, "/")
 	if len(parts) < 2 {
@@ -78,6 +90,8 @@ func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) (
 		return mergeReferrers(parts)
 	case indexTags:
 		return mergeTagLists(imageName, parts)
+	case indexCatalog:
+		return mergeCatalogs(parts)
 	default:
 		return nil, "", fmt.Errorf("path %q is not a mergeable OCI index", p)
 	}
@@ -173,11 +187,39 @@ func mergeTagLists(imageName string, parts []formats.GroupIndexPart) ([]byte, st
 	return body, jsonListContentType, nil
 }
 
+// mergeCatalogs builds the union of the image names the members hold.
+//
+// An image in two members is one image name: the client pulls it from the group,
+// and the group resolves the manifest through its usual first-member fan-out. A
+// name listed twice would also break the ?last= cursor, which assumes a strictly
+// ascending list.
+//
+// The catalog of a group is deliberately the catalog of its MEMBERS' images and
+// not the member repository names. Each Nexspence repository is its own registry
+// namespace, so a client that connected to the group addresses
+// <group>/<image> — the member it happens to live in is never part of a
+// pullable name, and listing member names would hand the client names it cannot
+// pull from where it is.
+func mergeCatalogs(parts []formats.GroupIndexPart) ([]byte, string, error) {
+	repos, err := mergeStringLists(parts, "repository", func(doc *mergedLists) []string { return doc.Repositories })
+	if err != nil {
+		return nil, "", err
+	}
+	body, err := json.Marshal(struct {
+		Repositories []string `json:"repositories"`
+	}{Repositories: repos})
+	if err != nil {
+		return nil, "", err
+	}
+	return body, jsonListContentType, nil
+}
+
 // mergedLists is the shape of the merged list documents; each merge reads its
 // own field out of it.
 type mergedLists struct {
-	Name string   `json:"name"`
-	Tags []string `json:"tags"`
+	Name         string   `json:"name"`
+	Tags         []string `json:"tags"`
+	Repositories []string `json:"repositories"`
 }
 
 // mergeStringLists unions one field of every member's document, sorted and
@@ -213,12 +255,13 @@ func mergeStringLists(parts []formats.GroupIndexPart, kind string, pick func(*me
 // credentials answers 502 for exactly that reason. Merging the remaining members
 // and calling the result complete would convert "I could not check" into a
 // statement about the content: no referrers, so the image is unsigned; no such
-// tag, so that version was never published. Signature gates and retention jobs
-// act on both, and a list one entry short reads exactly like a complete one.
+// tag, so that version was never published; no such image name, so nothing is
+// there to keep. Signature gates, retention jobs and mirroring jobs act on all
+// three, and a list one entry short reads exactly like a complete one.
 //
-// This is affordable because neither endpoint consults an upstream: a proxy
-// member answers both from what it has cached, so a non-2xx here is a local
-// fault rather than the ordinary flakiness of somebody else's registry. 404
+// This is affordable because none of the three endpoints consults an upstream: a
+// proxy member answers all of them from what it has cached, so a non-2xx here is
+// a local fault rather than the ordinary flakiness of somebody else's registry. 404
 // stays the one non-2xx that says something about the request rather than about
 // the member, and it contributes nothing.
 func (h *Handler) GroupIndexMemberFailureIsFatal(p string, status int) bool {
@@ -235,7 +278,7 @@ func (h *Handler) GroupIndexMemberFailureIsFatal(p string, status int) bool {
 // than paged, and its artifactType must reach the members — a filter narrows
 // what a member answers without putting anything the merge needs out of reach.
 func (h *Handler) GroupIndexMemberQuery(p, clientQuery string) string {
-	if kind, _ := groupIndexKind(p); kind != indexTags {
+	if kind, _ := groupIndexKind(p); !kind.paginated() {
 		return clientQuery
 	}
 	q, err := url.ParseQuery(clientQuery)
@@ -255,12 +298,18 @@ func (h *Handler) GroupIndexMemberQuery(p, clientQuery string) string {
 // own URL, so the cursor a client sends back names an entry of the list it was
 // actually served.
 func (h *Handler) PageGroupIndex(c *gin.Context, p string, merged []byte) ([]byte, error) {
-	if kind, _ := groupIndexKind(p); kind != indexTags {
+	kind, _ := groupIndexKind(p)
+	if !kind.paginated() {
 		return merged, nil
 	}
 	var doc mergedLists
 	if err := json.Unmarshal(merged, &doc); err != nil {
-		return nil, fmt.Errorf("the merged tag list could not be paginated: %w", err)
+		return nil, fmt.Errorf("the merged list could not be paginated: %w", err)
+	}
+	if kind == indexCatalog {
+		return json.Marshal(struct {
+			Repositories []string `json:"repositories"`
+		}{Repositories: pageMergedList(c, doc.Repositories)})
 	}
 	return json.Marshal(struct {
 		Name string   `json:"name"`

--- a/internal/formats/oci/groupindex_test.go
+++ b/internal/formats/oci/groupindex_test.go
@@ -22,6 +22,7 @@ func TestOCI_GroupIndexSourcePath(t *testing.T) {
 	for _, p := range []string{
 		"/v2/charts/nginx/referrers/" + digest("subject"),
 		"/v2/charts/nginx/tags/list",
+		"/v2/_catalog",
 	} {
 		src, ok := h.GroupIndexSourcePath(p)
 		assert.True(t, ok, p)
@@ -86,6 +87,44 @@ func TestOCI_MergeGroupIndex_UnreadableTagListIsAnError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// The merged catalog is the union of the members' image names, sorted, each name
+// once, and empty is [] rather than null.
+func TestOCI_MergeGroupIndex_CatalogUnionSortedDeduplicated(t *testing.T) {
+	h := groupMerger()
+	body, ct, err := h.MergeGroupIndex("grp", "/v2/_catalog", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(`{"repositories":["library/ubuntu","charts/nginx"]}`)},
+		{Member: "m2", Body: []byte(`{"repositories":["charts/nginx","apps/api"]}`)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "application/json; charset=utf-8", ct)
+	assert.JSONEq(t, `{"repositories":["apps/api","charts/nginx","library/ubuntu"]}`, string(body))
+
+	empty, _, err := h.MergeGroupIndex("grp", "/v2/_catalog", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(`{"repositories":[]}`)},
+		{Member: "m2", Body: []byte(`{"repositories":null}`)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `{"repositories":[]}`, string(empty))
+}
+
+// An image name is not a tag: the catalog merge must not pick up the tags field,
+// nor the tag merge the repositories field, or a group would answer one endpoint
+// with the other's content.
+func TestOCI_MergeGroupIndex_ListsDoNotBleedIntoEachOther(t *testing.T) {
+	h := groupMerger()
+	mixed := []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(`{"name":"img","tags":["v1"],"repositories":["img"]}`)},
+	}
+
+	tags, _, err := h.MergeGroupIndex("grp", "/v2/img/tags/list", mixed)
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"img","tags":["v1"]}`, string(tags))
+
+	catalog, _, err := h.MergeGroupIndex("grp", "/v2/_catalog", mixed)
+	require.NoError(t, err)
+	assert.Equal(t, `{"repositories":["img"]}`, string(catalog))
+}
+
 // The paging arguments never reach a member: a member that paged its own list
 // would drop the entries past its cut out of every page of the group. Everything
 // else survives, because the referrers filter travels the same road.
@@ -93,6 +132,7 @@ func TestOCI_GroupIndexMemberQuery(t *testing.T) {
 	h := groupMerger()
 
 	assert.Empty(t, h.GroupIndexMemberQuery("/v2/img/tags/list", "n=2&last=v1"))
+	assert.Empty(t, h.GroupIndexMemberQuery("/v2/_catalog", "n=2&last=img%2Fa"))
 	assert.Equal(t, "flavor=x", h.GroupIndexMemberQuery("/v2/img/tags/list", "n=2&flavor=x"))
 
 	filter := "artifactType=application%2Fspdx%2Bjson"

--- a/internal/formats/oci/groupindex_test.go
+++ b/internal/formats/oci/groupindex_test.go
@@ -14,30 +14,90 @@ import (
 
 func groupMerger() *oci.Handler { return oci.New(formats.Deps{}) }
 
-// Only the referrers index is merged across members. A manifest or a blob is a
+// The aggregated documents are merged across members; a manifest or a blob is a
 // single artifact, and the first member holding it is the right answer.
 func TestOCI_GroupIndexSourcePath(t *testing.T) {
 	h := groupMerger()
 
-	src, ok := h.GroupIndexSourcePath("/v2/charts/nginx/referrers/" + digest("subject"))
-	assert.True(t, ok)
-	assert.Equal(t, "/v2/charts/nginx/referrers/"+digest("subject"), src,
-		"every member is asked the same question, so the source is the path itself")
+	for _, p := range []string{
+		"/v2/charts/nginx/referrers/" + digest("subject"),
+		"/v2/charts/nginx/tags/list",
+	} {
+		src, ok := h.GroupIndexSourcePath(p)
+		assert.True(t, ok, p)
+		assert.Equal(t, p, src,
+			"every member is asked the same question, so the source is the path itself")
+	}
 
-	_, ok = h.GroupIndexSourcePath("/v2/charts/nginx/manifests/1.0.0")
+	_, ok := h.GroupIndexSourcePath("/v2/charts/nginx/manifests/1.0.0")
 	assert.False(t, ok)
 	_, ok = h.GroupIndexSourcePath("/v2/charts/nginx/blobs/" + digest("layer"))
-	assert.False(t, ok)
-	_, ok = h.GroupIndexSourcePath("/v2/charts/nginx/tags/list")
 	assert.False(t, ok)
 	_, ok = h.GroupIndexSourcePath("/v2/")
 	assert.False(t, ok)
 	_, ok = h.GroupIndexSourcePath("/charts/nginx/referrers/" + digest("subject"))
 	assert.False(t, ok, "a path outside /v2/ is not a referrers request")
+	_, ok = h.GroupIndexSourcePath("/charts/nginx/tags/list")
+	assert.False(t, ok, "a path outside /v2/ is not a tag list either")
 
 	// An image legitimately named ".../referrers" must keep its own manifests.
 	_, ok = h.GroupIndexSourcePath("/v2/lib/referrers/manifests/1.0.0")
 	assert.False(t, ok)
+	// And one named ".../tags" keeps its own manifests too: only the exact
+	// tags/list tail is the list endpoint.
+	_, ok = h.GroupIndexSourcePath("/v2/lib/tags/manifests/1.0.0")
+	assert.False(t, ok)
+}
+
+// The merged tag list is the union of the members', sorted, each tag once, under
+// the image name the client addressed.
+func TestOCI_MergeGroupIndex_TagsUnionSortedDeduplicated(t *testing.T) {
+	h := groupMerger()
+	body, ct, err := h.MergeGroupIndex("grp", "/v2/library/ubuntu/tags/list", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(`{"name":"library/ubuntu","tags":["v3","v1"]}`)},
+		{Member: "m2", Body: []byte(`{"name":"library/ubuntu","tags":["v2","v1"]}`)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "application/json; charset=utf-8", ct)
+	assert.JSONEq(t, `{"name":"library/ubuntu","tags":["v1","v2","v3"]}`, string(body))
+}
+
+// Members holding nothing merge into an empty list whose tags is [] and not
+// null, and the name still names the image: a client reads the document to learn
+// that this image has no tags here, not to learn that the endpoint is broken.
+func TestOCI_MergeGroupIndex_TagsAllEmptyIsEmptyList(t *testing.T) {
+	h := groupMerger()
+	body, _, err := h.MergeGroupIndex("grp", "/v2/img/tags/list", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(`{"name":"img","tags":[]}`)},
+		{Member: "m2", Body: []byte(`{"name":"img","tags":null}`)},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, `{"name":"img","tags":[]}`, string(body))
+}
+
+// A member body that cannot be read is a member whose tags are missing from the
+// result, and nothing in the merged list would show that it is short.
+func TestOCI_MergeGroupIndex_UnreadableTagListIsAnError(t *testing.T) {
+	h := groupMerger()
+	_, _, err := h.MergeGroupIndex("grp", "/v2/img/tags/list", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte("<html>captive portal</html>")},
+		{Member: "m2", Body: []byte(`{"name":"img","tags":["v1"]}`)},
+	})
+	require.Error(t, err)
+}
+
+// The paging arguments never reach a member: a member that paged its own list
+// would drop the entries past its cut out of every page of the group. Everything
+// else survives, because the referrers filter travels the same road.
+func TestOCI_GroupIndexMemberQuery(t *testing.T) {
+	h := groupMerger()
+
+	assert.Empty(t, h.GroupIndexMemberQuery("/v2/img/tags/list", "n=2&last=v1"))
+	assert.Equal(t, "flavor=x", h.GroupIndexMemberQuery("/v2/img/tags/list", "n=2&flavor=x"))
+
+	filter := "artifactType=application%2Fspdx%2Bjson"
+	assert.Equal(t, filter, h.GroupIndexMemberQuery("/v2/img/referrers/"+digest("s"), filter),
+		"a filter narrows a member's answer without hiding what the merge must reach")
 }
 
 // indexWith builds one member's referrers answer from raw descriptor bodies.
@@ -154,19 +214,21 @@ func TestOCI_MergeGroupIndex_UnreadableMemberBodyIsAnError(t *testing.T) {
 // one non-2xx that is a fact about the subject rather than about the member.
 func TestOCI_GroupIndexMemberFailureIsFatal(t *testing.T) {
 	h := groupMerger()
-	p := "/v2/img/referrers/" + digest("s")
 
-	assert.False(t, h.GroupIndexMemberFailureIsFatal(p, http.StatusNotFound),
-		"404 contributes nothing and is not a failure to look")
-	for _, status := range []int{
-		http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
-		http.StatusTooManyRequests, http.StatusInternalServerError,
-		http.StatusBadGateway, http.StatusServiceUnavailable,
-	} {
-		assert.True(t, h.GroupIndexMemberFailureIsFatal(p, status),
-			"%d means the member could not be consulted", status)
+	for _, p := range []string{"/v2/img/referrers/" + digest("s"), "/v2/img/tags/list"} {
+		assert.False(t, h.GroupIndexMemberFailureIsFatal(p, http.StatusNotFound),
+			"404 contributes nothing and is not a failure to look")
+		for _, status := range []int{
+			http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden,
+			http.StatusTooManyRequests, http.StatusInternalServerError,
+			http.StatusBadGateway, http.StatusServiceUnavailable,
+		} {
+			assert.True(t, h.GroupIndexMemberFailureIsFatal(p, status),
+				"%s: %d means the member could not be consulted", p, status)
+		}
 	}
 
 	assert.False(t, h.GroupIndexMemberFailureIsFatal("/v2/img/manifests/1.0.0", http.StatusBadGateway),
-		"the policy belongs to the referrers index alone")
+		"the policy belongs to the merged documents alone — a manifest a member cannot serve "+
+			"is a manifest another member may hold")
 }


### PR DESCRIPTION
Phase 4 of five. A group repository stops shadowing its members on the two remaining listing endpoints.

## The bug

The group handler returns the **first non-404 member response**. That is right for content addressed by name or digest — a manifest, a blob — and wrong for a listing, where the first member hides every later one:

- an image whose `v1` lives in member A and `v2` in member B listed only one of them
- `_catalog` returned only the first member's image names

Phase 2 hit the same shape with referrers and built the mechanism for it (`GroupIndexMerger`, plus `GroupIndexStrictMerger` so a member that cannot be consulted fails the group rather than quietly contributing nothing). This extends that to `tags/list` and `_catalog`.

## Pagination across members needed real plumbing

The naive version is not merely imprecise, it loses data permanently: forwarding `?n=` to each member truncates that member's contribution, and **no later cursor can reach the entries past its cut** — they become unreachable through every subsequent page. The failing test showed member 2's only tag disappearing on page 2.

So members are asked *without* pagination, the group pages the **merged** document, and the `Link` header is built from the group's own URL. That is sound because the cursor is a value in a deterministic sorted list rather than an offset, so page N+1 of a re-merged list resumes exactly where page N ended. It needed a third optional interface next to the existing two — `GroupIndexPaginator` — because the group layer forwarded the client's query verbatim and gave the merger no access to response headers. Referrers adopts it as a no-op: it is filtered, not paged, so `artifactType` still reaches members untouched.

## A member that cannot be consulted fails the group

Same policy as referrers, and it applies more strongly here. On all three endpoints a member with nothing to contribute answers **200 with an empty list** — 404 is not reachable — so a non-2xx is by construction "I could not look", never "I hold nothing". A listing one entry short is indistinguishable from a complete one, and its consumers act destructively on absence: retention jobs delete tags not in the list, mirroring skips catalog entries, release gates read a missing tag as never published. The usual counterargument — one flaky upstream should not take the group down — does not apply, because neither endpoint ever consults an upstream: a proxy member answers both from cache, so a non-2xx is a local fault.

## What still shadows, and is not fixed here

A member skipped by *configuration* rather than by answering — offline, a nested group, a foreign format — shrinks the merged list silently, where a member that answers badly fails loudly. That predates this phase and referrers has it too, so changing it belongs in its own change with its own reasoning. Likewise, a group whose members are all skipped answers 404 rather than an empty document.

## Verification

`go test ./internal/...` 1794 passing (only the sandbox-networking webhook test fails locally; it passes in CI); `golangci-lint run --new-from-rev=origin/main` zero issues. 19 group-level tests (the 6 referrers ones byte-identical) and 13 unit tests.

One pre-existing assertion changed: `TestOCI_GroupIndexSourcePath` asserted `tags/list` was *not* mergeable — which was the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW