### PR TITLE
feat(ui): show what kind of artifact each OCI manifest is

### DIFF
--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -521,6 +521,63 @@ describe('BrowsePage — OCI tree', () => {
     expect(await screen.findByText('my-chart')).toBeInTheDocument()
     expect(screen.queryByText('No components in this repository')).not.toBeInTheDocument()
   })
+
+  // The tree is where a chart, a WASM module and a signature stop looking alike.
+  function seedOciTree(leaves: Record<string, unknown>[]) {
+    server.use(
+      http.get('/api/v1/browse/repositories/:name/docker-tree', () =>
+        HttpResponse.json({
+          root: {
+            kind: 'folder', label: '', path: '', children: [
+              {
+                kind: 'folder', label: 'my-chart', path: '/my-chart', imageRef: 'my-chart', children: [
+                  { kind: 'folder', label: 'Tags', path: '/my-chart/Tags', children: leaves },
+                ],
+              },
+            ],
+          },
+        }),
+      ),
+    )
+  }
+
+  it('badges a tag with the artifact type the manifest declared', async () => {
+    const user = userEvent.setup()
+    seedOciTree([
+      { kind: 'tag', label: '1.0.0', path: '/my-chart/Tags/1.0.0', imageRef: 'my-chart', version: '1.0.0', componentId: 'oc1', artifactType: 'chart' },
+    ])
+    renderBrowse('?repo=oci-hosted')
+    await user.click(await screen.findByText('my-chart'))
+    await user.click(await screen.findByText('Tags'))
+    const tagRow = (await screen.findByText('1.0.0')).closest('[role="button"]') as HTMLElement
+    expect(within(tagRow).getByText('chart')).toBeInTheDocument()
+  })
+
+  it('shows an unrecognized artifact type verbatim', async () => {
+    const user = userEvent.setup()
+    seedOciTree([
+      { kind: 'tag', label: '2.0.0', path: '/my-chart/Tags/2.0.0', imageRef: 'my-chart', version: '2.0.0', componentId: 'oc2', artifactType: 'application/vnd.acme.model.config.v1+json' },
+    ])
+    renderBrowse('?repo=oci-hosted')
+    await user.click(await screen.findByText('my-chart'))
+    await user.click(await screen.findByText('Tags'))
+    const tagRow = (await screen.findByText('2.0.0')).closest('[role="button"]') as HTMLElement
+    expect(within(tagRow).getByText('application/vnd.acme.model.config.v1+json')).toBeInTheDocument()
+  })
+
+  // Everything pushed before this feature existed arrives without the field, and
+  // must render exactly as it did then — no badge, empty or otherwise.
+  it('renders no badge for a tag with no artifact type', async () => {
+    const user = userEvent.setup()
+    seedOciTree([
+      { kind: 'tag', label: '3.0.0', path: '/my-chart/Tags/3.0.0', imageRef: 'my-chart', version: '3.0.0', componentId: 'oc3' },
+    ])
+    renderBrowse('?repo=oci-hosted')
+    await user.click(await screen.findByText('my-chart'))
+    await user.click(await screen.findByText('Tags'))
+    const tagRow = (await screen.findByText('3.0.0')).closest('[role="button"]') as HTMLElement
+    expect(within(tagRow).queryByTestId('artifact-type')).not.toBeInTheDocument()
+  })
 })
 
 describe('BrowsePage — promote flow', () => {

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -75,6 +75,10 @@ interface DockerTreeNode {
   imageRef?: string
   version?: string
   componentId?: string
+  /** What the manifest holds — 'chart', 'image', 'wasm' — or the raw media type
+   *  when the server did not recognize it. Absent for components stored before
+   *  the registry recorded OCI metadata. */
+  artifactType?: string
   children?: DockerTreeNode[]
 }
 
@@ -638,6 +642,18 @@ const FORMAT_COLORS: Record<string, string> = {
   yum: '#10b981',
 }
 
+// Colors for the artifact-type labels the registry browse tree reports. A media
+// type the server did not recognize arrives verbatim and has no entry here, so
+// it falls back to a neutral tone rather than borrowing another kind's color.
+const ARTIFACT_TYPE_COLORS: Record<string, string> = {
+  chart: '#0ea5e9',
+  image: '#3b82f6',
+  wasm: '#8b5cf6',
+  sbom: '#10b981',
+  signature: '#f59e0b',
+  attestation: '#f97316',
+}
+
 function DockerBrowseDetailBody({
   comp,
   sel,
@@ -757,6 +773,14 @@ function DockerTreeRows({
       >
         {icon}
         <span style={{ fontFamily: 'monospace', fontSize: 12 }}>{node.label}</span>
+        {node.artifactType && (
+          <span
+            data-testid="artifact-type"
+            style={S.badge(ARTIFACT_TYPE_COLORS[node.artifactType] ?? '#94a3b8')}
+          >
+            {node.artifactType}
+          </span>
+        )}
         {node.imageRef && <span style={S.muted}>— {node.imageRef}</span>}
         {showDelete && (node.kind === 'tag') && onDelete && (
           <GhostBtn danger onClick={e => { e.stopPropagation(); onDelete(node) }} title="Delete tag">

--- a/frontend/src/pages/DocsPage.test.tsx
+++ b/frontend/src/pages/DocsPage.test.tsx
@@ -39,7 +39,29 @@ describe('DocsPage', () => {
     expect(screen.getByRole('button', { name: /Cleanup Policies/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /API Tokens/ })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Maven 2/3' })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Docker / OCI' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Docker' })).toBeInTheDocument()
+    // Formats without a brand icon render an emoji into the button label.
+    expect(screen.getByRole('button', { name: /OCI Artifacts/ })).toBeInTheDocument()
+  })
+
+  // The two OCI Distribution formats are pushed with different tools: `docker`
+  // repositories hold container images, `oci` ones hold charts and ORAS
+  // artifacts. Showing docker commands for both left oci users with nothing.
+  it('shows docker commands for the docker format', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DocsPage />)
+    await user.click(screen.getByRole('button', { name: 'Docker' }))
+    expect(screen.getByText(new RegExp(`docker login ${ORIGIN.replace(/^https?:\/\//, '')}`))).toBeInTheDocument()
+    expect(screen.getByText(/docker pull /)).toBeInTheDocument()
+  })
+
+  it('shows oras and helm oci:// commands for the oci format', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<DocsPage />)
+    await user.click(screen.getByRole('button', { name: /OCI Artifacts/ }))
+    expect(screen.getByRole('heading', { name: /OCI Artifacts/ })).toBeInTheDocument()
+    expect(screen.getByText(/oras push /)).toBeInTheDocument()
+    expect(screen.getByText(/helm push mychart-1\.2\.3\.tgz oci:\/\//)).toBeInTheDocument()
   })
 
   it('switches through every guide section', async () => {
@@ -76,7 +98,8 @@ describe('DocsPage', () => {
       { label: /Maven 2\/3/, heading: /Maven 2\/3/ },
       { label: /^npm$/, heading: /npm/ },
       { label: /PyPI/, heading: /PyPI/ },
-      { label: /Docker \/ OCI/, heading: /Docker \/ OCI/ },
+      { label: /^Docker$/, heading: /Docker/ },
+      { label: /OCI Artifacts/, heading: /OCI Artifacts/ },
       { label: /Go Modules/, heading: /Go Modules/ },
       { label: /NuGet/, heading: /NuGet/ },
       { label: /Raw/, heading: /Raw/ },

--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -263,10 +263,10 @@ twine upload \\
   },
   {
     id: 'docker',
-    name: 'Docker / OCI',
+    name: 'Docker',
     icon: '🐳',
     iconUrl: 'https://cdn.simpleicons.org/docker/2496ED',
-    description: 'OCI Distribution Spec v2 compliant registry. Supports docker pull/push, image tagging, and multi-arch manifests.',
+    description: 'Container images over the OCI Distribution Spec v2. Supports docker pull/push, image tagging, and multi-arch manifests. For charts and ORAS artifacts, see OCI Artifacts.',
     sections: (base) => {
       const regHost = base.replace(/^https?:\/\//, '')
       return [
@@ -301,6 +301,68 @@ docker push ${regHost}/docker-hosted/myapp:latest` }],
         {
           title: 'List Tags',
           codes: [{ lang: 'bash', content: `curl -u admin:admin123 "${base}/v2/myapp/tags/list"` }],
+        },
+      ]
+    },
+  },
+  {
+    id: 'oci',
+    name: 'OCI Artifacts',
+    icon: '📦',
+    description: 'The same OCI Distribution registry, for everything that is not a container image: Helm charts pushed over oci://, ORAS artifacts such as WASM modules and ML models, and the cosign signatures, SBOMs and attestations attached to them.',
+    sections: (base) => {
+      const regHost = base.replace(/^https?:\/\//, '')
+      return [
+        {
+          title: 'Registry Host',
+          text: 'Like Docker, OCI clients address the host:port directly — no /repository/ prefix. The artifact name includes the Nexspence repository name.',
+          codes: [{ lang: 'text', content: `${regHost}/<repository-name>/<artifact-name>:<tag>` }],
+        },
+        {
+          title: 'Login',
+          codes: [
+            { label: 'Using oras:', lang: 'bash', content: `oras login ${regHost} -u admin -p admin123` },
+            { label: 'Using helm:', lang: 'bash', content: `helm registry login ${regHost} -u admin -p admin123` },
+          ],
+        },
+        {
+          title: 'Push a Helm Chart',
+          text: 'helm push takes an already-packaged chart and an oci:// target. The chart name and version come from the archive, so the target is the namespace it goes in — not the full reference.',
+          codes: [{ lang: 'bash', content: `helm package mychart/
+
+helm push mychart-1.2.3.tgz oci://${regHost}/oci-hosted/charts` }],
+        },
+        {
+          title: 'Install a Helm Chart',
+          codes: [
+            { label: 'Install directly from the registry:', lang: 'bash', content: `helm install my-release \\
+  oci://${regHost}/oci-hosted/charts/mychart --version 1.2.3` },
+            { label: 'Or pull the archive first:', lang: 'bash', content: `helm pull oci://${regHost}/oci-hosted/charts/mychart --version 1.2.3` },
+          ],
+        },
+        {
+          title: 'Push an Artifact with ORAS',
+          text: 'Each file is pushed with its own layer media type, and --artifact-type declares what the whole thing is. Nexspence records both and shows the artifact type in the browse tree.',
+          codes: [{ lang: 'bash', content: `oras push ${regHost}/oci-hosted/my-module:1.0 \\
+  --artifact-type application/vnd.wasm.config.v1+json \\
+  module.wasm:application/vnd.wasm.content.layer.v1+wasm` }],
+        },
+        {
+          title: 'Pull an Artifact',
+          codes: [
+            { label: 'Using oras pull:', lang: 'bash', content: `oras pull ${regHost}/oci-hosted/my-module:1.0` },
+            { label: 'Inspect the manifest with curl:', lang: 'bash', content: `curl -u admin:admin123 \\
+  "${base}/v2/oci-hosted/my-module/manifests/1.0" \\
+  -H "Accept: application/vnd.oci.image.manifest.v1+json"` },
+          ],
+        },
+        {
+          title: 'Signatures, SBOMs and Attestations',
+          text: 'Artifacts attached with a subject are discoverable through the referrers API.',
+          codes: [
+            { label: 'Sign a chart or artifact:', lang: 'bash', content: `cosign sign --key cosign.key ${regHost}/oci-hosted/my-module:1.0` },
+            { label: 'List what is attached to it:', lang: 'bash', content: `oras discover ${regHost}/oci-hosted/my-module:1.0` },
+          ],
         },
       ]
     },

--- a/internal/api/handlers/browse_docker.go
+++ b/internal/api/handlers/browse_docker.go
@@ -34,13 +34,17 @@ func NewBrowseHandler(deps formats.Deps, rbac *service.RBACService) *BrowseHandl
 
 // dockerBrowseNode is a Nexus-style folder or leaf in the Docker browse tree.
 type dockerBrowseNode struct {
-	Kind        string              `json:"kind"` // folder | tag | manifest | blob
-	Label       string              `json:"label"`
-	Path        string              `json:"path"`
-	ImageRef    string              `json:"imageRef,omitempty"`
-	Version     string              `json:"version,omitempty"`
-	ComponentID string              `json:"componentId,omitempty"`
-	Children    []*dockerBrowseNode `json:"children,omitempty"`
+	Kind        string `json:"kind"` // folder | tag | manifest | blob
+	Label       string `json:"label"`
+	Path        string `json:"path"`
+	ImageRef    string `json:"imageRef,omitempty"`
+	Version     string `json:"version,omitempty"`
+	ComponentID string `json:"componentId,omitempty"`
+	// ArtifactType names what the manifest holds — "chart", "image", "wasm" — or
+	// repeats the raw media type when it is not one this registry recognizes. It
+	// is omitted entirely for a component that carries no OCI metadata.
+	ArtifactType string              `json:"artifactType,omitempty"`
+	Children     []*dockerBrowseNode `json:"children,omitempty"`
 }
 
 // DockerTree handles GET /api/v1/browse/repositories/:name/docker-tree
@@ -251,12 +255,13 @@ func insertDockerBrowseRow(root *dockerBrowseNode, row domain.DockerBrowseRow) {
 		}
 	}
 	leaf := &dockerBrowseNode{
-		Kind:        leafKind,
-		Label:       row.Version,
-		Path:        leafPath,
-		ImageRef:    image,
-		Version:     row.Version,
-		ComponentID: row.ComponentID,
+		Kind:         leafKind,
+		Label:        row.Version,
+		Path:         leafPath,
+		ImageRef:     image,
+		Version:      row.Version,
+		ComponentID:  row.ComponentID,
+		ArtifactType: ociArtifactLabel(row.ArtifactType),
 	}
 	catNode.Children = append(catNode.Children, leaf)
 }

--- a/internal/api/handlers/browse_docker_test.go
+++ b/internal/api/handlers/browse_docker_test.go
@@ -54,15 +54,16 @@ func mountBrowse(t *testing.T) (*gin.Engine, *testutil.RepoRepo, *testutil.Compo
 
 // browseNode mirrors the JSON shape of dockerBrowseNode / rawBrowseNode for assertions.
 type browseNode struct {
-	Kind        string       `json:"kind"`
-	Label       string       `json:"label"`
-	Path        string       `json:"path"`
-	Size        int64        `json:"size"`
-	SHA256      string       `json:"sha256"`
-	ImageRef    string       `json:"imageRef"`
-	Version     string       `json:"version"`
-	ComponentID string       `json:"componentId"`
-	Children    []browseNode `json:"children"`
+	Kind         string       `json:"kind"`
+	Label        string       `json:"label"`
+	Path         string       `json:"path"`
+	Size         int64        `json:"size"`
+	SHA256       string       `json:"sha256"`
+	ImageRef     string       `json:"imageRef"`
+	Version      string       `json:"version"`
+	ComponentID  string       `json:"componentId"`
+	ArtifactType string       `json:"artifactType"`
+	Children     []browseNode `json:"children"`
 }
 
 type browseTreeResp struct {

--- a/internal/api/handlers/browse_oci_artifact.go
+++ b/internal/api/handlers/browse_oci_artifact.go
@@ -1,0 +1,78 @@
+package handlers
+
+import "strings"
+
+// This file names the kind of artifact an OCI manifest holds, for display only.
+// Nothing in the OCI Distribution protocol reads it: a manifest is served,
+// referenced and deleted by its media type exactly as pushed, and a media type
+// this table does not know is shown to the user verbatim rather than hidden or
+// rewritten. The table exists so a Helm chart, a WASM module and a container
+// image do not all read as the same anonymous entry in the browse tree.
+
+// ociExactArtifactLabels holds the media types that must match whole, because
+// the words in them recur across unrelated families. "image" in particular
+// appears in an image index and in a BuildKit attestation manifest, neither of
+// which is a container image, so it cannot be matched as a substring.
+var ociExactArtifactLabels = map[string]string{
+	// Container image configs. The OCI one is what `docker push` writes today;
+	// the Docker one is what older daemons and Docker schema 2 manifests write,
+	// and plenty of stored images still carry it.
+	"application/vnd.oci.image.config.v1+json":       "image",
+	"application/vnd.docker.container.image.v1+json": "image",
+}
+
+// ociArtifactLabelPatterns names the remaining families by substring, first
+// match winning. Order carries meaning: cosign labels its SBOM and attestation
+// attachments with media types that read like its signature ones, so those have
+// to be recognized before any signature rule can claim them.
+var ociArtifactLabelPatterns = []struct {
+	substr string
+	label  string
+}{
+	// cosign OCI 1.1 artifact types — .sbom and .att before .sig.
+	{"cosign.artifact.sbom", "sbom"},
+	{"cosign.artifact.att", "attestation"},
+	{"cosign.artifact.sig", "signature"},
+	// cosign's original signature layer type, and sigstore bundles.
+	{"cosign.simplesigning", "signature"},
+	{"sigstore.bundle", "signature"},
+	// Helm charts pushed with `helm push oci://` — config and chart content.
+	{"helm", "chart"},
+	// WASM modules, from wasm-to-oci and from ORAS pushes of component binaries.
+	{"wasm", "wasm"},
+	// SBOMs: SPDX (cosign writes text/spdx*, ORAS and Syft write
+	// application/spdx+json), CycloneDX, and Syft's native document.
+	{"spdx", "sbom"},
+	{"cyclonedx", "sbom"},
+	{"syft", "sbom"},
+	// Attestations: in-toto statements, their DSSE envelopes, and the manifests
+	// BuildKit attaches to a build.
+	{"in-toto", "attestation"},
+	{"dsse", "attestation"},
+	{"attestation", "attestation"},
+	// A last catch for anything that spells out what it is.
+	{"signature", "signature"},
+}
+
+// ociArtifactLabel turns the media type recorded in oci_artifact_type into a
+// short label. An empty type stays empty — a component pushed before this
+// metadata was recorded must not gain a label it never had — and an unknown
+// type is returned exactly as it was given, so the browse tree never claims to
+// know more about an artifact than the registry does.
+func ociArtifactLabel(mediaType string) string {
+	if strings.TrimSpace(mediaType) == "" {
+		return ""
+	}
+	// Media types are case-insensitive and may carry parameters
+	// ("application/vnd.cyclonedx+json; version=1.4"); neither may defeat a match.
+	base := strings.ToLower(strings.TrimSpace(strings.SplitN(mediaType, ";", 2)[0]))
+	if label, ok := ociExactArtifactLabels[base]; ok {
+		return label
+	}
+	for _, p := range ociArtifactLabelPatterns {
+		if strings.Contains(base, p.substr) {
+			return p.label
+		}
+	}
+	return mediaType
+}

--- a/internal/api/handlers/browse_oci_test.go
+++ b/internal/api/handlers/browse_oci_test.go
@@ -58,3 +58,113 @@ func TestDockerTree_OCIFormatRepo_ComponentAppearsInTree(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "c1", leaf.ComponentID)
 }
+
+// ── artifact types in the browse tree ─────────────────────────────────────────
+
+// ociLeaf drives one browse row through the tree and returns its leaf, so the
+// artifact-type tests read as "this media type produces this label".
+func ociLeaf(t *testing.T, row domain.DockerBrowseRow) browseNode {
+	t.Helper()
+	r, repos, comps, _, _, _ := mountBrowse(t)
+	require.NoError(t, repos.Create(context.Background(), &domain.Repository{
+		ID: "r1", Name: "oci-hosted", Format: domain.FormatOCI, Type: domain.TypeHosted,
+	}))
+	comps.DockerRowsByRepo = map[string][]domain.DockerBrowseRow{"oci-hosted": {row}}
+
+	rec := do(t, r, http.MethodGet, "/api/v1/browse/repositories/oci-hosted/docker-tree", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got browseTreeResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	img, ok := findChild(got.Root, row.ImageName)
+	require.True(t, ok, "image %q must appear in the tree", row.ImageName)
+	cat, ok := findChild(img, "Tags")
+	require.True(t, ok)
+	leaf, ok := findChild(cat, row.Version)
+	require.True(t, ok)
+	return leaf
+}
+
+// A chart pushed with `helm push oci://` carries the Helm config media type. The
+// tree must say "chart" rather than show nothing.
+func TestDockerTree_ArtifactType_HelmChartIsLabelledChart(t *testing.T) {
+	leaf := ociLeaf(t, domain.DockerBrowseRow{
+		ComponentID: "c1", ImageName: "nginx", Version: "1.2.3",
+		SamplePath:   "/manifests/nginx/1.2.3",
+		ArtifactType: "application/vnd.cncf.helm.config.v1+json",
+	})
+	assert.Equal(t, "chart", leaf.ArtifactType)
+}
+
+// Everything pushed before this feature existed has no oci_artifact_type. Those
+// rows must produce no artifact type at all — not an empty-looking one.
+func TestDockerTree_ArtifactType_AbsentStaysAbsent(t *testing.T) {
+	leaf := ociLeaf(t, domain.DockerBrowseRow{
+		ComponentID: "c1", ImageName: "nginx", Version: "1.2.3",
+		SamplePath: "/manifests/nginx/1.2.3",
+	})
+	assert.Empty(t, leaf.ArtifactType, "a component with no OCI metadata must not gain a label")
+}
+
+// The recognition table is presentation only: it shortens the media types the
+// registry actually sees, and passes anything else through verbatim.
+func TestDockerTree_ArtifactType_RecognitionTable(t *testing.T) {
+	cases := []struct {
+		mediaType string
+		want      string
+	}{
+		// Helm charts — `helm push oci://`.
+		{"application/vnd.cncf.helm.config.v1+json", "chart"},
+		{"application/vnd.cncf.helm.chart.content.v1.tar+gzip", "chart"},
+		// Container images — OCI and Docker config media types.
+		{"application/vnd.oci.image.config.v1+json", "image"},
+		{"application/vnd.docker.container.image.v1+json", "image"},
+		// WASM — wasm-to-oci config and layer types.
+		{"application/vnd.wasm.config.v1+json", "wasm"},
+		{"application/vnd.wasm.content.layer.v1+wasm", "wasm"},
+		// SBOMs — SPDX (cosign's text/spdx family and the ORAS artifactType),
+		// CycloneDX, Syft, and cosign's own SBOM attachment type.
+		{"application/spdx+json", "sbom"},
+		{"text/spdx", "sbom"},
+		{"text/spdx+json", "sbom"},
+		{"application/vnd.cyclonedx+json", "sbom"},
+		{"application/vnd.cyclonedx+xml", "sbom"},
+		{"application/vnd.syft+json", "sbom"},
+		{"application/vnd.dev.cosign.artifact.sbom.v1+json", "sbom"},
+		// Signatures — cosign simplesigning, the OCI 1.1 artifactType, and
+		// sigstore bundles.
+		{"application/vnd.dev.cosign.simplesigning.v1+json", "signature"},
+		{"application/vnd.dev.cosign.artifact.sig.v1+json", "signature"},
+		{"application/vnd.dev.sigstore.bundle.v0.3+json", "signature"},
+		// Attestations — in-toto statements, DSSE envelopes, BuildKit and cosign.
+		{"application/vnd.in-toto+json", "attestation"},
+		{"application/vnd.in-toto.provenance+dsse", "attestation"},
+		{"application/vnd.dsse.envelope.v1+json", "attestation"},
+		{"application/vnd.docker.attestation.manifest.v1+json", "attestation"},
+		{"application/vnd.dev.cosign.artifact.att.v1+json", "attestation"},
+		// Anything else is shown exactly as the registry stored it.
+		{"application/vnd.acme.model.config.v1+json", "application/vnd.acme.model.config.v1+json"},
+		{"application/vnd.oci.empty.v1+json", "application/vnd.oci.empty.v1+json"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.mediaType, func(t *testing.T) {
+			leaf := ociLeaf(t, domain.DockerBrowseRow{
+				ComponentID: "c1", ImageName: "art", Version: "1.0",
+				SamplePath:   "/manifests/art/1.0",
+				ArtifactType: tc.mediaType,
+			})
+			assert.Equal(t, tc.want, leaf.ArtifactType)
+		})
+	}
+}
+
+// Media types carry parameters (`; version=1.4`) and arbitrary case in practice;
+// recognition must not be defeated by either.
+func TestDockerTree_ArtifactType_ParametersAndCaseIgnored(t *testing.T) {
+	leaf := ociLeaf(t, domain.DockerBrowseRow{
+		ComponentID: "c1", ImageName: "art", Version: "1.0",
+		SamplePath:   "/manifests/art/1.0",
+		ArtifactType: "Application/vnd.cyclonedx+json; version=1.4",
+	})
+	assert.Equal(t, "sbom", leaf.ArtifactType)
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -526,6 +526,10 @@ type DockerBrowseRow struct {
 	ImageName   string `json:"imageName"`
 	Version     string `json:"version"`
 	SamplePath  string `json:"samplePath"`
+	// ArtifactType is the raw oci_artifact_type recorded on the component when
+	// its manifest was stored, or empty for anything pushed before that metadata
+	// existed. It is carried verbatim; naming it is the browse handler's job.
+	ArtifactType string `json:"artifactType,omitempty"`
 }
 
 // RawBrowseAsset is a flat asset record used to build the raw browse tree.

--- a/internal/repository/postgres/component_repo.go
+++ b/internal/repository/postgres/component_repo.go
@@ -251,13 +251,18 @@ func (r *componentRepo) ListDockerBrowseRows(ctx context.Context, repoNames []st
 	}
 	lim := len(args) + 1
 	args = append(args, maxRows)
+	// oci_artifact_type is grouped, not aggregated: it belongs to the component,
+	// and c.id — the components primary key — is already in the GROUP BY, so one
+	// value per group is all there is. Components pushed before that metadata
+	// existed have no such key and COALESCE reports them as carrying no type.
 	q := fmt.Sprintf(`
-		SELECT c.id, c.name, c.version, COALESCE(MIN(a.path), '') AS sample_path
+		SELECT c.id, c.name, c.version, COALESCE(MIN(a.path), '') AS sample_path,
+		       COALESCE(c.extra->>'oci_artifact_type', '') AS artifact_type
 		FROM components c
 		JOIN repositories rep ON rep.id = c.repository_id
 		LEFT JOIN assets a ON a.component_id = c.id
 		WHERE rep.name IN (%s) AND lower(trim(rep.format)) IN ('docker', 'oci')
-		GROUP BY c.id, c.name, c.version
+		GROUP BY c.id, c.name, c.version, c.extra
 		ORDER BY c.name, c.version
 		LIMIT $%d`, strings.Join(ph, ","), lim)
 	rows, err := r.db.Query(ctx, q, args...)
@@ -269,7 +274,7 @@ func (r *componentRepo) ListDockerBrowseRows(ctx context.Context, repoNames []st
 	var out []domain.DockerBrowseRow
 	for rows.Next() {
 		var row domain.DockerBrowseRow
-		if err := rows.Scan(&row.ComponentID, &row.ImageName, &row.Version, &row.SamplePath); err != nil {
+		if err := rows.Scan(&row.ComponentID, &row.ImageName, &row.Version, &row.SamplePath, &row.ArtifactType); err != nil {
 			return nil, err
 		}
 		out = append(out, row)

--- a/internal/repository/postgres/component_repo_integration_test.go
+++ b/internal/repository/postgres/component_repo_integration_test.go
@@ -1275,6 +1275,73 @@ func TestComponentRepo_ListDockerBrowseRows_ReturnsOCIComponents(t *testing.T) {
 	}
 }
 
+// The browse tree names the kind of each artifact, and the only record of that
+// is oci_artifact_type on the component. A row that dropped it would leave the
+// UI unable to tell a chart from an image.
+func TestComponentRepo_ListDockerBrowseRows_CarriesArtifactType(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+
+	bsRepo := NewBlobStoreRepo(pool)
+	bs := &domain.BlobStore{
+		Name:   "oci_bs_arttype",
+		Type:   "local",
+		Config: map[string]any{"path": "/data/oci_arttype"},
+	}
+	if err := bsRepo.Create(ctx, bs); err != nil {
+		t.Fatalf("Create blob store: %v", err)
+	}
+	rRepo := NewRepositoryRepo(pool)
+	r := &domain.Repository{
+		Name:        "oci-arttype-repo",
+		Format:      domain.FormatOCI,
+		Type:        domain.TypeHosted,
+		BlobStoreID: &bs.ID,
+		Online:      true,
+	}
+	if err := rRepo.Create(ctx, r); err != nil {
+		t.Fatalf("Create oci repo: %v", err)
+	}
+
+	repo := NewComponentRepo(pool)
+	chart := &domain.Component{
+		RepositoryID: r.ID,
+		Format:       "oci",
+		Name:         "charts/nginx",
+		Version:      "1.2.3",
+		Extra:        map[string]any{"oci_artifact_type": "application/vnd.cncf.helm.config.v1+json"},
+	}
+	if err := repo.Create(ctx, chart); err != nil {
+		t.Fatalf("Create chart component: %v", err)
+	}
+	// A component pushed before this metadata was recorded.
+	legacy := &domain.Component{
+		RepositoryID: r.ID,
+		Format:       "oci",
+		Name:         "legacy/app",
+		Version:      "1.0",
+	}
+	if err := repo.Create(ctx, legacy); err != nil {
+		t.Fatalf("Create legacy component: %v", err)
+	}
+
+	rows, err := repo.ListDockerBrowseRows(ctx, []string{"oci-arttype-repo"}, 100)
+	if err != nil {
+		t.Fatalf("ListDockerBrowseRows: %v", err)
+	}
+	byName := map[string]domain.DockerBrowseRow{}
+	for _, row := range rows {
+		byName[row.ImageName] = row
+	}
+	if got := byName["charts/nginx"].ArtifactType; got != "application/vnd.cncf.helm.config.v1+json" {
+		t.Errorf("chart row lost its artifact type: got %q", got)
+	}
+	if got := byName["legacy/app"].ArtifactType; got != "" {
+		t.Errorf("a component with no OCI metadata must report no artifact type, got %q", got)
+	}
+}
+
 func TestComponentRepo_ListDockerBrowseRows_EmptyRepoNamesReturnsNil(t *testing.T) {
 	pool := pgtest.Pool(t)
 	pgtest.Truncate(t, pool, "blob_stores", "repositories")

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -267,6 +267,9 @@ type ComponentRepo struct {
 	Err        error // when non-nil, ListByRepoNames/Get/Search/Delete/SetTags return it (500-branch seam)
 	// DockerRowsByRepo maps repoName→browse rows; ListDockerBrowseRows returns the
 	// union of rows for the requested repo names (mirrors the SQL WHERE rep.name IN (...)).
+	// A row's ArtifactType stands for the SQL's extra->>'oci_artifact_type': the
+	// query projects it verbatim and reports the absent key as the empty string,
+	// so a row here is set the same way.
 	DockerRowsByRepo map[string][]domain.DockerBrowseRow
 	DockerBrowseErr  error // when non-nil, ListDockerBrowseRows returns it (500-branch seam)
 	// LastListLimit/LastListOffset record the paging arguments of the most recent


### PR DESCRIPTION
Phase 5 of five — the last. A chart, a WASM module, a signature and a container image stop looking identical in the browse tree.

## Artifact types in the tree

Phase 1 has been recording `oci_artifact_type` on every manifest since v1.26.0, on both the push and the proxy cache-fill paths, and nothing displayed it. The browse row now carries it — `DockerBrowseRow` gained a field rather than growing a parallel structure, because the rows already pass through RBAC filtering one at a time and a side channel would have to be threaded through that too — and the handler names it for display.

The row holds the **raw** media type; naming it is presentation, and an unrecognised type passes through verbatim, case and parameters intact. Nothing here can affect protocol behaviour.

The recognition table was checked against the actual specifications rather than written from memory, and that mattered:

- **The cosign family is not uniformly signatures.** `…artifact.sbom.v1+json` is an SBOM and `…artifact.att.v1+json` is an attestation; a "contains cosign → signature" rule mislabels two of the three. Those are matched before any signature rule runs.
- **SPDX is two families** — cosign writes `text/spdx…`, ORAS and Syft write `application/spdx+json`.
- **CycloneDX routinely carries a parameter** (`; version=1.4`), so parameters are stripped before matching.
- **Three of the four in-toto shapes contain no "in-toto"** — DSSE envelopes and BuildKit's `application/vnd.docker.attestation.manifest.v1+json` among them.
- **"image" must match whole media types**, since `…image.manifest.v1+json` and `…image.index.v1+json` are not container images.

A repository predating the feature renders exactly as it does today: the field is `omitempty`, the badge is guarded, and no empty badges appear.

**Known limit:** a multi-arch push stores an index at the tag, and an index has no `config.mediaType`, so the tag stays unlabelled while its child manifests are labelled. That is honest — an index is not an image config — but it is worth knowing.

## Command hints

There is no per-repository "how to use" panel in this app; BrowsePage's "Example Usage" modal says `Documentation coming soon` for every format. The only per-format commands live in the docs page catalog, which had a single `Docker / OCI` entry and **no `oci` entry at all**, despite `oci` being a first-class format with its own proxy default.

So that catalog is where the hints went: `Docker` keeps its container commands, and a new `OCI Artifacts` entry covers `oras login/push/pull`, `helm push oci://`, `cosign sign`, and `oras discover` against the referrers API from phase 2. Filling in the modal for two formats while twelve stayed "coming soon" would have been a framework, not a hint.

## Verification

`go test ./internal/...` 1821 passing (only the sandbox-networking webhook test fails locally; it passes in CI); integration suite 405 passing; frontend 492 passing, up from 487; `golangci-lint run --new-from-rev=origin/main` zero issues.

`website/docs/index.html` still says "Docker / OCI" in two places — that is the public site and editing it triggers a deploy, so it is left for a deliberate change rather than folded in here.

---

This completes the five-phase OCI plan: the format itself (v1.26.0), referrers (v1.27.0), then catalog, tag pagination and cross-repo mounts, group index merging, and now the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW