### PR TITLE
fix: charge storage quotas for bytes stored, and serve the conda indexes clients ask for

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -774,6 +774,25 @@ paths:
         '400': { description: Invalid min_age }
         '503': { description: GC service not configured }
 
+  /api/v1/blobstores/recompute-usage:
+    post:
+      tags: [BlobStores]
+      summary: Recompute every blob store's used_bytes
+      description: >
+        Restates each store's usage from the assets that reference it: one size
+        per stored object, however many assets name it. Repairs a counter that
+        drifted from what is on the disk — a store emptied out of band, a
+        restored backup. Admin only.
+      operationId: recomputeBlobStoreUsage
+      responses:
+        '200':
+          description: The repaired blob stores
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/BlobStore' }
+
   /service/rest/v1/blobstores/file:
     post:
       tags: [BlobStores]

--- a/internal/api/handlers/blobstores.go
+++ b/internal/api/handlers/blobstores.go
@@ -525,6 +525,29 @@ func (h *BlobStoreHandler) TestConnection(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"ok": true})
 }
 
+// RecomputeUsage handles POST /api/v1/blobstores/recompute-usage
+// It restates every store's used_bytes from the assets that reference it — one
+// size per stored object, however many assets name it — and answers with the
+// repaired stores. Deployments upgraded past the per-asset accounting are
+// repaired once by migration 024; this is the way back for drift found later: a
+// store emptied out of band, a restored backup, a write that raced a recompute.
+func (h *BlobStoreHandler) RecomputeUsage(c *gin.Context) {
+	ctx := c.Request.Context()
+	if err := h.repo.RecomputeUsedBytes(ctx); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	stores, err := h.repo.List(ctx)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if stores == nil {
+		stores = []domain.BlobStore{}
+	}
+	c.JSON(http.StatusOK, domain.RedactedBlobStores(stores))
+}
+
 // Compact handles POST /api/v1/blobstores/:name/compact
 // Query params: ?dry_run=true reports orphans without deleting;
 // ?min_age=24h overrides the configured grace period (0/absent → server default).

--- a/internal/api/handlers/blobstores_test.go
+++ b/internal/api/handlers/blobstores_test.go
@@ -22,9 +22,9 @@ import (
 // exercises the "S3 only" guard branches in the presign/lifecycle endpoints.
 func mountBlobStores(t *testing.T, stores ...*domain.BlobStore) (*gin.Engine, *testutil.BlobStoreRepo, *testutil.RepoRepo, *testutil.AssetRepo, *testutil.BlobStore) {
 	t.Helper()
-	blobRepo := testutil.NewBlobStoreRepo(stores...)
 	repoRepo := testutil.NewRepoRepo()
 	assetRepo := testutil.NewAssetRepo()
+	blobRepo := testutil.NewBlobStoreRepo(stores...).WithAssets(assetRepo)
 	blobStore := testutil.NewBlobStore()
 	gc := &service.BlobGCService{
 		Assets:   assetRepo,
@@ -49,6 +49,7 @@ func mountBlobStores(t *testing.T, stores ...*domain.BlobStore) (*gin.Engine, *t
 	r.GET("/api/v1/blob-stores/:name/usage", h.Usage)
 	r.POST("/api/v1/blobstores/test", h.TestConnection)
 	r.POST("/api/v1/blobstores/:name/compact", h.Compact)
+	r.POST("/api/v1/blobstores/recompute-usage", h.RecomputeUsage)
 	return r, blobRepo, repoRepo, assetRepo, blobStore
 }
 
@@ -456,4 +457,53 @@ func TestBlobStoreHandler_Update_DropsSecretKeySetMarker(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, stored.Config, domain.SecretKeySetKey)
 	assert.Equal(t, "sup3rs3cret", stored.Config["secret_key"])
+}
+
+// ── Usage recompute ──────────────────────────────────────────────────────────
+
+// Counters inflated by the old per-asset accounting (#146) are repaired on
+// upgrade by a migration, but drift found later — a store emptied out of band,
+// a restored backup — needs a repair an operator can run. The honest figure is
+// one size per stored object, however many assets name it.
+func TestBlobStore_RecomputeUsage_SharedBlobKeyCountedOnce(t *testing.T) {
+	inflated := &domain.BlobStore{
+		ID: "bs-recompute", Name: "default", Type: "local",
+		UsedBytes: 1000, Config: map[string]any{},
+	}
+	r, blobRepo, _, assets, _ := mountBlobStores(t, inflated)
+
+	ctx := testContext()
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
+		Path: "/manifests/app/1.0", BlobKey: "shared", SizeBytes: 500,
+		BlobStoreID: "bs-recompute",
+	}))
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
+		Path: "/manifests/app/sha256:abc", BlobKey: "shared", SizeBytes: 500,
+		BlobStoreID: "bs-recompute",
+	}))
+
+	rec := do(t, r, http.MethodPost, "/api/v1/blobstores/recompute-usage", nil)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	stored, err := blobRepo.Get(ctx, "default")
+	require.NoError(t, err)
+	assert.Equal(t, int64(500), stored.UsedBytes,
+		"two assets, one stored object, one size")
+
+	var resp []domain.BlobStore
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, int64(500), resp[0].UsedBytes, "the response shows the repaired figure")
+}
+
+// The recompute answers with the stores, and a store's credentials are no more
+// readable here than through the list endpoint.
+func TestBlobStore_RecomputeUsage_RedactsSecrets(t *testing.T) {
+	r, _, _, _, _ := mountBlobStores(t, s3Store("s3-recompute", "super-secret"))
+
+	rec := do(t, r, http.MethodPost, "/api/v1/blobstores/recompute-usage", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "super-secret")
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -461,6 +461,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		admin.PUT("/service/rest/v1/blobstores/:type/:name", blobH.Update)
 		admin.DELETE("/service/rest/v1/blobstores/:name", blobH.Delete)
 		admin.POST("/api/v1/blobstores/:name/compact", blobH.Compact)
+		admin.POST("/api/v1/blobstores/recompute-usage", blobH.RecomputeUsage)
 
 		// ── Users ─────────────────────────────────────────────
 		admin.GET("/service/rest/v1/security/users", userH.List)

--- a/internal/db/migrations/024_recompute_blob_store_usage.sql
+++ b/internal/db/migrations/024_recompute_blob_store_usage.sql
@@ -1,0 +1,42 @@
+-- blob_stores.used_bytes is what checkQuota reads to decide whether a write
+-- fits, so it has to mean how full the store is. Until this release it was
+-- incremented once per registered asset, and several paths register more than
+-- one asset against a single stored object: an OCI manifest push registers the
+-- tag and the sha256: digest alias, a cross-repository blob mount registers a
+-- second asset on a blob already stored, and a proxy cache refresh re-registered
+-- a path it had already counted. Every existing deployment therefore carries an
+-- inflated counter, and a store that reports itself fuller than it is refuses
+-- writes that fit.
+--
+-- The code fix only governs writes from here on, so the counters have to be
+-- restated once. Doing it as a migration rather than an operator action is
+-- deliberate: the symptom is a spurious "storage quota exceeded" that gives no
+-- hint the counter is wrong, so an install nobody thinks to repair stays broken.
+--
+-- The honest figure is one size per distinct blob key per store — that is what
+-- the store holds. Rows that disagree about a key's size (an alias left behind
+-- when the path was overwritten in place) are read at their largest, the only
+-- reading that cannot let a store overfill. Bytes on disk that no asset
+-- references are not counted here; the blob GC now decrements what it collects,
+-- so the counter converges rather than drifting.
+--
+-- Repeatable through BlobStoreRepo.RecomputeUsedBytes, which runs the same
+-- statement for drift found later.
+
+-- +goose Up
+UPDATE blob_stores bs
+SET used_bytes = COALESCE((
+        SELECT SUM(k.size_bytes) FROM (
+            SELECT DISTINCT ON (a.blob_key) a.size_bytes
+            FROM assets a
+            WHERE COALESCE(a.blob_store_id,
+                           (SELECT d.id FROM blob_stores d WHERE d.name = 'default')) = bs.id
+              AND a.blob_key IS NOT NULL AND TRIM(a.blob_key) <> ''
+            ORDER BY a.blob_key, a.size_bytes DESC
+        ) k
+    ), 0),
+    updated_at = NOW();
+
+-- +goose Down
+-- Down is a no-op: the previous numbers were wrong, and nothing recorded them.
+SELECT 1;

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -347,8 +347,9 @@ func DeleteArtifact(ctx context.Context, d formats.Deps, repoName, filePath stri
 }
 
 // DecrementBlobStoreUsage reduces the owning blob store's used_bytes by asset.SizeBytes.
-// Symmetric to the UpdateUsedBytes(+size) call in RegisterStoredBlob. Best-effort — callers
-// typically ignore the error.
+// Call it only once the object itself has left the store: the counter is how full the
+// store is, and a registration adds a blob's size once however many assets name it.
+// Best-effort — callers typically ignore the error.
 func DecrementBlobStoreUsage(ctx context.Context, blobs repository.BlobStoreRepo, asset *domain.Asset) error {
 	if asset == nil || asset.SizeBytes <= 0 {
 		return nil

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -167,6 +167,20 @@ func RegisterStoredBlob(ctx context.Context, d formats.Deps, repo *domain.Reposi
 			return nil, err
 		}
 	}
+	if blobStoreName == "" {
+		// A caller that pins the store by id — the OCI digest alias, a mount —
+		// pins where the bytes are, and used_bytes is keyed by name.
+		if bs, err := d.Blobs.GetByID(ctx, blobStoreID); err == nil && bs != nil {
+			blobStoreName = bs.Name
+		}
+	}
+
+	// Read before the upsert: whether these bytes are new to the store depends on
+	// what the path held a moment ago.
+	prev, perr := d.Assets.GetByPath(ctx, repo.Name, filePath)
+	if perr != nil {
+		prev = nil
+	}
 
 	version := coords.Version
 	if version == "" {
@@ -212,8 +226,36 @@ func RegisterStoredBlob(ctx context.Context, d formats.Deps, repo *domain.Reposi
 		return nil, fmt.Errorf("upsert asset: %w", err)
 	}
 
-	_ = d.Blobs.UpdateUsedBytes(ctx, blobStoreName, size)
+	if delta := usageDelta(ctx, d, asset, prev); delta != 0 {
+		_ = d.Blobs.UpdateUsedBytes(ctx, blobStoreName, delta)
+	}
 	return asset, nil
+}
+
+// usageDelta reports how much the blob store's used_bytes has to move for a
+// registration. The counter is how full the store is, not what its asset rows
+// add up to: several assets routinely name one blob — an OCI manifest's tag and
+// its digest alias, a cross-repository mount — and the store holds one copy of
+// it (issue #146). prev is the asset that held the same path before the upsert,
+// or nil if the path is new.
+func usageDelta(ctx context.Context, d formats.Deps, asset, prev *domain.Asset) int64 {
+	if prev != nil && prev.BlobKey == asset.BlobKey && prev.BlobStoreID == asset.BlobStoreID {
+		// The write landed on the object the path already had: the store holds
+		// the new size where it held the old one.
+		return asset.SizeBytes - prev.SizeBytes
+	}
+	// A blob key another asset already carries is already counted. Shared keys
+	// live in one store by construction: a key is derived from (repository,
+	// path), and the two paths that deliberately share one — an OCI digest alias
+	// and a mounted blob — are registered against the store of the asset they
+	// alias. A count that cannot be read counts the bytes: overstating a store
+	// costs a rejected write, understating it overfills the disk.
+	if others, err := d.Assets.CountByBlobKey(ctx, asset.BlobKey, asset.ID); err == nil && others > 0 {
+		return 0
+	}
+	// A path that moved to a different key or store leaves its old bytes behind;
+	// they stay counted where they lie until the blob GC reclaims them.
+	return asset.SizeBytes
 }
 
 // FetchArtifact retrieves a blob from storage and increments download count.
@@ -271,20 +313,24 @@ func DeleteArtifact(ctx context.Context, d formats.Deps, repoName, filePath stri
 	// survivor — and the referrers index built from it — advertising content that
 	// is gone. A count that cannot be read keeps the blob: an orphan is reclaimed
 	// by the blob GC, whereas bytes deleted under a live asset are lost.
+	freed := false
 	others, cerr := d.Assets.CountByBlobKey(ctx, asset.BlobKey, asset.ID)
 	if cerr == nil && others == 0 {
-		_ = delStore.Delete(ctx, asset.BlobKey)
+		// Both blob store backends report a missing object as a successful
+		// delete, so a nil error means the bytes are not there any more.
+		freed = delStore.Delete(ctx, asset.BlobKey) == nil
 	}
 	if err := d.Assets.Delete(ctx, asset.ID); err != nil {
 		return err
 	}
 	metrics.ArtifactsDeleted.Add(1)
-	// Decremented whether or not the bytes went away, because the counter is
-	// incremented once per registered asset — the alias registration in
-	// RegisterStoredBlob adds size a second time for the same blob. Skipping the
-	// decrement for a surviving blob would leave that second size on the store
-	// forever and walk it into a false quota rejection.
-	_ = DecrementBlobStoreUsage(ctx, d.Blobs, asset)
+	// Decremented only when the bytes actually left the store, mirroring the
+	// registration side, which counts a blob once however many assets name it.
+	// Decrementing for a blob a surviving asset still reads would take a size off
+	// the store that is still on the disk.
+	if freed {
+		_ = DecrementBlobStoreUsage(ctx, d.Blobs, asset)
+	}
 	if d.Webhooks != nil {
 		d.Webhooks.Dispatch(domain.WebhookPayload{
 			Event:      domain.EventArtifactDeleted,

--- a/internal/formats/base/usage_test.go
+++ b/internal/formats/base/usage_test.go
@@ -136,6 +136,35 @@ func TestDeleteArtifact_SharedBlobKey_DecrementsOnlyWhenTheBytesGo(t *testing.T)
 		"the last reference frees the blob and its size")
 }
 
+// The repository quota is measured the same way, off the assets in the
+// repository: a manifest the repository stores once must not be charged to it
+// twice because a digest alias names it too.
+func TestStoreArtifact_ManifestAliasDoesNotEatTheRepositoryQuota(t *testing.T) {
+	const manifest = `{"schemaVersion":2}`
+	quota := int64(2 * len(manifest))
+	repo := testutil.SimpleRepo("usage-repoquota", "oci")
+	repo.QuotaBytes = &quota
+	d, _, _, _ := deps(repo)
+	ctx := context.Background()
+
+	res, err := base.StoreArtifact(ctx, d,
+		"usage-repoquota", "/manifests/app/1.0", "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "1.0"},
+		strings.NewReader(manifest), int64(len(manifest)))
+	require.NoError(t, err)
+	_, err = base.RegisterStoredBlob(ctx, d, repo,
+		"/manifests/app/sha256:"+res.SHA256, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "sha256:" + res.SHA256},
+		res.Asset.BlobKey, res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+	require.NoError(t, err)
+
+	_, err = base.StoreArtifact(ctx, d,
+		"usage-repoquota", "/manifests/app/2.0", "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "2.0"},
+		strings.NewReader(manifest), int64(len(manifest)))
+	require.NoError(t, err, "the repository holds one manifest and has room for another")
+}
+
 // The user-visible symptom: a store whose counter double-counted an OCI
 // manifest refuses the next push although the bytes fit.
 func TestStoreArtifact_ManifestAliasDoesNotEatTheQuota(t *testing.T) {

--- a/internal/formats/base/usage_test.go
+++ b/internal/formats/base/usage_test.go
@@ -1,0 +1,176 @@
+package base_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// usedBytes reads the counter checkQuota reads.
+func usedBytes(t *testing.T, d formats.Deps, storeName string) int64 {
+	t.Helper()
+	bs, err := d.Blobs.Get(context.Background(), storeName)
+	require.NoError(t, err)
+	return bs.UsedBytes
+}
+
+// An OCI manifest push registers two assets on ONE blob: the tag path and the
+// digest-alias path. used_bytes is how full the store is, and the store holds
+// one copy — so the counter moves by one manifest size, not two (#146).
+func TestRegisterStoredBlob_SecondAssetOnSameBlobKey_CountsBytesOnce(t *testing.T) {
+	repo := testutil.SimpleRepo("usage-alias", "oci")
+	d, _, _, _ := deps(repo)
+	ctx := context.Background()
+
+	content := `{"schemaVersion":2}`
+	res, err := base.StoreArtifact(ctx, d,
+		"usage-alias", "/manifests/app/1.0", "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "1.0"},
+		strings.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+	require.Equal(t, int64(len(content)), usedBytes(t, d, "default"))
+
+	// The digest alias: a second asset record on the SAME blob key.
+	_, err = base.RegisterStoredBlob(ctx, d, repo,
+		"/manifests/app/sha256:"+res.SHA256, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "sha256:" + res.SHA256},
+		res.Asset.BlobKey, res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(len(content)), usedBytes(t, d, "default"),
+		"the alias stores no second copy, so it adds no second size")
+}
+
+// A caller that pins the store by id — the OCI digest alias pins the store the
+// manifest bytes went to, a mount pins its source's — says where the bytes are.
+// used_bytes is keyed by name, so the name has to be looked up rather than the
+// registration silently counting against nothing.
+func TestRegisterStoredBlob_StoreIDWithoutName_CountsAgainstThatStore(t *testing.T) {
+	repo := testutil.SimpleRepo("usage-byid", "raw")
+	d, _, _, _ := deps(repo)
+	ctx := context.Background()
+
+	def, err := d.Blobs.Get(ctx, "default")
+	require.NoError(t, err)
+
+	content := "counted against the pinned store"
+	_, err = base.RegisterStoredBlob(ctx, d, repo,
+		"/pinned.bin", "application/octet-stream",
+		base.Coords{Name: "pinned.bin"},
+		base.BlobKey("usage-byid", "/pinned.bin"), "sha", "sha1", "md5",
+		int64(len(content)), def.ID, "")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(len(content)), usedBytes(t, d, "default"))
+}
+
+// Re-publishing a path overwrites the bytes at the same blob key. The store now
+// holds the new size instead of the old one, so the counter moves by the
+// difference — not by the whole new size on top of the old.
+func TestStoreArtifact_OverwritingAPath_CountsOnlyTheSizeDifference(t *testing.T) {
+	repo := testutil.SimpleRepo("usage-overwrite", "raw")
+	d, blobStore, _, _ := deps(repo)
+	ctx := context.Background()
+
+	first := "small"
+	_, err := base.StoreArtifact(ctx, d,
+		"usage-overwrite", "/pkg.bin", "application/octet-stream",
+		base.Coords{Name: "pkg.bin"},
+		strings.NewReader(first), int64(len(first)))
+	require.NoError(t, err)
+
+	second := "a much larger payload"
+	_, err = base.StoreArtifact(ctx, d,
+		"usage-overwrite", "/pkg.bin", "application/octet-stream",
+		base.Coords{Name: "pkg.bin"},
+		strings.NewReader(second), int64(len(second)))
+	require.NoError(t, err)
+
+	physical, err := blobStore.UsedBytes(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(len(second)), physical, "one object holds the newest bytes")
+	assert.Equal(t, int64(len(second)), usedBytes(t, d, "default"),
+		"the counter tracks what is stored, not the sum of everything ever written")
+}
+
+// Deletion has to match the registration side or the counter drifts: the bytes
+// only leave the store with the last asset that references them.
+func TestDeleteArtifact_SharedBlobKey_DecrementsOnlyWhenTheBytesGo(t *testing.T) {
+	repo := testutil.SimpleRepo("usage-del", "oci")
+	d, blobStore, _, _ := deps(repo)
+	ctx := context.Background()
+
+	content := `{"schemaVersion":2}`
+	tagPath := "/manifests/app/1.0"
+	res, err := base.StoreArtifact(ctx, d,
+		"usage-del", tagPath, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "1.0"},
+		strings.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+
+	digestPath := "/manifests/app/sha256:" + res.SHA256
+	_, err = base.RegisterStoredBlob(ctx, d, repo,
+		digestPath, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "sha256:" + res.SHA256},
+		res.Asset.BlobKey, res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+	require.NoError(t, err)
+
+	// First delete: the alias still needs the bytes, so nothing is freed.
+	require.NoError(t, base.DeleteArtifact(ctx, d, "usage-del", tagPath))
+	require.True(t, blobStore.Has(res.Asset.BlobKey), "the alias still references the blob")
+	assert.Equal(t, int64(len(content)), usedBytes(t, d, "default"),
+		"no bytes left the store, so the counter must not move")
+
+	// Second delete: the bytes go, and so does their size.
+	require.NoError(t, base.DeleteArtifact(ctx, d, "usage-del", digestPath))
+	require.False(t, blobStore.Has(res.Asset.BlobKey))
+	assert.Equal(t, int64(0), usedBytes(t, d, "default"),
+		"the last reference frees the blob and its size")
+}
+
+// The user-visible symptom: a store whose counter double-counted an OCI
+// manifest refuses the next push although the bytes fit.
+func TestStoreArtifact_ManifestAliasDoesNotEatTheQuota(t *testing.T) {
+	const manifest = `{"schemaVersion":2}`
+	quota := int64(2 * len(manifest)) // room for the manifest and one more of its size
+	bs := &domain.BlobStore{
+		ID: "quota-bs", Name: "default", Type: "local",
+		QuotaBytes: &quota, Config: map[string]any{},
+	}
+	repo := testutil.SimpleRepo("usage-quota", "oci")
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(bs),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost",
+	}
+	ctx := context.Background()
+
+	res, err := base.StoreArtifact(ctx, d,
+		"usage-quota", "/manifests/app/1.0", "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "1.0"},
+		strings.NewReader(manifest), int64(len(manifest)))
+	require.NoError(t, err)
+	_, err = base.RegisterStoredBlob(ctx, d, repo,
+		"/manifests/app/sha256:"+res.SHA256, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "sha256:" + res.SHA256},
+		res.Asset.BlobKey, res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+	require.NoError(t, err)
+
+	// One manifest is stored; half the quota is still free.
+	_, err = base.StoreArtifact(ctx, d,
+		"usage-quota", "/manifests/app/2.0", "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "2.0"},
+		strings.NewReader(manifest), int64(len(manifest)))
+	require.NoError(t, err, "the store has room for these bytes and must accept them")
+}

--- a/internal/formats/conda/conda_extra_test.go
+++ b/internal/formats/conda/conda_extra_test.go
@@ -283,7 +283,7 @@ func TestParseMeta_Filename_TwoPartName(t *testing.T) {
 	assert.Equal(t, "pkg", meta.Name)
 }
 
-// ─── proxyRepodata error paths ───────────────────────────────────
+// ─── proxyIndex error paths ──────────────────────────────────────
 
 func TestConda_ProxyRepodata_NoRemoteURL(t *testing.T) {
 	repo := &domain.Repository{

--- a/internal/formats/conda/handler.go
+++ b/internal/formats/conda/handler.go
@@ -3,7 +3,8 @@
 // Conda channel layout:
 //
 //	GET /repository/<repo>/<platform>/repodata.json      → channel index
-//	GET /repository/<repo>/<platform>/repodata.json.bz2  → bz2-compressed index (returns 404)
+//	GET /repository/<repo>/<platform>/current_repodata.json → trimmed channel index (proxy)
+//	GET /repository/<repo>/<platform>/repodata.json.bz2  → compressed index (returns 404)
 //	GET /repository/<repo>/<platform>/<filename>          → download package
 //	PUT /repository/<repo>/<platform>/<filename>          → upload package
 //	DELETE /repository/<repo>/<platform>/<filename>       → delete package
@@ -194,17 +195,17 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 		return
 	}
 
-	if c.Request.Method == http.MethodGet && filename == "repodata.json" {
-		h.proxyRepodata(c, repo, repoName, platform)
+	if c.Request.Method == http.MethodGet && isIndexDocument(filename) {
+		h.proxyIndex(c, repo, repoName, platform, filename)
 		return
 	}
-	if filename == "repodata.json.bz2" {
-		c.JSON(http.StatusNotFound, gin.H{"error": "use repodata.json"})
+	if want, ok := refusedIndexVariant(filename); ok {
+		c.JSON(http.StatusNotFound, gin.H{"error": "use " + want})
 		return
 	}
 
 	// Package binary: cache via repoproxy. Conda packages are immutable
-	// (repodata.json — the mutable index — is handled by proxyRepodata above).
+	// (the index documents — which are not — are handled by proxyIndex above).
 	// A repodata.json entry may point below the subdir, so filename can carry a
 	// directory; the component is named after the package file alone.
 	coords := base.Coords{Name: path.Base(filename), Group: platform}
@@ -213,14 +214,68 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 	}
 }
 
-func (h *Handler) proxyRepodata(c *gin.Context, repo *domain.Repository, repoName, platform string) {
+// indexDocuments are the channel documents that carry package download URLs. All
+// three share repodata.json's schema and resolve their entries against the subdir
+// they were fetched from, so one rewriter serves them all, and none of them is
+// immutable — each is read from upstream on every request (#145).
+//
+// current_repodata.json is repodata.json trimmed to the newest build of each
+// package and is what a recent conda client asks for first. The third is the
+// unpatched index conda-index writes beside them, which a client reaches by naming
+// it in repodata_fns.
+var indexDocuments = []string{
+	"repodata.json",
+	"current_repodata.json",
+	"repodata_from_packages.json",
+}
+
+// isIndexDocument reports whether filename is an index document this proxy rewrites.
+func isIndexDocument(filename string) bool {
+	for _, name := range indexDocuments {
+		if filename == name {
+			return true
+		}
+	}
+	return false
+}
+
+// refusedIndexVariant reports whether filename is an alternate encoding of an index
+// document and, if so, names the document the client should ask for instead.
+//
+// Conda publishes each index in several encodings — .json.bz2, .json.zst, and the
+// .jlap patch stream — and every one of them carries the package URLs that have to
+// be rewritten onto this proxy. Serving one means decompressing it, rewriting it and
+// re-encoding it on every request (and, for zstd, carrying a codec this module does
+// not otherwise need), all for an index that runs to hundreds of megabytes on a
+// channel the size of conda-forge and that exists only as a transfer optimization: a
+// client denied the variant falls back to the plain document, which is served
+// rewritten and re-read from upstream. That is what repodata.json.bz2 has answered
+// since this handler was written, and the fallback is why it works.
+func refusedIndexVariant(filename string) (string, bool) {
+	for _, ext := range []string{".bz2", ".zst"} {
+		if base := strings.TrimSuffix(filename, ext); base != filename && isIndexDocument(base) {
+			return base, true
+		}
+	}
+	// The patch stream drops the ".json" instead of appending: "repodata.jlap".
+	if base := strings.TrimSuffix(filename, ".jlap"); base != filename && isIndexDocument(base+".json") {
+		return base + ".json", true
+	}
+	return "", false
+}
+
+// proxyIndex fetches one index document from upstream and serves it with its
+// package URLs rewritten onto this proxy. It deliberately does not go through
+// repoproxy's blob cache: the document is rebuilt whenever the channel changes, and
+// a cached copy of it would be served as though it were an immutable package.
+func (h *Handler) proxyIndex(c *gin.Context, repo *domain.Repository, repoName, platform, filename string) {
 	remoteBase, err := repoproxy.RemoteURL(repo)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	upstreamURL := remoteBase + "/" + platform + "/repodata.json"
+	upstreamURL := remoteBase + "/" + platform + "/" + filename
 	req, err := http.NewRequestWithContext(c.Request.Context(), http.MethodGet, upstreamURL, nil)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -241,7 +296,7 @@ func (h *Handler) proxyRepodata(c *gin.Context, repo *domain.Repository, repoNam
 
 	var doc map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
-		c.JSON(http.StatusBadGateway, gin.H{"error": "parse upstream repodata.json: " + err.Error()})
+		c.JSON(http.StatusBadGateway, gin.H{"error": "parse upstream " + filename + ": " + err.Error()})
 		return
 	}
 

--- a/internal/formats/conda/proxy_index_test.go
+++ b/internal/formats/conda/proxy_index_test.go
@@ -1,0 +1,197 @@
+package conda_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Index documents other than repodata.json (#145). conda clients prefer
+// current_repodata.json, and conda-index also publishes repodata_from_packages.json;
+// all three carry the same schema and must be rewritten onto this proxy, and none of
+// them may be cached as if it were an immutable package.
+
+// countingUpstream serves indexName under /linux-64/ with a single "packages" entry
+// naming pkgFile, plus the package bytes at /linux-64/<pkgFile>. The body of the
+// index changes on every request (the version counts up) and hits records how many
+// requests the whole server saw, so a test can tell a fresh fetch from a cache hit.
+func countingUpstream(t *testing.T, indexName, pkgFile string) (srv *httptest.Server, hits *atomic.Int64) {
+	t.Helper()
+	hits = &atomic.Int64{}
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		switch r.URL.Path {
+		case "/linux-64/" + indexName:
+			doc := map[string]any{
+				"info": map[string]any{"subdir": "linux-64"},
+				"packages": map[string]any{
+					pkgFile: map[string]any{
+						"name": "numpy",
+						// A different version per request stands in for a channel
+						// that changed: a stale copy is visible in the response.
+						"version": fmt.Sprintf("1.24.%d", hits.Load()),
+						"url":     pkgFile,
+					},
+				},
+				"packages.conda": map[string]any{},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(doc)
+		case "/linux-64/" + pkgFile:
+			w.Header().Set("Content-Type", "application/x-tar")
+			_, _ = w.Write([]byte("package-bytes"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	return srv, hits
+}
+
+// indexVersion fetches indexName through the proxy and returns the version the
+// document advertises for pkgFile.
+func indexVersion(t *testing.T, r *gin.Engine, repoName, indexName, pkgFile string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/repository/"+repoName+"/linux-64/"+indexName, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "%s body: %s", indexName, w.Body.String())
+
+	var doc struct {
+		Packages map[string]struct {
+			Version string `json:"version"`
+		} `json:"packages"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+	entry, ok := doc.Packages[pkgFile]
+	require.True(t, ok, "package entry missing from %s", indexName)
+	return entry.Version
+}
+
+// TestConda_Proxy_CurrentRepodata_RewritesURLs_RoundTrip is the reported case (#145):
+// current_repodata.json is what a recent conda client asks for first, and its URLs
+// were handed to the client untouched, sending the download straight to the upstream.
+// The download path comes out of the rewritten document, so this proves the round trip.
+func TestConda_Proxy_CurrentRepodata_RewritesURLs_RoundTrip(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/current_repodata.json",
+		"pkgs/"+condaPkgFile, "/linux-64/pkgs/"+condaPkgFile, "current-package-bytes")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-current", upstream.URL)
+
+	pkgURL := indexPackageURL(t, r, "conda-current", "linux-64", "current_repodata.json")
+	assert.Equal(t, condaBaseURL+"/repository/conda-current/linux-64/pkgs/"+condaPkgFile, pkgURL,
+		"current_repodata.json must be rewritten the way repodata.json is")
+
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "current-package-bytes", w.Body.String())
+}
+
+// TestConda_Proxy_RepodataFromPackages_RewritesURLs_RoundTrip covers the third
+// document conda-index publishes with repodata.json's schema; a client pointed at it
+// through repodata_fns has the same claim on rewritten URLs.
+func TestConda_Proxy_RepodataFromPackages_RewritesURLs_RoundTrip(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata_from_packages.json",
+		"pkgs/"+condaPkgFile, "/linux-64/pkgs/"+condaPkgFile, "from-packages-bytes")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-fromjson", upstream.URL)
+
+	pkgURL := indexPackageURL(t, r, "conda-fromjson", "linux-64", "repodata_from_packages.json")
+	assert.Equal(t, condaBaseURL+"/repository/conda-fromjson/linux-64/pkgs/"+condaPkgFile, pkgURL)
+
+	w := fetchThrough(t, r, pkgURL)
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "from-packages-bytes", w.Body.String())
+}
+
+// TestConda_Proxy_IndexDocuments_NotCachedAsImmutable pins the second half of #145:
+// these documents are indexes, not packages. The immutable-artifact branch caches a
+// path forever and never contacts upstream again, so a channel that gained a package
+// would never be seen. repodata.json is the reference — it is re-read from upstream on
+// every request — and the other index documents must be treated identically rather
+// than to some TTL of their own.
+func TestConda_Proxy_IndexDocuments_NotCachedAsImmutable(t *testing.T) {
+	for _, indexName := range []string{
+		"repodata.json",
+		"current_repodata.json",
+		"repodata_from_packages.json",
+	} {
+		t.Run(indexName, func(t *testing.T) {
+			upstream, hits := countingUpstream(t, indexName, condaPkgFile)
+			defer upstream.Close()
+
+			r, _ := subpathProxy(t, "conda-fresh", upstream.URL)
+
+			first := indexVersion(t, r, "conda-fresh", indexName, condaPkgFile)
+			second := indexVersion(t, r, "conda-fresh", indexName, condaPkgFile)
+
+			assert.NotEqual(t, first, second,
+				"the channel changed between the two requests and the client was not told")
+			assert.Equal(t, int64(2), hits.Load(),
+				"an index must be re-read from upstream, not served from the immutable cache")
+		})
+	}
+}
+
+// TestConda_Proxy_CompressedIndexVariants_NotServed pins the decision on the
+// compressed variants. repodata.json.bz2 has always answered 404 and conda clients
+// fall back to the plain document; .zst gets the same answer, for the same reason —
+// serving it would mean decompressing, rewriting and recompressing an index that can
+// run to hundreds of megabytes on every request. Upstream must not be contacted at
+// all, and nothing may be cached under the path.
+func TestConda_Proxy_CompressedIndexVariants_NotServed(t *testing.T) {
+	for name, want := range map[string]string{
+		"repodata.json.bz2":               "repodata.json",
+		"repodata.json.zst":               "repodata.json",
+		"current_repodata.json.zst":       "current_repodata.json",
+		"current_repodata.json.bz2":       "current_repodata.json",
+		"repodata_from_packages.json.zst": "repodata_from_packages.json",
+		"repodata.jlap":                   "repodata.json",
+		"current_repodata.jlap":           "current_repodata.json",
+	} {
+		t.Run(name, func(t *testing.T) {
+			upstream, hits := countingUpstream(t, "repodata.json", condaPkgFile)
+			defer upstream.Close()
+
+			r, _ := subpathProxy(t, "conda-compressed", upstream.URL)
+
+			req := httptest.NewRequest(http.MethodGet,
+				"/repository/conda-compressed/linux-64/"+name, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusNotFound, w.Code, "body: %s", w.Body.String())
+			assert.Contains(t, w.Body.String(), "use "+want,
+				"the 404 must name the document the client should ask for instead")
+			assert.Equal(t, int64(0), hits.Load(),
+				"a refused variant must not be fetched from upstream")
+		})
+	}
+}
+
+// TestConda_Proxy_PackageNamedLikeAnIndex_StillDownloads guards the refusal rule
+// against overreach: only an index document at the root of a subdir is refused, and a
+// package file that happens to sit under a directory of that name is still a download.
+func TestConda_Proxy_PackageNamedLikeAnIndex_StillDownloads(t *testing.T) {
+	upstream := subdirUpstream(t, "/linux-64/repodata.json",
+		"pkgs/repodata.json.zst", "/linux-64/pkgs/repodata.json.zst", "not-an-index")
+	defer upstream.Close()
+
+	r, _ := subpathProxy(t, "conda-lookalike", upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/conda-lookalike/linux-64/pkgs/repodata.json.zst", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "not-an-index", w.Body.String())
+}

--- a/internal/formats/conda/proxy_subpath_test.go
+++ b/internal/formats/conda/proxy_subpath_test.go
@@ -82,11 +82,18 @@ func subdirUpstream(t *testing.T, repodataPath, entryURL, pkgPath, body string) 
 // download URL a conda client would follow.
 func firstPackageURL(t *testing.T, r *gin.Engine, repoName, platform string) string {
 	t.Helper()
+	return indexPackageURL(t, r, repoName, platform, "repodata.json")
+}
+
+// indexPackageURL is firstPackageURL for any of the index documents conda may ask
+// for — they share repodata.json's schema, so the same extraction works on all.
+func indexPackageURL(t *testing.T, r *gin.Engine, repoName, platform, indexName string) string {
+	t.Helper()
 	req := httptest.NewRequest(http.MethodGet,
-		"/repository/"+repoName+"/"+platform+"/repodata.json", nil)
+		"/repository/"+repoName+"/"+platform+"/"+indexName, nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
-	require.Equal(t, http.StatusOK, w.Code, "repodata.json body: %s", w.Body.String())
+	require.Equal(t, http.StatusOK, w.Code, "%s body: %s", indexName, w.Body.String())
 
 	var doc struct {
 		Packages map[string]struct {
@@ -95,7 +102,7 @@ func firstPackageURL(t *testing.T, r *gin.Engine, repoName, platform string) str
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
 	entry, ok := doc.Packages[condaPkgFile]
-	require.True(t, ok, "package entry missing from rewritten repodata.json")
+	require.True(t, ok, "package entry missing from rewritten %s", indexName)
 	return entry.URL
 }
 

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -324,11 +324,14 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 	digestRef := "sha256:" + res.SHA256
 	if reference != digestRef {
 		if repo, err2 := h.deps.Repos.Get(c.Request.Context(), repoName); err2 == nil && repo != nil {
+			// Pinned to the store the manifest bytes went to. Re-resolving would
+			// let a group store round-robin the alias onto a different member,
+			// which holds neither the object the alias names nor its size.
 			alias, aerr := base.RegisterStoredBlob(c.Request.Context(), h.deps, repo,
 				manifestPath(imageName, digestRef), ct,
 				base.Coords{Name: imageName, Version: digestRef},
 				res.Asset.BlobKey,
-				res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+				res.SHA256, res.SHA1, res.MD5, res.Size, res.Asset.BlobStoreID, "")
 			// The alias carries the same metadata: the referrers API resolves a
 			// subject by digest, not by tag.
 			if aerr == nil && alias != nil && len(extra) > 0 {

--- a/internal/formats/oci/mount_test.go
+++ b/internal/formats/oci/mount_test.go
@@ -396,12 +396,11 @@ func TestMount_SourceAssetWithMissingBlob_FallsBackInsteadOfPromisingABrokenLaye
 
 // ── Usage accounting ──────────────────────────────────────────
 
-// The bytes are already on disk, so a mount writes none. The used_bytes counter
-// follows the convention RegisterStoredBlob already sets everywhere else — one
-// increment per registered asset, exactly as the manifest digest alias does
-// (issue #146). Deletion decrements per asset unconditionally, so skipping the
-// increment here would drive the counter permanently negative.
-func TestMount_WritesNoBytesAndCountsUsageOncePerAsset(t *testing.T) {
+// The bytes are already on disk, so a mount writes none — and used_bytes, which
+// is what checkQuota reads to decide whether a write fits, is how full the store
+// is. A second asset on a blob the store already holds moves it by nothing
+// (issue #146).
+func TestMount_WritesNoBytesAndCountsNoUsage(t *testing.T) {
 	repo := testutil.SimpleRepo("mnt10", "docker")
 	r, _, d, store := mountDeps(repo)
 
@@ -421,13 +420,13 @@ func TestMount_WritesNoBytesAndCountsUsageOncePerAsset(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, physicalBefore, physicalAfter, "a mount adds no bytes to the store")
 
-	assert.Equal(t, countedBefore+int64(len(layer)), usedBytes(t, d),
-		"one asset, one increment — the same convention the manifest digest alias follows (#146)")
+	assert.Equal(t, countedBefore, usedBytes(t, d),
+		"no bytes were stored, so the store is no fuller than it was (#146)")
 }
 
 // Mounting makes two images depend on one stored object, so deleting either one
-// must not take the bytes out from under the other (#144). The counter comes
-// back down with each asset, matching the per-asset increment above.
+// must not take the bytes out from under the other (#144). The counter follows
+// the bytes: it moves only when the object itself goes.
 func TestMount_DeletingTheSourceLeavesTheMountedBlobPullable(t *testing.T) {
 	repo := testutil.SimpleRepo("mnt11", "docker")
 	r, _, d, _ := mountDeps(repo)
@@ -449,6 +448,14 @@ func TestMount_DeletingTheSourceLeavesTheMountedBlobPullable(t *testing.T) {
 	require.Equal(t, http.StatusOK, wg.Code, "the mounted image still needs the bytes the source registered")
 	assert.Equal(t, layer, wg.Body.String())
 
+	assert.Equal(t, counted, usedBytes(t, d),
+		"the object is still stored for the mounted image, so its size is still used")
+
+	// Deleting the last asset on the object frees it, and the size with it.
+	delMount := httptest.NewRequest(http.MethodDelete, "/repository/mnt11/v2/library/ubuntu/blobs/"+dgst, nil)
+	wdm := httptest.NewRecorder()
+	r.ServeHTTP(wdm, delMount)
+	require.Equal(t, http.StatusAccepted, wdm.Code)
 	assert.Equal(t, counted-int64(len(layer)), usedBytes(t, d),
-		"the deleted asset gives back exactly the size its registration added")
+		"the last reference gives the object's size back to the store")
 }

--- a/internal/formats/oci/usage_test.go
+++ b/internal/formats/oci/usage_test.go
@@ -1,0 +1,52 @@
+package oci_test
+
+import (
+	"context"
+	"net/http"
+
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A manifest push stores one object and registers two assets on it: the tag the
+// client pushed and the sha256: digest alias a pull re-fetches by. used_bytes is
+// how full the store is, so it moves by one manifest size (issue #146).
+func TestPutManifest_CountsTheManifestOnce(t *testing.T) {
+	repo := testutil.SimpleRepo("usage1", "docker")
+	r, _, d, store := mountDeps(repo)
+
+	body := referrerManifest(sbomArtifactType, "sha256:"+
+		"0000000000000000000000000000000000000000000000000000000000000000")
+	pushManifestBody(t, r, "usage1", "library/app", "1.0", body)
+
+	physical, err := store.UsedBytes(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(len(body)), physical, "one manifest, one stored object")
+
+	assert.Equal(t, int64(len(body)), usedBytes(t, d),
+		"the digest alias names the same object; it does not double the store's usage")
+}
+
+// Both assets have to go before the object does, and the size comes off exactly
+// once — with the object.
+func TestPutManifest_DeletingBothAssetsGivesTheSizeBackOnce(t *testing.T) {
+	repo := testutil.SimpleRepo("usage2", "docker")
+	r, _, d, _ := mountDeps(repo)
+
+	body := referrerManifest(sbomArtifactType, "sha256:"+
+		"1111111111111111111111111111111111111111111111111111111111111111")
+	dgst := pushManifestBody(t, r, "usage2", "library/app", "1.0", body)
+	require.Equal(t, int64(len(body)), usedBytes(t, d))
+
+	require.Equal(t, http.StatusAccepted, deleteManifest(t, r, "usage2", "library/app", "1.0").Code)
+	assert.Equal(t, int64(len(body)), usedBytes(t, d),
+		"the digest alias still reads the object, so its bytes are still stored")
+
+	require.Equal(t, http.StatusAccepted, deleteManifest(t, r, "usage2", "library/app", dgst).Code)
+	assert.Equal(t, int64(0), usedBytes(t, d),
+		"the last asset takes the object away, and its size with it")
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -276,6 +276,10 @@ type BlobStoreRepo interface {
 	Update(ctx context.Context, b *domain.BlobStore) error
 	Delete(ctx context.Context, name string) error
 	UpdateUsedBytes(ctx context.Context, name string, delta int64) error
+	// RecomputeUsedBytes restates every store's used_bytes as the bytes it holds:
+	// one size per distinct blob key, since several assets can name one stored
+	// object. Repairs a counter that drifted from what is on the disk.
+	RecomputeUsedBytes(ctx context.Context) error
 }
 
 // BlobStoreMigrationRepo persists blob store migration job records.

--- a/internal/repository/postgres/asset_repo.go
+++ b/internal/repository/postgres/asset_repo.go
@@ -353,12 +353,21 @@ func (r *assetRepo) ListAllBlobKeys(ctx context.Context) ([]string, error) {
 	return keys, rows.Err()
 }
 
+// SumSizeByRepo returns the bytes the repository occupies: one size per stored
+// object, since several assets can name one — an OCI manifest's tag and its
+// digest alias, a blob mounted from another image in the same repository.
+// Charging a repository once per asset row put it over its quota at half the
+// bytes it actually stored (issue #146). Rows that disagree about the size of a
+// key are read at their largest, the reading that cannot let a quota overrun.
 func (r *assetRepo) SumSizeByRepo(ctx context.Context, repoName string) (int64, error) {
 	row := r.db.QueryRow(ctx, `
-		SELECT COALESCE(SUM(a.size_bytes), 0)
-		FROM assets a
-		JOIN repositories rep ON rep.id = a.repository_id
-		WHERE rep.name = $1`, repoName)
+		SELECT COALESCE(SUM(k.size_bytes), 0) FROM (
+			SELECT DISTINCT ON (a.blob_key) a.size_bytes
+			FROM assets a
+			JOIN repositories rep ON rep.id = a.repository_id
+			WHERE rep.name = $1
+			ORDER BY a.blob_key, a.size_bytes DESC
+		) k`, repoName)
 	var n int64
 	if err := row.Scan(&n); err != nil {
 		return 0, err

--- a/internal/repository/postgres/asset_repo_crud_integration_test.go
+++ b/internal/repository/postgres/asset_repo_crud_integration_test.go
@@ -667,6 +667,46 @@ func TestAssetRepo_SumSizeByRepo_ReturnsCorrectSum(t *testing.T) {
 	}
 }
 
+// A repository holds one copy of an object however many assets name it — an OCI
+// manifest's tag and its digest alias, a blob mounted from another image — and
+// the repository quota is measured off this sum (issue #146).
+func TestAssetRepo_SumSizeByRepo_SharedBlobKeyCountedOnce(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "sumshared")
+	repo := NewAssetRepo(pool)
+
+	const shared = "bk_sum_shared"
+	tag := makeAsset(p, "/manifests/app/1.0")
+	tag.BlobKey = shared
+	tag.SizeBytes = 500
+	if err := repo.Create(ctx, tag); err != nil {
+		t.Fatalf("Create tag: %v", err)
+	}
+	alias := makeAsset(p, "/manifests/app/sha256:abc")
+	alias.BlobKey = shared
+	alias.SizeBytes = 500
+	if err := repo.Create(ctx, alias); err != nil {
+		t.Fatalf("Create alias: %v", err)
+	}
+	other := makeAsset(p, "/blobs/app/layer")
+	other.BlobKey = "bk_sum_other"
+	other.SizeBytes = 70
+	if err := repo.Create(ctx, other); err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+
+	total, err := repo.SumSizeByRepo(ctx, p.RepoName)
+	if err != nil {
+		t.Fatalf("SumSizeByRepo: %v", err)
+	}
+	if total != 570 {
+		t.Errorf("SumSizeByRepo: got %d want 570 (one object counted once, plus the layer)", total)
+	}
+}
+
 func TestAssetRepo_SumSizeByRepo_EmptyReturnsZero(t *testing.T) {
 	pool := pgtest.Pool(t)
 	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")

--- a/internal/repository/postgres/blobstore_repo.go
+++ b/internal/repository/postgres/blobstore_repo.go
@@ -96,6 +96,41 @@ func (r *blobStoreRepo) UpdateUsedBytes(ctx context.Context, name string, delta 
 	return err
 }
 
+// recomputeUsedBytesSQL restates every store's used_bytes as the bytes it
+// holds: one size per distinct blob key, since several assets routinely name
+// one stored object (an OCI manifest's tag and its digest alias, a
+// cross-repository mount). Rows that disagree about the size of a key — an
+// alias left behind by an in-place overwrite — are read at their largest, which
+// is the reading that cannot let a store overfill.
+//
+// Kept in step with migration 024, which runs the same statement once to repair
+// deployments whose counters were inflated by the old per-asset increment.
+const recomputeUsedBytesSQL = `
+	UPDATE blob_stores bs
+	SET used_bytes = COALESCE((
+		    SELECT SUM(k.size_bytes) FROM (
+		        SELECT DISTINCT ON (a.blob_key) a.size_bytes
+		        FROM assets a
+		        WHERE COALESCE(a.blob_store_id,
+		                       (SELECT d.id FROM blob_stores d WHERE d.name = 'default')) = bs.id
+		          AND a.blob_key IS NOT NULL AND TRIM(a.blob_key) <> ''
+		        ORDER BY a.blob_key, a.size_bytes DESC
+		    ) k
+		), 0),
+	    updated_at = NOW()`
+
+// RecomputeUsedBytes restates every blob store's used_bytes from the assets that
+// reference it. It repairs counters that drifted — the per-asset inflation this
+// release fixes, a store whose blobs were removed out of band, a restored
+// backup. One statement, so it never loses a concurrent increment the way a
+// read-modify-write would; an upload that commits its asset row while the
+// statement is in flight can still land on either side of the new figure, which
+// is why the repair is repeatable rather than a one-shot.
+func (r *blobStoreRepo) RecomputeUsedBytes(ctx context.Context) error {
+	_, err := r.db.Exec(ctx, recomputeUsedBytesSQL)
+	return err
+}
+
 func scanBlobStore(row scanner) (*domain.BlobStore, error) {
 	var bs domain.BlobStore
 	var cfgRaw []byte

--- a/internal/repository/postgres/blobstore_usage_integration_test.go
+++ b/internal/repository/postgres/blobstore_usage_integration_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
+)
+
+// usedBytesOf reads a store's counter straight back from the row.
+func usedBytesOf(t *testing.T, ctx context.Context, repo *blobStoreRepo, name string) int64 {
+	t.Helper()
+	bs, err := repo.Get(ctx, name)
+	if err != nil {
+		t.Fatalf("Get %q: %v", name, err)
+	}
+	return bs.UsedBytes
+}
+
+// Existing deployments carry counters inflated by the per-asset increment: an
+// OCI manifest push registered two assets on one object and added its size
+// twice. The repair has to count what is stored — one size per blob key —
+// not what the asset rows add up to (issue #146).
+func TestBlobStoreRepo_RecomputeUsedBytes_SharedBlobKeyCountedOnce(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "recompute_shared")
+	assets := NewAssetRepo(pool)
+	repo := NewBlobStoreRepo(pool)
+
+	const shared = "blobkey_shared_manifest"
+	tag := makeAsset(p, "/manifests/app/1.0")
+	tag.BlobKey = shared
+	tag.SizeBytes = 500
+	if err := assets.Create(ctx, tag); err != nil {
+		t.Fatalf("Create tag asset: %v", err)
+	}
+	alias := makeAsset(p, "/manifests/app/sha256:abc")
+	alias.BlobKey = shared
+	alias.SizeBytes = 500
+	if err := assets.Create(ctx, alias); err != nil {
+		t.Fatalf("Create alias asset: %v", err)
+	}
+
+	storeName := "asset_bs_recompute_shared"
+	// What the old code left behind: one size per asset.
+	if err := repo.UpdateUsedBytes(ctx, storeName, 1000); err != nil {
+		t.Fatalf("UpdateUsedBytes: %v", err)
+	}
+
+	if err := repo.RecomputeUsedBytes(ctx); err != nil {
+		t.Fatalf("RecomputeUsedBytes: %v", err)
+	}
+	if got := usedBytesOf(t, ctx, repo, storeName); got != 500 {
+		t.Errorf("used_bytes after recompute: got %d, want 500 (one object, one size)", got)
+	}
+}
+
+// Each store is repaired from its own assets: bytes in one store never count
+// against another.
+func TestBlobStoreRepo_RecomputeUsedBytes_AttributesPerStore(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	a := makeAssetParent(t, ctx, "recompute_a")
+	b := makeAssetParent(t, ctx, "recompute_b")
+	assets := NewAssetRepo(pool)
+	repo := NewBlobStoreRepo(pool)
+
+	first := makeAsset(a, "/a/one.bin")
+	first.SizeBytes = 300
+	if err := assets.Create(ctx, first); err != nil {
+		t.Fatalf("Create a: %v", err)
+	}
+	second := makeAsset(b, "/b/one.bin")
+	second.SizeBytes = 70
+	third := makeAsset(b, "/b/two.bin")
+	third.SizeBytes = 30
+	for _, as := range []*domain.Asset{second, third} {
+		if err := assets.Create(ctx, as); err != nil {
+			t.Fatalf("Create b: %v", err)
+		}
+	}
+
+	if err := repo.UpdateUsedBytes(ctx, "asset_bs_recompute_a", 999999); err != nil {
+		t.Fatalf("UpdateUsedBytes: %v", err)
+	}
+
+	if err := repo.RecomputeUsedBytes(ctx); err != nil {
+		t.Fatalf("RecomputeUsedBytes: %v", err)
+	}
+	if got := usedBytesOf(t, ctx, repo, "asset_bs_recompute_a"); got != 300 {
+		t.Errorf("store a: got %d, want 300", got)
+	}
+	if got := usedBytesOf(t, ctx, repo, "asset_bs_recompute_b"); got != 100 {
+		t.Errorf("store b: got %d, want 100", got)
+	}
+}
+
+// A store nothing points at holds nothing, however large its counter grew.
+func TestBlobStoreRepo_RecomputeUsedBytes_StoreWithoutAssetsGoesToZero(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	repo := NewBlobStoreRepo(pool)
+	bs := makeLocalBS("recompute_empty_bs")
+	insertBS(t, ctx, repo, bs)
+	if err := repo.UpdateUsedBytes(ctx, bs.Name, 4096); err != nil {
+		t.Fatalf("UpdateUsedBytes: %v", err)
+	}
+
+	if err := repo.RecomputeUsedBytes(ctx); err != nil {
+		t.Fatalf("RecomputeUsedBytes: %v", err)
+	}
+	if got := usedBytesOf(t, ctx, repo, bs.Name); got != 0 {
+		t.Errorf("used_bytes: got %d, want 0", got)
+	}
+}
+
+// assets.blob_store_id is NOT NULL today, and every write path resolves a store
+// before inserting. The Go side nevertheless reads an unset store as "default"
+// (DecrementBlobStoreUsage does), so the repair follows the same rule rather
+// than dropping those bytes on the floor if the column is ever relaxed.
+func TestBlobStoreRepo_RecomputeUsedBytes_UnsetStoreCountsAgainstDefault(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "recompute_null")
+	assets := NewAssetRepo(pool)
+	repo := NewBlobStoreRepo(pool)
+
+	def := makeLocalBS("default")
+	insertBS(t, ctx, repo, def)
+
+	if _, err := pool.Exec(ctx, `ALTER TABLE assets ALTER COLUMN blob_store_id DROP NOT NULL`); err != nil {
+		t.Fatalf("relax blob_store_id: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(),
+			`DELETE FROM assets WHERE blob_store_id IS NULL`)
+		if _, err := pool.Exec(context.Background(),
+			`ALTER TABLE assets ALTER COLUMN blob_store_id SET NOT NULL`); err != nil {
+			t.Fatalf("restore blob_store_id NOT NULL: %v", err)
+		}
+	})
+
+	orphanRow := makeAsset(p, "/no-store/file.bin")
+	orphanRow.SizeBytes = 42
+	if err := assets.Create(ctx, orphanRow); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE assets SET blob_store_id = NULL WHERE id = $1`, orphanRow.ID); err != nil {
+		t.Fatalf("null out blob_store_id: %v", err)
+	}
+
+	if err := repo.RecomputeUsedBytes(ctx); err != nil {
+		t.Fatalf("RecomputeUsedBytes: %v", err)
+	}
+	if got := usedBytesOf(t, ctx, repo, "default"); got != 42 {
+		t.Errorf("default store: got %d, want 42", got)
+	}
+}

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -278,14 +278,33 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 				continue
 			}
 			asset := a
-			if err := s.storeForAsset(ctx, &asset).Delete(ctx, a.BlobKey); err != nil {
-				s.log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
+			// One object can carry several assets — an OCI manifest's tag and its
+			// digest alias, a mounted layer — and expiring one of them says
+			// nothing about the others. Deleting the bytes under a surviving
+			// asset would leave it advertising content that is gone (#144); an
+			// unreadable count keeps them, since an orphan is reclaimed by the
+			// blob GC while bytes deleted under a live asset are lost.
+			bytesFreed := false
+			others, cerr := s.assets.CountByBlobKey(ctx, a.BlobKey, a.ID)
+			if cerr != nil {
+				s.log.Warn("cleanup: blob reference count failed, keeping blob",
+					"key", a.BlobKey, "err", cerr)
+			} else if others == 0 {
+				if err := s.storeForAsset(ctx, &asset).Delete(ctx, a.BlobKey); err != nil {
+					s.log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
+				} else {
+					bytesFreed = true
+				}
 			}
 			if err := s.assets.Delete(ctx, a.ID); err != nil {
 				s.log.Warn("cleanup: asset delete failed", "id", a.ID, "err", err)
 				continue
 			}
-			_ = base.DecrementBlobStoreUsage(ctx, s.blobs, &asset)
+			// used_bytes is how full the store is, so it only moves when bytes
+			// actually left it (#146).
+			if bytesFreed {
+				_ = base.DecrementBlobStoreUsage(ctx, s.blobs, &asset)
+			}
 			freed += a.SizeBytes
 			deleted++
 		}

--- a/internal/service/cleanup_service_test.go
+++ b/internal/service/cleanup_service_test.go
@@ -507,3 +507,74 @@ func TestRunPolicy_RecordsRunStats_NotViaUpdate(t *testing.T) {
 	assert.Equal(t, int64(7), policies.RunRecords[0].Freed)
 	assert.Empty(t, policies.Updates, "run stats must not go through the config Update path")
 }
+
+// ── Shared blobs ──────────────────────────────────────────────
+
+// One object can carry several assets: an OCI manifest's tag and its digest
+// alias, a cross-repository mount. Retention that expires one of them must not
+// delete the bytes the other still reads (#144) — and must not give their size
+// back to the store while they are still on the disk (#146).
+func TestRunPolicy_SharedBlob_KeepsBytesAndUsageForTheSurvivingAsset(t *testing.T) {
+	ctx := context.Background()
+	assets := testutil.NewAssetRepo()
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: "r1", Repository: "r",
+		Path: "/manifests/app/sha256:abc", BlobKey: "shared", SizeBytes: 100,
+	}))
+	assets.Stale = []domain.Asset{
+		{ID: "expiring", BlobKey: "shared", SizeBytes: 100, Path: "/manifests/app/1.0"},
+	}
+
+	blobs := testutil.NewBlobStore()
+	require.NoError(t, blobs.Put(ctx, "shared", testutil.MakeReader("payload"), 7))
+	blobRepo := testutil.NewBlobStoreRepo()
+	require.NoError(t, blobRepo.UpdateUsedBytes(ctx, "default", 100))
+
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "p-shared", Name: "p-shared", Enabled: true, Format: "*",
+		Criteria: map[string]any{"artifactAgeDays": float64(7)},
+	})
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "r", ID: "r1", Format: domain.FormatRaw, CleanupPolicyIDs: []string{"p-shared"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	require.NoError(t, svc.RunAll(ctx))
+
+	assert.True(t, blobs.Has("shared"), "the surviving asset still reads these bytes")
+	assert.Empty(t, blobs.Deleted)
+
+	got, err := blobRepo.Get(ctx, "default")
+	require.NoError(t, err)
+	assert.Equal(t, int64(100), got.UsedBytes, "nothing left the store, so nothing comes off the counter")
+}
+
+// The last asset on an object takes the object with it, and its size.
+func TestRunPolicy_LastAssetOnBlob_FreesBytesAndUsage(t *testing.T) {
+	ctx := context.Background()
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{
+		{ID: "only", BlobKey: "lonely", SizeBytes: 100, Path: "/pkg.tgz"},
+	}
+
+	blobs := testutil.NewBlobStore()
+	require.NoError(t, blobs.Put(ctx, "lonely", testutil.MakeReader("payload"), 7))
+	blobRepo := testutil.NewBlobStoreRepo()
+	require.NoError(t, blobRepo.UpdateUsedBytes(ctx, "default", 100))
+
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "p-lonely", Name: "p-lonely", Enabled: true, Format: "*",
+		Criteria: map[string]any{"artifactAgeDays": float64(7)},
+	})
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "r", ID: "r1", Format: domain.FormatRaw, CleanupPolicyIDs: []string{"p-lonely"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	require.NoError(t, svc.RunAll(ctx))
+
+	assert.Contains(t, blobs.Deleted, "lonely")
+	got, err := blobRepo.Get(ctx, "default")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), got.UsedBytes)
+}

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -152,6 +152,7 @@ func (s *BlobGCService) compact(ctx context.Context, name string, store storage.
 	}
 	result.ScannedBlobs = len(entries)
 
+	var removed int64
 	for _, e := range entries {
 		if _, ok := referenced[e.Key]; ok {
 			continue // still referenced
@@ -166,7 +167,19 @@ func (s *BlobGCService) compact(ctx context.Context, name string, store storage.
 		if !opts.DryRun {
 			if derr := store.Delete(ctx, e.Key); derr != nil {
 				result.Errors = append(result.Errors, fmt.Sprintf("delete %s: %v", e.Key, derr))
+				continue
 			}
+			removed += e.Size
+		}
+	}
+	// used_bytes is how full the store is, and it just got emptier. A collected
+	// store that keeps its old number reports space it does not use and starts
+	// refusing writes that fit (issue #146). Only what was really deleted is
+	// given back: a blob whose delete failed is still on the disk.
+	if removed > 0 {
+		if err := s.Stores.UpdateUsedBytes(ctx, name, -removed); err != nil {
+			s.log().Error("blob gc: usage decrement failed", "store", name, "bytes", removed, "err", err)
+			result.Errors = append(result.Errors, fmt.Sprintf("update used_bytes: %v", err))
 		}
 	}
 	return result

--- a/internal/service/gc_service_test.go
+++ b/internal/service/gc_service_test.go
@@ -145,6 +145,81 @@ func TestGC_StartCronScheduler_ValidScheduleStopsOnCancel(t *testing.T) {
 	svc.StartCronScheduler(ctx, "0 0 * * *", time.Hour)
 }
 
+// ── Usage accounting ──────────────────────────────────────────
+
+// gcWithStores builds the service over a blob store repo the test can read back,
+// so the effect of a collection on used_bytes is visible.
+func gcWithStores(assets *testutil.AssetRepo, bs *testutil.BlobStore,
+	stores *testutil.BlobStoreRepo) *service.BlobGCService {
+	return &service.BlobGCService{
+		Assets:   assets,
+		Stores:   stores,
+		Resolver: testutil.NewFakeResolver(bs),
+	}
+}
+
+// Collecting an orphan takes bytes off the disk, so it has to take them off the
+// counter that says how full the store is — otherwise a garbage-collected store
+// stays permanently overstated and walks into a quota rejection (#146).
+func TestGC_OrphanCollected_DecrementsTheStoreUsage(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	bs := testutil.NewBlobStore()
+	ctx := context.Background()
+	require.NoError(t, bs.Put(ctx, "orphan-usage", bytes.NewReader([]byte("garbage")), 7))
+
+	stores := testutil.NewBlobStoreRepo()
+	require.NoError(t, stores.UpdateUsedBytes(ctx, "default", 30)) // 7 orphaned, 23 still referenced
+
+	result, err := gcWithStores(assets, bs, stores).CompactStore(ctx, "default", service.GCOptions{})
+	require.NoError(t, err)
+	require.Equal(t, int64(7), result.FreedBytes)
+
+	got, err := stores.Get(ctx, "default")
+	require.NoError(t, err)
+	assert.Equal(t, int64(23), got.UsedBytes, "the freed bytes come off the store")
+}
+
+// A dry run reports what it would free and frees nothing, so the counter must
+// not move either.
+func TestGC_DryRun_LeavesTheStoreUsageAlone(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	bs := testutil.NewBlobStore()
+	ctx := context.Background()
+	require.NoError(t, bs.Put(ctx, "orphan-dry", bytes.NewReader([]byte("dry")), 3))
+
+	stores := testutil.NewBlobStoreRepo()
+	require.NoError(t, stores.UpdateUsedBytes(ctx, "default", 10))
+
+	_, err := gcWithStores(assets, bs, stores).CompactStore(ctx, "default", service.GCOptions{DryRun: true})
+	require.NoError(t, err)
+
+	got, err := stores.Get(ctx, "default")
+	require.NoError(t, err)
+	assert.Equal(t, int64(10), got.UsedBytes)
+}
+
+// A blob that is still referenced is neither deleted nor discounted.
+func TestGC_ReferencedBlob_LeavesTheStoreUsageAlone(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	bs := testutil.NewBlobStore()
+	ctx := context.Background()
+	require.NoError(t, bs.Put(ctx, "kept", bytes.NewReader([]byte("data")), 4))
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
+		Path: "/file.txt", BlobKey: "kept", BlobStoreID: "bs1", SizeBytes: 4,
+	}))
+
+	stores := testutil.NewBlobStoreRepo()
+	require.NoError(t, stores.UpdateUsedBytes(ctx, "default", 4))
+
+	_, err := gcWithStores(assets, bs, stores).CompactStore(ctx, "default", service.GCOptions{})
+	require.NoError(t, err)
+
+	got, err := stores.Get(ctx, "default")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), got.UsedBytes)
+}
+
 func TestGC_CompactAllSkipsWhenLockHeld(t *testing.T) {
 	assets := testutil.NewAssetRepo()
 	bs := testutil.NewBlobStore()

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -183,6 +183,10 @@ func (r *RepoRepo) DetachCleanupPolicyID(_ context.Context, policyID string) err
 type BlobStoreRepo struct {
 	mu     sync.Mutex
 	stores map[string]*domain.BlobStore
+	// assets backs RecomputeUsedBytes, which in postgres reads the assets table
+	// this repo shares a database with. Without it a recompute finds no assets
+	// and zeroes every store, exactly as the SQL would against an empty table.
+	assets *AssetRepo
 }
 
 func NewBlobStoreRepo(stores ...*domain.BlobStore) *BlobStoreRepo {
@@ -254,6 +258,66 @@ func (b *BlobStoreRepo) UpdateUsedBytes(_ context.Context, name string, delta in
 	defer b.mu.Unlock()
 	if s, ok := b.stores[name]; ok {
 		s.UsedBytes += delta
+	}
+	return nil
+}
+
+// WithAssets wires the asset repo a recompute reads, mirroring the single
+// database the postgres implementations share. Returns the repo for chaining.
+func (b *BlobStoreRepo) WithAssets(a *AssetRepo) *BlobStoreRepo {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.assets = a
+	return b
+}
+
+// RecomputeUsedBytes mirrors the SQL: every store's used_bytes becomes the sum
+// of its assets' DISTINCT blob keys, largest size per key, with an unset
+// blob_store_id read as the store named "default". A stub answer would leave the
+// repair — the only thing that fixes a counter inflated by the old per-asset
+// increment — untestable.
+func (b *BlobStoreRepo) RecomputeUsedBytes(_ context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var assets []domain.Asset
+	if b.assets != nil {
+		assets = b.assets.Snapshot()
+	}
+	defaultID := ""
+	if def, ok := b.stores["default"]; ok {
+		defaultID = def.ID
+	}
+
+	// storeID → blobKey → largest size seen for that key.
+	perStore := make(map[string]map[string]int64)
+	for _, a := range assets {
+		if strings.TrimSpace(a.BlobKey) == "" {
+			continue
+		}
+		storeID := a.BlobStoreID
+		if storeID == "" {
+			storeID = defaultID
+		}
+		if storeID == "" {
+			continue
+		}
+		keys, ok := perStore[storeID]
+		if !ok {
+			keys = make(map[string]int64)
+			perStore[storeID] = keys
+		}
+		if a.SizeBytes > keys[a.BlobKey] {
+			keys[a.BlobKey] = a.SizeBytes
+		}
+	}
+
+	for _, s := range b.stores {
+		var total int64
+		for _, size := range perStore[s.ID] {
+			total += size
+		}
+		s.UsedBytes = total
 	}
 	return nil
 }
@@ -539,6 +603,18 @@ func NewAssetRepo() *AssetRepo {
 		assets: make(map[string]*domain.Asset),
 		byID:   make(map[string]*domain.Asset),
 	}
+}
+
+// Snapshot returns a copy of every stored asset row — the whole assets table,
+// as a recompute over it would see.
+func (a *AssetRepo) Snapshot() []domain.Asset {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out := make([]domain.Asset, 0, len(a.byID))
+	for _, v := range a.byID {
+		out = append(out, *v)
+	}
+	return out
 }
 
 func (a *AssetRepo) List(_ context.Context, _ string, _, _ int) (*domain.Page[domain.Asset], error) {

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -830,11 +830,20 @@ func (a *AssetRepo) SumSizeByRepo(_ context.Context, repoName string) (int64, er
 	if a.Err != nil {
 		return 0, a.Err
 	}
-	var total int64
+	// Mirrors the SQL: one size per distinct blob key, largest wins. Several
+	// assets can name one stored object, and the repository holds it once.
+	perKey := make(map[string]int64)
 	for _, v := range a.byID {
-		if v.Repository == repoName {
-			total += v.SizeBytes
+		if v.Repository != repoName {
+			continue
 		}
+		if v.SizeBytes > perKey[v.BlobKey] {
+			perKey[v.BlobKey] = v.SizeBytes
+		}
+	}
+	var total int64
+	for _, size := range perKey {
+		total += size
 	}
 	return total, nil
 }


### PR DESCRIPTION
Closes #146. Closes #145.

## Quotas counted asset rows, not stored bytes (#146)

`blob_stores.used_bytes` is what `checkQuota` reads to decide whether a write fits, but `RegisterStoredBlob` incremented it once **per registered asset**. Several paths register more than one asset against the same blob: an OCI manifest push registers the tag and the `sha256:` digest alias, and a cross-repository mount registers a second asset on a blob that is already there. A 568-byte manifest moved the counter by 1136.

The counter now moves when the **blob** does: on first store, and back down only when the physical object is actually removed — which `DeleteArtifact` already knows, since #144 made the physical delete conditional on `CountByBlobKey`. Blob GC decrements what it frees, which it never did.

**Four more defects surfaced while establishing the facts, all fixed here:**

- **The repository quota had the identical bug.** `checkQuota` reads `SUM(size_bytes)` over asset rows, so a repository holding 19 bytes reported 38 and refused a write that fit.
- **Retention deleted shared blobs unconditionally** — the #144 data-loss bug, still live in `cleanup_service.go`. It destroyed bytes a surviving asset still read, and refunded their size on the way out.
- **Proxy cache refreshes double-counted.** Re-caching a path added a second full increment for the same key.
- **The OCI digest alias re-resolved the blob store.** On a *group* blob store, round-robin could attribute the alias to a member holding neither the object nor its size — pull-by-digest would 404. It is now pinned to the manifest's own store, which is also what makes "one blob key, one store" true by construction.

**Existing installs are already inflated**, and the symptom — a spurious "storage quota exceeded" — gives an operator no reason to suspect the counter. So migration `024` recomputes every store on upgrade, and the same statement is exposed as `POST /api/v1/blobstores/recompute-usage` for the drift that a one-shot cannot cover: the increment decision is not atomic, and restored backups and out-of-band deletions drift too. The recompute sums **distinct** blob keys per store, taking the largest size when rows for one key disagree — the only reading that cannot let a store overfill.

Known and not fixed: two clients aliasing or mounting the same digest at the same instant can both decide the blob already exists, which *under*counts. That is the opposite direction from the bug being fixed, it is narrow, and the repeatable recompute is the answer until a per-store blob table with a unique constraint makes it impossible.

## conda served index documents nobody could use (#145)

The proxy intercepted only `repodata.json`. `current_repodata.json` — what recent conda clients prefer — and `repodata_from_packages.json` fell through to the immutable-binary branch, so their package URLs were never rewritten (clients went straight to the upstream, and the caching the repository exists for did not happen) and they were cached forever despite being indexes. A changed channel was invisible: two GETs across an upstream change returned the same stale document from one upstream request.

All three index documents now go through the same live-read-and-rewrite path. Note the brief I gave was wrong on one point and the implementer said so: `repodata.json` is not cached at all — it is read live per request — so "the same treatment" meant live, not a TTL.

`repodata.json.zst`, its `current_` sibling and `repodata.jlap` are refused with 404, the way `repodata.json.bz2` already is. Serving `.zst` would mean adding a compression dependency and doing decompress → decode → rewrite → encode → recompress per request on a document that is hundreds of megabytes decompressed on conda-forge. Every client that asks for it falls back — conda records `has_zst: false`, rattler and libmamba cascade zst → bz2 → plain — and `.bz2` has answered 404 here since the handler was written. jlap is refused for a second reason: serving upstream patches against a document we have rewritten produces hash mismatches.

## Verification

`go test ./internal/...` 1851 passing (only the sandbox-networking webhook test fails locally; it passes in CI); integration suite 410 passing, including the migration applied and rolled back against a real database; `golangci-lint run --new-from-rev=origin/main` zero issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FHoCv3o3J7U3Hb4LMFR1rW