### PR TITLE
fix(security): honor auth.anonymous_enabled and stop trusting X-Forwarded-For

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -66,24 +66,8 @@ func cmdServe() *cobra.Command {
 				log.Info("outbound proxy configured for upstream fetches",
 					"http", p.HTTPProxy != "", "https", p.HTTPSProxy != "", "socks5", p.SOCKS5Proxy != "")
 			}
-			if cfg.Auth.AnonymousEnabled {
-				log.Warn("auth.anonymous_enabled is true — unauthenticated artifact access is allowed; set false to require authentication")
-			}
-
-			// Fail closed on shipped insecure defaults unless explicitly allowed
-			// (local dev / quick-start sets auth.allow_insecure_defaults=true).
-			insecureJWT := config.IsDevDefaultJWTSecret(cfg.Auth.JWTSecret)
-			insecureAdmin := cfg.Bootstrap.AdminPassword == "admin123"
-			if insecureJWT || insecureAdmin {
-				if !cfg.Auth.AllowInsecureDefaults {
-					return fmt.Errorf("refusing to start with shipped default secrets (jwt_default=%v, admin123=%v); set unique secrets or auth.allow_insecure_defaults=true for local dev", insecureJWT, insecureAdmin)
-				}
-				if insecureJWT {
-					log.Warn("auth.jwt_secret is the shipped development default — set a unique secret (NEXSPENCE_AUTH_JWT_SECRET) before production use")
-				}
-				if insecureAdmin {
-					log.Warn("bootstrap.admin_password is the shipped development default (admin123) — set a unique password (NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD) before production use")
-				}
+			if err := checkStartupSecurity(cfg, log); err != nil {
+				return err
 			}
 
 			// Auto-migrate on every startup so the schema is always up-to-date.

--- a/cmd/server/startup_security.go
+++ b/cmd/server/startup_security.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nexspence-oss/nexspence/internal/api"
+	"github.com/nexspence-oss/nexspence/internal/config"
+	"github.com/nexspence-oss/nexspence/internal/logger"
+)
+
+// checkStartupSecurity refuses to boot on a configuration that would leave a
+// security control silently ineffective, and warns about the ones that are
+// merely permissive. Returning an error here is deliberate: a server that
+// starts with a broken control is worse than one that does not start.
+func checkStartupSecurity(cfg *config.Config, log logger.Logger) error {
+	if cfg.Auth.AnonymousEnabled {
+		log.Warn("auth.anonymous_enabled is true — repositories with allow_anonymous serve unauthenticated reads; set false to require authentication everywhere")
+	}
+
+	// A mistyped entry would leave the real proxy untrusted and every ClientIP
+	// wrong — in the audit log and in the rate limiter — so fail loudly.
+	if err := api.ValidateTrustedProxies(cfg.HTTP.TrustedProxies); err != nil {
+		return fmt.Errorf("invalid http.trusted_proxies: %w", err)
+	}
+	if len(cfg.HTTP.TrustedProxies) == 0 {
+		log.Info("http.trusted_proxies is empty — X-Forwarded-For is ignored; set it when running behind a reverse proxy")
+	}
+
+	// Fail closed on shipped insecure defaults unless explicitly allowed
+	// (local dev / quick-start sets auth.allow_insecure_defaults=true).
+	insecureJWT := config.IsDevDefaultJWTSecret(cfg.Auth.JWTSecret)
+	insecureAdmin := cfg.Bootstrap.AdminPassword == "admin123"
+	if insecureJWT || insecureAdmin {
+		if !cfg.Auth.AllowInsecureDefaults {
+			return fmt.Errorf("refusing to start with shipped default secrets (jwt_default=%v, admin123=%v); set unique secrets or auth.allow_insecure_defaults=true for local dev", insecureJWT, insecureAdmin)
+		}
+		if insecureJWT {
+			log.Warn("auth.jwt_secret is the shipped development default — set a unique secret (NEXSPENCE_AUTH_JWT_SECRET) before production use")
+		}
+		if insecureAdmin {
+			log.Warn("bootstrap.admin_password is the shipped development default (admin123) — set a unique password (NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD) before production use")
+		}
+	}
+	return nil
+}

--- a/cmd/server/startup_security_test.go
+++ b/cmd/server/startup_security_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nexspence-oss/nexspence/internal/config"
+)
+
+func secureCfg() *config.Config {
+	cfg := &config.Config{}
+	cfg.Auth.JWTSecret = "a-unique-production-secret-at-least-32b"
+	cfg.Bootstrap.AdminPassword = "a-unique-admin-password"
+	return cfg
+}
+
+func TestCheckStartupSecurity_SecureConfig_Passes(t *testing.T) {
+	require.NoError(t, checkStartupSecurity(secureCfg(), zap.NewNop().Sugar()))
+}
+
+func TestCheckStartupSecurity_InvalidTrustedProxies_Refuses(t *testing.T) {
+	cfg := secureCfg()
+	cfg.HTTP.TrustedProxies = []string{"10.0.0.0/8", "not-an-ip"}
+
+	err := checkStartupSecurity(cfg, zap.NewNop().Sugar())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trusted_proxies")
+}
+
+func TestCheckStartupSecurity_ValidTrustedProxies_Passes(t *testing.T) {
+	cfg := secureCfg()
+	cfg.HTTP.TrustedProxies = []string{"10.0.0.0/8", "*"}
+
+	require.NoError(t, checkStartupSecurity(cfg, zap.NewNop().Sugar()))
+}
+
+func TestCheckStartupSecurity_ShippedDefaults_Refuse(t *testing.T) {
+	cfg := secureCfg()
+	cfg.Auth.JWTSecret = config.DevDefaultJWTSecret
+
+	err := checkStartupSecurity(cfg, zap.NewNop().Sugar())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default secrets")
+}
+
+func TestCheckStartupSecurity_ShippedDefaults_AllowedWhenOptedIn(t *testing.T) {
+	cfg := secureCfg()
+	cfg.Auth.JWTSecret = config.DevDefaultJWTSecret
+	cfg.Bootstrap.AdminPassword = "admin123"
+	cfg.Auth.AllowInsecureDefaults = true
+
+	require.NoError(t, checkStartupSecurity(cfg, zap.NewNop().Sugar()))
+}

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -5,6 +5,12 @@ http:
   max_body_mb: 1024            # max request body size (MB); requests above this get 413 (artifact/upload routes exempt)
   cors_origins: []            # allowed CORS origins, e.g. ["https://ui.example.com"]; empty = wildcard (dev only)
   base_url: "http://localhost:8081"
+  # Peers allowed to set X-Forwarded-For, as IPs or CIDRs. Empty (the default)
+  # trusts nobody, so the audit log and the rate limiter use the real peer
+  # address. Set this to your reverse proxy when you run behind one, otherwise
+  # every request looks like it comes from the proxy. "*" trusts every hop —
+  # only safe when the server cannot be reached except through that proxy.
+  trusted_proxies: []         # e.g. ["10.0.0.0/8"] or ["*"]
   tls:
     enabled: false
     cert_file: ""
@@ -39,6 +45,8 @@ auth:
   # Leave false in production — the server refuses to start with shipped defaults
   # unless this is true (intended for local dev / quick-start only).
   allow_insecure_defaults: false
+  # Instance-wide switch above the per-repository allow_anonymous opt-in.
+  # false refuses every unauthenticated request, whatever the repositories say.
   anonymous_enabled: true
   password_min_length: 8
   bcrypt_cost: 12

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -137,6 +137,7 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 |-----|---------|-------------|
 | `http.addr` | `:8081` | Listen address |
 | `http.base_url` | `http://localhost:8081` | Public URL used in download links |
+| `http.trusted_proxies` | `[]` | Peers (IPs/CIDRs) whose `X-Forwarded-For` is believed. Empty trusts nobody, so the audit log and rate limiter see the real peer. Set it to your reverse proxy when you run behind one; `["*"]` trusts every hop. |
 | `database.dsn` | `postgres://nexspence:nexspence@localhost:5437/nexspence` | PostgreSQL connection string |
 | `storage.default_type` | `local` | `local` or `s3` |
 | `storage.local.base_path` | `./data/blobs` | Filesystem path for local blob store |
@@ -146,7 +147,7 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `auth.jwt_secret` | — | JWT signing key. **From source / native install: set this (min 32 chars) before production.** The Docker image and Helm chart auto-generate a unique secret when it is unset. |
 | `auth.encryption_key` | — | Optional base64 32-byte key for replication credentials (decouples them from `jwt_secret`; existing rows are re-encrypted automatically at startup). Generate: `openssl rand -base64 32` |
 | `auth.jwt_expiry_hours` | `24` | JWT token lifetime |
-| `auth.anonymous_enabled` | `true` | Allow unauthenticated read on public repos |
+| `auth.anonymous_enabled` | `true` | Instance-wide switch for unauthenticated reads. `false` refuses them everywhere, overriding any repository's `allow_anonymous`. |
 | `auth.token_max_days` | `180` | Maximum lifetime for user API tokens (`nxs_*`) |
 | `bootstrap.admin_password` | `admin123` | Auto-created admin password — **change this** |
 | `cleanup.default_schedule` | `0 2 * * *` | Default cron for cleanup policies |

--- a/docs/security-rbac.md
+++ b/docs/security-rbac.md
@@ -345,6 +345,23 @@ When a request is made for an artifact:
 
 ---
 
+## Anonymous Access
+
+Two switches must agree before an unauthenticated request is served:
+
+| Switch | Scope | Default |
+|---|---|---|
+| `auth.anonymous_enabled` | whole instance | `true` |
+| repository `allow_anonymous` | one repository | `false` |
+
+Setting `auth.anonymous_enabled: false` refuses every unauthenticated read
+regardless of how individual repositories are configured — repository listings,
+browse trees, component and asset listings, artifact downloads, and the Docker
+`/v2/` handshake, which then answers `401` with a `Basic` challenge so `docker
+login` is invoked. Anonymous writes are never allowed by either switch.
+
+---
+
 ## LDAP External Role Mapping
 
 On every LDAP login, Nexspence automatically syncs the user's roles from their LDAP group memberships (REPLACE semantics — existing roles are fully replaced each time).

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -272,6 +272,7 @@ func DockerV2Auth(
 	tokens *service.TokenService,
 	repos repository.RepositoryRepo,
 	rdb *redisclient.Client, // nil = use in-process cache
+	anonymousEnabled bool, // global auth.anonymous_enabled switch
 ) gin.HandlerFunc {
 	const redisKey = "nexspence:docker:anon_allowed"
 	var (
@@ -280,6 +281,12 @@ func DockerV2Auth(
 	)
 
 	anyAnonDocker := func(ctx context.Context) bool {
+		// The instance-wide switch wins over every per-repository opt-in, and
+		// short-circuits before the lookup: with anonymous access off there is
+		// nothing to cache.
+		if !anonymousEnabled {
+			return false
+		}
 		if repos == nil {
 			return false
 		}

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -319,11 +319,38 @@ var _ = stringReader // used in Login tests above
 // ── DockerV2Auth ──────────────────────────────────────────────
 
 func buildDockerV2AuthRouter(svc *service.UserService, repos ...*domain.Repository) *gin.Engine {
+	return buildDockerV2AuthRouterAnon(svc, true, repos...)
+}
+
+func buildDockerV2AuthRouterAnon(svc *service.UserService, anonymousEnabled bool, repos ...*domain.Repository) *gin.Engine {
 	r := gin.New()
-	h := handlers.DockerV2Auth(svc, nil, testutil.NewRepoRepo(repos...), nil)
+	h := handlers.DockerV2Auth(svc, nil, testutil.NewRepoRepo(repos...), nil, anonymousEnabled)
 	r.GET("/v2/", h)
 	r.HEAD("/v2/", h)
 	return r
+}
+
+// With the instance-wide switch off, a public repository must not open the
+// anonymous door — otherwise Docker is told it may pull without credentials and
+// only discovers otherwise on the next request.
+func TestDockerV2Auth_NoAuth_AnonymousDisabledGlobally_Returns401(t *testing.T) {
+	svc := newUserSvc()
+	publicRepo := &domain.Repository{
+		ID:             "r-pub",
+		Name:           "public-docker",
+		Format:         domain.FormatDocker,
+		Type:           domain.TypeProxy,
+		Online:         true,
+		AllowAnonymous: true,
+	}
+	r := buildDockerV2AuthRouterAnon(svc, false, publicRepo)
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Header().Get("WWW-Authenticate"), "Basic")
 }
 
 func TestDockerV2Auth_NoAuth_NoAnonymousRepo_Returns401(t *testing.T) {

--- a/internal/api/handlers/browse_delete_test.go
+++ b/internal/api/handlers/browse_delete_test.go
@@ -67,7 +67,7 @@ func mountBrowseOnSecondaryStore(t *testing.T) (
 
 	defaultStore := testutil.NewBlobStore()
 	hooks := &captureDispatcher{}
-	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar(), true)
 	h := handlers.NewBrowseHandler(formats.Deps{
 		Repos:      repos,
 		Components: comps,

--- a/internal/api/handlers/browse_docker_test.go
+++ b/internal/api/handlers/browse_docker_test.go
@@ -28,7 +28,7 @@ func mountBrowse(t *testing.T) (*gin.Engine, *testutil.RepoRepo, *testutil.Compo
 	assets := testutil.NewAssetRepo()
 	blobs := testutil.NewBlobStoreRepo()
 	store := testutil.NewBlobStore()
-	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar(), true)
 	h := handlers.NewBrowseHandler(formats.Deps{
 		Repos:      repos,
 		Components: comps,

--- a/internal/api/handlers/components_test.go
+++ b/internal/api/handlers/components_test.go
@@ -46,7 +46,7 @@ func mountComponentsRBAC(t *testing.T) (*gin.Engine, *testutil.ComponentRepo, *t
 	comps := testutil.NewComponentRepo()
 	assets := testutil.NewAssetRepo()
 	repos := testutil.NewRepoRepo()
-	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar(), true)
 	h := handlers.NewComponentHandler(comps, assets, repos, "http://localhost").WithRBAC(rbacSvc)
 
 	r := gin.New()
@@ -579,7 +579,7 @@ func TestComponentHandler_SearchAssetsDownload_RBAC_AdminPassthrough_302(t *test
 	comps := testutil.NewComponentRepo()
 	assets := testutil.NewAssetRepo()
 	repos := testutil.NewRepoRepo()
-	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar(), true)
 	h := handlers.NewComponentHandler(comps, assets, repos, "http://localhost").WithRBAC(rbacSvc)
 	r := gin.New()
 	r.Use(func(c *gin.Context) {

--- a/internal/api/handlers/rbac_middleware_test.go
+++ b/internal/api/handlers/rbac_middleware_test.go
@@ -39,7 +39,7 @@ func TestRBACMiddleware_UnauthenticatedPrivateDocker_OCIErrorBody(t *testing.T) 
 		AllowAnonymous: false,
 	}
 	repoRepo := testutil.NewRepoRepo(privateRepo)
-	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
 
 	r := gin.New()
 	v2 := r.Group("/v2", handlers.RBACMiddleware(rbacSvc, repoRepo))
@@ -81,7 +81,7 @@ func TestRBACMiddleware_UnauthenticatedNonDocker_UsesGenericBody(t *testing.T) {
 		AllowAnonymous: false,
 	}
 	repoRepo := testutil.NewRepoRepo(privateRepo)
-	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
 
 	r := gin.New()
 	rg := r.Group("/repository", handlers.RBACMiddleware(rbacSvc, repoRepo))

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -37,7 +37,7 @@ func mountRepos(t *testing.T) (*gin.Engine, *testutil.RepoRepo, *testutil.BlobSt
 	store := testutil.NewBlobStore()
 
 	repoSvc := service.NewRepositoryService(repos, blobs, store, policies)
-	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar(), true)
 	h := handlers.NewRepositoryHandler(repoSvc, rbacSvc)
 
 	r := gin.New()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -196,7 +196,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	// ── Format handlers ───────────────────────────────────────
 	// Built before the format handlers because they take Deps by value: a
 	// handler constructed without the checker would keep a nil copy of it.
-	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, log)
+	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, log, cfg.Auth.AnonymousEnabled)
 	formatDeps := formats.Deps{
 		Repos:        repoRepo,
 		Components:   componentRepo,
@@ -284,6 +284,16 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 
 	// ── Gin engine ────────────────────────────────────────────
 	r := gin.New()
+	// Decide whose X-Forwarded-For we believe before any middleware reads
+	// ClientIP. main validates the same list at startup, so an error here means
+	// the config changed underneath us: keep the fail-closed engine default of
+	// trusting nobody rather than silently trusting everyone.
+	if err := applyTrustedProxies(r, cfg.HTTP.TrustedProxies); err != nil {
+		log.Error("invalid http.trusted_proxies, trusting no proxy", "err", err)
+		if err := applyTrustedProxies(r, nil); err != nil {
+			log.Error("failed to reset trusted proxies", "err", err)
+		}
+	}
 	// Health probes — no auth, no middleware.
 	r.GET("/healthz", handlers.LivenessHandler())
 	r.GET("/readyz", handlers.ReadinessHandler(pool, rdb))
@@ -649,7 +659,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	// `repoRepo` lets DockerV2Auth fall through to 200 when at least one
 	// Docker repository has allow_anonymous=true — restoring anonymous
 	// `docker pull` against public proxies (see Phase 26).
-	dockerV2Root := handlers.DockerV2Auth(userSvc, tokenSvc, repoRepo, rdb)
+	dockerV2Root := handlers.DockerV2Auth(userSvc, tokenSvc, repoRepo, rdb, cfg.Auth.AnonymousEnabled)
 	r.GET("/v2/", dockerV2Root)
 	r.HEAD("/v2/", dockerV2Root)
 

--- a/internal/api/router_docker_test.go
+++ b/internal/api/router_docker_test.go
@@ -39,7 +39,7 @@ func buildDockerRouter(repos ...*domain.Repository) *gin.Engine {
 
 	repoRepo := testutil.NewRepoRepo(repos...)
 	rbacRepo := &allowAllRBACRepo{}
-	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, zap.NewNop().Sugar())
+	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, zap.NewNop().Sugar(), true)
 
 	stub := &stubDockerHandler{}
 	fmtRegistry := map[string]formats.FormatHandler{"docker": stub, "oci": stub}

--- a/internal/api/trusted_proxies.go
+++ b/internal/api/trusted_proxies.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+)
+
+// trustEveryoneCIDRs is what "*" expands to: both address families, wide open.
+var trustEveryoneCIDRs = []string{"0.0.0.0/0", "::/0"}
+
+// ValidateTrustedProxies reports whether http.trusted_proxies is well-formed.
+// The server calls it at startup so a mistyped entry stops the boot instead of
+// quietly leaving a real proxy untrusted.
+func ValidateTrustedProxies(proxies []string) error {
+	return applyTrustedProxies(gin.New(), proxies)
+}
+
+// applyTrustedProxies tells gin which peers may set X-Forwarded-For.
+//
+// gin trusts every proxy unless told otherwise, which means c.ClientIP() would
+// return whatever the caller writes in the header — and that value is what the
+// audit log records and what the rate limiter buckets on. An empty list is the
+// shipped default and trusts nobody, so ClientIP falls back to the real peer
+// address. "*" restores the trust-everything behavior for deployments that
+// cannot enumerate their proxies.
+func applyTrustedProxies(r *gin.Engine, proxies []string) error {
+	for _, p := range proxies {
+		if p == "*" {
+			if err := r.SetTrustedProxies(trustEveryoneCIDRs); err != nil {
+				return fmt.Errorf("trusted proxies: %w", err)
+			}
+			return nil
+		}
+	}
+	if err := r.SetTrustedProxies(proxies); err != nil {
+		return fmt.Errorf("trusted proxies: %w", err)
+	}
+	return nil
+}

--- a/internal/api/trusted_proxies_test.go
+++ b/internal/api/trusted_proxies_test.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// clientIPFor builds an engine with the given trusted-proxy config and reports
+// what c.ClientIP() resolves to for a request carrying a forged
+// X-Forwarded-For. The audit log and the rate limiter both key on that value.
+func clientIPFor(t *testing.T, trusted []string, remoteAddr, xff string) string {
+	t.Helper()
+	r := gin.New()
+	require.NoError(t, applyTrustedProxies(r, trusted))
+
+	var got string
+	r.GET("/ip", func(c *gin.Context) {
+		got = c.ClientIP()
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ip", nil)
+	req.RemoteAddr = remoteAddr
+	req.Header.Set("X-Forwarded-For", xff)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+	return got
+}
+
+func TestTrustedProxies_EmptyConfig_IgnoresForgedXForwardedFor(t *testing.T) {
+	// The shipped default trusts nothing, so a client cannot choose the IP that
+	// lands in the audit log or the rate-limit bucket.
+	got := clientIPFor(t, nil, "203.0.113.7:5555", "1.2.3.4")
+	assert.Equal(t, "203.0.113.7", got)
+}
+
+func TestTrustedProxies_ConfiguredProxy_HonorsXForwardedFor(t *testing.T) {
+	// Behind a real reverse proxy the header is the only way to see the client.
+	got := clientIPFor(t, []string{"203.0.113.7"}, "203.0.113.7:5555", "1.2.3.4")
+	assert.Equal(t, "1.2.3.4", got)
+}
+
+func TestTrustedProxies_CIDR_HonorsXForwardedFor(t *testing.T) {
+	got := clientIPFor(t, []string{"203.0.113.0/24"}, "203.0.113.7:5555", "1.2.3.4")
+	assert.Equal(t, "1.2.3.4", got)
+}
+
+func TestTrustedProxies_UntrustedPeer_IgnoresXForwardedFor(t *testing.T) {
+	// A peer outside the configured range does not get to rewrite its own IP.
+	got := clientIPFor(t, []string{"10.0.0.0/8"}, "203.0.113.7:5555", "1.2.3.4")
+	assert.Equal(t, "203.0.113.7", got)
+}
+
+func TestTrustedProxies_Wildcard_TrustsEveryone(t *testing.T) {
+	// Opt-in escape hatch for deployments that cannot enumerate their proxies.
+	got := clientIPFor(t, []string{"*"}, "203.0.113.7:5555", "1.2.3.4")
+	assert.Equal(t, "1.2.3.4", got)
+}
+
+func TestTrustedProxies_InvalidEntry_ReturnsError(t *testing.T) {
+	err := applyTrustedProxies(gin.New(), []string{"not-an-ip"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not-an-ip")
+}
+
+// The server validates the list at startup so a typo fails loudly instead of
+// silently leaving the proxy untrusted.
+func TestValidateTrustedProxies(t *testing.T) {
+	require.NoError(t, ValidateTrustedProxies(nil))
+	require.NoError(t, ValidateTrustedProxies([]string{"10.0.0.0/8", "192.168.1.1"}))
+	require.NoError(t, ValidateTrustedProxies([]string{"*"}))
+	require.Error(t, ValidateTrustedProxies([]string{"10.0.0.0/8", "bogus"}))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,6 +61,12 @@ type HTTPConfig struct {
 	CORSOrigins     []string  `mapstructure:"cors_origins"`
 	TLS             TLSConfig `mapstructure:"tls"`
 	BaseURL         string    `mapstructure:"base_url"`
+	// TrustedProxies lists the peers (IPs or CIDRs) allowed to set
+	// X-Forwarded-For. Empty — the default — trusts nobody, so the audit log
+	// and the rate limiter see the real peer address. Use "*" to trust every
+	// hop, which is only safe when the server is unreachable except through a
+	// proxy you control.
+	TrustedProxies []string `mapstructure:"trusted_proxies"`
 }
 
 // TLSConfig holds the optional server certificate and key for HTTPS.
@@ -383,6 +389,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("http.write_timeout_sec", 1800)
 	v.SetDefault("http.max_body_mb", 1024)
 	v.SetDefault("http.cors_origins", []string{})
+	v.SetDefault("http.trusted_proxies", []string{})
 	v.SetDefault("http.base_url", "http://localhost:8081")
 	// Viper bug: AutomaticEnv + Unmarshal silently skips keys that have no
 	// default/config-file value (not in AllKeys). Empty-string defaults ensure

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,6 +193,36 @@ func TestLoad_GCDefaults(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, cfg.GC.MinAge)
 }
 
+func TestLoad_TrustedProxies_DefaultsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Empty(t, cfg.HTTP.TrustedProxies,
+		"http.trusted_proxies must default to empty so X-Forwarded-For is not believed")
+}
+
+func TestLoad_TrustedProxies_EnvOverride(t *testing.T) {
+	// Viper skips keys with no default when unmarshalling with AutomaticEnv,
+	// so this also guards the SetDefault that makes the env var resolvable.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	t.Setenv("NEXSPENCE_HTTP_TRUSTED_PROXIES", "10.0.0.0/8,192.168.1.1")
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.0/8", "192.168.1.1"}, cfg.HTTP.TrustedProxies)
+}
+
 func TestLoad_AllowInsecureDefaults_EnvOverride(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/formats/oci/mount_test.go
+++ b/internal/formats/oci/mount_test.go
@@ -306,7 +306,7 @@ func publicOnlyRBAC(repoName string) formats.RBACChecker {
 	return service.NewRBACService(rbacRepoStub{privs: []repository.PrivilegeWithSelector{{
 		Actions:    []string{"read", "browse", "write"},
 		Expression: `repository == "` + repoName + `" && path.startsWith("/public/")`,
-	}}}, nil, zap.NewNop().Sugar())
+	}}}, nil, zap.NewNop().Sugar(), true)
 }
 
 // The security case. A content selector that stops a pull but not a mount is not

--- a/internal/service/rbac_anonymous_gate_test.go
+++ b/internal/service/rbac_anonymous_gate_test.go
@@ -1,0 +1,103 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
+)
+
+// The global auth.anonymous_enabled switch gates every anonymous path in the
+// service. A repository that opted into AllowAnonymous must still be refused
+// once the operator turns the switch off — otherwise the setting is a control
+// that does nothing.
+
+func TestRBAC_CanAccessRepo_AnonymousReadDeniedWhenGloballyDisabled(t *testing.T) {
+	svc := newRBACTestSvcAnon(false, nil)
+	repo := &domain.Repository{Name: "public-repo", Format: domain.FormatRaw, AllowAnonymous: true}
+
+	ok, err := svc.CanAccessRepo(context.Background(), "", nil, repo, "/file.txt", "read")
+	require.NoError(t, err)
+	assert.False(t, ok, "global switch off must override the per-repository opt-in")
+}
+
+func TestRBAC_CanAccessRepo_PrivilegesStillWorkWhenAnonymousDisabled(t *testing.T) {
+	// The switch only governs anonymous access; an authenticated user with a
+	// matching privilege is unaffected.
+	privs := []repository.PrivilegeWithSelector{
+		{Actions: []string{"read"}, Expression: `repository == "public-repo"`},
+	}
+	svc := newRBACTestSvcAnon(false, privs)
+	repo := &domain.Repository{Name: "public-repo", Format: domain.FormatRaw, AllowAnonymous: true}
+
+	ok, err := svc.CanAccessRepo(context.Background(), "user1", nil, repo, "/file.txt", "read")
+	require.NoError(t, err)
+	assert.True(t, ok)
+}
+
+func TestRBAC_FilterRepos_AnonymousReposHiddenWhenGloballyDisabled(t *testing.T) {
+	repos := []domain.Repository{
+		{Name: "public", AllowAnonymous: true},
+		{Name: "private"},
+	}
+	svc := newRBACTestSvcAnon(false, nil)
+
+	got := svc.FilterRepos(context.Background(), "", nil, repos)
+	assert.Empty(t, got)
+}
+
+func TestRBAC_FilterPaths_AnonymousDeniedWhenGloballyDisabled(t *testing.T) {
+	svc := newRBACTestSvcAnon(false, nil)
+	paths := []string{"/a", "/b"}
+
+	got := svc.FilterPaths(context.Background(), "", nil, "repo", true, paths)
+	assert.Empty(t, got)
+}
+
+func TestRBAC_FilterDockerRows_AnonymousDeniedWhenGloballyDisabled(t *testing.T) {
+	rows := []domain.DockerBrowseRow{
+		{ImageName: "img1", SamplePath: "/v2/img1/manifests/latest"},
+	}
+	svc := newRBACTestSvcAnon(false, nil)
+
+	got := svc.FilterDockerRows(context.Background(), "", nil, "repo", true, rows)
+	assert.Empty(t, got)
+}
+
+func TestRBAC_FilterComponents_AnonymousDeniedWhenGloballyDisabled(t *testing.T) {
+	items := []domain.Component{
+		{Repository: "public", Name: "pkg"},
+	}
+	svc := newRBACTestSvcAnon(false, nil)
+
+	got := svc.FilterComponents(context.Background(), "", nil, items, map[string]bool{"public": true})
+	assert.Empty(t, got)
+}
+
+func TestRBAC_FilterAssets_AnonymousDeniedWhenGloballyDisabled(t *testing.T) {
+	items := []domain.Asset{
+		{Repository: "public", Path: "/pkg/file.txt"},
+	}
+	svc := newRBACTestSvcAnon(false, nil)
+
+	got := svc.FilterAssets(context.Background(), "", nil, items, map[string]bool{"public": true})
+	assert.Empty(t, got)
+}
+
+// Admins are an orthogonal concern: the switch governs anonymous access only
+// and must not change what an administrator sees.
+func TestRBAC_AdminUnaffectedWhenAnonymousDisabled(t *testing.T) {
+	svc := newRBACTestSvcAnon(false, nil)
+	repo := &domain.Repository{Name: "public-repo", Format: domain.FormatRaw, AllowAnonymous: true}
+
+	ok, err := svc.CanAccessRepo(context.Background(), "u1", []string{"nx-admin"}, repo, "/file.txt", "read")
+	require.NoError(t, err)
+	assert.True(t, ok)
+
+	repos := []domain.Repository{{Name: "public", AllowAnonymous: true}}
+	assert.Len(t, svc.FilterRepos(context.Background(), "u1", []string{"nx-admin"}, repos), 1)
+}

--- a/internal/service/rbac_service.go
+++ b/internal/service/rbac_service.go
@@ -14,11 +14,17 @@ type RBACService struct {
 	rbac  repository.RBACRepo
 	repos repository.RepositoryRepo
 	log   logger.Logger
+	// anonymousEnabled mirrors auth.anonymous_enabled. It is the instance-wide
+	// switch above every per-repository AllowAnonymous opt-in: when false, no
+	// unauthenticated request is served regardless of how a repository is
+	// configured.
+	anonymousEnabled bool
 }
 
 // NewRBACService constructs a service that evaluates repository access decisions.
-func NewRBACService(rbac repository.RBACRepo, repos repository.RepositoryRepo, log logger.Logger) *RBACService {
-	return &RBACService{rbac: rbac, repos: repos, log: log}
+// anonymousEnabled is the global auth.anonymous_enabled switch.
+func NewRBACService(rbac repository.RBACRepo, repos repository.RepositoryRepo, log logger.Logger, anonymousEnabled bool) *RBACService {
+	return &RBACService{rbac: rbac, repos: repos, log: log, anonymousEnabled: anonymousEnabled}
 }
 
 // CanAccessRepo checks whether the user (identified by userID + roles) may perform action
@@ -28,7 +34,7 @@ func (s *RBACService) CanAccessRepo(ctx context.Context, userID string, roles []
 	if isAdmin(roles) {
 		return true, nil
 	}
-	if repo.AllowAnonymous && isReadAction(action) {
+	if s.anonymousAllowed(repo.AllowAnonymous) && isReadAction(action) {
 		return true, nil
 	}
 	if userID == "" {
@@ -66,7 +72,7 @@ func (s *RBACService) FilterRepos(ctx context.Context, userID string, roles []st
 	for _, repo := range repos {
 		// For repo listing: check repo-level access only, ignoring path restrictions.
 		// Path restrictions are enforced at artifact download time via CanAccessRepo.
-		if repo.AllowAnonymous || matchPrivilegesRepoOnly(privs, repo.Name) {
+		if s.anonymousAllowed(repo.AllowAnonymous) || matchPrivilegesRepoOnly(privs, repo.Name) {
 			result = append(result, repo)
 		}
 	}
@@ -74,6 +80,13 @@ func (s *RBACService) FilterRepos(ctx context.Context, userID string, roles []st
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+// anonymousAllowed reports whether an unauthenticated request may be served for
+// a repository whose AllowAnonymous flag is repoAllows. Both the instance-wide
+// switch and the per-repository opt-in must agree.
+func (s *RBACService) anonymousAllowed(repoAllows bool) bool {
+	return s.anonymousEnabled && repoAllows
+}
 
 func isAdmin(roles []string) bool {
 	for _, r := range roles {
@@ -150,7 +163,7 @@ func evalPathClause(expr, path string) bool {
 // FilterPaths returns only the paths accessible to the user in the given repo.
 // Used by PathTree browse endpoint to hide assets the user cannot read.
 func (s *RBACService) FilterPaths(ctx context.Context, userID string, roles []string, repoName string, allowAnonymous bool, paths []string) []string {
-	if isAdmin(roles) || allowAnonymous {
+	if isAdmin(roles) || s.anonymousAllowed(allowAnonymous) {
 		return paths
 	}
 	var privs []repository.PrivilegeWithSelector
@@ -175,7 +188,7 @@ func (s *RBACService) FilterPaths(ctx context.Context, userID string, roles []st
 // image (e.g. a blob), all rows for that image (Blobs, Manifests, Tags) are returned.
 // This matches Docker semantics where access is granted per image, not per layer type.
 func (s *RBACService) FilterDockerRows(ctx context.Context, userID string, roles []string, repoName string, allowAnonymous bool, rows []domain.DockerBrowseRow) []domain.DockerBrowseRow {
-	if isAdmin(roles) || allowAnonymous {
+	if isAdmin(roles) || s.anonymousAllowed(allowAnonymous) {
 		return rows
 	}
 	var privs []repository.PrivilegeWithSelector
@@ -234,7 +247,7 @@ func (s *RBACService) FilterComponents(
 	}
 	result := make([]domain.Component, 0, len(items))
 	for _, comp := range items {
-		if allowAnonByRepo[comp.Repository] {
+		if s.anonymousAllowed(allowAnonByRepo[comp.Repository]) {
 			result = append(result, comp)
 			continue
 		}
@@ -271,7 +284,7 @@ func (s *RBACService) FilterAssets(
 	}
 	result := make([]domain.Asset, 0, len(items))
 	for _, a := range items {
-		if allowAnonByRepo[a.Repository] {
+		if s.anonymousAllowed(allowAnonByRepo[a.Repository]) {
 			result = append(result, a)
 			continue
 		}

--- a/internal/service/rbac_service_test.go
+++ b/internal/service/rbac_service_test.go
@@ -29,17 +29,23 @@ func (m *mockRBACRepo) GetUserPrivilegesWithSelectors(_ context.Context, _ strin
 // ── constructor helper ────────────────────────────────────────
 
 func newRBACTestSvc(privs []repository.PrivilegeWithSelector, repos ...*domain.Repository) *service.RBACService {
+	return newRBACTestSvcAnon(true, privs, repos...)
+}
+
+// newRBACTestSvcAnon builds a service with the global anonymous switch set
+// explicitly; see rbac_anonymous_gate_test.go.
+func newRBACTestSvcAnon(anonymousEnabled bool, privs []repository.PrivilegeWithSelector, repos ...*domain.Repository) *service.RBACService {
 	rbacRepo := &mockRBACRepo{privs: privs}
 	repoRepo := testutil.NewRepoRepo(repos...)
 	log := zap.NewNop().Sugar()
-	return service.NewRBACService(rbacRepo, repoRepo, log)
+	return service.NewRBACService(rbacRepo, repoRepo, log, anonymousEnabled)
 }
 
 func newRBACTestSvcWithErr(repoErr error) *service.RBACService {
 	rbacRepo := &mockRBACRepo{err: repoErr}
 	repoRepo := testutil.NewRepoRepo()
 	log := zap.NewNop().Sugar()
-	return service.NewRBACService(rbacRepo, repoRepo, log)
+	return service.NewRBACService(rbacRepo, repoRepo, log, true)
 }
 
 // ── CanAccessRepo ─────────────────────────────────────────────


### PR DESCRIPTION
Fixes H-1 and H-3 from the 2026-08-03 security audit. Both were settings that read like security controls but had no effect.

## H-1 — `auth.anonymous_enabled` was a control that did nothing

It was read in exactly one place (`cmd/server/main.go`) to print a warning. Every anonymous decision was made per-repository, so an operator who set it to `false` to lock the instance down got a config that silently changed nothing.

It now gates every anonymous path:

- all six in `RBACService` — `CanAccessRepo`, `FilterRepos`, `FilterPaths`, `FilterDockerRows`, `FilterComponents`, `FilterAssets`
- the Docker `/v2/` handshake, which now answers `401` + `WWW-Authenticate: Basic` instead of `200`, so `docker login` is invoked rather than the client discovering the refusal one request later

**The default stays `true`** — upgrading changes no behavior until an operator flips the switch. Repositories are still private unless they opt into `allow_anonymous` (DB default `FALSE`). Anonymous writes were never allowed and still aren't.

## H-3 — `SetTrustedProxies` was never called

gin trusts every proxy by default, so `c.ClientIP()` returned whatever the caller put in `X-Forwarded-For`. Two consequences:

- **rate limiting was trivially evadable** — buckets key on `ip:` + ClientIP, so rotating the header per request yields unlimited buckets
- **the audit log was forgeable** — an attacker picked the IP recorded against their own actions, in `AuditMiddleware` and in the login/OIDC/SAML success and failure records

New `http.trusted_proxies` (IPs or CIDRs) drives it. **Empty by default — trust nobody**, so ClientIP falls back to the real peer. `"*"` is an explicit opt-in for deployments that cannot enumerate their proxies. A malformed entry stops the boot rather than quietly leaving a real proxy untrusted.

The shipped `docker-compose.yml` has no reverse proxy in front of the server, so the empty default is correct for the quick start.

## Refactor

The startup security checks move out of `cmdServe` into `checkStartupSecurity` — needed to stay under the gocyclo threshold, and it makes them testable. The fail-closed path on shipped default secrets had no test coverage before this.

## Verification

- `go test ./...` — 1880 passed, 1 failed: `TestWebhookHandler_Test_200`, which dials a loopback httptest server and fails identically on a clean `main` in this sandbox (network-only, not a regression)
- `golangci-lint run ./...` — clean on every file touched here. The 19 remaining `SA5011` hits are pre-existing in test files this PR does not touch and reproduce on a clean `main`
- coverage: `internal/service` 81.4%, `internal/config` 89.6%, `internal/api/handlers` 81.1% — all above the 80% floor
- new tests: 8 for the anonymous gate, 7 for trusted proxies, 5 for the startup checks, 2 for config defaults, 1 for the Docker `/v2/` gate

Each was written first and watched fail for the right reason. The config env-override test was confirmed to fail with the `SetDefault` removed, which is what makes `NEXSPENCE_HTTP_TRUSTED_PROXIES` resolvable at all.

## Docs

`config.yaml.example`, `docs/deployment.md`, and a new "Anonymous Access" section in `docs/security-rbac.md` covering the two-switch model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Remfwxfq7rC6efLT8Mh7XQ