### PR TITLE
fix(security): stop wildcarding CORS and throttle password guessing

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -3,7 +3,13 @@ http:
   read_timeout_sec: 1800
   write_timeout_sec: 1800
   max_body_mb: 1024            # max request body size (MB); requests above this get 413 (artifact/upload routes exempt)
-  cors_origins: []            # allowed CORS origins, e.g. ["https://ui.example.com"]; empty = wildcard (dev only)
+  # Origins allowed to read API responses from a browser. Empty (the default)
+  # sends no Access-Control-Allow-Origin at all, which is what you want when the
+  # bundled UI is served from this same origin. List the origins that need it
+  # when the UI is hosted separately; ["*"] lets any website read responses —
+  # including internal artifacts from anonymous repositories — so opt in only
+  # for a deliberately public instance.
+  cors_origins: []            # e.g. ["https://ui.example.com"] or ["*"]
   base_url: "http://localhost:8081"
   # Peers allowed to set X-Forwarded-For, as IPs or CIDRs. Empty (the default)
   # trusts nobody, so the audit log and the rate limiter use the real peer
@@ -51,7 +57,12 @@ auth:
   password_min_length: 8
   bcrypt_cost: 12
   token_max_days: 180
-  rate_limit_enabled: false   # per-user/IP token-bucket throttling
+  # Token-bucket throttle per authenticated user, or per client address for
+  # anonymous calls. On by default: without it /api/v1/login is an unmetered
+  # guessing surface that also burns a bcrypt (cost 12) per attempt. Independent
+  # of this, repeated failed logins are throttled per account — see
+  # docs/security-rbac.md.
+  rate_limit_enabled: true
   rate_limit_rps: 50          # sustained requests/sec
   rate_limit_burst: 100       # burst capacity
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -138,6 +138,7 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `http.addr` | `:8081` | Listen address |
 | `http.base_url` | `http://localhost:8081` | Public URL used in download links |
 | `http.trusted_proxies` | `[]` | Peers (IPs/CIDRs) whose `X-Forwarded-For` is believed. Empty trusts nobody, so the audit log and rate limiter see the real peer. Set it to your reverse proxy when you run behind one; `["*"]` trusts every hop. |
+| `http.cors_origins` | `[]` | Origins allowed to read API responses from a browser. Empty sends no CORS header — correct when the bundled UI shares this origin. `["*"]` lets any site read responses; opt in only for a public instance. |
 | `database.dsn` | `postgres://nexspence:nexspence@localhost:5437/nexspence` | PostgreSQL connection string |
 | `storage.default_type` | `local` | `local` or `s3` |
 | `storage.local.base_path` | `./data/blobs` | Filesystem path for local blob store |
@@ -149,6 +150,8 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `auth.jwt_expiry_hours` | `24` | JWT token lifetime |
 | `auth.anonymous_enabled` | `true` | Instance-wide switch for unauthenticated reads. `false` refuses them everywhere, overriding any repository's `allow_anonymous`. |
 | `auth.token_max_days` | `180` | Maximum lifetime for user API tokens (`nxs_*`) |
+| `auth.rate_limit_enabled` | `true` | Token-bucket throttle per user (per client address when anonymous). Turning it off leaves `/api/v1/login` unmetered. |
+| `auth.rate_limit_rps` / `auth.rate_limit_burst` | `50` / `100` | Sustained rate and burst for the above |
 | `bootstrap.admin_password` | `admin123` | Auto-created admin password — **change this** |
 | `cleanup.default_schedule` | `0 2 * * *` | Default cron for cleanup policies |
 | `audit.retention_days` | `90` | Audit log partition retention |

--- a/docs/security-rbac.md
+++ b/docs/security-rbac.md
@@ -345,6 +345,35 @@ When a request is made for an artifact:
 
 ---
 
+## Brute-force Protection
+
+Two independent throttles sit in front of every password check.
+
+**Per-account failed-login backoff.** Five consecutive failures for an account
+are free, so a mistyped password never costs anything. After that each further
+failure doubles the wait — 1s, 2s, 4s … capped at 15 minutes — and the account's
+next attempt is refused with `429` and a `Retry-After` header *before* the
+password is hashed, so the attack stops paying for bcrypt. A successful login
+clears the count, and a quiet account forgets it after 30 minutes.
+
+The budget is keyed on the account name rather than the client address,
+deliberately: an address is only as trustworthy as `http.trusted_proxies`, and
+an attacker rotating addresses still spends the same budget. It applies at every
+place credentials are accepted — `/api/v1/login`, Basic auth on `/repository/…`
+and `/v2/…`, and the API middleware — so moving the guessing to another endpoint
+does not buy a fresh allowance. When Redis is enabled the count is shared across
+HA nodes, so spreading attempts over servers does not multiply it.
+
+Failed credentials are logged wherever they occur, including on the paths that
+fall through to anonymous access; previously those left no trace at all.
+
+**Request rate limit.** `auth.rate_limit_enabled` (on by default) additionally
+buckets requests per authenticated user, or per client address for anonymous
+calls. It is coarser and complements, rather than replaces, the per-account
+backoff above.
+
+---
+
 ## Anonymous Access
 
 Two switches must agree before an unauthenticated request is served:

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/auth"
+	"github.com/nexspence-oss/nexspence/internal/auth/loginguard"
 	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/redisclient"
@@ -22,11 +24,19 @@ type AuthHandler struct {
 	users *service.UserService
 	cfg   config.Config
 	log   logger.Logger
+	guard *loginguard.Guard
 }
 
 // NewAuthHandler constructs an AuthHandler backed by the given user service and logger.
 func NewAuthHandler(users *service.UserService, log logger.Logger) *AuthHandler {
 	return &AuthHandler{users: users, log: log}
+}
+
+// WithLoginGuard attaches the per-account failed-login throttle. A nil guard
+// disables throttling. Returns the same handler for chaining.
+func (h *AuthHandler) WithLoginGuard(g *loginguard.Guard) *AuthHandler {
+	h.guard = g
+	return h
 }
 
 // WithConfig enables the /api/v1/auth/config feature-detection endpoint.
@@ -75,12 +85,25 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	// Set username in context early so the audit middleware records who attempted the login.
 	c.Set("username", req.Username)
 
-	token, user, err := h.users.Login(c.Request.Context(), req.Username, req.Password)
+	ctx := c.Request.Context()
+	// Refuse before hashing: the bcrypt is the expensive half of an attempt, and
+	// the answer is identical whether or not the account exists, so a throttled
+	// response tells an attacker nothing beyond "keep waiting".
+	if wait := h.guard.RetryAfter(ctx, req.Username); wait > 0 {
+		h.log.Infow("login throttled", "username", req.Username, "ip", c.ClientIP(), "retryAfter", wait)
+		c.Header("Retry-After", strconv.Itoa(retryAfterSeconds(wait)))
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": "too many failed attempts"})
+		return
+	}
+
+	token, user, err := h.users.Login(ctx, req.Username, req.Password)
 	if err != nil {
+		h.guard.RecordFailure(ctx, req.Username)
 		h.log.Infow("login failed", "username", req.Username, "ip", c.ClientIP(), "err", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 		return
 	}
+	h.guard.RecordSuccess(ctx, req.Username)
 
 	c.Set("userID", user.ID)
 	h.log.Infow("login success", "username", user.Username, "ip", c.ClientIP(), "roles", user.Roles)
@@ -194,7 +217,8 @@ func jwtNotRevoked(c *gin.Context, users *service.UserService, claims *auth.Clai
 
 // AuthMiddleware validates Bearer JWT, Bearer API-token, or Basic auth.
 // Tokens may be nil when API tokens are disabled; Bearer then only accepts JWT.
-func AuthMiddleware(users *service.UserService, tokens *service.TokenService) gin.HandlerFunc {
+// guard and log may be nil, which disables throttling and logging respectively.
+func AuthMiddleware(users *service.UserService, tokens *service.TokenService, guard *loginguard.Guard, log logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var raw string
 
@@ -217,11 +241,21 @@ func AuthMiddleware(users *service.UserService, tokens *service.TokenService) gi
 						return
 					}
 				}
-				_, user, err := users.Login(c.Request.Context(), username, password)
+				ctx := c.Request.Context()
+				if wait := guard.RetryAfter(ctx, username); wait > 0 {
+					logAuthEvent(log, "authentication throttled", c, username, "retryAfter", wait)
+					c.Header("Retry-After", strconv.Itoa(retryAfterSeconds(wait)))
+					c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many failed attempts"})
+					return
+				}
+				_, user, err := users.Login(ctx, username, password)
 				if err != nil {
+					guard.RecordFailure(ctx, username)
+					logAuthEvent(log, "authentication failed", c, username, "err", err)
 					c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
 					return
 				}
+				guard.RecordSuccess(ctx, username)
 				c.Set("username", user.Username)
 				c.Set("userID", user.ID)
 				c.Set("roles", user.Roles)
@@ -273,6 +307,8 @@ func DockerV2Auth(
 	repos repository.RepositoryRepo,
 	rdb *redisclient.Client, // nil = use in-process cache
 	anonymousEnabled bool, // global auth.anonymous_enabled switch
+	guard *loginguard.Guard, // nil = no per-account throttling
+	log logger.Logger, // nil = no auth logging
 ) gin.HandlerFunc {
 	const redisKey = "nexspence:docker:anon_allowed"
 	var (
@@ -361,12 +397,23 @@ func DockerV2Auth(
 						return
 					}
 				}
-				if _, user, err := users.Login(c.Request.Context(), username, password); err == nil {
+				ctx := c.Request.Context()
+				if wait := guard.RetryAfter(ctx, username); wait > 0 {
+					logAuthEvent(log, "authentication throttled", c, username, "retryAfter", wait)
+					c.Header("Retry-After", strconv.Itoa(retryAfterSeconds(wait)))
+					c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "too many failed attempts"})
+					return
+				}
+				_, user, err := users.Login(ctx, username, password)
+				if err == nil {
+					guard.RecordSuccess(ctx, username)
 					c.Set("username", user.Username)
 					c.Set("userID", user.ID)
 					c.Status(http.StatusOK)
 					return
 				}
+				guard.RecordFailure(ctx, username)
+				logAuthEvent(log, "authentication failed", c, username, "err", err)
 			}
 		}
 
@@ -379,8 +426,8 @@ func DockerV2Auth(
 // set the Authorization header. It accepts a JWT or API token in `?token=...`.
 // Falls back to AuthMiddleware behavior (Bearer/Basic) when the query param
 // is absent.
-func QueryTokenAuth(users *service.UserService, tokens *service.TokenService) gin.HandlerFunc {
-	mw := AuthMiddleware(users, tokens)
+func QueryTokenAuth(users *service.UserService, tokens *service.TokenService, guard *loginguard.Guard, log logger.Logger) gin.HandlerFunc {
+	mw := AuthMiddleware(users, tokens, guard, log)
 	return func(c *gin.Context) {
 		if c.GetHeader("Authorization") == "" {
 			if t := c.Query("token"); t != "" {
@@ -395,7 +442,13 @@ func QueryTokenAuth(users *service.UserService, tokens *service.TokenService) gi
 // Basic auth is present, but does not block unauthenticated requests. Basic
 // auth is required for Docker clients (`docker login`) so that pushes/cached
 // pulls are attributed to a real user instead of "anonymous".
-func OptionalAuth(users *service.UserService, tokens *service.TokenService) gin.HandlerFunc {
+//
+// A wrong password here degrades to anonymous rather than returning 401 — that
+// is the point of the middleware — but it is still a failed credential, so it
+// is logged and charged to the same per-account budget as /api/v1/login.
+// Otherwise guessing against /repository/… is invisible to the audit trail
+// while costing a bcrypt per try.
+func OptionalAuth(users *service.UserService, tokens *service.TokenService, guard *loginguard.Guard, log logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 
@@ -409,8 +462,9 @@ func OptionalAuth(users *service.UserService, tokens *service.TokenService) gin.
 
 		// Basic auth (Docker registry clients, Maven, curl, etc.)
 		if username, password, ok := c.Request.BasicAuth(); ok && username != "" {
+			ctx := c.Request.Context()
 			if tokens != nil && strings.HasPrefix(password, service.TokenPrefix) {
-				if u, err := tokens.Authenticate(c.Request.Context(), password); err == nil && u != nil {
+				if u, err := tokens.Authenticate(ctx, password); err == nil && u != nil {
 					c.Set("username", u.Username)
 					c.Set("userID", u.ID)
 					c.Set("roles", u.Roles)
@@ -418,12 +472,42 @@ func OptionalAuth(users *service.UserService, tokens *service.TokenService) gin.
 					return
 				}
 			}
-			if _, user, err := users.Login(c.Request.Context(), username, password); err == nil {
+			// Throttled accounts skip the password check entirely: the request
+			// continues as anonymous and RBAC decides, without spending a bcrypt.
+			if wait := guard.RetryAfter(ctx, username); wait > 0 {
+				logAuthEvent(log, "authentication throttled", c, username, "retryAfter", wait)
+				c.Next()
+				return
+			}
+			if _, user, err := users.Login(ctx, username, password); err == nil {
+				guard.RecordSuccess(ctx, username)
 				c.Set("username", user.Username)
 				c.Set("userID", user.ID)
 				c.Set("roles", user.Roles)
+			} else {
+				guard.RecordFailure(ctx, username)
+				logAuthEvent(log, "authentication failed", c, username, "err", err)
 			}
 		}
 		c.Next()
 	}
+}
+
+// logAuthEvent records an authentication outcome when a logger is wired up.
+func logAuthEvent(log logger.Logger, msg string, c *gin.Context, username string, kv ...any) {
+	if log == nil {
+		return
+	}
+	args := append([]any{"username", username, "ip", c.ClientIP(), "path", c.Request.URL.Path}, kv...)
+	log.Infow(msg, args...)
+}
+
+// retryAfterSeconds renders a wait as the whole seconds a Retry-After header
+// needs, never below 1 so clients do not treat it as "retry immediately".
+func retryAfterSeconds(d time.Duration) int {
+	s := int(d.Round(time.Second) / time.Second)
+	if s < 1 {
+		return 1
+	}
+	return s
 }

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -54,7 +54,7 @@ func bearerToken(svc *service.UserService, username string) string {
 
 func buildAuthRouter(svc *service.UserService) *gin.Engine {
 	r := gin.New()
-	r.Use(handlers.AuthMiddleware(svc, nil))
+	r.Use(handlers.AuthMiddleware(svc, nil, nil, nil))
 	r.GET("/protected", func(c *gin.Context) {
 		username, _ := c.Get("username")
 		c.JSON(http.StatusOK, gin.H{"user": username})
@@ -200,7 +200,7 @@ func TestAuthMiddleware_AfterRoleChange_RejectsOldToken(t *testing.T) {
 
 func buildOptionalAuthRouter(svc *service.UserService) *gin.Engine {
 	r := gin.New()
-	r.Use(handlers.OptionalAuth(svc, nil))
+	r.Use(handlers.OptionalAuth(svc, nil, nil, nil))
 	r.GET("/open", func(c *gin.Context) {
 		username, _ := c.Get("username")
 		c.JSON(http.StatusOK, gin.H{"user": username})
@@ -324,7 +324,7 @@ func buildDockerV2AuthRouter(svc *service.UserService, repos ...*domain.Reposito
 
 func buildDockerV2AuthRouterAnon(svc *service.UserService, anonymousEnabled bool, repos ...*domain.Repository) *gin.Engine {
 	r := gin.New()
-	h := handlers.DockerV2Auth(svc, nil, testutil.NewRepoRepo(repos...), nil, anonymousEnabled)
+	h := handlers.DockerV2Auth(svc, nil, testutil.NewRepoRepo(repos...), nil, anonymousEnabled, nil, nil)
 	r.GET("/v2/", h)
 	r.HEAD("/v2/", h)
 	return r

--- a/internal/api/handlers/login_throttle_test.go
+++ b/internal/api/handlers/login_throttle_test.go
@@ -1,0 +1,229 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/nexspence-oss/nexspence/internal/api/handlers"
+	"github.com/nexspence-oss/nexspence/internal/auth/loginguard"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func testGuard() *loginguard.Guard {
+	return loginguard.New(nil, loginguard.Policy{
+		Threshold: 2, BaseDelay: time.Second, MaxDelay: time.Minute,
+	})
+}
+
+func postLogin(r *gin.Engine, username, password string) *httptest.ResponseRecorder {
+	body := `{"username":"` + username + `","password":"` + password + `"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/login", stringReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func buildLoginRouter(svc *service.UserService, guard *loginguard.Guard) *gin.Engine {
+	r := gin.New()
+	authH := handlers.NewAuthHandler(svc, zap.NewNop().Sugar()).WithLoginGuard(guard)
+	r.POST("/api/v1/login", authH.Login)
+	return r
+}
+
+// Without a throttle, /api/v1/login is an unmetered credential-guessing surface
+// that also burns a bcrypt (cost 12) per attempt.
+func TestLogin_RepeatedFailures_Get429WithRetryAfter(t *testing.T) {
+	svc := newUserSvc(activeUser("eve", "mypass"))
+	r := buildLoginRouter(svc, testGuard())
+
+	// Threshold failures are free, so an honest typo is never throttled; the
+	// attempt after that is the first one refused.
+	for range 3 {
+		require.Equal(t, http.StatusUnauthorized, postLogin(r, "eve", "wrong").Code)
+	}
+
+	w := postLogin(r, "eve", "wrong")
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.NotEmpty(t, w.Header().Get("Retry-After"))
+}
+
+// The response must not distinguish a throttled real account from a throttled
+// name that does not exist, or the throttle becomes a user-enumeration oracle.
+func TestLogin_ThrottleDoesNotRevealAccountExistence(t *testing.T) {
+	svc := newUserSvc(activeUser("eve", "mypass"))
+	r := buildLoginRouter(svc, testGuard())
+
+	for range 3 {
+		postLogin(r, "eve", "wrong")
+		postLogin(r, "ghost", "wrong")
+	}
+
+	real := postLogin(r, "eve", "wrong")
+	missing := postLogin(r, "ghost", "wrong")
+	assert.Equal(t, http.StatusTooManyRequests, real.Code)
+	assert.Equal(t, http.StatusTooManyRequests, missing.Code)
+	assert.Equal(t, real.Body.String(), missing.Body.String())
+}
+
+func TestLogin_SuccessClearsTheCount(t *testing.T) {
+	svc := newUserSvc(activeUser("eve", "mypass"))
+	guard := testGuard()
+	r := buildLoginRouter(svc, guard)
+
+	postLogin(r, "eve", "wrong")
+	postLogin(r, "eve", "wrong")
+	require.Equal(t, http.StatusOK, postLogin(r, "eve", "mypass").Code)
+
+	// The successful login reset the budget, so a fresh mistake is tolerated.
+	assert.Equal(t, http.StatusUnauthorized, postLogin(r, "eve", "wrong").Code)
+}
+
+func TestLogin_NoGuard_StillWorks(t *testing.T) {
+	svc := newUserSvc(activeUser("eve", "mypass"))
+	r := buildLoginRouter(svc, nil)
+
+	for range 5 {
+		require.Equal(t, http.StatusUnauthorized, postLogin(r, "eve", "wrong").Code)
+	}
+}
+
+// ── OptionalAuth: the silent path ─────────────────────────────
+
+func basicReq(username, password string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/open", nil)
+	req.Header.Set("Authorization", "Basic "+
+		base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
+	return req
+}
+
+func buildOptionalAuthRouterGuarded(svc *service.UserService, guard *loginguard.Guard, log *zap.SugaredLogger) *gin.Engine {
+	r := gin.New()
+	r.Use(handlers.OptionalAuth(svc, nil, guard, log))
+	r.GET("/open", func(c *gin.Context) {
+		username, _ := c.Get("username")
+		c.JSON(http.StatusOK, gin.H{"user": username})
+	})
+	return r
+}
+
+// A failed password on /repository/... used to fall through to anonymous with
+// no log line at all, so guessing there was invisible to the audit trail while
+// still costing a bcrypt per try.
+func TestOptionalAuth_BadCredentials_AreLogged(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	svc := newUserSvc(activeUser("dave", "pw"))
+	r := buildOptionalAuthRouterGuarded(svc, testGuard(), zap.New(core).Sugar())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, basicReq("dave", "wrong"))
+
+	assert.Equal(t, http.StatusOK, w.Code, "OptionalAuth still falls through to anonymous")
+	require.NotEmpty(t, logs.FilterMessageSnippet("authentication failed").All(),
+		"a failed credential must leave a trace")
+}
+
+func TestOptionalAuth_BadCredentials_CountTowardsTheSameBudget(t *testing.T) {
+	guard := testGuard()
+	svc := newUserSvc(activeUser("dave", "pw"))
+	r := buildOptionalAuthRouterGuarded(svc, guard, zap.NewNop().Sugar())
+
+	for range 3 {
+		r.ServeHTTP(httptest.NewRecorder(), basicReq("dave", "wrong"))
+	}
+
+	assert.Positive(t, guard.RetryAfter(context.Background(), "dave"),
+		"guessing via Basic auth must spend the same budget as /api/v1/login")
+}
+
+// Once an account is throttled the middleware must stop hashing passwords for
+// it — that bcrypt is the whole cost of the attack.
+func TestOptionalAuth_ThrottledAccount_SkipsPasswordCheck(t *testing.T) {
+	guard := testGuard()
+	svc := newUserSvc(activeUser("dave", "pw"))
+	r := buildOptionalAuthRouterGuarded(svc, guard, zap.NewNop().Sugar())
+
+	for range 3 {
+		r.ServeHTTP(httptest.NewRecorder(), basicReq("dave", "wrong"))
+	}
+	require.Positive(t, guard.RetryAfter(context.Background(), "dave"))
+
+	// Correct credentials, but the account is in its penalty window: the request
+	// proceeds as anonymous rather than authenticating.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, basicReq("dave", "pw"))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, w.Body.String(), "dave")
+}
+
+// ── the same budget applies wherever a password is checked ────
+
+// A throttle that only covers /api/v1/login is evaded by moving the guessing to
+// another endpoint that takes the same credentials.
+func TestAuthMiddleware_RepeatedBasicFailures_Get429(t *testing.T) {
+	guard := testGuard()
+	svc := newUserSvc(activeUser("dave", "pw"))
+
+	r := gin.New()
+	r.Use(handlers.AuthMiddleware(svc, nil, guard, zap.NewNop().Sugar()))
+	r.GET("/open", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	for range 3 {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, basicReq("dave", "wrong"))
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, basicReq("dave", "wrong"))
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.NotEmpty(t, w.Header().Get("Retry-After"))
+}
+
+func TestDockerV2Auth_RepeatedBasicFailures_Get429(t *testing.T) {
+	guard := testGuard()
+	svc := newUserSvc(activeUser("dave", "pw"))
+
+	r := gin.New()
+	h := handlers.DockerV2Auth(svc, nil, testutil.NewRepoRepo(), nil, true, guard, zap.NewNop().Sugar())
+	r.GET("/v2/", h)
+
+	dockerReq := func() *http.Request {
+		req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+		req.Header.Set("Authorization", "Basic "+
+			base64.StdEncoding.EncodeToString([]byte("dave:wrong")))
+		return req
+	}
+
+	for range 3 {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, dockerReq())
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, dockerReq())
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+}
+
+func TestOptionalAuth_GoodCredentials_ClearTheCount(t *testing.T) {
+	guard := testGuard()
+	svc := newUserSvc(activeUser("dave", "pw"))
+	r := buildOptionalAuthRouterGuarded(svc, guard, zap.NewNop().Sugar())
+
+	r.ServeHTTP(httptest.NewRecorder(), basicReq("dave", "wrong"))
+	r.ServeHTTP(httptest.NewRecorder(), basicReq("dave", "pw"))
+
+	assert.Zero(t, guard.RetryAfter(context.Background(), "dave"))
+}

--- a/internal/api/handlers/metrics_test.go
+++ b/internal/api/handlers/metrics_test.go
@@ -23,7 +23,7 @@ func TestPrometheusHandler_NoToken_Returns401(t *testing.T) {
 	authSvc := auth.NewService(testSecret, 24, bcryptCostTest)
 	uSvc := service.NewUserService(testutil.NewUserRepo(), testutil.NewRoleRepo(), authSvc, zap.NewNop().Sugar())
 	tSvc := service.NewTokenService(testutil.NewUserTokenRepo(), testutil.NewUserRepo())
-	r.GET("/metrics", handlers.AuthMiddleware(uSvc, tSvc),
+	r.GET("/metrics", handlers.AuthMiddleware(uSvc, tSvc, nil, nil),
 		gin.WrapH(promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{})))
 
 	w := httptest.NewRecorder()
@@ -37,7 +37,7 @@ func TestPrometheusHandler_ValidToken_Returns200(t *testing.T) {
 	uSvc := service.NewUserService(testutil.NewUserRepo(user), testutil.NewRoleRepo(), authSvc, zap.NewNop().Sugar())
 	tSvc := service.NewTokenService(testutil.NewUserTokenRepo(), testutil.NewUserRepo(user))
 	r := gin.New()
-	r.GET("/metrics", handlers.AuthMiddleware(uSvc, tSvc),
+	r.GET("/metrics", handlers.AuthMiddleware(uSvc, tSvc, nil, nil),
 		gin.WrapH(promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{})))
 
 	tok := bearerToken(newUserSvc(user), "admin")

--- a/internal/api/handlers/tokens_test.go
+++ b/internal/api/handlers/tokens_test.go
@@ -25,7 +25,7 @@ func newTokenStack(users ...*domain.User) (*service.UserService, *service.TokenS
 
 func buildTokenAPIRouter(userSvc *service.UserService, tokenSvc *service.TokenService) *gin.Engine {
 	r := gin.New()
-	r.Use(handlers.AuthMiddleware(userSvc, tokenSvc))
+	r.Use(handlers.AuthMiddleware(userSvc, tokenSvc, nil, nil))
 	h := handlers.NewTokenHandler(tokenSvc, userSvc, 90)
 	r.GET("/api/v1/user-tokens", h.List)
 	r.POST("/api/v1/user-tokens", h.Create)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -24,15 +24,24 @@ func requestLogger(log logger.Logger) gin.HandlerFunc {
 	}
 }
 
-// corsMiddleware reflects an Origin only when it is present in allowed. When
-// allowed is empty, it falls back to a permissive wildcard (development default).
+// corsMiddleware reflects an Origin only when it is present in allowed.
+//
+// An empty list sends no Access-Control-Allow-Origin at all. It used to mean
+// "wildcard", which was exploitable: this API authenticates by Authorization
+// header and serves anonymous repositories, so a page the user visits could
+// fetch an internal artifact from inside their network and read the response.
+// A wildcard now has to be written out as cors_origins: ["*"].
 func corsMiddleware(allowed []string) gin.HandlerFunc {
+	wildcard := false
 	set := make(map[string]struct{}, len(allowed))
 	for _, o := range allowed {
+		if o == "*" {
+			wildcard = true
+		}
 		set[o] = struct{}{}
 	}
 	return func(c *gin.Context) {
-		if len(set) == 0 {
+		if wildcard {
 			c.Header("Access-Control-Allow-Origin", "*")
 		} else if origin := c.GetHeader("Origin"); origin != "" {
 			if _, ok := set[origin]; ok {

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -59,18 +59,59 @@ func TestCORS_UnknownOriginNotReflected(t *testing.T) {
 	}
 }
 
-func TestCORS_EmptyAllowlistFallsBackToWildcard(t *testing.T) {
+// An empty allowlist used to mean "wildcard". That let any website read
+// responses from an internal instance: the API authenticates by Authorization
+// header and serves anonymous repositories, so a page on evil.com could fetch
+// an internal artifact from inside the corporate network and read the body.
+// Empty now means no CORS header at all.
+func TestCORS_EmptyAllowlistSendsNoACAO(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.Use(corsMiddleware(nil))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("ACAO = %q, want empty", got)
+	}
+}
+
+// The wildcard stays available, but has to be asked for.
+func TestCORS_ExplicitWildcardStillWorks(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(corsMiddleware([]string{"*"}))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Origin", "https://anything.example.com")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
 	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
 		t.Fatalf("ACAO = %q, want %q", got, "*")
+	}
+}
+
+// A preflight against an instance with no allowlist must not be told the
+// request is permitted.
+func TestCORS_PreflightWithoutAllowlistSendsNoACAO(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(corsMiddleware(nil))
+	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodOptions, "/", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("ACAO = %q, want empty", got)
 	}
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -19,6 +19,7 @@ import (
 	uiembed "github.com/nexspence-oss/nexspence"
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/auth"
+	"github.com/nexspence-oss/nexspence/internal/auth/loginguard"
 	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/distlock"
 	"github.com/nexspence-oss/nexspence/internal/domain"
@@ -73,6 +74,16 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	if rdb != nil {
 		locker = distlock.NewRedisLocker(rdb)
 	}
+
+	// ── Failed-login throttle ─────────────────────────────────
+	// Keyed on the account, not the address: the IP bucket in the rate limiter
+	// is only as trustworthy as http.trusted_proxies. Backed by Redis when it is
+	// available so attempts cannot be spread across HA nodes for a bigger budget.
+	var guardStore loginguard.Store
+	if rdb != nil {
+		guardStore = loginguard.NewRedisStore(rdb)
+	}
+	loginGuard := loginguard.New(guardStore, loginguard.DefaultPolicy())
 
 	// ── Repositories / services ───────────────────────────────
 	repoRepo := postgres.NewRepositoryRepo(pool)
@@ -233,7 +244,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	groupHandler := group.New(formatDeps, formatRegistry)
 
 	// ── Handlers ──────────────────────────────────────────────
-	authH := handlers.NewAuthHandler(userSvc, log).WithConfig(*cfg)
+	authH := handlers.NewAuthHandler(userSvc, log).WithConfig(*cfg).WithLoginGuard(loginGuard)
 	repoH := handlers.NewRepositoryHandler(repoSvc, rbacSvc)
 	userH := handlers.NewUserHandler(userSvc)
 	blobH := handlers.NewBlobStoreHandler(blobRepo).WithUsageDeps(repoRepo, assetRepo).WithRegistry(blobRegistry).WithGC(gcSvc)
@@ -308,7 +319,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		r.Use(RateLimitMiddleware(cfg.Auth.RateLimitRPS, cfg.Auth.RateLimitBurst))
 	}
 
-	authMW := handlers.AuthMiddleware(userSvc, tokenSvc)
+	authMW := handlers.AuthMiddleware(userSvc, tokenSvc, loginGuard, log)
 	adminMW := handlers.AdminRequired()
 
 	// ── Public endpoints ──────────────────────────────────────
@@ -598,7 +609,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	// ── Artifact protocol endpoints ───────────────────────────
 	// Route /repository/:repoName/* to the appropriate format handler.
 	// The format is looked up from the repository record in the DB.
-	repo := r.Group("/repository/:repoName", handlers.OptionalAuth(userSvc, tokenSvc), rbacMW)
+	repo := r.Group("/repository/:repoName", handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log), rbacMW)
 	{
 		repo.Any("/*path", func(c *gin.Context) {
 			repoName := c.Param("repoName")
@@ -659,18 +670,18 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	// `repoRepo` lets DockerV2Auth fall through to 200 when at least one
 	// Docker repository has allow_anonymous=true — restoring anonymous
 	// `docker pull` against public proxies (see Phase 26).
-	dockerV2Root := handlers.DockerV2Auth(userSvc, tokenSvc, repoRepo, rdb, cfg.Auth.AnonymousEnabled)
+	dockerV2Root := handlers.DockerV2Auth(userSvc, tokenSvc, repoRepo, rdb, cfg.Auth.AnonymousEnabled, loginGuard, log)
 	r.GET("/v2/", dockerV2Root)
 	r.HEAD("/v2/", dockerV2Root)
 
 	dockerV2H := serveDockerV2(repoRepo, groupHandler, formatRegistry)
-	v2docker := r.Group("/v2/repository", handlers.OptionalAuth(userSvc, tokenSvc), handlers.RBACMiddleware(rbacSvc, repoRepo))
+	v2docker := r.Group("/v2/repository", handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log), handlers.RBACMiddleware(rbacSvc, repoRepo))
 	v2docker.Any("/:repoName/*dockerpath", dockerV2H)
 
 	// Short-path Docker: /v2/:repoName/* — no "repository/" segment required.
 	// Gin static segments take priority, so /v2/repository/:repoName/... still
 	// matches v2docker above; this group catches everything else under /v2/.
-	v2short := r.Group("/v2", handlers.OptionalAuth(userSvc, tokenSvc), handlers.RBACMiddleware(rbacSvc, repoRepo))
+	v2short := r.Group("/v2", handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log), handlers.RBACMiddleware(rbacSvc, repoRepo))
 	v2short.Any("/:repoName/*dockerpath", dockerV2H)
 
 	// ── Frontend static (production build) ────────────────────

--- a/internal/auth/loginguard/loginguard.go
+++ b/internal/auth/loginguard/loginguard.go
@@ -1,0 +1,185 @@
+// Package loginguard throttles password guessing per account.
+//
+// It deliberately keys on the username rather than the client address: the
+// rate limiter already buckets by IP, and an IP is only as trustworthy as the
+// proxy configuration behind it. An attacker rotating addresses still spends
+// the same budget against one account.
+package loginguard
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+)
+
+// entryTTL is how long a quiet account keeps its failure count. Long enough
+// that a slow drip of guesses still accumulates, short enough that a user who
+// mistyped a password this morning is not penalized tonight.
+const entryTTL = 30 * time.Minute
+
+// Policy describes how quickly failures escalate.
+type Policy struct {
+	// Threshold is how many failures are tolerated before delays begin, so a
+	// human fumbling a password is never affected.
+	Threshold int
+	// BaseDelay is the first penalty; each further failure doubles it.
+	BaseDelay time.Duration
+	// MaxDelay caps the penalty.
+	MaxDelay time.Duration
+}
+
+// DefaultPolicy is what the server uses unless configured otherwise: five free
+// attempts, then 1s doubling up to 15 minutes.
+func DefaultPolicy() Policy {
+	return Policy{Threshold: 5, BaseDelay: time.Second, MaxDelay: 15 * time.Minute}
+}
+
+type state struct {
+	failures     int
+	blockedUntil time.Time
+	lastSeen     time.Time
+}
+
+// Store persists failure state across nodes. Implementations must tolerate a
+// missing key by returning ok=false.
+type Store interface {
+	Load(ctx context.Context, key string) (failures int, blockedUntil time.Time, ok bool)
+	Save(ctx context.Context, key string, failures int, blockedUntil time.Time, ttl time.Duration)
+	Delete(ctx context.Context, key string)
+}
+
+// Guard tracks consecutive login failures per account. A nil *Guard is a valid
+// no-op guard, which is what the server uses when the feature is off.
+type Guard struct {
+	policy Policy
+	store  Store // nil = single-node, in-process only
+
+	mu      sync.Mutex
+	entries map[string]*state
+
+	now func() time.Time
+}
+
+// New builds a Guard. store may be nil for single-node deployments; when set
+// (Redis), the count is shared so an attacker cannot spread attempts across
+// nodes to multiply the allowance.
+func New(store Store, policy Policy) *Guard {
+	return &Guard{
+		policy:  policy,
+		store:   store,
+		entries: make(map[string]*state),
+		now:     time.Now,
+	}
+}
+
+// RetryAfter reports how long the caller must wait before another attempt on
+// this account is worth making. Zero means "go ahead".
+func (g *Guard) RetryAfter(ctx context.Context, username string) time.Duration {
+	if g == nil {
+		return 0
+	}
+	key := normalize(username)
+	now := g.now()
+
+	_, blockedUntil := g.load(ctx, key)
+	if blockedUntil.After(now) {
+		return blockedUntil.Sub(now)
+	}
+	return 0
+}
+
+// RecordFailure counts one failed attempt and extends the penalty window.
+func (g *Guard) RecordFailure(ctx context.Context, username string) {
+	if g == nil {
+		return
+	}
+	key := normalize(username)
+	now := g.now()
+
+	failures, _ := g.load(ctx, key)
+	failures++
+	blockedUntil := now.Add(g.penalty(failures))
+
+	g.mu.Lock()
+	g.sweep(now)
+	g.entries[key] = &state{failures: failures, blockedUntil: blockedUntil, lastSeen: now}
+	g.mu.Unlock()
+
+	if g.store != nil {
+		g.store.Save(ctx, key, failures, blockedUntil, entryTTL)
+	}
+}
+
+// RecordSuccess clears the account's history — the credentials were right, so
+// whatever came before was noise rather than an attack in progress.
+func (g *Guard) RecordSuccess(ctx context.Context, username string) {
+	if g == nil {
+		return
+	}
+	key := normalize(username)
+
+	g.mu.Lock()
+	delete(g.entries, key)
+	g.mu.Unlock()
+
+	if g.store != nil {
+		g.store.Delete(ctx, key)
+	}
+}
+
+// penalty returns the wait imposed after the given number of failures.
+func (g *Guard) penalty(failures int) time.Duration {
+	over := failures - g.policy.Threshold
+	if over <= 0 {
+		return 0
+	}
+	d := g.policy.BaseDelay
+	for range over - 1 {
+		d *= 2
+		if d >= g.policy.MaxDelay {
+			return g.policy.MaxDelay
+		}
+	}
+	if d > g.policy.MaxDelay {
+		return g.policy.MaxDelay
+	}
+	return d
+}
+
+// load reads the shared store first so that HA nodes agree, falling back to the
+// in-process map when there is no store or the key is absent from it.
+func (g *Guard) load(ctx context.Context, key string) (int, time.Time) {
+	if g.store != nil {
+		if failures, blockedUntil, ok := g.store.Load(ctx, key); ok {
+			return failures, blockedUntil
+		}
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if e, ok := g.entries[key]; ok {
+		return e.failures, e.blockedUntil
+	}
+	return 0, time.Time{}
+}
+
+// sweep drops entries nobody has touched for entryTTL. Callers hold g.mu.
+func (g *Guard) sweep(now time.Time) {
+	cutoff := now.Add(-entryTTL)
+	for k, e := range g.entries {
+		if e.lastSeen.Before(cutoff) {
+			delete(g.entries, k)
+		}
+	}
+}
+
+// size reports how many accounts are being tracked in process. Test hook.
+func (g *Guard) size() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return len(g.entries)
+}
+
+func normalize(username string) string {
+	return strings.ToLower(strings.TrimSpace(username))
+}

--- a/internal/auth/loginguard/loginguard_test.go
+++ b/internal/auth/loginguard/loginguard_test.go
@@ -1,0 +1,134 @@
+package loginguard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock lets the tests move time without sleeping.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time      { return c.t }
+func (c *fakeClock) add(d time.Duration) { c.t = c.t.Add(d) }
+
+func newTestGuard() (*Guard, *fakeClock) {
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	g := New(nil, Policy{Threshold: 3, BaseDelay: time.Second, MaxDelay: time.Minute})
+	g.now = clk.now
+	return g, clk
+}
+
+func TestGuard_UnderThreshold_NotBlocked(t *testing.T) {
+	g, _ := newTestGuard()
+	ctx := context.Background()
+
+	// Threshold failures are tolerated, so a human fumbling a password is never
+	// delayed. The penalty starts on the one after that.
+	for range 3 {
+		require.Zero(t, g.RetryAfter(ctx, "alice"))
+		g.RecordFailure(ctx, "alice")
+	}
+	require.Zero(t, g.RetryAfter(ctx, "alice"), "three failures is still within the allowance")
+
+	g.RecordFailure(ctx, "alice")
+	assert.Positive(t, g.RetryAfter(ctx, "alice"))
+}
+
+func TestGuard_DelayGrowsAndIsCapped(t *testing.T) {
+	g, clk := newTestGuard()
+	ctx := context.Background()
+
+	var delays []time.Duration
+	for range 12 {
+		g.RecordFailure(ctx, "alice")
+		d := g.RetryAfter(ctx, "alice")
+		delays = append(delays, d)
+		clk.add(d) // wait it out, then fail again
+	}
+
+	assert.Zero(t, delays[0], "first failure must not block")
+	assert.Zero(t, delays[2], "still inside the allowance")
+	assert.Equal(t, time.Second, delays[3], "first penalty is BaseDelay")
+	assert.Equal(t, 2*time.Second, delays[4])
+	assert.Equal(t, 4*time.Second, delays[5])
+	assert.Equal(t, time.Minute, delays[11], "capped at MaxDelay")
+}
+
+func TestGuard_WaitingItOutAllowsRetry(t *testing.T) {
+	g, clk := newTestGuard()
+	ctx := context.Background()
+
+	for range 4 {
+		g.RecordFailure(ctx, "alice")
+	}
+	blocked := g.RetryAfter(ctx, "alice")
+	require.Positive(t, blocked)
+
+	clk.add(blocked)
+	assert.Zero(t, g.RetryAfter(ctx, "alice"), "the window has passed")
+}
+
+func TestGuard_SuccessResets(t *testing.T) {
+	g, _ := newTestGuard()
+	ctx := context.Background()
+
+	for range 5 {
+		g.RecordFailure(ctx, "alice")
+	}
+	require.Positive(t, g.RetryAfter(ctx, "alice"))
+
+	g.RecordSuccess(ctx, "alice")
+	assert.Zero(t, g.RetryAfter(ctx, "alice"))
+}
+
+func TestGuard_AccountsAreIndependent(t *testing.T) {
+	g, _ := newTestGuard()
+	ctx := context.Background()
+
+	for range 5 {
+		g.RecordFailure(ctx, "alice")
+	}
+	require.Positive(t, g.RetryAfter(ctx, "alice"))
+	assert.Zero(t, g.RetryAfter(ctx, "bob"), "one account under attack must not lock out another")
+}
+
+// Usernames are counted case-insensitively, otherwise "Alice" and "alice" are
+// two budgets for one account.
+func TestGuard_UsernameCaseInsensitive(t *testing.T) {
+	g, _ := newTestGuard()
+	ctx := context.Background()
+
+	for range 5 {
+		g.RecordFailure(ctx, "Alice")
+	}
+	assert.Positive(t, g.RetryAfter(ctx, "alice"))
+}
+
+// A guard with no policy configured must never block — this is the path taken
+// when the feature is switched off.
+func TestGuard_Disabled_NeverBlocks(t *testing.T) {
+	var g *Guard
+	ctx := context.Background()
+
+	for range 100 {
+		g.RecordFailure(ctx, "alice")
+	}
+	assert.Zero(t, g.RetryAfter(ctx, "alice"))
+	g.RecordSuccess(ctx, "alice")
+}
+
+func TestGuard_StaleEntriesAreEvicted(t *testing.T) {
+	g, clk := newTestGuard()
+	ctx := context.Background()
+
+	g.RecordFailure(ctx, "alice")
+	require.Equal(t, 1, g.size())
+
+	clk.add(2 * entryTTL)
+	g.RecordFailure(ctx, "bob") // any write triggers the sweep
+	assert.Equal(t, 1, g.size(), "alice's stale entry should be gone")
+}

--- a/internal/auth/loginguard/redis_store.go
+++ b/internal/auth/loginguard/redis_store.go
@@ -1,0 +1,70 @@
+package loginguard
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// kv is the slice of redisclient.Client this store needs.
+type kv interface {
+	Get(ctx context.Context, key string) (string, error)
+	Set(ctx context.Context, key, value string, ttl time.Duration) error
+	Del(ctx context.Context, key string) error
+}
+
+// redisStore shares failure counts across HA nodes so that spreading guesses
+// over several servers does not multiply the allowance.
+//
+// Every operation is best-effort: Redis being unreachable degrades the guard to
+// per-node counting rather than locking anyone out or failing the login path.
+type redisStore struct{ c kv }
+
+// NewRedisStore adapts a Redis client to Store.
+func NewRedisStore(c kv) Store { return &redisStore{c: c} }
+
+func redisKey(account string) string { return "nexspence:loginfail:" + account }
+
+func (s *redisStore) Load(ctx context.Context, key string) (int, time.Time, bool) {
+	raw, err := s.c.Get(ctx, redisKey(key))
+	if err != nil || raw == "" {
+		return 0, time.Time{}, false
+	}
+	failures, blockedUntil, ok := parseEntry(raw)
+	if !ok {
+		return 0, time.Time{}, false
+	}
+	return failures, blockedUntil, true
+}
+
+func (s *redisStore) Save(ctx context.Context, key string, failures int, blockedUntil time.Time, ttl time.Duration) {
+	_ = s.c.Set(ctx, redisKey(key), formatEntry(failures, blockedUntil), ttl)
+}
+
+func (s *redisStore) Delete(ctx context.Context, key string) {
+	_ = s.c.Del(ctx, redisKey(key))
+}
+
+// formatEntry encodes as "<failures>:<unixNano>" — small, and readable when
+// someone is staring at redis-cli during an incident.
+func formatEntry(failures int, blockedUntil time.Time) string {
+	return fmt.Sprintf("%d:%d", failures, blockedUntil.UnixNano())
+}
+
+func parseEntry(raw string) (int, time.Time, bool) {
+	parts := strings.SplitN(raw, ":", 2)
+	if len(parts) != 2 {
+		return 0, time.Time{}, false
+	}
+	failures, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, time.Time{}, false
+	}
+	nanos, err := strconv.ParseInt(parts[1], 10, 64)
+	if err != nil {
+		return 0, time.Time{}, false
+	}
+	return failures, time.Unix(0, nanos), true
+}

--- a/internal/auth/loginguard/redis_store_test.go
+++ b/internal/auth/loginguard/redis_store_test.go
@@ -1,0 +1,126 @@
+package loginguard
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKV stands in for redisclient.Client.
+type fakeKV struct {
+	data   map[string]string
+	ttls   map[string]time.Duration
+	getErr error
+	setErr error
+}
+
+func newFakeKV() *fakeKV {
+	return &fakeKV{data: map[string]string{}, ttls: map[string]time.Duration{}}
+}
+
+func (f *fakeKV) Get(_ context.Context, key string) (string, error) {
+	if f.getErr != nil {
+		return "", f.getErr
+	}
+	v, ok := f.data[key]
+	if !ok {
+		return "", errors.New("redis: nil")
+	}
+	return v, nil
+}
+
+func (f *fakeKV) Set(_ context.Context, key, value string, ttl time.Duration) error {
+	if f.setErr != nil {
+		return f.setErr
+	}
+	f.data[key] = value
+	f.ttls[key] = ttl
+	return nil
+}
+
+func (f *fakeKV) Del(_ context.Context, key string) error {
+	delete(f.data, key)
+	return nil
+}
+
+func TestRedisStore_RoundTrip(t *testing.T) {
+	kv := newFakeKV()
+	s := NewRedisStore(kv)
+	ctx := context.Background()
+	until := time.Unix(1_700_000_123, 0)
+
+	s.Save(ctx, "alice", 7, until, 30*time.Minute)
+
+	failures, blockedUntil, ok := s.Load(ctx, "alice")
+	require.True(t, ok)
+	assert.Equal(t, 7, failures)
+	assert.True(t, blockedUntil.Equal(until), "got %v want %v", blockedUntil, until)
+	assert.Equal(t, 30*time.Minute, kv.ttls[redisKey("alice")])
+}
+
+func TestRedisStore_MissingKey(t *testing.T) {
+	s := NewRedisStore(newFakeKV())
+	_, _, ok := s.Load(context.Background(), "nobody")
+	assert.False(t, ok)
+}
+
+// Redis being unreachable must not lock everyone out, nor blow up the login
+// path — the guard falls back to its in-process count.
+func TestRedisStore_ErrorIsNotFatal(t *testing.T) {
+	kv := newFakeKV()
+	kv.getErr = errors.New("connection refused")
+	kv.setErr = errors.New("connection refused")
+	s := NewRedisStore(kv)
+	ctx := context.Background()
+
+	s.Save(ctx, "alice", 3, time.Now(), time.Minute) // must not panic
+	_, _, ok := s.Load(ctx, "alice")
+	assert.False(t, ok)
+}
+
+func TestRedisStore_CorruptValueIgnored(t *testing.T) {
+	kv := newFakeKV()
+	kv.data[redisKey("alice")] = "garbage"
+	s := NewRedisStore(kv)
+
+	_, _, ok := s.Load(context.Background(), "alice")
+	assert.False(t, ok, "an unparsable value must read as absent, not as zero failures")
+}
+
+func TestRedisStore_Delete(t *testing.T) {
+	kv := newFakeKV()
+	s := NewRedisStore(kv)
+	ctx := context.Background()
+
+	s.Save(ctx, "alice", 4, time.Now().Add(time.Minute), time.Minute)
+	s.Delete(ctx, "alice")
+
+	_, _, ok := s.Load(ctx, "alice")
+	assert.False(t, ok)
+}
+
+// The shared store is what stops an attacker spreading guesses across HA nodes
+// to multiply the allowance.
+func TestGuard_SharedStoreCountsAcrossNodes(t *testing.T) {
+	kv := newFakeKV()
+	ctx := context.Background()
+	policy := Policy{Threshold: 3, BaseDelay: time.Second, MaxDelay: time.Minute}
+
+	nodeA := New(NewRedisStore(kv), policy)
+	nodeB := New(NewRedisStore(kv), policy)
+
+	for range 2 {
+		nodeA.RecordFailure(ctx, "alice")
+	}
+	require.Zero(t, nodeB.RetryAfter(ctx, "alice"))
+
+	nodeB.RecordFailure(ctx, "alice")
+	nodeB.RecordFailure(ctx, "alice")
+
+	assert.Positive(t, nodeA.RetryAfter(ctx, "alice"),
+		"the fourth failure was on another node, but the budget is shared")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -413,7 +413,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("auth.password_min_length", 8)
 	v.SetDefault("auth.bcrypt_cost", 12)
 	v.SetDefault("auth.token_max_days", 90)
-	v.SetDefault("auth.rate_limit_enabled", false)
+	v.SetDefault("auth.rate_limit_enabled", true)
 	v.SetDefault("auth.rate_limit_rps", 50.0)
 	v.SetDefault("auth.rate_limit_burst", 100.0)
 	v.SetDefault("auth.allow_insecure_defaults", false)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,6 +193,20 @@ func TestLoad_GCDefaults(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, cfg.GC.MinAge)
 }
 
+func TestLoad_RateLimit_DefaultsEnabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Auth.RateLimitEnabled,
+		"auth.rate_limit_enabled must default to true: /api/v1/login is otherwise an unmetered bcrypt-cost-12 surface")
+}
+
 func TestLoad_TrustedProxies_DefaultsEmpty(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
Fixes H-2, M-1 and M-2 from the 2026-08-03 security audit.

## H-2 — CORS defaulted to a wildcard

`cors_origins: []` (the shipped default) sent `Access-Control-Allow-Origin: *` on every response. There is no `Allow-Credentials`, so cookie flows were never at risk — but this API authenticates by `Authorization` header **and** serves anonymous repositories, which is enough:

> employee visits `evil.com` → page issues `fetch('http://nexspence.internal:8081/repository/private-maven/…')` → the browser sends it from inside the corporate network → the wildcard lets the page **read the response**.

Empty now means no CORS header at all. The wildcard is still available, but has to be asked for as `cors_origins: ["*"]`.

The bundled UI is served from the same origin and never needed CORS; the Vite dev server proxies `/api`, `/service` and `/repository`, so local development is unaffected too.

## M-1 — no ceiling on password guessing

`auth.rate_limit_enabled` shipped `false`, so `/api/v1/login` was unmetered — a guessing surface, and with `bcrypt_cost: 12` (~250ms of CPU per attempt) also a cheap way to saturate the box. **Now defaults to `true`** at the existing 50 rps / 100 burst, which no ordinary client will notice.

There was also no account lockout or backoff of any kind. New `internal/auth/loginguard`:

- five consecutive failures per account are free, so a mistyped password costs nothing
- each failure after that doubles the wait — 1s, 2s, 4s … capped at 15 minutes
- the next attempt is refused with `429` + `Retry-After` **before the password is hashed**, so the attack stops paying for bcrypt
- a successful login clears the count; a quiet account forgets it after 30 minutes

Two design points worth calling out:

**Keyed on the account, not the address.** The IP bucket in the rate limiter is only as trustworthy as `http.trusted_proxies` (see #153). An attacker rotating addresses still spends the same per-account budget.

**Enforced at every place credentials are accepted** — `/api/v1/login`, Basic auth in `AuthMiddleware`, `OptionalAuth`, and the Docker `/v2/` handshake. A throttle covering only the login endpoint is evaded by moving the guessing elsewhere; those three extra sites were not in the audit and turned up while wiring this in.

**Shared across nodes when Redis is on**, so spreading attempts over HA servers does not multiply the allowance. Redis being unreachable degrades to per-node counting rather than locking anyone out.

The 429 body is identical for a real account and a name that does not exist, so the throttle is not a user-enumeration oracle.

## M-2 — bad credentials degraded to anonymous, unlogged

`OptionalAuth` fell through to `c.Next()` on a failed `users.Login` with no log line, and `/repository/*` and `/v2/*` all use it. Guessing there produced no failed-login record at all — invisible to the audit log and to any alerting built on it, while still costing a bcrypt per try.

Failures are now logged wherever they occur, with username, client address and path, and charged to the same budget as above. The fall-through to anonymous is unchanged — that is the point of the middleware — but a throttled account now skips the password check entirely.

## Verification

- `go test ./...` — 1907 passed, 1 failed: `TestWebhookHandler_Test_200`, which dials a loopback httptest server and fails identically on a clean `main` in this sandbox (network-only, not a regression)
- `golangci-lint run ./...` — clean on every file touched here; the 19 remaining `SA5011` hits are pre-existing in untouched test files
- coverage: `internal/auth/loginguard` 93.8%, `internal/api/handlers` 81.6%, `internal/config` 89.6%
- 26 new tests, each written first and watched fail for the right reason

Two of them were written wrong and the code was right: with `Threshold: N`, N failures are tolerated and the penalty starts on the one after. Both tests were corrected to match that, not the other way round.

## Docs

`config.yaml.example`, `docs/deployment.md`, and a new "Brute-force Protection" section in `docs/security-rbac.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Remfwxfq7rC6efLT8Mh7XQ