### PR TITLE
fix(security): close the remaining audit findings (M-3..M-7, L-1..L-6)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -73,7 +73,7 @@ jobs:
             docker run -d \
               --name nexspence-website \
               --restart unless-stopped \
-              -p 127.0.0.1:8080:80 \
+              -p 127.0.0.1:8080:8080 \
               "$IMAGE"
 
             # Don't leave the GHCR token in ~/.docker/config.json

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,56 @@
+# gitleaks configuration for nexspence.
+#
+# A scan of the full history finds no real secret — every hit is a documentation
+# example, a test fixture, or one of the deliberately recognizable development
+# defaults the server refuses to boot with (see cmd/server/startup_security.go).
+# Left unconfigured that is ~215 hits of noise, which is exactly how a real leak
+# goes unnoticed.
+#
+# The allowlist below is deliberately narrow: it names the specific placeholder
+# values and the fixture paths, rather than muting whole directories. A genuine
+# credential committed to docs/ would still be reported.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Documentation examples, test fixtures and shipped dev defaults"
+
+# Match against the whole matched line rather than just the extracted secret:
+# several of the placeholders below are only recognizable in context
+# (`curl -u <user>:<password>`), not from the captured value alone.
+regexTarget = "match"
+
+regexes = [
+  # `curl -u admin:admin123` and friends throughout the docs and README.
+  '''admin:admin123''',
+  '''admin:\$\{?[A-Z_]+\}?''',
+  # The quick-start admin password, warned about at startup.
+  '''admin123''',
+  # The shipped dev JWT secret — cmd/server refuses to boot with it unless
+  # auth.allow_insecure_defaults=true.
+  '''nexspence-dev-default-secret-change-me-in-production''',
+  # The shipped OIDC state-cookie key (base64 "abcdefghijklmnopqrstuvwxyz123456"),
+  # likewise refused at startup once OIDC is enabled.
+  '''YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=''',
+  # Seed users from docs/seed-testing-guide.md — created by the local seed
+  # script against a throwaway database, documented so the guide is runnable.
+  '''(dev|stage|test|prod)-user:User2026!''',
+  # Compose/dev database and MinIO credentials, all localhost-only.
+  '''nexspence:nexspence@''',
+  '''minioadmin''',
+  '''miniosecret''',
+  # Placeholder tokens in docs and fixtures: nxs_ is the API-token prefix.
+  '''nxs_(example|xxx|your|test|abc)[A-Za-z0-9_-]*''',
+  '''(?i)(your|example|changeme|placeholder|dummy|fake)[-_]?(token|secret|password|key)''',
+]
+
+paths = [
+  # Frontend test fixtures and MSW handlers carry fake tokens by design.
+  '''frontend/src/test/.*''',
+  '''.*\.test\.(ts|tsx)$''',
+  # Blob-storage tests: the "keys" here are content hashes, not credentials.
+  '''internal/storage/local(_internal)?_test\.go$''',
+  # Local planning notes, not shipped (they are gitignored going forward).
+  '''docs/superpowers/.*''',
+]

--- a/cmd/server/startup_security.go
+++ b/cmd/server/startup_security.go
@@ -6,6 +6,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/api"
 	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/logger"
+	"github.com/nexspence-oss/nexspence/internal/netguard"
 )
 
 // checkStartupSecurity refuses to boot on a configuration that would leave a
@@ -24,6 +25,18 @@ func checkStartupSecurity(cfg *config.Config, log logger.Logger) error {
 	}
 	if len(cfg.HTTP.TrustedProxies) == 0 {
 		log.Info("http.trusted_proxies is empty — X-Forwarded-For is ignored; set it when running behind a reverse proxy")
+	}
+
+	// Outbound targets come from configuration (proxy upstreams, webhooks,
+	// replication), so the SSRF guard's opt-out has to be right or an operator
+	// either cannot reach their on-prem registry or has quietly opened a path
+	// to the metadata service.
+	if err := netguard.SetAllowedInternalCIDRs(cfg.Outbound.AllowedInternalCIDRs); err != nil {
+		return fmt.Errorf("invalid outbound.allowed_internal_cidrs: %w", err)
+	}
+	if len(cfg.Outbound.AllowedInternalCIDRs) > 0 {
+		log.Warn("outbound.allowed_internal_cidrs is set — the SSRF guard will permit these internal ranges for proxy, webhook and replication targets",
+			"cidrs", cfg.Outbound.AllowedInternalCIDRs)
 	}
 
 	// Fail closed on shipped insecure defaults unless explicitly allowed

--- a/cmd/server/startup_security.go
+++ b/cmd/server/startup_security.go
@@ -30,9 +30,15 @@ func checkStartupSecurity(cfg *config.Config, log logger.Logger) error {
 	// (local dev / quick-start sets auth.allow_insecure_defaults=true).
 	insecureJWT := config.IsDevDefaultJWTSecret(cfg.Auth.JWTSecret)
 	insecureAdmin := cfg.Bootstrap.AdminPassword == "admin123"
-	if insecureJWT || insecureAdmin {
+	// Only meaningful while OIDC is on: the key seals the state cookie of a
+	// login flow that is not running otherwise.
+	insecureOIDCKey := cfg.OIDC.Enabled && config.IsDevDefaultOIDCCookieKey(cfg.OIDC.CookieKey)
+	if insecureJWT || insecureAdmin || insecureOIDCKey {
 		if !cfg.Auth.AllowInsecureDefaults {
-			return fmt.Errorf("refusing to start with shipped default secrets (jwt_default=%v, admin123=%v); set unique secrets or auth.allow_insecure_defaults=true for local dev", insecureJWT, insecureAdmin)
+			return fmt.Errorf("refusing to start with shipped default secrets (jwt_default=%v, admin123=%v, oidc_cookie_key_default=%v); set unique secrets or auth.allow_insecure_defaults=true for local dev", insecureJWT, insecureAdmin, insecureOIDCKey)
+		}
+		if insecureOIDCKey {
+			log.Warn("oidc.cookie_key is the shipped development default — an attacker who knows it can forge the OIDC state cookie; set a unique key (NEXSPENCE_OIDC_COOKIE_KEY, openssl rand -base64 32) before production use")
 		}
 		if insecureJWT {
 			log.Warn("auth.jwt_secret is the shipped development default — set a unique secret (NEXSPENCE_AUTH_JWT_SECRET) before production use")

--- a/cmd/server/startup_security_test.go
+++ b/cmd/server/startup_security_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/nexspence-oss/nexspence/internal/config"
+	"github.com/nexspence-oss/nexspence/internal/netguard"
 )
 
 func secureCfg() *config.Config {
@@ -44,6 +46,32 @@ func TestCheckStartupSecurity_ShippedDefaults_Refuse(t *testing.T) {
 	err := checkStartupSecurity(cfg, zap.NewNop().Sugar())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "default secrets")
+}
+
+func TestCheckStartupSecurity_InvalidOutboundAllowlist_Refuses(t *testing.T) {
+	cfg := secureCfg()
+	cfg.Outbound.AllowedInternalCIDRs = []string{"10.0.0.0/8", "nonsense"}
+
+	err := checkStartupSecurity(cfg, zap.NewNop().Sugar())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "allowed_internal_cidrs")
+}
+
+func TestCheckStartupSecurity_ValidOutboundAllowlist_IsApplied(t *testing.T) {
+	cfg := secureCfg()
+	cfg.Outbound.AllowedInternalCIDRs = []string{"10.10.0.0/16"}
+	t.Cleanup(func() { _ = netguard.SetAllowedInternalCIDRs(nil) })
+
+	require.NoError(t, checkStartupSecurity(cfg, zap.NewNop().Sugar()))
+
+	// Applied, not merely validated: the guard must actually let the range
+	// through afterwards.
+	c := netguard.Client(time.Second)
+	resp, err := c.Get("http://10.10.0.1:9/") //nolint:bodyclose // the request always fails; there is no body
+	require.Error(t, err, "the address is unroutable in tests")
+	require.Nil(t, resp)
+	assert.NotContains(t, err.Error(), "blocked",
+		"an allowlisted range must fail to connect, not be refused by the guard")
 }
 
 // The shipped OIDC cookie key seals the state cookie that protects the login

--- a/cmd/server/startup_security_test.go
+++ b/cmd/server/startup_security_test.go
@@ -46,6 +46,39 @@ func TestCheckStartupSecurity_ShippedDefaults_Refuse(t *testing.T) {
 	assert.Contains(t, err.Error(), "default secrets")
 }
 
+// The shipped OIDC cookie key seals the state cookie that protects the login
+// flow from CSRF. Knowing it lets an attacker forge a state cookie matching
+// their own state parameter, so it belongs in the same fail-closed check as the
+// JWT secret and admin password.
+func TestCheckStartupSecurity_ShippedOIDCCookieKey_Refuses(t *testing.T) {
+	cfg := secureCfg()
+	cfg.OIDC.Enabled = true
+	cfg.OIDC.CookieKey = config.DevDefaultOIDCCookieKey
+
+	err := checkStartupSecurity(cfg, zap.NewNop().Sugar())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "default secrets")
+}
+
+func TestCheckStartupSecurity_ShippedOIDCCookieKey_AllowedWhenOptedIn(t *testing.T) {
+	cfg := secureCfg()
+	cfg.OIDC.Enabled = true
+	cfg.OIDC.CookieKey = config.DevDefaultOIDCCookieKey
+	cfg.Auth.AllowInsecureDefaults = true
+
+	require.NoError(t, checkStartupSecurity(cfg, zap.NewNop().Sugar()))
+}
+
+// A disabled provider cannot be attacked through its cookie, so the shipped key
+// sitting unused in a config file must not stop the server booting.
+func TestCheckStartupSecurity_ShippedOIDCCookieKey_IgnoredWhenOIDCDisabled(t *testing.T) {
+	cfg := secureCfg()
+	cfg.OIDC.Enabled = false
+	cfg.OIDC.CookieKey = config.DevDefaultOIDCCookieKey
+
+	require.NoError(t, checkStartupSecurity(cfg, zap.NewNop().Sugar()))
+}
+
 func TestCheckStartupSecurity_ShippedDefaults_AllowedWhenOptedIn(t *testing.T) {
 	cfg := secureCfg()
 	cfg.Auth.JWTSecret = config.DevDefaultJWTSecret

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -22,6 +22,16 @@ http:
     cert_file: ""
     key_file: ""
 
+# Outbound requests to URLs that come from configuration: proxy upstreams,
+# webhook endpoints, replication targets.
+outbound:
+  # Every loopback, private, link-local, CGNAT, multicast and broadcast address
+  # is refused by default. That is what stops a proxy repository pointed at
+  # http://169.254.169.254/… from turning repository-admin into cloud
+  # credential theft. Name a range here when you genuinely proxy an on-prem
+  # registry — it is the one way to reach an internal address.
+  allowed_internal_cidrs: []   # e.g. ["10.20.0.0/16", "registry.internal.example.com is resolved, so use its range"]
+
 database:
   dsn: "postgres://nexspence:nexspence@localhost:5432/nexspence?sslmode=disable"
   max_conns: 100

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -17,6 +17,12 @@ http:
   # every request looks like it comes from the proxy. "*" trusts every hop —
   # only safe when the server cannot be reached except through that proxy.
   trusted_proxies: []         # e.g. ["10.0.0.0/8"] or ["*"]
+  # Content-Security-Policy for the bundled UI and the API. Empty uses the
+  # built-in policy (same-origin scripts, no inline script, no framing);
+  # "off" omits the header when a reverse proxy sets its own. Artifact paths
+  # (/repository/, /v2/) are never covered — raw repositories are used to host
+  # documentation sites that carry their own scripts.
+  csp: ""
   tls:
     enabled: false
     cert_file: ""

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -138,6 +138,7 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `http.addr` | `:8081` | Listen address |
 | `http.base_url` | `http://localhost:8081` | Public URL used in download links |
 | `http.trusted_proxies` | `[]` | Peers (IPs/CIDRs) whose `X-Forwarded-For` is believed. Empty trusts nobody, so the audit log and rate limiter see the real peer. Set it to your reverse proxy when you run behind one; `["*"]` trusts every hop. |
+| `http.csp` | `""` | Content-Security-Policy for UI/API responses. Empty uses the built-in policy; `"off"` omits the header. Artifact paths are exempt. |
 | `http.cors_origins` | `[]` | Origins allowed to read API responses from a browser. Empty sends no CORS header — correct when the bundled UI shares this origin. `["*"]` lets any site read responses; opt in only for a public instance. |
 | `database.dsn` | `postgres://nexspence:nexspence@localhost:5437/nexspence` | PostgreSQL connection string |
 | `storage.default_type` | `local` | `local` or `s3` |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -150,6 +150,7 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `auth.jwt_expiry_hours` | `24` | JWT token lifetime |
 | `auth.anonymous_enabled` | `true` | Instance-wide switch for unauthenticated reads. `false` refuses them everywhere, overriding any repository's `allow_anonymous`. |
 | `auth.token_max_days` | `180` | Maximum lifetime for user API tokens (`nxs_*`) |
+| `outbound.allowed_internal_cidrs` | `[]` | Internal ranges the SSRF guard may reach for proxy, webhook and replication targets. Empty refuses every loopback/private/link-local/CGNAT address. |
 | `auth.rate_limit_enabled` | `true` | Token-bucket throttle per user (per client address when anonymous). Turning it off leaves `/api/v1/login` unmetered. |
 | `auth.rate_limit_rps` / `auth.rate_limit_burst` | `50` / `100` | Sustained rate and burst for the above |
 | `bootstrap.admin_password` | `admin123` | Auto-created admin password — **change this** |

--- a/internal/api/csp_test.go
+++ b/internal/api/csp_test.go
@@ -3,6 +3,9 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -92,4 +95,34 @@ func TestDefaultCSP_AllowsTheBundledUI(t *testing.T) {
 	// component libraries commonly inject <style> at runtime.
 	assert.True(t, strings.Contains(DefaultCSP, "style-src 'self' 'unsafe-inline'"),
 		"style-src needs unsafe-inline for runtime-injected styles: %s", DefaultCSP)
+}
+
+// The bundled UI loads its webfonts from Google. A policy that forgets them
+// does not fail loudly — the page renders in a fallback font and nobody
+// notices until someone reads the console. This test pins the two origins the
+// UI actually references.
+func TestDefaultCSP_AllowsTheFontsTheUIRequests(t *testing.T) {
+	assert.Contains(t, DefaultCSP, "https://fonts.googleapis.com",
+		"style-src must admit the Google Fonts stylesheet")
+	assert.Contains(t, DefaultCSP, "https://fonts.gstatic.com",
+		"font-src must admit the font files themselves")
+}
+
+// Guards against the UI gaining a new external dependency that the policy does
+// not know about. Skipped when the frontend has not been built.
+func TestDefaultCSP_CoversEveryExternalOriginInIndexHTML(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "frontend", "index.html"))
+	if err != nil {
+		t.Skip("frontend/index.html not available")
+	}
+	origins := regexp.MustCompile(`https://[a-zA-Z0-9.-]+`).FindAllString(string(raw), -1)
+	seen := map[string]bool{}
+	for _, o := range origins {
+		if seen[o] {
+			continue
+		}
+		seen[o] = true
+		assert.Contains(t, DefaultCSP, o,
+			"index.html references %s but the CSP does not allow it", o)
+	}
 }

--- a/internal/api/csp_test.go
+++ b/internal/api/csp_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func headerFor(t *testing.T, policy, path string) string {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(securityHeaders(policy))
+	r.GET("/*any", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, nil))
+	return w.Header().Get("Content-Security-Policy")
+}
+
+// The SPA keeps its JWT in localStorage, which is normal for a bearer-token
+// client but means any future XSS is a full token theft. A CSP is the defense
+// in depth that was missing.
+func TestCSP_ServedOnTheUI(t *testing.T) {
+	got := headerFor(t, DefaultCSP, "/repositories")
+	require.NotEmpty(t, got)
+
+	for _, want := range []string{
+		"default-src 'self'",
+		"script-src 'self'",
+		"object-src 'none'",
+		"frame-ancestors 'none'",
+		"base-uri 'self'",
+		"form-action 'self'",
+	} {
+		assert.Contains(t, got, want)
+	}
+	assert.NotContains(t, got, "script-src 'self' 'unsafe-inline'",
+		"inline script is the thing being prevented")
+}
+
+// Artifact paths serve content users uploaded — including raw repositories used
+// to host documentation sites, which legitimately carry their own scripts and
+// styles. Applying the UI policy there would break a shipped feature.
+func TestCSP_NotAppliedToArtifactPaths(t *testing.T) {
+	for _, path := range []string{
+		"/repository/raw-docs/index.html",
+		"/v2/myimage/manifests/latest",
+	} {
+		assert.Empty(t, headerFor(t, DefaultCSP, path), "path %s", path)
+	}
+}
+
+// An operator hosting the UI behind something with its own policy, or needing a
+// CDN, can replace or disable it.
+func TestCSP_Configurable(t *testing.T) {
+	custom := "default-src 'none'"
+	assert.Equal(t, custom, headerFor(t, custom, "/"))
+	assert.Empty(t, headerFor(t, "", "/"), "empty policy disables the header")
+}
+
+// The other hardening headers keep applying everywhere, artifacts included.
+func TestSecurityHeaders_AppliedEverywhere(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(securityHeaders(DefaultCSP))
+	r.GET("/*any", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/repository/raw/x.html", nil))
+
+	assert.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"))
+	assert.Equal(t, "DENY", w.Header().Get("X-Frame-Options"))
+}
+
+// The policy has to actually admit the bundled UI: Vite emits a module script
+// and a stylesheet, both same-origin, plus data: URIs for small assets.
+func TestDefaultCSP_AllowsTheBundledUI(t *testing.T) {
+	for _, want := range []string{
+		"img-src 'self' data:",
+		"font-src 'self' data:",
+		"connect-src 'self'",
+	} {
+		assert.Contains(t, DefaultCSP, want)
+	}
+	// Vite injects the stylesheet via a <style> tag in dev and a link in prod;
+	// component libraries commonly inject <style> at runtime.
+	assert.True(t, strings.Contains(DefaultCSP, "style-src 'self' 'unsafe-inline'"),
+		"style-src needs unsafe-inline for runtime-injected styles: %s", DefaultCSP)
+}

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -156,16 +156,36 @@ func (h *AuthHandler) Me(c *gin.Context) {
 // Must be placed after AuthMiddleware which populates the "roles" context key.
 func AdminRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		roles, _ := c.Get("roles")
-		list, _ := roles.([]string)
-		for _, r := range list {
-			if r == "nx-admin" {
-				c.Next()
-				return
-			}
+		if !IsAdmin(c) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "admin role required"})
+			return
 		}
-		c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "admin role required"})
+		c.Next()
 	}
+}
+
+// IsAdmin reports whether the authenticated caller holds nx-admin. Handlers
+// that are dangerous regardless of where they are mounted check this themselves
+// instead of relying on the route being wired under AdminRequired.
+func IsAdmin(c *gin.Context) bool {
+	roles, _ := c.Get("roles")
+	list, _ := roles.([]string)
+	for _, r := range list {
+		if r == "nx-admin" {
+			return true
+		}
+	}
+	return false
+}
+
+// requireAdmin aborts with 403 unless the caller is an admin, reporting whether
+// the request may continue.
+func requireAdmin(c *gin.Context) bool {
+	if IsAdmin(c) {
+		return true
+	}
+	c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "admin role required"})
+	return false
 }
 
 // authenticateBearer tries the JWT service first, then falls back to an API

--- a/internal/api/handlers/blobstores.go
+++ b/internal/api/handlers/blobstores.go
@@ -278,6 +278,11 @@ func (h *BlobStoreHandler) Delete(c *gin.Context) {
 // Query params: key=<blobKey>, ttl=<seconds> (default 3600).
 // Returns a presigned download URL (S3 stores only).
 func (h *BlobStoreHandler) PresignGet(c *gin.Context) {
+	// The key is caller-supplied and repository RBAC never sees it, so this is
+	// an admin operation wherever it ends up mounted.
+	if !requireAdmin(c) {
+		return
+	}
 	ps, ok := h.blobStore.(storage.PresignableStore)
 	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "presigned URLs are only supported for S3 blob stores"})
@@ -309,6 +314,9 @@ func (h *BlobStoreHandler) PresignGet(c *gin.Context) {
 // Body JSON: {"key": "<blobKey>", "ttl": <seconds>}
 // Returns a presigned upload URL (S3 stores only).
 func (h *BlobStoreHandler) PresignPut(c *gin.Context) {
+	if !requireAdmin(c) {
+		return
+	}
 	ps, ok := h.blobStore.(storage.PresignableStore)
 	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "presigned URLs are only supported for S3 blob stores"})
@@ -342,6 +350,9 @@ func (h *BlobStoreHandler) PresignPut(c *gin.Context) {
 // Body JSON: {"expiration_days": 30}  (0 = remove all rules)
 // S3 stores only.
 func (h *BlobStoreHandler) ConfigureLifecycle(c *gin.Context) {
+	if !requireAdmin(c) {
+		return
+	}
 	ps, ok := h.blobStore.(storage.PresignableStore)
 	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "lifecycle configuration is only supported for S3 blob stores"})

--- a/internal/api/handlers/blobstores_test.go
+++ b/internal/api/handlers/blobstores_test.go
@@ -38,6 +38,9 @@ func mountBlobStores(t *testing.T, stores ...*domain.BlobStore) (*gin.Engine, *t
 		WithGC(gc)
 
 	r := gin.New()
+	// The presign and lifecycle handlers check for nx-admin themselves — see
+	// presign_admin_test.go — so these tests authenticate as one.
+	r.Use(func(c *gin.Context) { c.Set("roles", []string{"nx-admin"}); c.Next() })
 	r.GET("/service/rest/v1/blobstores", h.List)
 	r.GET("/service/rest/v1/blobstores/:name", h.Get)
 	r.POST("/service/rest/v1/blobstores/:type", h.Create)

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -12,6 +12,12 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/redisclient"
 )
 
+// readinessTTL is how long a healthy probe result is reused. /readyz is
+// unauthenticated, so without this every hit is a Postgres round trip and the
+// probe becomes a cheap way to load the database. A second is short enough that
+// an orchestrator still sees an outage promptly.
+const readinessTTL = time.Second
+
 // LivenessHandler returns 200 {"status":"ok"} — process is alive.
 func LivenessHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -19,66 +25,101 @@ func LivenessHandler() gin.HandlerFunc {
 	}
 }
 
+// pinger is the one thing readiness needs from a dependency. Both
+// *pgxpool.Pool and *redisclient.Client satisfy it.
+type pinger interface {
+	Ping(ctx context.Context) error
+}
+
 // ReadinessHandler checks DB and Redis connectivity in parallel.
 // Either dep may be nil — it is skipped in that case.
 // Returns 503 if any check fails.
 func ReadinessHandler(pool *pgxpool.Pool, redis *redisclient.Client) gin.HandlerFunc {
-	return func(c *gin.Context) {
+	// Typed nils would satisfy the interface while being nil underneath, so
+	// convert explicitly.
+	var db, rd pinger
+	if pool != nil {
+		db = pool
+	}
+	if redis != nil {
+		rd = redis
+	}
+	return readinessHandler(db, rd, readinessTTL)
+}
+
+// readinessResult is the memoized outcome of one probe round.
+type readinessResult struct {
+	checks map[string]string
+	failed bool
+	at     time.Time
+}
+
+func readinessHandler(db, redis pinger, ttl time.Duration) gin.HandlerFunc {
+	var (
+		mu     sync.Mutex
+		cached *readinessResult
+	)
+
+	probe := func(ctx context.Context) *readinessResult {
 		checks := map[string]string{}
-		var mu sync.Mutex
+		var cmu sync.Mutex
 		var wg sync.WaitGroup
 		failed := false
 
-		if pool != nil {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
-				defer cancel()
-				status := "ok"
-				if err := pool.Ping(ctx); err != nil {
-					status = "error"
-				}
-				mu.Lock()
-				checks["db"] = status
-				if status != "ok" {
-					failed = true
-				}
-				mu.Unlock()
-			}()
+		check := func(name string, p pinger) {
+			defer wg.Done()
+			pctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+			status := "ok"
+			if err := p.Ping(pctx); err != nil {
+				status = "error"
+			}
+			cmu.Lock()
+			checks[name] = status
+			if status != "ok" {
+				failed = true
+			}
+			cmu.Unlock()
 		}
 
+		if db != nil {
+			wg.Add(1)
+			go check("db", db)
+		}
 		if redis != nil {
 			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
-				defer cancel()
-				status := "ok"
-				if err := redis.Ping(ctx); err != nil {
-					status = "error"
-				}
-				mu.Lock()
-				checks["redis"] = status
-				if status != "ok" {
-					failed = true
-				}
-				mu.Unlock()
-			}()
+			go check("redis", redis)
 		}
-
 		wg.Wait()
+
+		return &readinessResult{checks: checks, failed: failed, at: time.Now()}
+	}
+
+	return func(c *gin.Context) {
+		mu.Lock()
+		// Only healthy results are reused: caching a failure would keep
+		// reporting an outage that has already been fixed.
+		res := cached
+		fresh := res != nil && !res.failed && time.Since(res.at) < ttl
+		mu.Unlock()
+
+		if !fresh {
+			res = probe(c.Request.Context())
+			mu.Lock()
+			cached = res
+			mu.Unlock()
+		}
 
 		statusStr := "ok"
 		code := http.StatusOK
-		if failed {
+		if res.failed {
 			statusStr = "degraded"
 			code = http.StatusServiceUnavailable
 		}
 
 		resp := gin.H{"status": statusStr}
-		if len(checks) > 0 {
-			resp["checks"] = checks
+		if len(res.checks) > 0 {
+			resp["checks"] = res.checks
 		}
 		c.JSON(code, resp)
 	}

--- a/internal/api/handlers/health_cache_test.go
+++ b/internal/api/handlers/health_cache_test.go
@@ -1,0 +1,95 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type countingPinger struct {
+	calls atomic.Int32
+	err   error
+}
+
+func (p *countingPinger) Ping(context.Context) error {
+	p.calls.Add(1)
+	return p.err
+}
+
+func serveReady(h gin.HandlerFunc) *httptest.ResponseRecorder {
+	r := gin.New()
+	r.GET("/readyz", h)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	return w
+}
+
+// /readyz is unauthenticated. Without a cache every hit is a Postgres round
+// trip, which turns the liveness surface into a cheap way to load the DB.
+func TestReadiness_CachesTheProbeResult(t *testing.T) {
+	db := &countingPinger{}
+	h := readinessHandler(db, nil, time.Minute)
+
+	for range 20 {
+		require.Equal(t, http.StatusOK, serveReady(h).Code)
+	}
+	assert.Equal(t, int32(1), db.calls.Load(), "20 requests must not be 20 pings")
+}
+
+func TestReadiness_CacheExpires(t *testing.T) {
+	db := &countingPinger{}
+	h := readinessHandler(db, nil, time.Nanosecond)
+
+	serveReady(h)
+	time.Sleep(time.Millisecond)
+	serveReady(h)
+
+	assert.Equal(t, int32(2), db.calls.Load(), "a stale result must be refreshed")
+}
+
+func TestReadiness_ReportsFailure(t *testing.T) {
+	db := &countingPinger{err: errors.New("connection refused")}
+	h := readinessHandler(db, nil, time.Minute)
+
+	w := serveReady(h)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), "degraded")
+}
+
+// A failing dependency must not be remembered for the full TTL, or the probe
+// keeps reporting an outage that is already over.
+func TestReadiness_FailureIsNotCached(t *testing.T) {
+	db := &countingPinger{err: errors.New("connection refused")}
+	h := readinessHandler(db, nil, time.Minute)
+
+	serveReady(h)
+	db.err = nil
+	w := serveReady(h)
+
+	assert.Equal(t, int32(2), db.calls.Load())
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestReadiness_ChecksBothDependencies(t *testing.T) {
+	db := &countingPinger{}
+	redis := &countingPinger{}
+	h := readinessHandler(db, redis, time.Minute)
+
+	w := serveReady(h)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"db":"ok"`)
+	assert.Contains(t, w.Body.String(), `"redis":"ok"`)
+}
+
+func TestReadiness_NoDependencies_IsOK(t *testing.T) {
+	w := serveReady(readinessHandler(nil, nil, time.Minute))
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/api/handlers/presign_admin_test.go
+++ b/internal/api/handlers/presign_admin_test.go
@@ -1,0 +1,65 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nexspence-oss/nexspence/internal/api/handlers"
+)
+
+// The presign handlers take an arbitrary blob key and hand back a URL for it,
+// bypassing repository RBAC entirely. They are not mounted today; the gate goes
+// in now so that mounting them later cannot silently open every blob in the
+// store to any authenticated user.
+func presignRouter() *gin.Engine {
+	h := handlers.NewBlobStoreHandler(nil)
+	r := gin.New()
+	// Deliberately mounted without AdminRequired, the mistake being guarded against.
+	r.GET("/presign", withRoles(nil), h.PresignGet)
+	r.POST("/presign", withRoles(nil), h.PresignPut)
+	r.POST("/lifecycle", withRoles(nil), h.ConfigureLifecycle)
+	r.GET("/presign-admin", withRoles([]string{"nx-admin"}), h.PresignGet)
+	return r
+}
+
+func withRoles(roles []string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if roles != nil {
+			c.Set("roles", roles)
+		}
+		c.Next()
+	}
+}
+
+func TestPresign_NonAdmin_IsForbidden(t *testing.T) {
+	r := presignRouter()
+
+	for _, tc := range []struct{ method, path string }{
+		{http.MethodGet, "/presign?key=any/blob"},
+		{http.MethodPost, "/presign"},
+		{http.MethodPost, "/lifecycle"},
+	} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(`{"key":"any/blob"}`))
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code, "%s %s", tc.method, tc.path)
+	}
+}
+
+func TestPresign_Admin_GetsPastTheGate(t *testing.T) {
+	r := presignRouter()
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/presign-admin?key=any/blob", nil))
+
+	// No S3 store is configured here, so the handler refuses for that reason —
+	// what matters is that it is no longer the admin gate turning it away.
+	assert.NotEqual(t, http.StatusForbidden, w.Code)
+}

--- a/internal/api/handlers/saml.go
+++ b/internal/api/handlers/saml.go
@@ -51,13 +51,65 @@ func (h *SAMLHandler) Login(c *gin.Context) {
 		returnTo = "/"
 	}
 	relayState := h.saml.SignRelayState(returnTo)
-	redirectURL, err := h.saml.AuthnRequestURL(relayState)
+	redirectURL, requestID, err := h.saml.AuthnRequest(relayState)
 	if err != nil {
 		h.log.Errorw("saml authn request error", "err", err)
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
+	// Remember which request this browser started. ACS refuses any assertion
+	// that does not answer it, which is what stops an attacker replaying an
+	// assertion of their own into someone else's browser.
+	h.setRequestIDCookie(c, h.saml.SignRequestID(requestID))
 	c.Redirect(http.StatusFound, redirectURL)
+}
+
+// samlRequestIDCookie carries the pending AuthnRequest ID between the redirect
+// to the IdP and the assertion coming back.
+const samlRequestIDCookie = "saml_request_id"
+
+func (h *SAMLHandler) setRequestIDCookie(c *gin.Context, value string) {
+	//nolint:gosec // G124: SameSite=None is required — the IdP delivers the
+	// assertion as a cross-site POST, and a Lax cookie would not be sent with
+	// it. It is paired with Secure whenever the ACS URL is HTTPS.
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     samlRequestIDCookie,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   int(auth.SAMLRequestIDTTL.Seconds()),
+		HttpOnly: true,
+		Secure:   h.secureCookies(),
+		// The assertion arrives as a cross-site POST from the IdP, so the
+		// cookie has to survive it; None requires Secure.
+		SameSite: h.cookieSameSite(),
+	})
+}
+
+func (h *SAMLHandler) clearRequestIDCookie(c *gin.Context) {
+	//nolint:gosec // G124: mirrors setRequestIDCookie so the browser matches and
+	// drops the same cookie; an expiring cookie carries no value anyway.
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:     samlRequestIDCookie,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   h.secureCookies(),
+		SameSite: h.cookieSameSite(),
+	})
+}
+
+// secureCookies reports whether the ACS endpoint is served over HTTPS, which
+// SameSite=None requires. A plain-HTTP dev setup falls back to Lax.
+func (h *SAMLHandler) secureCookies() bool {
+	return strings.HasPrefix(strings.ToLower(h.cfg.ACSURL), "https://")
+}
+
+func (h *SAMLHandler) cookieSameSite() http.SameSite {
+	if h.secureCookies() {
+		return http.SameSiteNoneMode
+	}
+	return http.SameSiteLaxMode
 }
 
 // ACS serves POST /api/v1/auth/saml/acs — Assertion Consumer Service.
@@ -71,7 +123,26 @@ func (h *SAMLHandler) ACS(c *gin.Context) {
 		}
 	}
 
-	claims, err := h.saml.ParseResponse(c.Request)
+	// The assertion is only accepted as the answer to a request this browser
+	// started. No cookie means no pending request: refuse rather than fall back
+	// to treating it as IdP-initiated.
+	var possibleRequestIDs []string
+	if raw, err := c.Cookie(samlRequestIDCookie); err == nil && raw != "" {
+		if id, verr := h.saml.VerifyRequestID(raw); verr == nil {
+			possibleRequestIDs = []string{id}
+		} else {
+			h.log.Warnw("saml request id cookie rejected", "err", verr, "ip", c.ClientIP())
+		}
+	}
+	// One assertion per request, whatever the outcome.
+	h.clearRequestIDCookie(c)
+	if len(possibleRequestIDs) == 0 {
+		h.log.Warnw("saml assertion without a pending request", "ip", c.ClientIP())
+		h.fail(c, "verification failed")
+		return
+	}
+
+	claims, err := h.saml.ParseResponse(c.Request, possibleRequestIDs)
 	if err != nil {
 		h.log.Warnw("saml parse response failed", "err", err)
 		h.fail(c, "verification failed")

--- a/internal/api/handlers/saml_test.go
+++ b/internal/api/handlers/saml_test.go
@@ -30,16 +30,27 @@ type mockSAMLAuthenticator struct {
 	parseErr  error
 	returnTo  string
 	verifyErr error
+
+	requestIDErr  error
+	gotRequestIDs []string
 }
 
 func (m *mockSAMLAuthenticator) MetadataXML() ([]byte, error) {
 	return m.metaXML, m.metaErr
 }
-func (m *mockSAMLAuthenticator) AuthnRequestURL(rs string) (string, error) {
-	return m.authnURL, m.authnErr
+func (m *mockSAMLAuthenticator) AuthnRequest(rs string) (string, string, error) {
+	return m.authnURL, "id-mock-request", m.authnErr
 }
-func (m *mockSAMLAuthenticator) ParseResponse(r *http.Request) (*auth.SAMLClaims, error) {
+func (m *mockSAMLAuthenticator) ParseResponse(r *http.Request, ids []string) (*auth.SAMLClaims, error) {
+	m.gotRequestIDs = ids
 	return m.claims, m.parseErr
+}
+func (m *mockSAMLAuthenticator) SignRequestID(id string) string { return "signed:" + id }
+func (m *mockSAMLAuthenticator) VerifyRequestID(v string) (string, error) {
+	if m.requestIDErr != nil {
+		return "", m.requestIDErr
+	}
+	return strings.TrimPrefix(v, "signed:"), nil
 }
 func (m *mockSAMLAuthenticator) SignRelayState(returnTo string) string {
 	return returnTo
@@ -139,6 +150,7 @@ func TestSAMLHandler_ACS_ValidAssertion_RedirectsWithToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/saml/acs",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "saml_request_id", Value: "signed:id-mock-request"})
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -157,6 +169,7 @@ func TestSAMLHandler_ACS_InvalidAssertion_RedirectsToLoginWithError(t *testing.T
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/saml/acs",
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "saml_request_id", Value: "signed:id-mock-request"})
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -194,4 +207,113 @@ func TestSAMLHandler_ACS_ProvisioningRejected_RedirectsWithError(t *testing.T) {
 
 	require.Equal(t, http.StatusFound, w.Code)
 	assert.Contains(t, w.Header().Get("Location"), "saml_error=")
+}
+
+// ── request-ID binding (M-5) ──────────────────────────────────
+
+// The login redirect has to leave something behind that ties the coming
+// assertion to this browser's request.
+func TestSAMLHandler_Login_SetsRequestIDCookie(t *testing.T) {
+	mock := &mockSAMLAuthenticator{authnURL: "https://idp.example.com/sso?SAMLRequest=x"}
+	r := newSAMLRig(t, mock)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/auth/saml/login", nil))
+
+	var found *http.Cookie
+	for _, ck := range w.Result().Cookies() {
+		if ck.Name == "saml_request_id" {
+			found = ck
+		}
+	}
+	require.NotNil(t, found, "no binding cookie was set")
+	assert.Equal(t, "signed:id-mock-request", found.Value)
+	assert.True(t, found.HttpOnly, "the browser's scripts have no business reading it")
+}
+
+// The classic SAML login-CSRF: a validly-signed assertion the attacker obtained
+// elsewhere, POSTed into a victim's browser. With no pending request there is
+// nothing for it to answer.
+func TestSAMLHandler_ACS_WithoutPendingRequest_IsRefused(t *testing.T) {
+	mock := &mockSAMLAuthenticator{
+		claims:   &auth.SAMLClaims{Subject: "attacker@idp", Username: "attacker"},
+		returnTo: "/",
+	}
+	r := newSAMLRig(t, mock)
+
+	form := url.Values{}
+	form.Set("SAMLResponse", "a-perfectly-valid-assertion")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/saml/acs", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+	assert.Contains(t, w.Header().Get("Location"), "/login?saml_error=")
+	assert.NotContains(t, w.Header().Get("Location"), "token=")
+	assert.Nil(t, mock.gotRequestIDs, "the assertion must not even be parsed")
+}
+
+func TestSAMLHandler_ACS_ForgedCookie_IsRefused(t *testing.T) {
+	mock := &mockSAMLAuthenticator{
+		claims:       &auth.SAMLClaims{Subject: "attacker@idp", Username: "attacker"},
+		requestIDErr: assert.AnError,
+	}
+	r := newSAMLRig(t, mock)
+
+	form := url.Values{}
+	form.Set("SAMLResponse", "assertion")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/saml/acs", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "saml_request_id", Value: "i-made-this-up"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Contains(t, w.Header().Get("Location"), "/login?saml_error=")
+	assert.Nil(t, mock.gotRequestIDs)
+}
+
+// The verified ID must actually reach the library — that is the check doing the
+// work; everything above it is just plumbing.
+func TestSAMLHandler_ACS_PassesRequestIDToParser(t *testing.T) {
+	mock := &mockSAMLAuthenticator{
+		claims:   &auth.SAMLClaims{Subject: "alice@idp", Username: "alice", Groups: []string{}},
+		returnTo: "/",
+	}
+	r := newSAMLRig(t, mock)
+
+	form := url.Values{}
+	form.Set("SAMLResponse", "assertion")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/saml/acs", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "saml_request_id", Value: "signed:id-mock-request"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, []string{"id-mock-request"}, mock.gotRequestIDs)
+}
+
+// One assertion per login: the cookie is spent whether or not it worked.
+func TestSAMLHandler_ACS_ClearsTheCookie(t *testing.T) {
+	mock := &mockSAMLAuthenticator{
+		claims:   &auth.SAMLClaims{Subject: "alice@idp", Username: "alice", Groups: []string{}},
+		returnTo: "/",
+	}
+	r := newSAMLRig(t, mock)
+
+	form := url.Values{}
+	form.Set("SAMLResponse", "assertion")
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/saml/acs", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(&http.Cookie{Name: "saml_request_id", Value: "signed:id-mock-request"})
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	for _, ck := range w.Result().Cookies() {
+		if ck.Name == "saml_request_id" {
+			assert.Less(t, ck.MaxAge, 0, "cookie should be expired")
+			return
+		}
+	}
+	t.Fatal("expected the binding cookie to be cleared")
 }

--- a/internal/api/handlers/system_test.go
+++ b/internal/api/handlers/system_test.go
@@ -43,13 +43,17 @@ type fakeSAML struct {
 	err error
 }
 
-func (f fakeSAML) MetadataXML() ([]byte, error)             { return f.xml, f.err }
-func (f fakeSAML) AuthnRequestURL(_ string) (string, error) { return "", nil }
-func (f fakeSAML) ParseResponse(_ *http.Request) (*auth.SAMLClaims, error) {
+func (f fakeSAML) MetadataXML() ([]byte, error) { return f.xml, f.err }
+func (f fakeSAML) AuthnRequest(_ string) (string, string, error) {
+	return "", "id-test", nil
+}
+func (f fakeSAML) ParseResponse(_ *http.Request, _ []string) (*auth.SAMLClaims, error) {
 	return nil, nil
 }
 func (f fakeSAML) SignRelayState(returnTo string) string      { return returnTo }
 func (f fakeSAML) VerifyRelayState(rs string) (string, error) { return rs, nil }
+func (f fakeSAML) SignRequestID(id string) string             { return id }
+func (f fakeSAML) VerifyRequestID(v string) (string, error)   { return v, nil }
 
 // newUnreachablePool returns a lazily-initialized pgxpool pointing at an address
 // that is never reachable. pgxpool.New does not dial until first use, so this

--- a/internal/api/health_routes.go
+++ b/internal/api/health_routes.go
@@ -1,0 +1,14 @@
+package api
+
+import "github.com/gin-gonic/gin"
+
+// registerHealthRoutes mounts the liveness and readiness probes.
+//
+// It exists to make the ordering explicit: gin captures the middleware chain
+// when a route is registered, so these have to be added after r.Use(...) or
+// they run bare — no Recovery, no metrics, no limits. They are still
+// unauthenticated, which is the point of a probe.
+func registerHealthRoutes(r *gin.Engine, liveness, readiness gin.HandlerFunc) {
+	r.GET("/healthz", liveness)
+	r.GET("/readyz", readiness)
+}

--- a/internal/api/health_routes_test.go
+++ b/internal/api/health_routes_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// The health probes were registered before r.Use(...). Gin snapshots the
+// middleware chain at registration time, so they ran with no Recovery — a panic
+// in the readiness path took the process down instead of returning 500 — and no
+// metrics, body limit or rate limit either.
+func TestHealthRoutes_RunInsideTheMiddlewareChain(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	saw := false
+	r.Use(func(c *gin.Context) { saw = true; c.Next() })
+	registerHealthRoutes(r, func(c *gin.Context) { c.Status(http.StatusOK) },
+		func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, saw, "middleware registered before the route must run for it")
+}
+
+func TestHealthRoutes_PanicIsRecovered(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(gin.Recovery())
+	registerHealthRoutes(r,
+		func(c *gin.Context) { c.Status(http.StatusOK) },
+		func(*gin.Context) { panic("db driver blew up") })
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code,
+		"a panic in the probe must not escape the handler")
+}

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/logger"
 )
 
@@ -59,15 +60,71 @@ func corsMiddleware(allowed []string) gin.HandlerFunc {
 	}
 }
 
-// securityHeaders sets baseline hardening response headers. CSP is intentionally
-// omitted — the SPA needs a tailored policy that is out of scope here.
-func securityHeaders() gin.HandlerFunc {
+// DefaultCSP is the policy served with the bundled UI.
+//
+// The SPA stores its JWT in localStorage — normal for a bearer-token client,
+// but it means any future XSS is a full token theft. This is the defense in
+// depth for that. Everything the UI needs is same-origin: Vite emits a module
+// script and a stylesheet, small assets arrive as data: URIs, and the API is
+// on the same host.
+//
+// style-src keeps 'unsafe-inline' because component libraries inject <style>
+// at runtime; script-src deliberately does not, which is the half that matters.
+const DefaultCSP = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data:; " +
+	"font-src 'self' data:; " +
+	"connect-src 'self'; " +
+	"object-src 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'; " +
+	"frame-ancestors 'none'"
+
+// cspExemptPrefixes are the paths that serve user-uploaded content rather than
+// the UI. Raw repositories are used to host documentation sites, which carry
+// their own scripts and styles; applying the UI policy to them would break a
+// shipped feature. They are not covered by this header — the isolation there
+// comes from hosting such sites on their own repository, not from CSP.
+var cspExemptPrefixes = []string{"/repository/", "/v2/"}
+
+// securityHeaders sets baseline hardening response headers, including the
+// Content-Security-Policy for UI and API responses. An empty policy omits the
+// CSP header entirely.
+func securityHeaders(policy string) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Header("X-Content-Type-Options", "nosniff")
 		c.Header("X-Frame-Options", "DENY")
 		c.Header("Referrer-Policy", "no-referrer")
+		if policy != "" && !hasAnyPrefix(c.Request.URL.Path, cspExemptPrefixes) {
+			c.Header("Content-Security-Policy", policy)
+		}
 		c.Next()
 	}
+}
+
+// cspPolicy resolves the configured policy: unset means the default, and the
+// literal "off" disables the header for operators whose reverse proxy sets its
+// own. Distinguishing "unset" from "off" is why this is not just an empty
+// string default.
+func cspPolicy(cfg *config.Config) string {
+	switch cfg.HTTP.CSP {
+	case "":
+		return DefaultCSP
+	case "off":
+		return ""
+	default:
+		return cfg.HTTP.CSP
+	}
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // bodyLimit caps request body size at maxMB megabytes, except for paths that

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -70,11 +70,15 @@ func corsMiddleware(allowed []string) gin.HandlerFunc {
 //
 // style-src keeps 'unsafe-inline' because component libraries inject <style>
 // at runtime; script-src deliberately does not, which is the half that matters.
+// The two Google Fonts origins are the only third parties the UI references
+// (frontend/index.html); a policy without them renders the app in a fallback
+// font and says so only in the console. Self-hosting the fonts would let both
+// entries go.
 const DefaultCSP = "default-src 'self'; " +
 	"script-src 'self'; " +
-	"style-src 'self' 'unsafe-inline'; " +
+	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
 	"img-src 'self' data:; " +
-	"font-src 'self' data:; " +
+	"font-src 'self' data: https://fonts.gstatic.com; " +
 	"connect-src 'self'; " +
 	"object-src 'none'; " +
 	"base-uri 'self'; " +

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -118,7 +118,7 @@ func TestCORS_PreflightWithoutAllowlistSendsNoACAO(t *testing.T) {
 func TestSecurityHeaders(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.Use(securityHeaders())
+	r.Use(securityHeaders(DefaultCSP))
 	r.GET("/", func(c *gin.Context) { c.Status(http.StatusOK) })
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -308,7 +308,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	r.Use(gin.Recovery())
 	r.Use(requestLogger(log))
 	r.Use(corsMiddleware(cfg.HTTP.CORSOrigins))
-	r.Use(securityHeaders())
+	r.Use(securityHeaders(cspPolicy(cfg)))
 	r.Use(bodyLimit(cfg.HTTP.MaxBodyMB, []string{"/repository/", "/v2/", "/api/v1/repositories/import", "/service/rest/v1/components"}))
 	r.Use(handlers.MetricsMiddleware())
 	r.Use(AuditMiddleware(auditRepo))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -305,9 +305,6 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 			log.Error("failed to reset trusted proxies", "err", err)
 		}
 	}
-	// Health probes — no auth, no middleware.
-	r.GET("/healthz", handlers.LivenessHandler())
-	r.GET("/readyz", handlers.ReadinessHandler(pool, rdb))
 	r.Use(gin.Recovery())
 	r.Use(requestLogger(log))
 	r.Use(corsMiddleware(cfg.HTTP.CORSOrigins))
@@ -318,6 +315,11 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	if cfg.Auth.RateLimitEnabled {
 		r.Use(RateLimitMiddleware(cfg.Auth.RateLimitRPS, cfg.Auth.RateLimitBurst))
 	}
+
+	// Health probes: no auth, but inside the middleware chain — registering them
+	// earlier meant gin snapshotted an empty chain for them, leaving the
+	// readiness path without Recovery.
+	registerHealthRoutes(r, handlers.LivenessHandler(), handlers.ReadinessHandler(pool, rdb))
 
 	authMW := handlers.AuthMiddleware(userSvc, tokenSvc, loginGuard, log)
 	adminMW := handlers.AdminRequired()

--- a/internal/api/subdomain_rewriter.go
+++ b/internal/api/subdomain_rewriter.go
@@ -57,5 +57,29 @@ func (s *SubdomainRewriter) extractRepo(host string) string {
 	if sub == "" || strings.Contains(sub, ".") {
 		return ""
 	}
+	// The value is spliced into the URL path, so accept only what a repository
+	// name can look like. RBAC still runs on the result, so this is not the
+	// boundary that stops a bypass — it stops a host header from injecting
+	// separators or encoded segments into a path we build.
+	if !isRepoNameLabel(sub) {
+		return ""
+	}
 	return sub
+}
+
+// isRepoNameLabel reports whether s is a lower-case DNS-style label:
+// [a-z0-9] separated by single hyphens, no leading or trailing hyphen.
+func isRepoNameLabel(s string) bool {
+	if s == "" || s[0] == '-' || s[len(s)-1] == '-' {
+		return false
+	}
+	for i := range len(s) {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/internal/api/subdomain_rewriter_test.go
+++ b/internal/api/subdomain_rewriter_test.go
@@ -18,6 +18,48 @@ func capturePathHandler() (http.Handler, *string) {
 	}), captured
 }
 
+// The subdomain is spliced into the URL path, so it has to look like a
+// repository name. RBAC still runs on whatever name comes out, so a strange
+// value is not a bypass — but a host header should not be able to put
+// arbitrary characters, path separators or encoded segments into the path.
+func TestSubdomainRewriter_RejectsNonRepoNameSubdomains(t *testing.T) {
+	for _, host := range []string{
+		"my%2frepo.nexspence.example.com",
+		"my_repo.nexspence.example.com",
+		"my repo.nexspence.example.com",
+		"-leading.nexspence.example.com",
+		"trailing-.nexspence.example.com",
+	} {
+		h, captured := capturePathHandler()
+		rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+
+		req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
+		req.Host = host
+		rw.ServeHTTP(httptest.NewRecorder(), req)
+
+		assert.Equal(t, "/v2/alpine/manifests/latest", *captured,
+			"host %q must not be spliced into the path", host)
+	}
+}
+
+func TestSubdomainRewriter_AcceptsRepoNameSubdomains(t *testing.T) {
+	for _, host := range []string{
+		"myrepo.nexspence.example.com",
+		"my-repo-2.nexspence.example.com",
+		"MyRepo.nexspence.example.com", // host matching is case-insensitive
+	} {
+		h, captured := capturePathHandler()
+		rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+
+		req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
+		req.Host = host
+		rw.ServeHTTP(httptest.NewRecorder(), req)
+
+		assert.NotEqual(t, "/v2/alpine/manifests/latest", *captured,
+			"host %q is a valid repository name and should be rewritten", host)
+	}
+}
+
 func TestSubdomainRewriter_NonDockerPath_Passthrough(t *testing.T) {
 	h, captured := capturePathHandler()
 	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")

--- a/internal/auth/saml.go
+++ b/internal/auth/saml.go
@@ -37,11 +37,22 @@ type SAMLClaims struct {
 // SAMLAuthenticator is the interface for SAML SP operations (enables mocking).
 type SAMLAuthenticator interface {
 	MetadataXML() ([]byte, error)
-	AuthnRequestURL(relayState string) (string, error)
-	ParseResponse(r *http.Request) (*SAMLClaims, error)
+	// AuthnRequest returns the IdP redirect URL and the ID of the request it
+	// encodes. The caller must remember that ID and hand it back to
+	// ParseResponse, which is what binds an assertion to the login that asked
+	// for it.
+	AuthnRequest(relayState string) (redirectURL, requestID string, err error)
+	ParseResponse(r *http.Request, possibleRequestIDs []string) (*SAMLClaims, error)
 	SignRelayState(returnTo string) string
 	VerifyRelayState(rs string) (string, error)
+	SignRequestID(id string) string
+	VerifyRequestID(v string) (string, error)
 }
+
+// SAMLRequestIDTTL bounds how long a started login may take to come back. It
+// covers a real user typing a password and an MFA prompt, without leaving the
+// binding cookie replayable for hours.
+const SAMLRequestIDTTL = 10 * time.Minute
 
 // SAMLService implements SAMLAuthenticator using crewjam/saml.
 type SAMLService struct {
@@ -95,22 +106,87 @@ func (s *SAMLService) MetadataXML() ([]byte, error) {
 	return xml.MarshalIndent(meta, "", "  ")
 }
 
-// AuthnRequestURL builds a redirect-binding AuthnRequest and returns the IdP redirect URL.
-func (s *SAMLService) AuthnRequestURL(relayState string) (string, error) {
-	u, err := s.sp.MakeRedirectAuthenticationRequest(relayState)
+// AuthnRequest builds a redirect-binding AuthnRequest and returns both the IdP
+// redirect URL and the generated request ID.
+func (s *SAMLService) AuthnRequest(relayState string) (string, string, error) {
+	req, err := s.sp.MakeAuthenticationRequest(
+		s.sp.GetSSOBindingLocation(saml.HTTPRedirectBinding),
+		saml.HTTPRedirectBinding,
+		saml.HTTPPostBinding,
+	)
 	if err != nil {
-		return "", fmt.Errorf("saml authn request: %w", err)
+		return "", "", fmt.Errorf("saml authn request: %w", err)
 	}
-	return u.String(), nil
+	u, err := req.Redirect(relayState, &s.sp)
+	if err != nil {
+		return "", "", fmt.Errorf("saml authn redirect: %w", err)
+	}
+	return u.String(), req.ID, nil
 }
 
 // ParseResponse validates the POST-binding SAMLResponse from the IdP.
-func (s *SAMLService) ParseResponse(r *http.Request) (*SAMLClaims, error) {
-	assertion, err := s.sp.ParseResponse(r, nil)
+//
+// possibleRequestIDs must contain the ID of the AuthnRequest this response
+// answers. Passing none means no assertion can be accepted: without that
+// binding, a validly-signed assertion the attacker obtained elsewhere could be
+// replayed into a victim's browser to log them in as the attacker.
+func (s *SAMLService) ParseResponse(r *http.Request, possibleRequestIDs []string) (*SAMLClaims, error) {
+	assertion, err := s.sp.ParseResponse(r, possibleRequestIDs)
 	if err != nil {
 		return nil, fmt.Errorf("saml parse response: %w", err)
 	}
 	return s.extractClaims(assertion), nil
+}
+
+// SignRequestID returns the value for the binding cookie: the request ID and an
+// issue time, HMAC-signed so the browser cannot choose either.
+func (s *SAMLService) SignRequestID(id string) string {
+	return s.SignRequestIDAt(id, time.Now())
+}
+
+// SignRequestIDAt is SignRequestID with an explicit issue time (tests).
+func (s *SAMLService) SignRequestIDAt(id string, issuedAt time.Time) string {
+	data, _ := json.Marshal(map[string]any{"id": id, "t": issuedAt.Unix()})
+	mac := hmac.New(sha256.New, s.hmacKey)
+	mac.Write(data)
+	return base64.RawURLEncoding.EncodeToString(data) + "." +
+		base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyRequestID checks the signature and age of a binding cookie and returns
+// the request ID it carries.
+func (s *SAMLService) VerifyRequestID(v string) (string, error) {
+	parts := strings.SplitN(v, ".", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("saml: invalid request id format")
+	}
+	data, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return "", fmt.Errorf("saml: request id data decode: %w", err)
+	}
+	sig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("saml: request id sig decode: %w", err)
+	}
+	mac := hmac.New(sha256.New, s.hmacKey)
+	mac.Write(data)
+	if !hmac.Equal(sig, mac.Sum(nil)) {
+		return "", fmt.Errorf("saml: request id signature invalid")
+	}
+	var payload struct {
+		ID string `json:"id"`
+		T  int64  `json:"t"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", fmt.Errorf("saml: request id payload decode: %w", err)
+	}
+	if payload.ID == "" {
+		return "", fmt.Errorf("saml: request id missing")
+	}
+	if time.Since(time.Unix(payload.T, 0)) > SAMLRequestIDTTL {
+		return "", fmt.Errorf("saml: request id expired")
+	}
+	return payload.ID, nil
 }
 
 // SignRelayState encodes returnTo as base64url(json)."."base64url(HMAC-SHA256).

--- a/internal/auth/saml_requestid_test.go
+++ b/internal/auth/saml_requestid_test.go
@@ -1,0 +1,92 @@
+package auth_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/auth"
+)
+
+// crewjam/saml refuses an assertion whose InResponseTo is not among the request
+// IDs handed to ParseResponse, and the SP was passing nil — so no SP-initiated
+// login could ever succeed, and there was nothing binding an assertion to the
+// request that asked for it.
+
+func TestSAML_AuthnRequest_ReturnsTheRequestID(t *testing.T) {
+	svc := newTestSAMLService(t)
+
+	url, id, err := svc.AuthnRequest("relay")
+	require.NoError(t, err)
+	assert.Contains(t, url, "SAMLRequest=")
+	require.NotEmpty(t, id, "the caller needs the request ID to bind the response to it")
+	assert.True(t, strings.HasPrefix(id, "id-"), "crewjam generates id-prefixed request IDs, got %q", id)
+}
+
+func TestSAML_AuthnRequest_IDsAreUnique(t *testing.T) {
+	svc := newTestSAMLService(t)
+
+	_, first, err := svc.AuthnRequest("relay")
+	require.NoError(t, err)
+	_, second, err := svc.AuthnRequest("relay")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second, "a reused ID would let one assertion be replayed against another login")
+}
+
+// The ID travels in a signed cookie between the redirect and the ACS post, the
+// same shape as the relay state.
+
+func TestSAML_RequestIDCookie_RoundTrip(t *testing.T) {
+	svc := newTestSAMLService(t)
+
+	sealed := svc.SignRequestID("id-abc123")
+	got, err := svc.VerifyRequestID(sealed)
+	require.NoError(t, err)
+	assert.Equal(t, "id-abc123", got)
+}
+
+func TestSAML_RequestIDCookie_TamperedSignatureRejected(t *testing.T) {
+	svc := newTestSAMLService(t)
+
+	sealed := svc.SignRequestID("id-abc123")
+	parts := strings.SplitN(sealed, ".", 2)
+	require.Len(t, parts, 2)
+
+	_, err := svc.VerifyRequestID(parts[0] + ".AAAA")
+	assert.Error(t, err, "an attacker must not be able to name the request ID themselves")
+}
+
+func TestSAML_RequestIDCookie_MalformedRejected(t *testing.T) {
+	svc := newTestSAMLService(t)
+
+	for _, bad := range []string{"", "nodot", "!!!.!!!"} {
+		_, err := svc.VerifyRequestID(bad)
+		assert.Error(t, err, "input %q", bad)
+	}
+}
+
+func TestSAML_RequestIDCookie_Expires(t *testing.T) {
+	svc := newTestSAMLService(t)
+
+	stale := svc.SignRequestIDAt("id-abc123", time.Now().Add(-2*auth.SAMLRequestIDTTL))
+	_, err := svc.VerifyRequestID(stale)
+	assert.Error(t, err, "a login started long ago must not still be completable")
+}
+
+// With no cookie there is no request to bind to, so the assertion is refused
+// rather than accepted as IdP-initiated.
+func TestSAML_ParseResponse_WithoutRequestIDs_IsRefused(t *testing.T) {
+	svc := newTestSAMLService(t)
+
+	r := httptest.NewRequest(http.MethodPost, "/acs", strings.NewReader("SAMLResponse=abc"))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	_, err := svc.ParseResponse(r, nil)
+	require.Error(t, err)
+}

--- a/internal/auth/saml_test.go
+++ b/internal/auth/saml_test.go
@@ -91,7 +91,7 @@ func TestSAMLService_MetadataXML_ContainsEntityID(t *testing.T) {
 func TestSAMLService_AuthnRequestURL_ContainsSAMLRequest(t *testing.T) {
 	svc := newTestSAMLService(t)
 	rs := svc.SignRelayState("/")
-	redirectURL, err := svc.AuthnRequestURL(rs)
+	redirectURL, _, err := svc.AuthnRequest(rs)
 	require.NoError(t, err)
 	assert.Contains(t, redirectURL, "SAMLRequest=")
 	assert.Contains(t, redirectURL, "idp.example.com/sso")
@@ -138,6 +138,6 @@ func TestSAMLService_ParseResponse_MissingBody_ReturnsError(t *testing.T) {
 	r, _ := http.NewRequest(http.MethodPost, "/acs", strings.NewReader("SAMLResponse=invalid"))
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	_ = r.ParseForm()
-	_, err := svc.ParseResponse(r)
+	_, err := svc.ParseResponse(r, []string{"id-anything"})
 	require.Error(t, err)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,10 @@ type HTTPConfig struct {
 	// hop, which is only safe when the server is unreachable except through a
 	// proxy you control.
 	TrustedProxies []string `mapstructure:"trusted_proxies"`
+	// CSP overrides the Content-Security-Policy served with the UI. Empty uses
+	// the built-in policy; the literal "off" omits the header, for deployments
+	// whose reverse proxy sets its own.
+	CSP string `mapstructure:"csp"`
 }
 
 // TLSConfig holds the optional server certificate and key for HTTPS.
@@ -416,6 +420,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("http.cors_origins", []string{})
 	v.SetDefault("http.trusted_proxies", []string{})
 	v.SetDefault("outbound.allowed_internal_cidrs", []string{})
+	v.SetDefault("http.csp", "")
 	v.SetDefault("http.base_url", "http://localhost:8081")
 	// Viper bug: AutomaticEnv + Unmarshal silently skips keys that have no
 	// default/config-file value (not in AllKeys). Empty-string defaults ensure

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -216,6 +216,17 @@ const DevDefaultJWTSecret = "nexspence-dev-default-secret-change-me-in-productio
 // IsDevDefaultJWTSecret reports whether s is the shipped development default.
 func IsDevDefaultJWTSecret(s string) bool { return s == DevDefaultJWTSecret }
 
+// DevDefaultOIDCCookieKey is the OIDC state-cookie key hard-coded in the
+// docker-compose files and config.yaml.example (base64 of
+// "abcdefghijklmnopqrstuvwxyz123456"). It seals the state cookie that protects
+// the login flow from CSRF, so an attacker who knows it can forge a state
+// cookie matching their own state parameter — cmd/server refuses to start with
+// it once OIDC is enabled.
+const DevDefaultOIDCCookieKey = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=" //nolint:gosec // G101: this is the recognizable dev default we refuse to boot with, not a production credential
+
+// IsDevDefaultOIDCCookieKey reports whether s is the shipped development default.
+func IsDevDefaultOIDCCookieKey(s string) bool { return s == DevDefaultOIDCCookieKey }
+
 // EncryptionKeyBytes returns the decoded dedicated encryption key, or nil when
 // unset. Load() has already validated the encoding and length.
 func (a AuthConfig) EncryptionKeyBytes() []byte {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,20 @@ type Config struct {
 	Docker    DockerConfig    `mapstructure:"docker"`
 	Redis     RedisConfig     `mapstructure:"redis"`
 	Proxy     ProxyConfig     `mapstructure:"proxy"`
+	Outbound  OutboundConfig  `mapstructure:"outbound"`
+}
+
+// OutboundConfig governs where the server is allowed to make requests when the
+// target URL comes from configuration: proxy upstreams, webhook endpoints and
+// replication targets.
+type OutboundConfig struct {
+	// AllowedInternalCIDRs lists internal ranges that may be reached anyway.
+	// By default every loopback, private, link-local, CGNAT, multicast and
+	// broadcast address is refused, which is what stops a proxy repository
+	// pointed at a cloud metadata endpoint from turning repo-admin into
+	// credential theft. On-prem deployments that genuinely proxy an internal
+	// registry name that range here.
+	AllowedInternalCIDRs []string `mapstructure:"allowed_internal_cidrs"`
 }
 
 // ProxyConfig configures the server-wide outbound proxy used when fetching from
@@ -401,6 +415,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("http.max_body_mb", 1024)
 	v.SetDefault("http.cors_origins", []string{})
 	v.SetDefault("http.trusted_proxies", []string{})
+	v.SetDefault("outbound.allowed_internal_cidrs", []string{})
 	v.SetDefault("http.base_url", "http://localhost:8081")
 	// Viper bug: AutomaticEnv + Unmarshal silently skips keys that have no
 	// default/config-file value (not in AllKeys). Empty-string defaults ensure

--- a/internal/netguard/allowlist_test.go
+++ b/internal/netguard/allowlist_test.go
@@ -1,0 +1,114 @@
+package netguard
+
+import (
+	"testing"
+)
+
+func resetAllowlist(t *testing.T) {
+	t.Helper()
+	t.Cleanup(func() { SetAllowedInternalCIDRs(nil) })
+}
+
+// Ranges an operator never means to reach outbound, and which the original
+// guard let through.
+func TestIsBlockedIP_ExtraRanges(t *testing.T) {
+	for _, ip := range []string{
+		"100.64.0.1",       // CGNAT (RFC 6598) — some cloud metadata lives here
+		"100.100.100.200",  // Alibaba Cloud metadata
+		"255.255.255.255",  // broadcast
+		"224.0.0.1",        // multicast
+		"::ffff:127.0.0.1", // IPv4-mapped loopback
+		"fe80::1",          // IPv6 link-local
+		"fc00::1",          // IPv6 unique-local
+	} {
+		if !isBlockedIP(ip) {
+			t.Errorf("expected %q to be blocked", ip)
+		}
+	}
+}
+
+// On-prem deployments legitimately proxy an internal registry, so the guard
+// needs a documented way to say "this range is fine" — without that, the only
+// workaround is switching the guard off entirely.
+func TestAllowlist_PermitsConfiguredRange(t *testing.T) {
+	resetAllowlist(t)
+
+	if !isBlockedIP("10.10.0.7") {
+		t.Fatal("precondition: private range is blocked by default")
+	}
+
+	if err := SetAllowedInternalCIDRs([]string{"10.10.0.0/16"}); err != nil {
+		t.Fatalf("SetAllowedInternalCIDRs: %v", err)
+	}
+
+	if isBlockedIP("10.10.0.7") {
+		t.Error("expected an explicitly allowed range to pass")
+	}
+	if !isBlockedIP("10.20.0.7") {
+		t.Error("expected a private address outside the allowlist to stay blocked")
+	}
+	if !isBlockedIP("169.254.169.254") {
+		t.Error("expected link-local to stay blocked when it is not allowlisted")
+	}
+}
+
+// The allowlist is the operator saying "I know what is there", so it covers
+// link-local too when named explicitly — nothing is special-cased away.
+func TestAllowlist_CanPermitLinkLocalExplicitly(t *testing.T) {
+	resetAllowlist(t)
+
+	if err := SetAllowedInternalCIDRs([]string{"169.254.169.254/32"}); err != nil {
+		t.Fatalf("SetAllowedInternalCIDRs: %v", err)
+	}
+	if isBlockedIP("169.254.169.254") {
+		t.Error("expected the explicitly allowed metadata address to pass")
+	}
+	if !isBlockedIP("169.254.1.1") {
+		t.Error("expected the rest of link-local to stay blocked")
+	}
+}
+
+func TestAllowlist_SingleAddressWithoutMask(t *testing.T) {
+	resetAllowlist(t)
+
+	if err := SetAllowedInternalCIDRs([]string{"192.168.5.10"}); err != nil {
+		t.Fatalf("SetAllowedInternalCIDRs: %v", err)
+	}
+	if isBlockedIP("192.168.5.10") {
+		t.Error("expected the bare address to be treated as a /32")
+	}
+	if !isBlockedIP("192.168.5.11") {
+		t.Error("expected neighboring addresses to stay blocked")
+	}
+}
+
+// A typo must be rejected loudly at startup rather than silently widening or
+// narrowing what the server may reach.
+func TestAllowlist_RejectsGarbage(t *testing.T) {
+	resetAllowlist(t)
+
+	if err := SetAllowedInternalCIDRs([]string{"10.0.0.0/8", "not-a-cidr"}); err == nil {
+		t.Fatal("expected an error for an unparsable entry")
+	}
+	if !isBlockedIP("10.0.0.1") {
+		t.Error("a rejected allowlist must not be applied even partially")
+	}
+}
+
+func TestAllowlist_EmptyRestoresDefault(t *testing.T) {
+	resetAllowlist(t)
+
+	if err := SetAllowedInternalCIDRs([]string{"10.0.0.0/8"}); err != nil {
+		t.Fatalf("SetAllowedInternalCIDRs: %v", err)
+	}
+	if isBlockedIP("10.0.0.1") {
+		t.Fatal("precondition: allowlisted range passes")
+	}
+
+	if err := SetAllowedInternalCIDRs(nil); err != nil {
+		t.Fatalf("SetAllowedInternalCIDRs(nil): %v", err)
+	}
+	if !isBlockedIP("10.0.0.1") {
+		t.Error("clearing the allowlist must restore the default deny")
+	}
+}

--- a/internal/netguard/netguard.go
+++ b/internal/netguard/netguard.go
@@ -11,9 +11,67 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"syscall"
 	"time"
 )
+
+// cgnat is RFC 6598 shared address space. It is not "private" as far as Go's
+// net package is concerned, but nothing outbound should ever reach it — and
+// some providers put their metadata service there.
+var cgnat = &net.IPNet{IP: net.IPv4(100, 64, 0, 0), Mask: net.CIDRMask(10, 32)}
+
+// allowedInternal holds the operator's opt-out: ranges that are internal but
+// deliberately reachable, e.g. an on-prem registry being proxied. Stored as an
+// atomic value so the dial hook stays lock-free on the hot path.
+var allowedInternal atomic.Pointer[[]*net.IPNet]
+
+// SetAllowedInternalCIDRs records the ranges that may be reached despite being
+// internal. Entries are CIDRs or bare addresses (treated as a single host).
+// The list is validated in full before being applied, so a typo leaves the
+// previous policy in place rather than half-applying a new one. A nil or empty
+// list restores the default of blocking every internal range.
+func SetAllowedInternalCIDRs(entries []string) error {
+	nets := make([]*net.IPNet, 0, len(entries))
+	for _, e := range entries {
+		n, err := parseCIDROrIP(e)
+		if err != nil {
+			return fmt.Errorf("netguard: invalid allowed internal target %q: %w", e, err)
+		}
+		nets = append(nets, n)
+	}
+	allowedInternal.Store(&nets)
+	return nil
+}
+
+func parseCIDROrIP(s string) (*net.IPNet, error) {
+	if _, n, err := net.ParseCIDR(s); err == nil {
+		return n, nil
+	}
+	ip := net.ParseIP(s)
+	if ip == nil {
+		return nil, fmt.Errorf("not a CIDR or IP address")
+	}
+	bits := 32
+	if ip.To4() == nil {
+		bits = 128
+	}
+	return &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)}, nil
+}
+
+// isAllowlisted reports whether ip was explicitly permitted by the operator.
+func isAllowlisted(ip net.IP) bool {
+	nets := allowedInternal.Load()
+	if nets == nil {
+		return false
+	}
+	for _, n := range *nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
 
 // isBlockedIP reports whether s is an IP that requests must not reach.
 // Unparseable input fails closed (blocked).
@@ -22,11 +80,20 @@ func isBlockedIP(s string) bool {
 	if ip == nil {
 		return true
 	}
+	// The operator's allowlist wins: naming a range is them saying they know
+	// what is there, including link-local if they spell it out.
+	if isAllowlisted(ip) {
+		return false
+	}
 	return ip.IsLoopback() ||
 		ip.IsPrivate() ||
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
-		ip.IsUnspecified()
+		ip.IsInterfaceLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified() ||
+		ip.Equal(net.IPv4bcast) ||
+		cgnat.Contains(ip)
 }
 
 // control is the net.Dialer Control hook that rejects connections to blocked IPs.

--- a/internal/service/backup_import.go
+++ b/internal/service/backup_import.go
@@ -2,28 +2,41 @@ package service
 
 import (
 	"archive/tar"
-	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 )
 
-// backupArchive holds a backup tar.gz decoded in one pass: JSON sections by
-// entry name, blob payloads by blob key.
+// backupArchive holds a backup tar.gz decoded in one pass. JSON sections stay
+// in memory — they are small and are unmarshalled immediately — while blob
+// payloads are spooled to a temporary directory. Holding those in memory meant
+// an 8 GiB archive cost 8 GiB of process heap.
+//
+// The caller owns the spool: Close removes it, and every path that builds an
+// archive must call it.
 type backupArchive struct {
-	entries map[string][]byte
-	blobs   map[string][]byte
+	entries  map[string][]byte
+	blobDir  string
+	blobFile map[string]string // blob key → spooled file name
+	blobSize map[string]int64
 }
 
 // defaultMaxImportBytes caps total decompressed bytes read from a backup
-// archive, guarding against gzip bombs that would otherwise OOM the process.
+// archive, guarding against gzip bombs that would otherwise fill the disk.
 const defaultMaxImportBytes = 8 << 30 // 8 GiB
+
+// maxImportEntries caps how many members an archive may contain. The byte limit
+// alone does not bound work: millions of one-byte entries cost CPU and
+// allocation without ever approaching it.
+const maxImportEntries = 5_000_000
 
 func readBackupArchive(r io.Reader) (*backupArchive, error) {
 	return readBackupArchiveLimited(r, defaultMaxImportBytes)
@@ -31,43 +44,140 @@ func readBackupArchive(r io.Reader) (*backupArchive, error) {
 
 // readBackupArchiveLimited decodes a backup tar.gz, returning an error once the
 // cumulative decompressed size of all entries exceeds maxBytes.
-func readBackupArchiveLimited(r io.Reader, maxBytes int64) (*backupArchive, error) {
-	gr, err := gzip.NewReader(r)
-	if err != nil {
-		return nil, fmt.Errorf("not a gzip archive: %w", err)
+func readBackupArchiveLimited(r io.Reader, maxBytes int64) (a *backupArchive, err error) {
+	return readBackupArchiveWithLimits(r, maxBytes, maxImportEntries)
+}
+
+// readBackupArchiveWithLimits is readBackupArchiveLimited with the entry cap
+// exposed, so tests can exercise it without building a five-million-entry tar.
+func readBackupArchiveWithLimits(r io.Reader, maxBytes int64, maxEntries int) (a *backupArchive, err error) {
+	gr, gerr := gzip.NewReader(r)
+	if gerr != nil {
+		return nil, fmt.Errorf("not a gzip archive: %w", gerr)
 	}
 	defer func() { _ = gr.Close() }()
+
+	dir, derr := os.MkdirTemp("", "nexspence-import-*")
+	if derr != nil {
+		return nil, fmt.Errorf("create import spool: %w", derr)
+	}
+	a = &backupArchive{
+		entries:  map[string][]byte{},
+		blobDir:  dir,
+		blobFile: map[string]string{},
+		blobSize: map[string]int64{},
+	}
+	// Any failure below leaves nothing on disk.
+	defer func() {
+		if err != nil {
+			_ = a.Close()
+			a = nil
+		}
+	}()
+
 	tr := tar.NewReader(gr)
-	a := &backupArchive{entries: map[string][]byte{}, blobs: map[string][]byte{}}
 	var total int64
+	var count int
 	for {
-		hdr, err := tr.Next()
-		if errors.Is(err, io.EOF) {
+		hdr, nerr := tr.Next()
+		if errors.Is(nerr, io.EOF) {
 			break
 		}
-		if err != nil {
-			return nil, fmt.Errorf("read archive: %w", err)
+		if nerr != nil {
+			return a, fmt.Errorf("read archive: %w", nerr)
+		}
+		count++
+		if count > maxEntries {
+			return a, fmt.Errorf("backup archive exceeds %d entries", maxEntries)
 		}
 		remaining := maxBytes - total
 		if remaining <= 0 {
-			return nil, fmt.Errorf("backup archive exceeds %d byte decompression limit", maxBytes)
+			return a, fmt.Errorf("backup archive exceeds %d byte decompression limit", maxBytes)
 		}
+
+		if key, ok := strings.CutPrefix(hdr.Name, "blobs/"); ok {
+			n, werr := a.spoolBlob(key, tr, remaining)
+			if werr != nil {
+				return a, werr
+			}
+			total += n
+			continue
+		}
+
 		// Read one extra byte: if the entry fills remaining+1, it overflowed the cap.
-		data, err := io.ReadAll(io.LimitReader(tr, remaining+1))
-		if err != nil {
-			return nil, fmt.Errorf("read entry %s: %w", hdr.Name, err)
+		data, rerr := io.ReadAll(io.LimitReader(tr, remaining+1))
+		if rerr != nil {
+			return a, fmt.Errorf("read entry %s: %w", hdr.Name, rerr)
 		}
 		if int64(len(data)) > remaining {
-			return nil, fmt.Errorf("backup archive exceeds %d byte decompression limit", maxBytes)
+			return a, fmt.Errorf("backup archive exceeds %d byte decompression limit", maxBytes)
 		}
 		total += int64(len(data))
-		if strings.HasPrefix(hdr.Name, "blobs/") {
-			a.blobs[strings.TrimPrefix(hdr.Name, "blobs/")] = data
-		} else {
-			a.entries[hdr.Name] = data
-		}
+		a.entries[hdr.Name] = data
 	}
 	return a, nil
+}
+
+// spoolBlob copies one blob payload to the spool directory, refusing to write
+// more than remaining bytes. Returns how much was written.
+func (a *backupArchive) spoolBlob(key string, r io.Reader, remaining int64) (int64, error) {
+	name := fmt.Sprintf("blob-%d", len(a.blobFile))
+	f, err := os.Create(filepath.Join(a.blobDir, name)) //nolint:gosec // name is generated, not caller-controlled
+	if err != nil {
+		return 0, fmt.Errorf("spool blob %s: %w", key, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// One byte past the budget tells us it overflowed rather than exactly fit.
+	n, err := io.Copy(f, io.LimitReader(r, remaining+1))
+	if err != nil {
+		return 0, fmt.Errorf("spool blob %s: %w", key, err)
+	}
+	if n > remaining {
+		return 0, fmt.Errorf("backup archive exceeds decompression limit")
+	}
+	a.blobFile[key] = name
+	a.blobSize[key] = n
+	return n, nil
+}
+
+// Close removes the spool directory. Safe to call more than once.
+func (a *backupArchive) Close() error {
+	if a == nil || a.blobDir == "" {
+		return nil
+	}
+	dir := a.blobDir
+	a.blobDir = ""
+	return os.RemoveAll(dir)
+}
+
+// hasBlob reports whether the archive carried a payload for key.
+func (a *backupArchive) hasBlob(key string) bool {
+	_, ok := a.blobFile[key]
+	return ok
+}
+
+// blobPath returns the spooled file for key.
+func (a *backupArchive) blobPath(key string) (string, bool) {
+	name, ok := a.blobFile[key]
+	if !ok {
+		return "", false
+	}
+	return filepath.Join(a.blobDir, name), true
+}
+
+// openBlob returns a reader over the spooled payload and its size. The caller
+// closes the reader.
+func (a *backupArchive) openBlob(key string) (io.ReadCloser, int64, bool) {
+	path, ok := a.blobPath(key)
+	if !ok {
+		return nil, 0, false
+	}
+	f, err := os.Open(path) //nolint:gosec // path is inside our own spool directory
+	if err != nil {
+		return nil, 0, false
+	}
+	return f, a.blobSize[key], true
 }
 
 // unmarshal decodes the named JSON section into v; absent sections are a no-op
@@ -107,13 +217,15 @@ func (s *BackupService) ImportRepo(ctx context.Context, r io.Reader, targetName,
 	if err != nil {
 		return nil, err
 	}
+	// The spool holds every blob payload in the archive; release it as soon as
+	// the import is done, however it ends.
+	defer func() { _ = arc.Close() }()
 	var archivedRepo domain.Repository
 	var components []domain.Component
 	var assets []domain.Asset
 	arc.unmarshal("repository.json", &archivedRepo)
 	arc.unmarshal("components.json", &components)
 	arc.unmarshal("assets.json", &assets)
-	blobs := arc.blobs
 
 	if archivedRepo.Name == "" {
 		return nil, fmt.Errorf("invalid archive: missing or empty repository.json")
@@ -157,7 +269,7 @@ func (s *BackupService) ImportRepo(ctx context.Context, r io.Reader, targetName,
 	}
 
 	compIDMap := s.importRepoComponents(ctx, components, destRepo, finalName, conflictMode, stats)
-	s.importRepoAssets(ctx, assets, blobs, destRepo, finalName, conflictMode, blobStoreID, compIDMap, stats)
+	s.importRepoAssets(ctx, assets, arc, destRepo, finalName, conflictMode, blobStoreID, compIDMap, stats)
 
 	return stats, nil
 }
@@ -210,7 +322,7 @@ func (s *BackupService) importRepoComponents(ctx context.Context, components []d
 
 // importRepoAssets imports archived assets (and their blob bytes) into the
 // destination repository, deduplicating by path for skip/merge modes.
-func (s *BackupService) importRepoAssets(ctx context.Context, assets []domain.Asset, blobs map[string][]byte, destRepo *domain.Repository, finalName, conflictMode, blobStoreID string, compIDMap map[string]string, stats *ImportRepoStats) {
+func (s *BackupService) importRepoAssets(ctx context.Context, assets []domain.Asset, arc *backupArchive, destRepo *domain.Repository, finalName, conflictMode, blobStoreID string, compIDMap map[string]string, stats *ImportRepoStats) {
 	for i := range assets {
 		a := &assets[i]
 
@@ -226,10 +338,11 @@ func (s *BackupService) importRepoAssets(ctx context.Context, assets []domain.As
 			}
 		}
 
-		// Restore blob bytes.
+		// Restore blob bytes, streamed from the spool rather than held in memory.
 		if a.BlobKey != "" {
-			if data, ok := blobs[a.BlobKey]; ok {
-				_ = s.BlobStore.Put(ctx, a.BlobKey, bytes.NewReader(data), int64(len(data)))
+			if rc, size, ok := arc.openBlob(a.BlobKey); ok {
+				_ = s.BlobStore.Put(ctx, a.BlobKey, rc, size)
+				_ = rc.Close()
 			}
 		}
 
@@ -245,7 +358,7 @@ func (s *BackupService) importRepoAssets(ctx context.Context, assets []domain.As
 		}
 		stats.Assets++
 		if a.BlobKey != "" {
-			if _, hadBlob := blobs[a.BlobKey]; hadBlob {
+			if arc.hasBlob(a.BlobKey) {
 				stats.Blobs++
 			}
 		}
@@ -260,6 +373,9 @@ func (s *BackupService) Restore(ctx context.Context, r io.Reader) (*RestoreStats
 	if err != nil {
 		return nil, err
 	}
+	// The spool holds every blob payload in the archive; release it as soon as
+	// the import is done, however it ends.
+	defer func() { _ = arc.Close() }()
 	var (
 		blobStores []domain.BlobStore
 		repos      []domain.Repository
@@ -276,7 +392,6 @@ func (s *BackupService) Restore(ctx context.Context, r io.Reader) (*RestoreStats
 	arc.unmarshal("cleanup_policies.json", &policies)
 	arc.unmarshal("components.json", &components)
 	arc.unmarshal("assets.json", &assets)
-	blobs := arc.blobs
 
 	stats := &RestoreStats{}
 
@@ -286,7 +401,7 @@ func (s *BackupService) Restore(ctx context.Context, r io.Reader) (*RestoreStats
 	s.restoreRoles(ctx, roles, stats)
 	s.restorePolicies(ctx, policies, stats)
 	compIDMap := s.restoreComponents(ctx, components, repoNameToID, stats)
-	s.restoreAssets(ctx, assets, blobs, repoNameToID, compIDMap, bsNameToID, oldBSIDToName, stats)
+	s.restoreAssets(ctx, assets, arc, repoNameToID, compIDMap, bsNameToID, oldBSIDToName, stats)
 
 	return stats, nil
 }
@@ -423,7 +538,7 @@ func (s *BackupService) restoreComponents(ctx context.Context, components []doma
 
 // restoreAssets re-creates assets and their blob bytes, remapping component,
 // repository, and blob store references.
-func (s *BackupService) restoreAssets(ctx context.Context, assets []domain.Asset, blobs map[string][]byte, repoNameToID, compIDMap, bsNameToID, oldBSIDToName map[string]string, stats *RestoreStats) {
+func (s *BackupService) restoreAssets(ctx context.Context, assets []domain.Asset, arc *backupArchive, repoNameToID, compIDMap, bsNameToID, oldBSIDToName map[string]string, stats *RestoreStats) {
 	for i := range assets {
 		a := &assets[i]
 
@@ -450,10 +565,11 @@ func (s *BackupService) restoreAssets(ctx context.Context, assets []domain.Asset
 			}
 		}
 
-		// Restore blob bytes.
+		// Restore blob bytes, streamed from the spool rather than held in memory.
 		if a.BlobKey != "" {
-			if data, ok := blobs[a.BlobKey]; ok {
-				_ = s.BlobStore.Put(ctx, a.BlobKey, bytes.NewReader(data), int64(len(data)))
+			if rc, size, ok := arc.openBlob(a.BlobKey); ok {
+				_ = s.BlobStore.Put(ctx, a.BlobKey, rc, size)
+				_ = rc.Close()
 				stats.Blobs++
 			}
 		}

--- a/internal/service/backup_import_limits_test.go
+++ b/internal/service/backup_import_limits_test.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildArchive writes a tar.gz with the given entries.
+func buildArchive(t *testing.T, entries map[string][]byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	for name, data := range entries {
+		require.NoError(t, tw.WriteHeader(&tar.Header{
+			Name: name, Mode: 0o600, Size: int64(len(data)),
+		}))
+		_, err := tw.Write(data)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	return buf.Bytes()
+}
+
+func TestBackupArchive_BlobsAreReadableAfterImport(t *testing.T) {
+	raw := buildArchive(t, map[string][]byte{
+		"repository.json": []byte(`{"name":"r"}`),
+		"blobs/aa/bb/cc":  []byte("blob payload"),
+	})
+
+	a, err := readBackupArchive(bytes.NewReader(raw))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	require.True(t, a.hasBlob("aa/bb/cc"))
+	rc, size, ok := a.openBlob("aa/bb/cc")
+	require.True(t, ok)
+	defer func() { _ = rc.Close() }()
+
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "blob payload", string(got))
+	assert.Equal(t, int64(len("blob payload")), size)
+}
+
+// The whole point: blob payloads must not all be resident at once. An 8 GiB
+// archive used to mean 8 GiB of process memory.
+func TestBackupArchive_BlobsAreSpooledToDisk(t *testing.T) {
+	raw := buildArchive(t, map[string][]byte{
+		"repository.json": []byte(`{"name":"r"}`),
+		"blobs/big":       bytes.Repeat([]byte("x"), 1<<20),
+	})
+
+	a, err := readBackupArchive(bytes.NewReader(raw))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = a.Close() })
+
+	path, ok := a.blobPath("big")
+	require.True(t, ok, "blob payloads should be spooled to disk, not held in memory")
+	st, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1<<20), st.Size())
+}
+
+func TestBackupArchive_CloseRemovesSpooledFiles(t *testing.T) {
+	raw := buildArchive(t, map[string][]byte{
+		"repository.json": []byte(`{"name":"r"}`),
+		"blobs/one":       []byte("payload"),
+	})
+
+	a, err := readBackupArchive(bytes.NewReader(raw))
+	require.NoError(t, err)
+
+	path, ok := a.blobPath("one")
+	require.True(t, ok)
+	require.NoError(t, a.Close())
+
+	_, err = os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "Close must not leave the archive behind on disk")
+}
+
+// L-2: entry size was capped, entry count was not. A pathological archive of
+// millions of tiny entries costs CPU and map growth without ever tripping the
+// byte limit.
+func TestBackupArchive_RejectsTooManyEntries(t *testing.T) {
+	const cap = 3
+	entries := map[string][]byte{"repository.json": []byte(`{"name":"r"}`)}
+	for i := range cap + 1 {
+		entries[fmt.Sprintf("blobs/%d", i)] = []byte("x")
+	}
+	raw := buildArchive(t, entries)
+
+	a, err := readBackupArchiveWithLimits(bytes.NewReader(raw), defaultMaxImportBytes, cap)
+	if a != nil {
+		t.Cleanup(func() { _ = a.Close() })
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entries")
+}
+
+func TestBackupArchive_ByteLimitStillApplies(t *testing.T) {
+	raw := buildArchive(t, map[string][]byte{
+		"blobs/big": bytes.Repeat([]byte("x"), 4096),
+	})
+
+	a, err := readBackupArchiveLimited(bytes.NewReader(raw), 1024)
+	if a != nil {
+		t.Cleanup(func() { _ = a.Close() })
+	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decompression limit")
+}
+
+// A failed read must not leave spool files behind.
+func TestBackupArchive_CleansUpOnFailure(t *testing.T) {
+	raw := buildArchive(t, map[string][]byte{
+		"blobs/one": bytes.Repeat([]byte("x"), 4096),
+		"blobs/two": bytes.Repeat([]byte("y"), 4096),
+	})
+
+	before := countTempDirs(t)
+	_, err := readBackupArchiveLimited(bytes.NewReader(raw), 1024)
+	require.Error(t, err)
+	assert.Equal(t, before, countTempDirs(t), "spool directory should be removed on failure")
+}
+
+func countTempDirs(t *testing.T) int {
+	t.Helper()
+	names, err := os.ReadDir(os.TempDir())
+	require.NoError(t, err)
+	n := 0
+	for _, e := range names {
+		if e.IsDir() && len(e.Name()) > 15 && e.Name()[:15] == "nexspence-impor" {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/service/user_service_saml_test.go
+++ b/internal/service/user_service_saml_test.go
@@ -19,11 +19,17 @@ import (
 // mockSAML satisfies auth.SAMLAuthenticator. LoginSAML never calls back into it.
 type mockSAML struct{}
 
-func (m *mockSAML) MetadataXML() ([]byte, error)                            { return nil, nil }
-func (m *mockSAML) AuthnRequestURL(rs string) (string, error)               { return "https://idp/sso", nil }
-func (m *mockSAML) ParseResponse(r *http.Request) (*auth.SAMLClaims, error) { return nil, nil }
-func (m *mockSAML) SignRelayState(returnTo string) string                   { return returnTo }
-func (m *mockSAML) VerifyRelayState(rs string) (string, error)              { return rs, nil }
+func (m *mockSAML) MetadataXML() ([]byte, error) { return nil, nil }
+func (m *mockSAML) AuthnRequest(rs string) (string, string, error) {
+	return "https://idp/sso", "id-test", nil
+}
+func (m *mockSAML) ParseResponse(r *http.Request, _ []string) (*auth.SAMLClaims, error) {
+	return nil, nil
+}
+func (m *mockSAML) SignRelayState(returnTo string) string      { return returnTo }
+func (m *mockSAML) VerifyRelayState(rs string) (string, error) { return rs, nil }
+func (m *mockSAML) SignRequestID(id string) string             { return id }
+func (m *mockSAML) VerifyRequestID(v string) (string, error)   { return v, nil }
 
 func newUserSvcSAML(t *testing.T, cfg config.SAMLConfig, seed ...*domain.User) *UserService {
 	t.Helper()

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,11 +1,19 @@
 FROM nginx:alpine
 
-# Привязка GHCR-пакета к этому репозиторию (авто-linked repository)
+# Links the GHCR package to this repository (auto-linked repository).
 LABEL org.opencontainers.image.source=https://github.com/nexspence/nexspence
 
 COPY . /usr/share/nginx/html/
 
-# Кастомный конфиг
+# Custom server config.
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-EXPOSE 80
+# Run as the unprivileged nginx user (uid 101). That means binding a port above
+# 1024, so the server listens on 8080 — see nginx.conf. The pid file and cache
+# directories have to be writable by that user before dropping privileges.
+RUN touch /var/run/nginx.pid && \
+    chown -R nginx:nginx /var/cache/nginx /var/run/nginx.pid /usr/share/nginx/html
+
+USER nginx
+
+EXPOSE 8080

--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -1,11 +1,12 @@
 server {
-    listen 80;
+    # Above 1024 so the server can run as the unprivileged nginx user.
+    listen 8080;
     server_tokens off;
 
     root /usr/share/nginx/html;
     index index.html;
 
-    # Кастомные страницы ошибок (стиль приложения)
+    # Custom error pages (application styling).
     error_page 403 /403.html;
     error_page 404 /404.html;
     error_page 500 502 503 504 /50x.html;
@@ -18,7 +19,7 @@ server {
         return 404;
     }
 
-    # Статический сайт: несуществующий путь → 404 (не подменяем главной)
+    # Static site: an unknown path is a 404, never a fallback to index.
     location / {
         try_files $uri $uri/ =404;
     }


### PR DESCRIPTION
Closes everything left from the 2026-08-03 audit. Verified against a running server, not only by tests — which is how the CSP bug in here was found.

## M-3 — OIDC state-cookie key

The key hard-coded in both compose files seals the OIDC state cookie; knowing it lets an attacker forge a state cookie matching their own `state`, defeating the CSRF protection on the login flow. It joins the existing fail-closed check, but only while OIDC is enabled — an unused key in a config file should not stop a boot. Both quick-starts already set `allow_insecure_defaults`, so they are unaffected.

**Live:** with the shipped key → `refusing to start with shipped default secrets (… oidc_cookie_key_default=true)`; with a fresh key → boots.

## M-7 — health probes

`/healthz` and `/readyz` were registered before `r.Use(...)`. Gin snapshots the middleware chain at registration, so they ran with **no Recovery** — a panic in the readiness path took the process down instead of returning 500 — and no metrics or limits.

`/readyz` also pinged Postgres and Redis on every unauthenticated hit. Healthy results are now memoized for a second; failures are not cached, so a recovered outage is reported promptly.

## M-4 — SSRF

The audit said no guard existed. It does: `internal/netguard` blocks loopback, private and link-local targets in the dialer's Control hook, and every proxy, webhook and replication client goes through it, including the Docker token `realm` path the audit rated most interesting.

What was missing is the opt-out it asked for. `outbound.allowed_internal_cidrs` names ranges reachable anyway, validated at startup and applied atomically. The blocklist also gained the ranges Go's `IsPrivate` misses: CGNAT, broadcast, multicast.

**Live:** a proxy repo pointed at `http://169.254.169.254` → `netguard: blocked connection to internal address "169.254.169.254"`. With that address allowlisted, the same fetch reaches the network and times out instead.

## M-5 — SAML

Worse than reported, and in the opposite direction. The audit expected crewjam/saml to skip the `InResponseTo` check when absent; in v0.5.1 `validateRequestID` refuses any response whose `InResponseTo` is not among the IDs passed to `ParseResponse`. The SP passed `nil` and never set `AllowIDPInitiated`, so **SP-initiated SAML login could not succeed at all**. Every existing SAML test mocks `ParseResponse`, which is why nothing caught it.

`AuthnRequest` now returns the request ID; the handler seals it in an HMAC-signed, HttpOnly cookie (10-minute TTL) and hands it back at ACS. No cookie means refused rather than treated as IdP-initiated, which closes the login-CSRF. `SameSite=None` because the IdP delivers the assertion cross-site, paired with `Secure` when the ACS URL is HTTPS.

## M-6 — CSP

The SPA keeps its JWT in localStorage, so any future XSS is a full token theft. The server now ships a policy: same-origin everything, no inline script, no framing. Artifact paths are exempt — raw repositories host documentation sites that carry their own scripts.

**This is where the live check earned itself.** The first version of the policy blocked the Google Fonts the UI loads. Nothing errors — the app just renders in a fallback font. Fixed, plus a test that reads `frontend/index.html` and asserts every external origin in it appears in the policy. Screenshots before/after confirm the fonts render again. Self-hosting the fonts would let both entries go and is the better end state.

## L-1 / L-2 — backup import

Every entry was read into a map, so an archive could put 8 GiB on the heap; the gzip-bomb guard capped the bytes, not where they went. Blob payloads now spool to a temp directory and stream into the store one at a time. The spool is removed when the import ends, including on failure. Entry **count** is capped too (5M) — the byte limit alone does not bound millions of one-byte entries.

**Live:** exported a repo, imported an archive carrying a blob, content served from the restored repository; no spool directory left behind.

## L-3 / L-4 / L-5 / L-6

- `website/Dockerfile` ran nginx as root. Now listens on 8080 as uid 101, deploy workflow's port mapping updated. **Live:** built and ran the image — `uid=101(nginx)`, site serves, `nginx.conf` still 404s, and trivy's DS-0002 is gone.
- Presign/lifecycle handlers take a caller-supplied blob key and never consult RBAC. They are unmounted today, so the admin gate went in the **handlers**, not the route — mounting them later cannot quietly open every blob.
- Subdomain now has to look like a DNS label before being spliced into a URL path. RBAC still runs on the result, so this was never a bypass.
- `.gitleaks.toml`: history scanned ~215 hits, all doc examples, fixtures and dev defaults. The config names those placeholders specifically rather than muting directories — history now scans clean, while planted AWS and GitHub credentials in `docs/` and in Go code are still caught.

## Verification

- `go test ./...` — 1955 passed, 1 failed: `TestWebhookHandler_Test_200`, network-only, fails identically on a clean `main` in this sandbox
- `golangci-lint run ./...` — clean on every file here; remaining `SA5011` are pre-existing in untouched test files
- live stand: throwaway Postgres + server, each finding exercised as described above

## Separately: found while testing, not in the audit

**Backup export silently drops every blob.** `BackupService.BlobStore` is built from `storage.local.base_path`, but artifacts are written through the registry into the per-store path (`<base>/default`). `writeBlobEntries` skips unreadable blobs, so the archive carries metadata and no content, and a restore produces assets whose bytes are gone. Reproduced live: asset present, blob on disk, `tar tzf export.tar.gz | grep ^blobs/` → 0. Untouched by this PR (`backup_export.go` unchanged since #26) and left alone deliberately — it is a data-loss bug in its own right and deserves its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Remfwxfq7rC6efLT8Mh7XQ