### PR TITLE
feat(scan): auto-scan uploads, a MALICIOUS severity tier, and no more silently dropped errors

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -168,7 +168,13 @@ func cmdServe() *cobra.Command {
 			defer cancelSampler()
 			metrics.StartSampler(samplerCtx, pool)
 
-			router := api.NewRouter(cfg, pool, log, Version)
+			// Lifetime of everything the router runs in the background. Kept
+			// separate from the HTTP server's shutdown context so the two can be
+			// wound down at the same time rather than one after the other.
+			bgCtx, cancelBg := context.WithCancel(cmd.Context())
+			defer cancelBg()
+
+			router := api.NewRouter(bgCtx, cfg, pool, log, Version)
 
 			srv := &http.Server{
 				Addr:              cfg.HTTP.Addr,
@@ -203,6 +209,10 @@ func cmdServe() *cobra.Command {
 			<-quit
 
 			log.Info("shutting down...")
+			// Before Shutdown, not after it: the background jobs then wind down
+			// while the server drains its in-flight requests, instead of being
+			// left running until the deferred cancel fires on the way out.
+			cancelBg()
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 			return srv.Shutdown(ctx)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -107,6 +107,16 @@ gc:
   schedule: "0 3 * * 0"      # cron: weekly, Sunday 03:00
   min_age: "24h"             # only collect orphans older than this (grace period)
 
+# Automatic vulnerability scanning (Trivy for docker/oci, OSV.dev for
+# npm/maven/pypi/cargo).
+# Every upload is queued for a background scan; the queue is bounded and drops
+# rather than delaying an upload, so the periodic full re-scan below is also the
+# safety net for what a burst skips. It re-checks already-scanned components
+# against newly published CVEs, which nothing else does.
+scan:
+  enabled: true              # false leaves scanning entirely on-demand (API only)
+  schedule: "0 3 * * *"      # cron: daily 03:00; empty disables only the bulk re-scan
+
 # Audit log retention.
 # Events live in monthly PostgreSQL partitions.
 # Rotator pre-creates partitions for the next `lookahead_months` ahead and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -440,6 +440,6 @@ migration_jobs      — source_url, status, progress JSONB
 routing_rules       — name, mode (ALLOW|BLOCK), matchers[]
 content_selectors   — name, expression (CEL)
 webhooks            — name, url, events[], secret, active
-scan_results        — component_id, scanner (trivy|osv), status, critical/high/medium/low/unknown/total counts, scanned_at, raw JSONB, error
+scan_results        — component_id, scanner (trivy|osv), status, malicious/critical/high/medium/low/unknown/total counts, scanned_at, raw JSONB, error
 ldap_servers        — host, port, bind_dn, search_base, group_map JSONB
 ```

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -418,6 +418,34 @@ describe('BrowsePage — Docker tree', () => {
     expect(screen.getByText('openssl')).toBeInTheDocument()
   })
 
+  // A malicious-package report has no CVSS severity. Without a badge of its own
+  // it was counted as UNKNOWN — indistinguishable from "the scanner could not
+  // classify this".
+  it('shows a MALICIOUS badge and filter for a malicious-package finding', async () => {
+    const user = userEvent.setup()
+    seedDocker()
+    server.use(
+      http.get('/api/v1/components/:id/scan', () => new HttpResponse(null, { status: 204 })),
+      http.post('/api/v1/components/:id/scan', () =>
+        HttpResponse.json({
+          scannedAt: new Date().toISOString(), imageRef: 'debug:4.4.2', status: 'ok',
+          summary: { malicious: 1, critical: 0, high: 0, medium: 0, low: 0, unknown: 0, total: 1 },
+          findings: [{ id: 'MAL-2025-46974', severity: 'MALICIOUS', pkgName: 'debug', installedVersion: '4.4.2', title: 'Malicious code in debug' }],
+        }),
+      ),
+    )
+    renderBrowse('?repo=docker-hosted')
+    await user.click(await screen.findByText('myapp'))
+    await user.click(await screen.findByText('Tags'))
+    await user.click(await screen.findByText('latest'))
+    await screen.findByText('Vulnerability scan')
+    await user.click(screen.getByRole('button', { name: /Scan now/ }))
+
+    expect(await screen.findByText('MALICIOUS: 1')).toBeInTheDocument()
+    expect(screen.getByText('MAL-2025-46974')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'MALICIOUS (1)' })).toBeInTheDocument()
+  })
+
   it('opens Example Usage and Promote from docker panel', async () => {
     const user = userEvent.setup()
     seedDocker()

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -113,6 +113,7 @@ interface RawFileSelection {
 }
 
 interface ScanSummary {
+  malicious: number
   critical: number
   high: number
   medium: number
@@ -149,6 +150,9 @@ interface PromotionRule {
 }
 
 const SEV_COLOR = {
+  // Off the red→green CVSS ramp on purpose: a compromised package is a
+  // different class of alert, not a worse CVE.
+  malicious: '#d946ef',
   critical: '#ef4444',
   high: '#f97316',
   medium: '#f59e0b',
@@ -158,6 +162,7 @@ const SEV_COLOR = {
 
 function sevChipColor(sev: string) {
   const k = sev.toUpperCase()
+  if (k === 'MALICIOUS') return SEV_COLOR.malicious
   if (k === 'CRITICAL') return SEV_COLOR.critical
   if (k === 'HIGH') return SEV_COLOR.high
   if (k === 'MEDIUM') return SEV_COLOR.medium
@@ -185,7 +190,7 @@ function CveBadge({ label, count, color }: { label: string; count: number; color
   )
 }
 
-const SCAN_SEVERITY_FILTERS = ['ALL', 'CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'UNKNOWN'] as const
+const SCAN_SEVERITY_FILTERS = ['ALL', 'MALICIOUS', 'CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'UNKNOWN'] as const
 
 function fmtElapsed(s: number): string {
   const m = Math.floor(s / 60)
@@ -275,6 +280,7 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
       ) : !scanMutation.isPending && s ? (
         <>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            <CveBadge label="MALICIOUS" count={s.malicious} color={SEV_COLOR.malicious} />
             <CveBadge label="CRITICAL" count={s.critical} color={SEV_COLOR.critical} />
             <CveBadge label="HIGH" count={s.high} color={SEV_COLOR.high} />
             <CveBadge label="MEDIUM" count={s.medium} color={SEV_COLOR.medium} />

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -11,10 +11,11 @@ import { HoloButton, HoloInput, HoloModal, HoloTabs, HoloPill, HoloCard, HoloTab
 /* ─── Types ─────────────────────────────────────────────── */
 interface Role { id: string; name: string; description: string; privileges: string[]; roles: string[]; readOnly: boolean; source?: string }
 interface CVEFinding { id: string; severity: string; pkgName: string; installedVersion: string; fixedVersion?: string; title?: string }
-interface ScanSummary { critical: number; high: number; medium: number; low: number; unknown: number; total: number }
+interface ScanSummary { malicious: number; critical: number; high: number; medium: number; low: number; unknown: number; total: number }
 interface ScanResult { scannedAt: string; imageRef: string; status: string; error?: string; summary: ScanSummary; findings: CVEFinding[] }
 
 interface SecuritySummary {
+  malicious: number
   critical: number
   high: number
   medium: number
@@ -29,6 +30,7 @@ interface VulnRow {
   componentId: string
   name: string
   version: string
+  malicious: number
   critical: number
   high: number
   medium: number
@@ -74,7 +76,10 @@ const PRIV_TYPE_COLOR: Record<string, string> = {
   'repository-content-selector': '#06b6d4',
 }
 
-const sevColor = (s: string) => s === 'CRITICAL' ? '#ef4444' : s === 'HIGH' ? '#f97316' : s === 'MEDIUM' ? '#f59e0b' : s === 'LOW' ? '#22c55e' : '#6b7280'
+// MALICIOUS is deliberately off the red→green CVSS ramp: a compromised package
+// is a different class of alert, not a worse CVE, and reading it as "extra red"
+// is exactly the confusion to avoid.
+const sevColor = (s: string) => s === 'MALICIOUS' ? '#d946ef' : s === 'CRITICAL' ? '#ef4444' : s === 'HIGH' ? '#f97316' : s === 'MEDIUM' ? '#f59e0b' : s === 'LOW' ? '#22c55e' : '#6b7280'
 const monoStyle = { fontFamily: 'monospace' as const, fontSize: 12 }
 const emptyStyle = { textAlign: 'center' as const, color: 'var(--holo-text-faint)', fontSize: 14, padding: 32 }
 
@@ -531,7 +536,7 @@ function RolesTab({ roles, loading, onRefresh, admin }: { roles: Role[]; loading
   )
 }
 
-const SEVERITY_ORDER = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'UNKNOWN']
+const SEVERITY_ORDER = ['MALICIOUS', 'CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'UNKNOWN']
 
 function fmtElapsedSec(s: number): string {
   const m = Math.floor(s / 60)
@@ -611,8 +616,8 @@ function ScanTab() {
       {result && result.status === 'ok' && (
         <>
           {/* Summary cards */}
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 8 }}>
-            {(['CRITICAL','HIGH','MEDIUM','LOW','UNKNOWN'] as const).map(sev => (
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 8 }}>
+            {SEVERITY_ORDER.map(sev => (
               <HoloCard key={sev} style={{ padding: '12px 16px', textAlign: 'center' as const }}>
                 <div style={{ fontSize: 20, fontWeight: 700, color: sevColor(sev) }}>{result.summary[sev.toLowerCase() as keyof ScanSummary] as number}</div>
                 <div style={{ fontSize: 11, color: 'var(--holo-text-dim)', marginTop: 2 }}>{sev}</div>
@@ -744,8 +749,8 @@ function VulnDashTab() {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
       {/* Summary cards */}
-      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: 8 }}>
-        {(['critical','high','medium','low','unknown'] as const).map(sev => (
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: 8 }}>
+        {(['malicious','critical','high','medium','low','unknown'] as const).map(sev => (
           <HoloCard key={sev} style={{ padding: '12px 16px', textAlign: 'center' as const }}>
             <div style={{ fontSize: 20, fontWeight: 700, color: sevColor(sev.toUpperCase()) }}>
               {summary ? summary[sev] : '—'}
@@ -778,7 +783,9 @@ function VulnDashTab() {
           }}
         >
           <option value="">All severities</option>
-          {['CRITICAL','HIGH','MEDIUM','LOW'].map(s => (
+          {/* MALICIOUS leads and stands alone: the CVE tiers below it are
+              minimums that also match malware, this one means malware only. */}
+          {['MALICIOUS','CRITICAL','HIGH','MEDIUM','LOW'].map(s => (
             <option key={s} value={s}>{s}</option>
           ))}
         </select>
@@ -811,6 +818,7 @@ function VulnDashTab() {
                 <th style={{ padding: '0 8px 10px 0', fontWeight: 600 }}>Format</th>
                 <th style={{ padding: '0 8px 10px 0', fontWeight: 600 }}>Component</th>
                 <th style={{ padding: '0 8px 10px 0', fontWeight: 600 }}>Version</th>
+                <th style={{ padding: '0 8px 10px 0', fontWeight: 600, color: sevColor('MALICIOUS') }}>MAL</th>
                 <th style={{ padding: '0 8px 10px 0', fontWeight: 600, color: sevColor('CRITICAL') }}>C</th>
                 <th style={{ padding: '0 8px 10px 0', fontWeight: 600, color: sevColor('HIGH') }}>H</th>
                 <th style={{ padding: '0 8px 10px 0', fontWeight: 600, color: sevColor('MEDIUM') }}>M</th>
@@ -825,6 +833,7 @@ function VulnDashTab() {
                   <td style={{ padding: '8px 8px 8px 0', color: 'var(--holo-text-dim)' }}>{row.format}</td>
                   <td style={{ padding: '8px 8px 8px 0', color: 'var(--holo-text)' }}>{row.name}</td>
                   <td style={{ padding: '8px 8px 8px 0', ...monoStyle, color: 'var(--holo-text-dim)' }}>{row.version}</td>
+                  <td style={{ padding: '8px 8px 8px 0', fontWeight: 700, color: row.malicious > 0 ? sevColor('MALICIOUS') : 'var(--holo-text-faint)' }}>{row.malicious}</td>
                   <td style={{ padding: '8px 8px 8px 0', fontWeight: 700, color: row.critical > 0 ? sevColor('CRITICAL') : 'var(--holo-text-faint)' }}>{row.critical}</td>
                   <td style={{ padding: '8px 8px 8px 0', fontWeight: row.high > 0 ? 700 : 400, color: row.high > 0 ? sevColor('HIGH') : 'var(--holo-text-faint)' }}>{row.high}</td>
                   <td style={{ padding: '8px 8px 8px 0', color: row.medium > 0 ? sevColor('MEDIUM') : 'var(--holo-text-faint)' }}>{row.medium}</td>

--- a/frontend/src/pages/SecurityPageMalicious.test.tsx
+++ b/frontend/src/pages/SecurityPageMalicious.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import SecurityPage from './SecurityPage'
+import { renderWithProviders, seedAuthAsAdmin } from '@/test/renderUtils'
+import { server } from '@/test/msw/server'
+import { fixtures } from '@/test/fixtures'
+
+/**
+ * A malicious-package report (OSV.dev `MAL-…`) carries no CVSS severity, so it
+ * used to be counted as "Unknown" — a column the org-wide dashboard did not even
+ * render. These cover the visibility side of that gap.
+ */
+
+function seedBaseline() {
+  server.use(
+    http.get('/service/rest/v1/security/roles', () => HttpResponse.json([
+      { id: 'role-1', name: 'nx-admin', description: 'Admin role', privileges: [], roles: [], readOnly: true },
+    ])),
+    http.get('/service/rest/v1/security/privileges', () => HttpResponse.json([])),
+    http.get('/service/rest/v1/security/content-selectors', () => HttpResponse.json([])),
+    http.get('/api/v1/security/privilege-role-map', () => HttpResponse.json({})),
+    http.get('/service/rest/v1/repositories', () => HttpResponse.json([fixtures.repository()])),
+    http.get('/service/rest/v1/security/users', () => HttpResponse.json([fixtures.user()])),
+    http.get('/api/v1/webhooks', () => HttpResponse.json([])),
+  )
+}
+
+function seedDashboard(opts: { malicious: number }) {
+  server.use(
+    http.get('/api/v1/security/summary', () =>
+      HttpResponse.json({
+        malicious: opts.malicious, critical: 3, high: 5, medium: 1, low: 0, unknown: 0, scanned_total: 9,
+      }),
+    ),
+    http.get('/api/v1/security/vulnerabilities', () =>
+      HttpResponse.json({
+        total: 1,
+        items: [
+          {
+            repoName: 'npm-hosted', format: 'npm', componentId: 'c1', name: 'debug', version: '4.4.2',
+            malicious: opts.malicious, critical: 0, high: 0, medium: 0, low: 0, unknown: 0,
+            scannedAt: '2026-06-01T00:00:00Z',
+          },
+        ],
+      }),
+    ),
+  )
+}
+
+async function openDashboard() {
+  const user = userEvent.setup()
+  renderWithProviders(<SecurityPage />)
+  await screen.findByText('nx-admin')
+  await user.click(screen.getByRole('button', { name: 'Vulnerability Dashboard' }))
+  return user
+}
+
+describe('SecurityPage — malicious packages', () => {
+  beforeEach(() => {
+    seedAuthAsAdmin()
+    seedBaseline()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows a MALICIOUS summary tile with its own count', async () => {
+    seedDashboard({ malicious: 2 })
+    await openDashboard()
+
+    // `selector: 'div'` skips the same-named <option> in the severity filter.
+    const tile = (await screen.findByText('MALICIOUS', { selector: 'div' })).parentElement
+    expect(tile).toBeTruthy()
+    expect(within(tile as HTMLElement).getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders a malicious column in the dashboard grid', async () => {
+    seedDashboard({ malicious: 1 })
+    await openDashboard()
+
+    await screen.findByText('debug')
+    expect(screen.getByRole('columnheader', { name: 'MAL' })).toBeInTheDocument()
+  })
+
+  it('offers MALICIOUS as its own filter and sends it to the API', async () => {
+    seedDashboard({ malicious: 1 })
+    let requestedSeverity: string | null = null
+    server.use(
+      http.get('/api/v1/security/vulnerabilities', ({ request }) => {
+        requestedSeverity = new URL(request.url).searchParams.get('severity')
+        return HttpResponse.json({ total: 0, items: [] })
+      }),
+    )
+    const user = await openDashboard()
+
+    const select = await screen.findByRole('combobox')
+    await user.selectOptions(select, 'MALICIOUS')
+
+    expect(requestedSeverity).toBe('MALICIOUS')
+  })
+})

--- a/internal/api/handlers/scan_test.go
+++ b/internal/api/handlers/scan_test.go
@@ -152,6 +152,44 @@ func TestScanHandler_Summary_OK(t *testing.T) {
 	assert.Equal(t, 1, s.ScannedTotal)
 }
 
+// The full chain for a malicious-package report, over the wire: OSV response →
+// service → persisted row → aggregate → JSON body. It is the one seam where a
+// wrong struct tag would go unnoticed by every other test.
+func TestScanHandler_Summary_ReportsMaliciousCount(t *testing.T) {
+	comps := testutil.NewComponentRepo()
+	scanRepo := testutil.NewScanResultRepo()
+
+	osvSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"vulns":[{"id":"MAL-2025-46974","summary":"Malicious code in debug"}]}`))
+	}))
+	t.Cleanup(osvSrv.Close)
+
+	svc := service.NewScanService(comps, "http://localhost").WithScanResults(scanRepo)
+	svc.OSVClient = &service.OSVClient{BaseURL: osvSrv.URL, HTTPClient: osvSrv.Client()}
+
+	h := handlers.NewScanHandler(svc)
+	r := gin.New()
+	r.POST("/api/v1/components/:id/scan", h.Scan)
+	r.GET("/api/v1/security/summary", h.Summary)
+
+	c := seedComponent(t, comps, "npm", "debug", "4.4.2")
+
+	rec := do(t, r, http.MethodPost, "/api/v1/components/"+c.ID+"/scan", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var res domain.ScanResult
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &res))
+	assert.Equal(t, 1, res.Summary.Malicious)
+	assert.Equal(t, 0, res.Summary.Unknown)
+
+	// And the field survives under the name the frontend reads it by.
+	rec = do(t, r, http.MethodGet, "/api/v1/security/summary", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, float64(1), body["malicious"])
+}
+
 func TestScanHandler_Summary_RepoError_500(t *testing.T) {
 	r, _, scanRepo, _ := mountScan(t)
 	scanRepo.Err = errors.New("agg down")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -51,8 +51,13 @@ import (
 
 // NewRouter wires all routes and returns a ready http.Handler.
 //
+// ctx is the lifetime of the background work the router starts — the cleanup,
+// GC, replication, download-counter and scan schedulers. Canceling it is how
+// they are told to stop; they used to be launched with context.Background(),
+// which meant none of them ever stopped before the process did.
+//
 //nolint:gocyclo // large router wiring function; splitting would hurt readability
-func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, version string) http.Handler {
+func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, version string) http.Handler {
 	if cfg.Log.Level != "debug" {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -175,7 +180,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	cleanupSvc.WithComponents(componentRepo)
 
 	// Start per-policy cron scheduler in background (default: cfg.Cleanup.DefaultSchedule).
-	go cleanupSvc.StartCronScheduler(context.Background(), cfg.Cleanup.DefaultSchedule)
+	go cleanupSvc.StartCronScheduler(ctx, cfg.Cleanup.DefaultSchedule)
 
 	gcSvc := &service.BlobGCService{
 		Assets:        assetRepo,
@@ -186,11 +191,11 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		DefaultMinAge: cfg.GC.MinAge,
 	}
 	if cfg.GC.Enabled {
-		go gcSvc.StartCronScheduler(context.Background(), cfg.GC.Schedule, cfg.GC.MinAge)
+		go gcSvc.StartCronScheduler(ctx, cfg.GC.Schedule, cfg.GC.MinAge)
 	}
 
 	replSvc := service.NewReplicationService(replRepo, assetRepo, localBlob, cfg.Auth.JWTSecret, cfg.Auth.EncryptionKeyBytes(), log)
-	go replSvc.StartCronScheduler(context.Background())
+	go replSvc.StartCronScheduler(ctx)
 
 	promotionSvc, err := service.NewPromotionService(
 		promotionRepo, componentRepo, assetRepo, repoRepo, blobRepo, scanRepo, localBlob, blobRegistry,
@@ -202,12 +207,28 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 
 	// Debounced download counter: in-memory aggregation, periodic batched flush.
 	dlCounter := service.NewDownloadCounter(assetRepo, log)
-	go dlCounter.Start(context.Background(), 10*time.Second)
+	go dlCounter.Start(ctx, 10*time.Second)
 
 	// ── Format handlers ───────────────────────────────────────
 	// Built before the format handlers because they take Deps by value: a
 	// handler constructed without the checker would keep a nil copy of it.
 	rbacSvc := service.NewRBACService(rbacRepo, repoRepo, log, cfg.Auth.AnonymousEnabled)
+
+	// Built here rather than with the other handlers below: the format handlers
+	// take Deps by value, so the scan trigger has to exist before Deps does or
+	// every handler keeps a nil copy of it.
+	scanSvc := service.NewScanService(componentRepo, cfg.HTTP.BaseURL).
+		WithScanResults(scanRepo).
+		WithCredentials(cfg.Bootstrap.AdminUsername, cfg.Bootstrap.AdminPassword)
+	// A nil trigger in Deps is what disables scan-on-upload, so the config
+	// switch is applied by not wiring the service rather than by a flag the
+	// storage layer would have to consult.
+	var scanTrigger formats.ScanTrigger
+	if cfg.Scan.Enabled {
+		scanTrigger = scanSvc
+		go scanSvc.StartScheduler(ctx, cfg.Scan.Schedule)
+	}
+
 	formatDeps := formats.Deps{
 		Repos:        repoRepo,
 		Components:   componentRepo,
@@ -220,6 +241,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 		Downloads:    dlCounter,
 		RoutingRules: rrRepo,
 		RBAC:         rbacSvc,
+		Scanner:      scanTrigger,
 	}
 	formatRegistry := map[string]formats.FormatHandler{
 		"raw":       raw.New(formatDeps),
@@ -255,9 +277,6 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	browseH := handlers.NewBrowseHandler(formatDeps, rbacSvc)
 	cleanupH := handlers.NewCleanupHandler(cleanupRepo, repoRepo, cleanupSvc)
 	auditH := handlers.NewAuditHandler(auditRepo)
-	scanSvc := service.NewScanService(componentRepo, cfg.HTTP.BaseURL).
-		WithScanResults(scanRepo).
-		WithCredentials(cfg.Bootstrap.AdminUsername, cfg.Bootstrap.AdminPassword)
 	scanH := handlers.NewScanHandler(scanSvc)
 	tokenH := handlers.NewTokenHandler(tokenSvc, userSvc, cfg.Auth.TokenMaxDays)
 	webhookH := handlers.NewWebhookHandler(webhookSvc)
@@ -278,8 +297,10 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, log logger.Logger, versio
 	blobMigSvc.WithLocker(locker)
 	blobMigH := handlers.NewBlobStoreMigrationHandler(blobMigSvc)
 
-	// Resume any migrations that were interrupted by a server restart.
-	go func() { _ = blobMigSvc.ResumeAll(context.Background()) }()
+	// Resume any migrations that were interrupted by a server restart — on the
+	// background context, so a shutdown mid-resume interrupts it the same way
+	// the restart that left it unfinished did.
+	go func() { _ = blobMigSvc.ResumeAll(ctx) }()
 	backupSvc := &service.BackupService{
 		BlobStores: blobRepo,
 		Repos:      repoRepo,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Search    SearchConfig    `mapstructure:"search"`
 	Cleanup   CleanupConfig   `mapstructure:"cleanup"`
 	GC        GCConfig        `mapstructure:"gc"`
+	Scan      ScanConfig      `mapstructure:"scan"`
 	Audit     AuditConfig     `mapstructure:"audit"`
 	Docker    DockerConfig    `mapstructure:"docker"`
 	Redis     RedisConfig     `mapstructure:"redis"`
@@ -380,6 +381,18 @@ type GCConfig struct {
 	MinAge   time.Duration `mapstructure:"min_age"`
 }
 
+// ScanConfig configures automatic vulnerability scanning of stored artifacts.
+type ScanConfig struct {
+	// Enabled queues every upload for a background scan and runs the periodic
+	// re-scan. Off, scanning stays entirely on-demand.
+	Enabled bool `mapstructure:"enabled"`
+	// Schedule is the cron expression for the full bulk re-scan, which covers
+	// artifacts uploaded before auto-scan was on and re-checks already-scanned
+	// ones against newly published CVEs. Empty disables the periodic run while
+	// leaving scan-on-upload in place.
+	Schedule string `mapstructure:"schedule"`
+}
+
 // AuditConfig controls audit-log retention, soft cap, and partition rotation.
 type AuditConfig struct {
 	RetentionDays    int           `mapstructure:"retention_days"`
@@ -455,6 +468,10 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("gc.enabled", true)
 	v.SetDefault("gc.schedule", "0 3 * * 0")
 	v.SetDefault("gc.min_age", "24h")
+	v.SetDefault("scan.enabled", true)
+	// Nightly, off-peak: a full re-scan re-queries OSV.dev per component and
+	// re-runs Trivy per image.
+	v.SetDefault("scan.schedule", "0 3 * * *")
 	v.SetDefault("audit.retention_days", 90)
 	v.SetDefault("audit.soft_cap", int64(1_000_000))
 	v.SetDefault("audit.rotation_interval", "24h")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,6 +193,37 @@ func TestLoad_GCDefaults(t *testing.T) {
 	assert.Equal(t, 24*time.Hour, cfg.GC.MinAge)
 }
 
+// Automatic scanning is on out of the box: an unscanned upload is the state
+// this feature exists to prevent, so opting in is the wrong default.
+func TestLoad_ScanDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Scan.Enabled, "scan.enabled default should be true")
+	assert.Equal(t, "0 3 * * *", cfg.Scan.Schedule)
+}
+
+func TestLoad_ScanCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n" +
+		"scan:\n  enabled: false\n  schedule: \"0 4 * * *\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Scan.Enabled)
+	assert.Equal(t, "0 4 * * *", cfg.Scan.Schedule)
+}
+
 func TestLoad_RateLimit_DefaultsEnabled(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/db/migrations/025_scan_results_malicious.sql
+++ b/internal/db/migrations/025_scan_results_malicious.sql
@@ -1,0 +1,15 @@
+-- A malicious-package report (OSV.dev `MAL-…`, sourced from OpenSSF's
+-- malicious-packages dataset) carries no CVSS score, so it used to land in the
+-- `unknown` bucket next to "the scanner could not classify this" — a compromised
+-- package counted toward a number nobody reads. It gets its own counter so it
+-- can be aggregated, filtered, and shown on its own.
+--
+-- Existing rows keep 0: they were scanned before the classification existed, and
+-- backfilling would mean re-querying OSV.dev for every component. The daily bulk
+-- re-scan refills them on its next run.
+
+-- +goose Up
+ALTER TABLE scan_results ADD COLUMN IF NOT EXISTS malicious INT NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE scan_results DROP COLUMN IF EXISTS malicious;

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -219,13 +219,19 @@ type ScanResult struct {
 }
 
 // ScanSummary holds per-severity CVE counts.
+//
+// Malicious is not a CVSS level: it counts malicious-package reports (OSV.dev
+// `MAL-…`), which carry no score and would otherwise be indistinguishable from
+// a finding the scanner could not classify. It leads the order everywhere
+// severities are listed.
 type ScanSummary struct {
-	Critical int `json:"critical"`
-	High     int `json:"high"`
-	Medium   int `json:"medium"`
-	Low      int `json:"low"`
-	Unknown  int `json:"unknown"`
-	Total    int `json:"total"`
+	Malicious int `json:"malicious"`
+	Critical  int `json:"critical"`
+	High      int `json:"high"`
+	Medium    int `json:"medium"`
+	Low       int `json:"low"`
+	Unknown   int `json:"unknown"`
+	Total     int `json:"total"`
 }
 
 // CVEFinding is a single vulnerability entry from the scanner.
@@ -244,6 +250,7 @@ type ScanResultRow struct {
 	ComponentID string
 	Scanner     string // "trivy" | "osv"
 	Status      ScanStatus
+	Malicious   int
 	Critical    int
 	High        int
 	Medium      int
@@ -257,6 +264,7 @@ type ScanResultRow struct {
 
 // SecuritySummary is an aggregate across all scan_results rows.
 type SecuritySummary struct {
+	Malicious    int `json:"malicious"`
 	Critical     int `json:"critical"`
 	High         int `json:"high"`
 	Medium       int `json:"medium"`
@@ -272,6 +280,7 @@ type VulnRow struct {
 	ComponentID string    `json:"componentId"`
 	Name        string    `json:"name"`
 	Version     string    `json:"version"`
+	Malicious   int       `json:"malicious"`
 	Critical    int       `json:"critical"`
 	High        int       `json:"high"`
 	Medium      int       `json:"medium"`

--- a/internal/formats/base/autoscan_test.go
+++ b/internal/formats/base/autoscan_test.go
@@ -1,0 +1,68 @@
+package base_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// recordingScanner captures the component ids the storage layer asks to scan.
+type recordingScanner struct {
+	mu  sync.Mutex
+	ids []string
+}
+
+func (r *recordingScanner) TriggerAsync(componentID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ids = append(r.ids, componentID)
+}
+
+func (r *recordingScanner) seen() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.ids...)
+}
+
+// Every upload is queued for a scan, so a new artifact cannot sit unscanned
+// waiting for someone to remember to ask.
+func TestStoreArtifact_QueuesStoredComponentForScanning(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-hosted", "npm")
+	d, _, comps, _ := deps(repo)
+	scanner := &recordingScanner{}
+	d.Scanner = scanner
+
+	content := `{"name":"lodash"}`
+	result, err := base.StoreArtifact(context.Background(), d,
+		"npm-hosted", "/lodash/-/lodash-4.17.20.tgz", "application/octet-stream",
+		base.Coords{Name: "lodash", Version: "4.17.20"},
+		strings.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+
+	comp, err := comps.Get(context.Background(), result.Asset.ComponentID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{comp.ID}, scanner.seen())
+}
+
+// Auto-scan is optional: a Deps without a scanner stores artifacts exactly as
+// before.
+func TestStoreArtifact_NilScannerIsAllowed(t *testing.T) {
+	repo := testutil.SimpleRepo("raw-hosted", "raw")
+	d, blobStore, _, _ := deps(repo)
+	require.Nil(t, d.Scanner)
+
+	_, err := base.StoreArtifact(context.Background(), d,
+		"raw-hosted", "/notes.txt", "text/plain",
+		base.Coords{Name: "notes.txt"},
+		strings.NewReader("data"), 4)
+
+	require.NoError(t, err)
+	assert.True(t, blobStore.Has(base.BlobKey("raw-hosted", "/notes.txt")))
+}

--- a/internal/formats/base/autoscan_test.go
+++ b/internal/formats/base/autoscan_test.go
@@ -51,6 +51,45 @@ func TestStoreArtifact_QueuesStoredComponentForScanning(t *testing.T) {
 	assert.Equal(t, []string{comp.ID}, scanner.seen())
 }
 
+// Not every write goes through StoreArtifact: a proxy repository caching an
+// upstream artifact registers the blob directly. Those are the artifacts most
+// worth scanning — a compromised upstream release arrives this way — so the
+// trigger has to sit on the path they share, not on the upload path alone.
+func TestRegisterStoredBlob_QueuesComponentForScanning(t *testing.T) {
+	repo := testutil.SimpleRepo("npm-proxy", "npm")
+	d, _, _, _ := deps(repo)
+	scanner := &recordingScanner{}
+	d.Scanner = scanner
+
+	asset, err := base.RegisterStoredBlob(context.Background(), d, repo,
+		"/lodash/-/lodash-4.17.20.tgz", "application/octet-stream",
+		base.Coords{Name: "lodash", Version: "4.17.20"},
+		"blobkey", "sha256sum", "sha1sum", "md5sum", 42, "", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{asset.ComponentID}, scanner.seen())
+}
+
+// An OCI push registers every layer as its own digest-versioned component,
+// before the manifest. Queuing those would fill a bounded queue with entries
+// that get discarded at the far end — and the manifest, the only one worth
+// scanning, arrives last and is the one that gets dropped.
+func TestStoreArtifact_DoesNotQueueDigestVersionedComponents(t *testing.T) {
+	repo := testutil.SimpleRepo("docker-hosted", "docker")
+	d, _, _, _ := deps(repo)
+	scanner := &recordingScanner{}
+	d.Scanner = scanner
+
+	digest := "sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+	_, err := base.StoreArtifact(context.Background(), d,
+		"docker-hosted", "/v2/myapp/blobs/"+digest, "application/octet-stream",
+		base.Coords{Name: "myapp", Version: digest},
+		strings.NewReader("layer bytes"), 11)
+	require.NoError(t, err)
+
+	assert.Empty(t, scanner.seen(), "a layer blob must not reach the scan queue")
+}
+
 // Auto-scan is optional: a Deps without a scanner stores artifacts exactly as
 // before.
 func TestStoreArtifact_NilScannerIsAllowed(t *testing.T) {

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -122,15 +122,6 @@ func StoreArtifact(ctx context.Context, d formats.Deps,
 		return nil, err
 	}
 
-	// Queue the stored component for a vulnerability scan. This is the common
-	// path every format handler writes through, so hooking it here is what makes
-	// auto-scan apply to all of them rather than to whichever ones remembered.
-	// The call returns immediately and cannot fail — an upload is never held up
-	// or refused on account of the scanner.
-	if d.Scanner != nil && asset.ComponentID != "" {
-		d.Scanner.TriggerAsync(asset.ComponentID)
-	}
-
 	if d.Webhooks != nil {
 		d.Webhooks.Dispatch(domain.WebhookPayload{
 			Event:      domain.EventArtifactPublished,
@@ -238,7 +229,35 @@ func RegisterStoredBlob(ctx context.Context, d formats.Deps, repo *domain.Reposi
 	if delta := usageDelta(ctx, d, asset, prev); delta != 0 {
 		_ = d.Blobs.UpdateUsedBytes(ctx, blobStoreName, delta)
 	}
+
+	queueForScanning(d, comp)
 	return asset, nil
+}
+
+// queueForScanning asks for a background scan of a component that has just been
+// registered.
+//
+// It sits here rather than in StoreArtifact because this is the narrower waist:
+// StoreArtifact goes through it, and so do the writes that skip StoreArtifact
+// entirely — a proxy repository caching an upstream artifact, an OCI blob
+// mount. Those are the ones most worth scanning, since their content comes from
+// somewhere nobody here controls.
+//
+// Digest-versioned components are not queued. An OCI push registers every layer
+// as one of these before it sends the manifest, so queuing them would fill a
+// bounded queue with entries the scanner discards anyway — and evict the
+// manifest, the only entry that describes a scannable image.
+//
+// The call returns immediately and cannot fail: no upload is ever held up or
+// refused on account of the scanner.
+func queueForScanning(d formats.Deps, comp *domain.Component) {
+	if d.Scanner == nil || comp == nil || comp.ID == "" {
+		return
+	}
+	if strings.HasPrefix(comp.Version, "sha256:") {
+		return
+	}
+	d.Scanner.TriggerAsync(comp.ID)
 }
 
 // usageDelta reports how much the blob store's used_bytes has to move for a

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -122,6 +122,15 @@ func StoreArtifact(ctx context.Context, d formats.Deps,
 		return nil, err
 	}
 
+	// Queue the stored component for a vulnerability scan. This is the common
+	// path every format handler writes through, so hooking it here is what makes
+	// auto-scan apply to all of them rather than to whichever ones remembered.
+	// The call returns immediately and cannot fail — an upload is never held up
+	// or refused on account of the scanner.
+	if d.Scanner != nil && asset.ComponentID != "" {
+		d.Scanner.TriggerAsync(asset.ComponentID)
+	}
+
 	if d.Webhooks != nil {
 		d.Webhooks.Dispatch(domain.WebhookPayload{
 			Event:      domain.EventArtifactPublished,

--- a/internal/formats/deps.go
+++ b/internal/formats/deps.go
@@ -28,6 +28,23 @@ type Deps struct {
 	// request itself; this is for the paths a handler reaches that the request
 	// URL does not name, such as a blob mount's client-supplied source.
 	RBAC RBACChecker
+	// Scanner is optional — nil disables automatic vulnerability scanning of
+	// uploads.
+	Scanner ScanTrigger
+}
+
+// ScanTrigger requests a background vulnerability scan of a stored component.
+//
+// It is the narrowest possible view of *service.ScanService, declared here for
+// the same reason RBACChecker is: internal/service already imports
+// internal/formats/base, so depending on it from this package would close a
+// cycle. Keeping it to one method also keeps the storage layer honest — it can
+// ask for a scan, and can do nothing else with the scanner.
+type ScanTrigger interface {
+	// TriggerAsync queues componentID for scanning and returns immediately. It
+	// is called on the upload path, so implementations must not block and must
+	// not report failure: a scan that cannot be queued is dropped, not raised.
+	TriggerAsync(componentID string)
 }
 
 // RBACChecker answers whether a caller may act on a path in a repository.

--- a/internal/repository/postgres/audit_repo.go
+++ b/internal/repository/postgres/audit_repo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -183,7 +184,7 @@ func scanAuditRow(rows interface {
 		return e, err
 	}
 	e.UserID = userID
-	_ = json.Unmarshal(ctxJSON, &e.Context)
+	unmarshalJSONB(ctxJSON, &e.Context, "audit_events", strconv.FormatInt(e.ID, 10), "context")
 	return e, nil
 }
 

--- a/internal/repository/postgres/blobstore_repo.go
+++ b/internal/repository/postgres/blobstore_repo.go
@@ -139,6 +139,6 @@ func scanBlobStore(row scanner) (*domain.BlobStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = json.Unmarshal(cfgRaw, &bs.Config)
+	unmarshalJSONB(cfgRaw, &bs.Config, "blob_stores", bs.ID, "config")
 	return &bs, nil
 }

--- a/internal/repository/postgres/cleanup_repo.go
+++ b/internal/repository/postgres/cleanup_repo.go
@@ -44,8 +44,8 @@ func (r *CleanupPolicyRepo) List(ctx context.Context) ([]domain.CleanupPolicy, e
 		); err != nil {
 			return nil, err
 		}
-		_ = json.Unmarshal(criteriaJSON, &p.Criteria)
-		_ = json.Unmarshal(scopeJSON, &p.Scope)
+		unmarshalJSONB(criteriaJSON, &p.Criteria, "cleanup_policies", p.ID, "criteria")
+		unmarshalJSONB(scopeJSON, &p.Scope, "cleanup_policies", p.ID, "scope")
 		out = append(out, p)
 	}
 	return out, rows.Err()
@@ -69,8 +69,8 @@ func (r *CleanupPolicyRepo) Get(ctx context.Context, id string) (*domain.Cleanup
 	if err != nil {
 		return nil, err
 	}
-	_ = json.Unmarshal(criteriaJSON, &p.Criteria)
-	_ = json.Unmarshal(scopeJSON, &p.Scope)
+	unmarshalJSONB(criteriaJSON, &p.Criteria, "cleanup_policies", p.ID, "criteria")
+	unmarshalJSONB(scopeJSON, &p.Scope, "cleanup_policies", p.ID, "scope")
 	return &p, nil
 }
 

--- a/internal/repository/postgres/component_repo.go
+++ b/internal/repository/postgres/component_repo.go
@@ -357,6 +357,6 @@ func scanComponent(row scanner) (*domain.Component, error) {
 	if c.Tags == nil {
 		c.Tags = []string{}
 	}
-	_ = json.Unmarshal(extraRaw, &c.Extra)
+	unmarshalJSONB(extraRaw, &c.Extra, "components", c.ID, "extra")
 	return &c, nil
 }

--- a/internal/repository/postgres/jsonlog.go
+++ b/internal/repository/postgres/jsonlog.go
@@ -1,0 +1,26 @@
+package postgres
+
+import (
+	"encoding/json"
+	"log"
+)
+
+// unmarshalJSONB decodes a JSONB column into dest, logging — rather than
+// discarding — a decode failure.
+//
+// A malformed column used to leave dest at its zero value with nothing written
+// anywhere, which is how a corrupted rbac `actions` array could silently turn a
+// privilege into one that grants nothing. The read still succeeds: a row that is
+// otherwise usable should not be lost because one column is unreadable, so this
+// makes the failure visible instead of fatal.
+//
+// An empty or NULL column is not a failure — it is an absent value, and dest
+// keeps its zero value without a log line.
+func unmarshalJSONB(raw []byte, dest any, table, id, field string) {
+	if len(raw) == 0 {
+		return
+	}
+	if err := json.Unmarshal(raw, dest); err != nil {
+		log.Printf("nexor: db: malformed json column table=%s id=%s field=%s err=%v", table, id, field, err)
+	}
+}

--- a/internal/repository/postgres/jsonlog_test.go
+++ b/internal/repository/postgres/jsonlog_test.go
@@ -1,0 +1,120 @@
+package postgres
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// captureLog redirects the standard logger for the duration of fn and returns
+// what was written to it.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+func TestUnmarshalJSONB_LogsMalformedColumn(t *testing.T) {
+	var dest map[string]any
+	out := captureLog(t, func() {
+		unmarshalJSONB([]byte(`{"broken`), &dest, "components", "comp-7", "extra")
+	})
+
+	for _, want := range []string{"components", "comp-7", "extra"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log %q does not mention %q", out, want)
+		}
+	}
+}
+
+func TestUnmarshalJSONB_SilentOnValidColumn(t *testing.T) {
+	var dest map[string]any
+	out := captureLog(t, func() {
+		unmarshalJSONB([]byte(`{"a":1}`), &dest, "components", "comp-7", "extra")
+	})
+
+	if out != "" {
+		t.Errorf("expected no log for a valid column, got %q", out)
+	}
+	if dest["a"] != float64(1) {
+		t.Errorf("expected the column to be decoded, got %#v", dest)
+	}
+}
+
+// An absent column is a value that is not there, not a value that failed to
+// decode — logging it would drown the real failures in noise.
+func TestUnmarshalJSONB_SilentOnEmptyColumn(t *testing.T) {
+	var dest map[string]any
+	out := captureLog(t, func() {
+		unmarshalJSONB(nil, &dest, "components", "comp-7", "extra")
+	})
+
+	if out != "" {
+		t.Errorf("expected no log for a NULL column, got %q", out)
+	}
+}
+
+// fakeRow implements scanner, feeding scanComponent a fixed set of column
+// values so a malformed `extra` can be exercised without a database.
+type fakeRow struct {
+	id       string
+	extraRaw []byte
+}
+
+func (f fakeRow) Scan(dest ...any) error {
+	strs := []string{f.id, "repo-id", "repo-name", "npm", "", "lodash", "1.0.0"}
+	next := 0
+	for _, d := range dest {
+		switch v := d.(type) {
+		case *string:
+			if next < len(strs) {
+				*v = strs[next]
+				next++
+			}
+		case *[]string:
+			*v = []string{}
+		case *[]byte:
+			*v = f.extraRaw
+		case **time.Time:
+			*v = nil
+		case *int64:
+			*v = 0
+		case *time.Time:
+			*v = time.Time{}
+		}
+	}
+	return nil
+}
+
+// The call site, not just the helper: a malformed column has to be reported by
+// the code that actually reads one.
+func TestScanComponent_LogsMalformedExtra(t *testing.T) {
+	var c *domain.Component
+	var err error
+	out := captureLog(t, func() {
+		c, err = scanComponent(fakeRow{id: "comp-42", extraRaw: []byte(`{"scan_result":`)})
+	})
+
+	if err != nil {
+		t.Fatalf("a malformed extra must not fail the read: %v", err)
+	}
+	if c.Name != "lodash" {
+		t.Errorf("expected the rest of the row to survive, got %#v", c)
+	}
+	if !strings.Contains(out, "comp-42") || !strings.Contains(out, "extra") {
+		t.Errorf("log %q does not identify the row and column", out)
+	}
+}

--- a/internal/repository/postgres/privilege_repo.go
+++ b/internal/repository/postgres/privilege_repo.go
@@ -143,9 +143,10 @@ func scanPrivilege(row scanner) (*domain.Privilege, error) {
 		return nil, err
 	}
 	p.Type = domain.PrivilegeType(ptype)
-	if len(attrsRaw) > 0 {
-		_ = json.Unmarshal(attrsRaw, &p.Attrs)
-	}
+	// Attrs carries the privilege's match criteria, so a silent decode failure
+	// here is the same class of problem as a corrupt rbac `actions` array: the
+	// privilege degrades to one that matches nothing, with no trace.
+	unmarshalJSONB(attrsRaw, &p.Attrs, "privileges", p.ID, "attrs")
 	if p.Attrs == nil {
 		p.Attrs = map[string]any{}
 	}

--- a/internal/repository/postgres/rbac_repo.go
+++ b/internal/repository/postgres/rbac_repo.go
@@ -2,7 +2,6 @@ package postgres
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -37,7 +36,10 @@ func (r *rbacRepo) GetUserPrivilegesWithSelectors(ctx context.Context, userID st
 		if err := rows.Scan(&actionsJSON, &ps.Expression); err != nil {
 			return nil, err
 		}
-		_ = json.Unmarshal([]byte(actionsJSON), &ps.Actions)
+		// A privilege whose actions fail to decode grants nothing — the one case
+		// here where silence is a security problem, so it is logged against the
+		// expression that identifies the row (the query selects no id).
+		unmarshalJSONB([]byte(actionsJSON), &ps.Actions, "privileges", ps.Expression, "actions")
 		result = append(result, ps)
 	}
 	return result, rows.Err()

--- a/internal/repository/postgres/repository_repo.go
+++ b/internal/repository/postgres/repository_repo.go
@@ -219,9 +219,9 @@ func scanRepository(row scanner) (*domain.Repository, error) {
 	repo.UpdatedAt = updatedAt
 	repo.CleanupPolicyIDs = cleanupIDs
 
-	_ = json.Unmarshal(fmtCfgRaw, &repo.FormatConfig)
-	_ = json.Unmarshal(httpCfgRaw, &repo.HTTPConfig)
-	_ = json.Unmarshal(proxyCfgRaw, &repo.ProxyConfig)
+	unmarshalJSONB(fmtCfgRaw, &repo.FormatConfig, "repositories", repo.ID, "format_config")
+	unmarshalJSONB(httpCfgRaw, &repo.HTTPConfig, "repositories", repo.ID, "http_config")
+	unmarshalJSONB(proxyCfgRaw, &repo.ProxyConfig, "repositories", repo.ID, "proxy_config")
 
 	return &repo, nil
 }

--- a/internal/repository/postgres/scan_malicious_integration_test.go
+++ b/internal/repository/postgres/scan_malicious_integration_test.go
@@ -1,0 +1,201 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
+)
+
+func TestScanResultRepo_Malicious_RoundTrips(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "scan_results", "components", "repositories", "blob_stores")
+	ctx := context.Background()
+	repo := NewScanResultRepo(pool)
+
+	compID, _, _ := makeScanComponent(t, ctx, "mal_roundtrip")
+
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: compID, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 2, Critical: 1, Total: 3, ScannedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	got, err := repo.GetLatestByComponent(ctx, compID)
+	if err != nil {
+		t.Fatalf("GetLatestByComponent: %v", err)
+	}
+	if got.Malicious != 2 {
+		t.Errorf("Malicious: got %d, want 2", got.Malicious)
+	}
+}
+
+func TestScanResultRepo_Aggregate_SumsMalicious(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "scan_results", "components", "repositories", "blob_stores")
+	ctx := context.Background()
+	repo := NewScanResultRepo(pool)
+
+	comp1, _, _ := makeScanComponent(t, ctx, "mal_agg1")
+	comp2, _, _ := makeScanComponent(t, ctx, "mal_agg2")
+	now := time.Now().Truncate(time.Second)
+
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: comp1, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 1, Total: 1, ScannedAt: now,
+	}); err != nil {
+		t.Fatalf("Insert comp1: %v", err)
+	}
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: comp2, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 2, Critical: 3, Total: 5, ScannedAt: now,
+	}); err != nil {
+		t.Fatalf("Insert comp2: %v", err)
+	}
+
+	sum, err := repo.Aggregate(ctx)
+	if err != nil {
+		t.Fatalf("Aggregate: %v", err)
+	}
+	if sum.Malicious != 3 {
+		t.Errorf("Malicious: got %d, want 3", sum.Malicious)
+	}
+	if sum.Critical != 3 {
+		t.Errorf("Critical: got %d, want 3", sum.Critical)
+	}
+}
+
+func TestScanResultRepo_List_ReturnsMaliciousCount(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "scan_results", "components", "repositories", "blob_stores")
+	ctx := context.Background()
+	repo := NewScanResultRepo(pool)
+
+	compID, _, _ := makeScanComponent(t, ctx, "mal_list")
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: compID, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 1, Total: 1, ScannedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	rows, total, err := repo.List(ctx, domain.VulnFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("rows: got %d (total %d), want 1", len(rows), total)
+	}
+	if rows[0].Malicious != 1 {
+		t.Errorf("Malicious: got %d, want 1", rows[0].Malicious)
+	}
+}
+
+// A compromised package has no CVE and therefore no CVSS level, but it is not
+// less urgent than one. Every minimum-severity tier has to match it — filtering
+// to CRITICAL and losing the malware is the blind spot this feature exists to
+// close.
+func TestScanResultRepo_List_MaliciousMatchesEverySeverityFilter(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "scan_results", "components", "repositories", "blob_stores")
+	ctx := context.Background()
+	repo := NewScanResultRepo(pool)
+
+	compID, _, _ := makeScanComponent(t, ctx, "mal_filter")
+	// Malicious only: no CVE counters at all.
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: compID, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 1, Total: 1, ScannedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	for _, sev := range []string{"MALICIOUS", "CRITICAL", "HIGH", "MEDIUM", "LOW"} {
+		rows, total, err := repo.List(ctx, domain.VulnFilter{Severity: sev})
+		if err != nil {
+			t.Fatalf("List(%s): %v", sev, err)
+		}
+		if total != 1 || len(rows) != 1 {
+			t.Errorf("List(%s): got %d rows (total %d), want 1", sev, len(rows), total)
+		}
+	}
+}
+
+// The MALICIOUS tier is a filter of its own: asking for it must not sweep in
+// rows that only have CVEs.
+func TestScanResultRepo_List_MaliciousFilterExcludesCVEOnlyRows(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "scan_results", "components", "repositories", "blob_stores")
+	ctx := context.Background()
+	repo := NewScanResultRepo(pool)
+
+	cveOnly, _, _ := makeScanComponent(t, ctx, "mal_excl_cve")
+	malicious, _, _ := makeScanComponent(t, ctx, "mal_excl_mal")
+	now := time.Now()
+
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: cveOnly, Scanner: "trivy", Status: domain.ScanStatusOK,
+		Critical: 5, Total: 5, ScannedAt: now,
+	}); err != nil {
+		t.Fatalf("Insert cve-only: %v", err)
+	}
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: malicious, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 1, Total: 1, ScannedAt: now,
+	}); err != nil {
+		t.Fatalf("Insert malicious: %v", err)
+	}
+
+	rows, total, err := repo.List(ctx, domain.VulnFilter{Severity: "MALICIOUS"})
+	if err != nil {
+		t.Fatalf("List(MALICIOUS): %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("got %d rows (total %d), want only the malicious one", len(rows), total)
+	}
+	if rows[0].ComponentID != malicious {
+		t.Errorf("got component %q, want %q", rows[0].ComponentID, malicious)
+	}
+}
+
+// Malicious leads the ordering: a compromised package must not be pushed below
+// a component that merely has more CVEs.
+func TestScanResultRepo_List_MaliciousSortsFirst(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "scan_results", "components", "repositories", "blob_stores")
+	ctx := context.Background()
+	repo := NewScanResultRepo(pool)
+
+	manyCVEs, _, _ := makeScanComponent(t, ctx, "mal_sort_cve")
+	malicious, _, _ := makeScanComponent(t, ctx, "mal_sort_mal")
+	now := time.Now()
+
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: manyCVEs, Scanner: "trivy", Status: domain.ScanStatusOK,
+		Critical: 99, High: 99, Total: 198, ScannedAt: now,
+	}); err != nil {
+		t.Fatalf("Insert cve-heavy: %v", err)
+	}
+	if err := repo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: malicious, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 1, Total: 1, ScannedAt: now,
+	}); err != nil {
+		t.Fatalf("Insert malicious: %v", err)
+	}
+
+	rows, _, err := repo.List(ctx, domain.VulnFilter{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows: got %d, want 2", len(rows))
+	}
+	if rows[0].ComponentID != malicious {
+		t.Errorf("first row: got %q, want the malicious component %q", rows[0].ComponentID, malicious)
+	}
+}

--- a/internal/repository/postgres/scan_result_repo.go
+++ b/internal/repository/postgres/scan_result_repo.go
@@ -56,9 +56,7 @@ func (r *scanResultRepo) GetLatestByComponent(ctx context.Context, componentID s
 		return nil, err
 	}
 	row.Status = domain.ScanStatus(st)
-	if raw != nil {
-		_ = json.Unmarshal(raw, &row.Raw)
-	}
+	unmarshalJSONB(raw, &row.Raw, "scan_results", row.ID, "raw")
 	return &row, nil
 }
 

--- a/internal/repository/postgres/scan_result_repo.go
+++ b/internal/repository/postgres/scan_result_repo.go
@@ -24,10 +24,10 @@ func (r *scanResultRepo) Insert(ctx context.Context, row *domain.ScanResultRow) 
 	raw, _ := json.Marshal(row.Raw)
 	_, err := r.pool.Exec(ctx, `
 		INSERT INTO scan_results
-		  (component_id, scanner, status, critical, high, medium, low, unknown, total, scanned_at, raw, error)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+		  (component_id, scanner, status, malicious, critical, high, medium, low, unknown, total, scanned_at, raw, error)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
 		row.ComponentID, row.Scanner, string(row.Status),
-		row.Critical, row.High, row.Medium, row.Low, row.Unknown, row.Total,
+		row.Malicious, row.Critical, row.High, row.Medium, row.Low, row.Unknown, row.Total,
 		row.ScannedAt, raw, row.Error,
 	)
 	return err
@@ -40,13 +40,13 @@ func (r *scanResultRepo) GetLatestByComponent(ctx context.Context, componentID s
 		st  string
 	)
 	err := r.pool.QueryRow(ctx, `
-		SELECT id, component_id, scanner, status, critical, high, medium, low, unknown, total, scanned_at, raw, COALESCE(error,'')
+		SELECT id, component_id, scanner, status, malicious, critical, high, medium, low, unknown, total, scanned_at, raw, COALESCE(error,'')
 		FROM scan_results
 		WHERE component_id = $1
 		ORDER BY scanned_at DESC
 		LIMIT 1`, componentID).Scan(
 		&row.ID, &row.ComponentID, &row.Scanner, &st,
-		&row.Critical, &row.High, &row.Medium, &row.Low, &row.Unknown, &row.Total,
+		&row.Malicious, &row.Critical, &row.High, &row.Medium, &row.Low, &row.Unknown, &row.Total,
 		&row.ScannedAt, &raw, &row.Error,
 	)
 	if err != nil {
@@ -67,11 +67,12 @@ func (r *scanResultRepo) Aggregate(ctx context.Context) (*domain.SecuritySummary
 	err := r.pool.QueryRow(ctx, `
 		WITH latest AS (
 			SELECT DISTINCT ON (component_id)
-				component_id, critical, high, medium, low, unknown
+				component_id, malicious, critical, high, medium, low, unknown
 			FROM scan_results
 			ORDER BY component_id, scanned_at DESC
 		)
 		SELECT
+			COALESCE(SUM(malicious),0),
 			COALESCE(SUM(critical),0),
 			COALESCE(SUM(high),0),
 			COALESCE(SUM(medium),0),
@@ -79,7 +80,7 @@ func (r *scanResultRepo) Aggregate(ctx context.Context) (*domain.SecuritySummary
 			COALESCE(SUM(unknown),0),
 			COUNT(*)
 		FROM latest`).Scan(
-		&s.Critical, &s.High, &s.Medium, &s.Low, &s.Unknown, &s.ScannedTotal,
+		&s.Malicious, &s.Critical, &s.High, &s.Medium, &s.Low, &s.Unknown, &s.ScannedTotal,
 	)
 	return &s, err
 }
@@ -89,17 +90,25 @@ func (r *scanResultRepo) List(ctx context.Context, f domain.VulnFilter) ([]*doma
 		f.Limit = 50
 	}
 
-	// severity → minimum column filter
+	// severity → minimum column filter.
+	//
+	// A malicious-package report has no CVSS level, so it cannot be ordered
+	// against the CVE tiers on its own terms — but it is never less urgent than
+	// one, so every minimum-severity tier matches it. Asking for MALICIOUS
+	// specifically is the one filter that does not widen: it means malware, not
+	// "malware and everything above LOW".
 	sevFilter := ""
 	switch f.Severity {
+	case "MALICIOUS":
+		sevFilter = "AND sr.malicious > 0"
 	case "CRITICAL":
-		sevFilter = "AND sr.critical > 0"
+		sevFilter = "AND (sr.malicious > 0 OR sr.critical > 0)"
 	case "HIGH":
-		sevFilter = "AND (sr.critical > 0 OR sr.high > 0)"
+		sevFilter = "AND (sr.malicious > 0 OR sr.critical > 0 OR sr.high > 0)"
 	case "MEDIUM":
-		sevFilter = "AND (sr.critical > 0 OR sr.high > 0 OR sr.medium > 0)"
+		sevFilter = "AND (sr.malicious > 0 OR sr.critical > 0 OR sr.high > 0 OR sr.medium > 0)"
 	case "LOW":
-		sevFilter = "AND (sr.critical > 0 OR sr.high > 0 OR sr.medium > 0 OR sr.low > 0)"
+		sevFilter = "AND (sr.malicious > 0 OR sr.critical > 0 OR sr.high > 0 OR sr.medium > 0 OR sr.low > 0)"
 	}
 
 	base := `
@@ -107,7 +116,7 @@ func (r *scanResultRepo) List(ctx context.Context, f domain.VulnFilter) ([]*doma
 			SELECT DISTINCT ON (sr.component_id)
 				r.name AS repo_name, r.format,
 				c.id AS component_id, c.name, c.version,
-				sr.critical, sr.high, sr.medium, sr.low, sr.unknown, sr.scanned_at
+				sr.malicious, sr.critical, sr.high, sr.medium, sr.low, sr.unknown, sr.scanned_at
 			FROM scan_results sr
 			JOIN components c ON c.id = sr.component_id
 			JOIN repositories r ON r.id = c.repository_id
@@ -123,8 +132,8 @@ func (r *scanResultRepo) List(ctx context.Context, f domain.VulnFilter) ([]*doma
 	}
 
 	rows, err := r.pool.Query(ctx,
-		"SELECT repo_name, format, component_id, name, version, critical, high, medium, low, unknown, scanned_at"+
-			base+" ORDER BY critical DESC, high DESC, scanned_at DESC LIMIT $3 OFFSET $4",
+		"SELECT repo_name, format, component_id, name, version, malicious, critical, high, medium, low, unknown, scanned_at"+
+			base+" ORDER BY malicious DESC, critical DESC, high DESC, scanned_at DESC LIMIT $3 OFFSET $4",
 		f.Repo, f.Format, f.Limit, f.Offset,
 	)
 	if err != nil {
@@ -137,7 +146,7 @@ func (r *scanResultRepo) List(ctx context.Context, f domain.VulnFilter) ([]*doma
 		var vr domain.VulnRow
 		var scannedAt time.Time
 		if err := rows.Scan(&vr.RepoName, &vr.Format, &vr.ComponentID, &vr.Name, &vr.Version,
-			&vr.Critical, &vr.High, &vr.Medium, &vr.Low, &vr.Unknown, &scannedAt); err != nil {
+			&vr.Malicious, &vr.Critical, &vr.High, &vr.Medium, &vr.Low, &vr.Unknown, &scannedAt); err != nil {
 			return nil, 0, err
 		}
 		vr.ScannedAt = scannedAt

--- a/internal/service/osv_client.go
+++ b/internal/service/osv_client.go
@@ -12,11 +12,22 @@ import (
 
 const osvDefaultBaseURL = "https://api.osv.dev"
 
+// SeverityMalicious marks a package that a malicious-package report names — a
+// compromised release, not a package with a vulnerability in it.
+//
+// It is not a CVSS level and does not come from one. OSV.dev indexes OpenSSF's
+// malicious-packages dataset under `MAL-…` ids, and those reports never carry a
+// `database_specific.severity`, so without a tier of their own they landed in
+// "Unknown" next to packages the scanner simply could not classify.
+const SeverityMalicious = "MALICIOUS"
+
+const osvMaliciousIDPrefix = "MAL-"
+
 // OSVVuln is a single vulnerability from the OSV.dev API.
 type OSVVuln struct {
 	ID       string
 	Summary  string
-	Severity string // "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "UNKNOWN"
+	Severity string // "MALICIOUS" | "CRITICAL" | "HIGH" | "MEDIUM" | "LOW" | "UNKNOWN"
 }
 
 // OSVClient queries the OSV.dev vulnerability database.
@@ -86,6 +97,16 @@ func (c *OSVClient) Query(ctx context.Context, name, version, ecosystem string) 
 
 	out := make([]OSVVuln, 0, len(result.Vulns))
 	for _, v := range result.Vulns {
+		// A malicious-package report outranks everything else the entry says.
+		// Its severity is forced — a MAL- report that happens to carry a CVSS
+		// score is still malware first — and its id is preferred over the CVE
+		// alias the display logic would otherwise pick, because a CVE number in
+		// place of a MAL- id hides exactly the fact worth seeing.
+		if malID := maliciousID(v.ID, v.Aliases); malID != "" {
+			out = append(out, OSVVuln{ID: malID, Summary: v.Summary, Severity: SeverityMalicious})
+			continue
+		}
+
 		id := v.ID
 		for _, alias := range v.Aliases {
 			if strings.HasPrefix(alias, "CVE-") {
@@ -100,6 +121,20 @@ func (c *OSVClient) Query(ctx context.Context, name, version, ecosystem string) 
 		out = append(out, OSVVuln{ID: id, Summary: v.Summary, Severity: sev})
 	}
 	return out, nil
+}
+
+// maliciousID returns the MAL- identifier of an OSV entry — its own id or the
+// first alias carrying one — or "" if the entry is not a malicious-package report.
+func maliciousID(id string, aliases []string) string {
+	if strings.HasPrefix(id, osvMaliciousIDPrefix) {
+		return id
+	}
+	for _, alias := range aliases {
+		if strings.HasPrefix(alias, osvMaliciousIDPrefix) {
+			return alias
+		}
+	}
+	return ""
 }
 
 // FormatToEcosystem maps Nexspence format names to OSV.dev ecosystem strings.

--- a/internal/service/osv_malicious_test.go
+++ b/internal/service/osv_malicious_test.go
@@ -1,0 +1,133 @@
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/service"
+)
+
+// osvServer replies to every query with the given raw `vulns` array.
+func osvServer(t *testing.T, vulns []map[string]any) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"vulns": vulns})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// OSV.dev indexes OpenSSF's malicious-packages dataset as `MAL-…` reports. They
+// carry no `database_specific.severity` — that field is CVSS-specific and
+// malware reports never set it — so a compromised package used to land in the
+// same "Unknown" bucket as a package the scanner could not classify.
+func TestOSVClient_MaliciousReportIsClassifiedMalicious(t *testing.T) {
+	t.Parallel()
+	srv := osvServer(t, []map[string]any{
+		{
+			"id":      "MAL-2025-46974",
+			"aliases": []string{},
+			"summary": "Malicious code in debug (npm)",
+		},
+	})
+
+	client := service.NewOSVClient()
+	client.BaseURL = srv.URL
+
+	vulns, err := client.Query(context.Background(), "debug", "4.4.2", "npm")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vulns) != 1 {
+		t.Fatalf("expected 1 vuln, got %d", len(vulns))
+	}
+	if vulns[0].Severity != "MALICIOUS" {
+		t.Errorf("expected MALICIOUS, got %q", vulns[0].Severity)
+	}
+	if vulns[0].ID != "MAL-2025-46974" {
+		t.Errorf("expected the MAL- id to be kept, got %q", vulns[0].ID)
+	}
+}
+
+// The CVE-alias preference exists to show a familiar identifier. Applying it to
+// a malware report would bury the one signal that matters most, so a MAL- id
+// wins over any alias.
+func TestOSVClient_MaliciousIDWinsOverCVEAlias(t *testing.T) {
+	t.Parallel()
+	srv := osvServer(t, []map[string]any{
+		{
+			"id":      "GHSA-aaaa-bbbb-cccc",
+			"aliases": []string{"CVE-2025-11111", "MAL-2025-46974"},
+			"summary": "Malicious code in chalk (npm)",
+		},
+	})
+
+	client := service.NewOSVClient()
+	client.BaseURL = srv.URL
+
+	vulns, err := client.Query(context.Background(), "chalk", "5.6.1", "npm")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(vulns) != 1 {
+		t.Fatalf("expected 1 vuln, got %d", len(vulns))
+	}
+	if vulns[0].Severity != "MALICIOUS" {
+		t.Errorf("expected MALICIOUS, got %q", vulns[0].Severity)
+	}
+	if vulns[0].ID != "MAL-2025-46974" {
+		t.Errorf("expected the MAL- alias as the displayed id, got %q", vulns[0].ID)
+	}
+}
+
+// Malware detection outranks a coincidental CVSS score: a MAL- report that does
+// carry a severity is still reported as malicious.
+func TestOSVClient_MaliciousOverridesReportedSeverity(t *testing.T) {
+	t.Parallel()
+	srv := osvServer(t, []map[string]any{
+		{
+			"id":                "MAL-2025-12345",
+			"aliases":           []string{},
+			"summary":           "Malicious package",
+			"database_specific": map[string]any{"severity": "LOW"},
+		},
+	})
+
+	client := service.NewOSVClient()
+	client.BaseURL = srv.URL
+
+	vulns, err := client.Query(context.Background(), "evil", "1.0.0", "npm")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vulns[0].Severity != "MALICIOUS" {
+		t.Errorf("expected MALICIOUS to override LOW, got %q", vulns[0].Severity)
+	}
+}
+
+// A plain CVE keeps behaving exactly as before.
+func TestOSVClient_NonMaliciousUnaffected(t *testing.T) {
+	t.Parallel()
+	srv := osvServer(t, []map[string]any{
+		{
+			"id":                "GHSA-aaaa-bbbb-cccc",
+			"aliases":           []string{"CVE-2023-1234"},
+			"summary":           "Prototype pollution",
+			"database_specific": map[string]any{"severity": "HIGH"},
+		},
+	})
+
+	client := service.NewOSVClient()
+	client.BaseURL = srv.URL
+
+	vulns, err := client.Query(context.Background(), "lodash", "4.17.20", "npm")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if vulns[0].Severity != "HIGH" || vulns[0].ID != "CVE-2023-1234" {
+		t.Errorf("expected the CVE-alias behavior to be unchanged, got %#v", vulns[0])
+	}
+}

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -183,8 +183,13 @@ func (s *PromotionService) Promote(ctx context.Context, ruleID string, component
 			if serr != nil || scan == nil {
 				return nil, fmt.Errorf("component %s: scan required but not yet run", compID)
 			}
-			if scan.Critical > 0 || scan.High > 0 {
-				return nil, fmt.Errorf("component %s: scan has %d critical, %d high findings", compID, scan.Critical, scan.High)
+			// Malicious is checked alongside the CVE tiers, not folded into
+			// them: a malicious-package report has no CVSS level, so a gate
+			// reading only Critical/High would pass a compromised release with
+			// a spotless CVE record straight into production.
+			if scan.Malicious > 0 || scan.Critical > 0 || scan.High > 0 {
+				return nil, fmt.Errorf("component %s: scan has %d malicious, %d critical, %d high findings",
+					compID, scan.Malicious, scan.Critical, scan.High)
 			}
 		}
 

--- a/internal/service/promotion_service_extra_test.go
+++ b/internal/service/promotion_service_extra_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/service"
@@ -392,6 +393,49 @@ func TestPromotionService_DeleteRule(t *testing.T) {
 }
 
 // ── Promote scan-pass gate ─────────────────────────────────────────────────────
+
+// The scan gate is the one place a severity count is enforced rather than
+// displayed. A malicious-package report carries no CVE and no CVSS level, so a
+// gate that only reads Critical/High waves a compromised release straight
+// through to production — the exact failure the MALICIOUS tier exists to stop.
+func TestPromotionService_Promote_ScanGate_BlocksMaliciousWithoutCVEs(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, scanRepo := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	fromRepo := testutil.SimpleRepo("mal-src", "raw")
+	toRepo := testutil.SimpleRepo("mal-dst", "raw")
+	repoRepo.Create(ctx, fromRepo)
+	repoRepo.Create(ctx, toRepo)
+
+	comp := &domain.Component{
+		ID: "comp-mal", Repository: fromRepo.Name, Format: "raw",
+		Group: "g", Name: "s", Version: "1",
+	}
+	compRepo.AddComponent(comp)
+
+	// Clean by every CVE measure, and malicious.
+	if err := scanRepo.Insert(ctx, &domain.ScanResultRow{
+		ComponentID: comp.ID, Scanner: "osv", Status: domain.ScanStatusOK,
+		Malicious: 1, Total: 1, ScannedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("Insert scan row: %v", err)
+	}
+
+	rule := &domain.PromotionRule{
+		Name: "mal-gate", FromRepo: fromRepo.Name, ToRepo: toRepo.Name, RequireScanPass: true,
+	}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	_, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user")
+	if err == nil {
+		t.Fatal("expected the promotion to be refused, got nil error")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "malicious") {
+		t.Errorf("the refusal must name what blocked it, got %v", err)
+	}
+}
 
 func TestPromotionService_Promote_ScanRequired_NoScan(t *testing.T) {
 	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)

--- a/internal/service/scan_autoscan_test.go
+++ b/internal/service/scan_autoscan_test.go
@@ -144,21 +144,31 @@ func TestScanService_StartScheduler_StopsOnContextCancel(t *testing.T) {
 // an error: the queue skips it without noise.
 func TestScanService_TriggerAsync_UnsupportedFormatIsHarmless(t *testing.T) {
 	comp := &domain.Component{Repository: "rawhosted", Format: "raw", Name: "notes.txt", Version: ""}
+	// Queued behind it: once this one has been scanned the raw component has
+	// demonstrably had its turn, which beats sleeping and hoping.
+	marker := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "lodash", Version: "4.17.20"}
 	comps := testutil.NewComponentRepo()
 	comps.Create(context.Background(), comp)
+	comps.Create(context.Background(), marker)
 
 	scanRepo := testutil.NewScanResultRepo()
 	svc := service.NewScanService(comps, "").WithScanResults(scanRepo)
+	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go svc.StartScheduler(ctx, "")
 
 	svc.TriggerAsync(comp.ID)
+	svc.TriggerAsync(marker.ID)
 
-	// Nothing to assert but the absence of a crash and of a persisted row.
-	time.Sleep(150 * time.Millisecond)
-	if n := len(scanRepo.Rows()); n != 0 {
-		t.Errorf("expected no scan row for an unscannable format, got %d", n)
+	waitFor(t, "the queue to reach the scannable component", func() bool {
+		return len(scanRepo.Rows()) > 0
+	})
+
+	for _, row := range scanRepo.Rows() {
+		if row.ComponentID == comp.ID {
+			t.Error("an unscannable format must not produce a scan row")
+		}
 	}
 }

--- a/internal/service/scan_autoscan_test.go
+++ b/internal/service/scan_autoscan_test.go
@@ -1,0 +1,164 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// waitFor polls cond until it holds or the deadline passes.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+func TestScanService_TriggerAsync_ScansInBackground(t *testing.T) {
+	comp := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "lodash", Version: "4.17.20"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	scanRepo := testutil.NewScanResultRepo()
+	svc := service.NewScanService(comps, "").WithScanResults(scanRepo)
+	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go svc.StartScheduler(ctx, "") // empty schedule: queue worker only, no cron
+
+	svc.TriggerAsync(comp.ID)
+
+	waitFor(t, "the queued component to be scanned", func() bool {
+		return len(scanRepo.Rows()) == 1
+	})
+	if got := scanRepo.Rows()[0].ComponentID; got != comp.ID {
+		t.Errorf("scanned component %q, want %q", got, comp.ID)
+	}
+}
+
+// An upload must never wait on a scan, and must never be refused because the
+// scanner is behind. The queue drops rather than blocks; the daily bulk scan is
+// the safety net for what it drops.
+func TestScanService_TriggerAsync_NeverBlocks(t *testing.T) {
+	comps := testutil.NewComponentRepo()
+	svc := service.NewScanService(comps, "")
+	// No scheduler started: nothing is draining the queue.
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 1000; i++ {
+			svc.TriggerAsync("comp-overflow")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("TriggerAsync blocked once the queue filled up")
+	}
+}
+
+// A docker push registers every layer and the digest alias as their own
+// components, versioned by digest. Scanning those means one Trivy run per layer
+// against a reference that is not an image — wasted work that also evicts the
+// real manifest scan from a bounded queue. BulkScan already skips them; the
+// upload path has to agree.
+func TestScanService_TriggerAsync_SkipsDigestAliases(t *testing.T) {
+	// The rule is the version, not the format — the same one BulkScan applies.
+	// A scannable format is used here so that "was not scanned" is observable:
+	// with a docker component it would be indistinguishable from a scan that
+	// simply found no Trivy.
+	layer := &domain.Component{
+		Repository: "npmhosted", Format: "npm", Name: "myapp",
+		Version: "sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+	}
+	// A scannable component queued behind the alias: once this one has been
+	// scanned, the alias has demonstrably had its turn in the queue.
+	marker := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "lodash", Version: "4.17.20"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), layer)
+	comps.Create(context.Background(), marker)
+
+	scanRepo := testutil.NewScanResultRepo()
+	svc := service.NewScanService(comps, "").WithScanResults(scanRepo)
+	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
+	// Point Trivy at a binary that does not exist: if the alias is scanned after
+	// all, it shells out and the assertion below catches it either way.
+	svc.TrivyBin = "nexspence-no-such-trivy"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go svc.StartScheduler(ctx, "")
+
+	svc.TriggerAsync(layer.ID)
+	svc.TriggerAsync(marker.ID)
+
+	waitFor(t, "the queue to reach the scannable component", func() bool {
+		return len(scanRepo.Rows()) > 0
+	})
+
+	for _, row := range scanRepo.Rows() {
+		if row.ComponentID == layer.ID {
+			t.Error("a digest-aliased component must not be scanned")
+		}
+	}
+	c, err := comps.Get(context.Background(), layer.ID)
+	if err != nil {
+		t.Fatalf("get layer component: %v", err)
+	}
+	if c.Extra["scan_result"] != nil {
+		t.Error("a digest-aliased component must not get a cached scan result")
+	}
+}
+
+func TestScanService_StartScheduler_StopsOnContextCancel(t *testing.T) {
+	svc := service.NewScanService(testutil.NewComponentRepo(), "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	returned := make(chan struct{})
+	go func() {
+		svc.StartScheduler(ctx, "0 3 * * *")
+		close(returned)
+	}()
+
+	cancel()
+	select {
+	case <-returned:
+	case <-time.After(3 * time.Second):
+		t.Fatal("StartScheduler did not return after its context was canceled")
+	}
+}
+
+// A component whose format has no scanner (raw, helm, …) is a normal upload, not
+// an error: the queue skips it without noise.
+func TestScanService_TriggerAsync_UnsupportedFormatIsHarmless(t *testing.T) {
+	comp := &domain.Component{Repository: "rawhosted", Format: "raw", Name: "notes.txt", Version: ""}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	scanRepo := testutil.NewScanResultRepo()
+	svc := service.NewScanService(comps, "").WithScanResults(scanRepo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go svc.StartScheduler(ctx, "")
+
+	svc.TriggerAsync(comp.ID)
+
+	// Nothing to assert but the absence of a crash and of a persisted row.
+	time.Sleep(150 * time.Millisecond)
+	if n := len(scanRepo.Rows()); n != 0 {
+		t.Errorf("expected no scan row for an unscannable format, got %d", n)
+	}
+}

--- a/internal/service/scan_malicious_test.go
+++ b/internal/service/scan_malicious_test.go
@@ -1,0 +1,54 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// The visibility gap this closes: the finding was always there, it was just
+// counted in a bucket nobody reads.
+func TestScanService_MaliciousFindingGetsItsOwnCounter(t *testing.T) {
+	comp := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "debug", Version: "4.4.2"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	srv := osvServer(t, []map[string]any{
+		{"id": "MAL-2025-46974", "aliases": []string{}, "summary": "Malicious code in debug (npm)"},
+		{"id": "GHSA-x", "aliases": []string{"CVE-2025-2"}, "summary": "RCE",
+			"database_specific": map[string]any{"severity": "HIGH"}},
+	})
+
+	scanRepo := testutil.NewScanResultRepo()
+	svc := service.NewScanService(comps, "").WithScanResults(scanRepo)
+	svc.OSVClient.BaseURL = srv.URL
+
+	result, err := svc.Scan(context.Background(), comp.ID, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Summary.Malicious != 1 {
+		t.Errorf("expected Malicious=1, got %d", result.Summary.Malicious)
+	}
+	if result.Summary.Unknown != 0 {
+		t.Errorf("a malicious report must leave the Unknown bucket, got Unknown=%d", result.Summary.Unknown)
+	}
+	if result.Summary.High != 1 {
+		t.Errorf("expected High=1, got %d", result.Summary.High)
+	}
+	if result.Summary.Total != 2 {
+		t.Errorf("expected Total=2, got %d", result.Summary.Total)
+	}
+
+	rows := scanRepo.Rows()
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 scan_results row, got %d", len(rows))
+	}
+	if rows[0].Malicious != 1 {
+		t.Errorf("expected the count to reach the history row, got Malicious=%d", rows[0].Malicious)
+	}
+}

--- a/internal/service/scan_persist_log_test.go
+++ b/internal/service/scan_persist_log_test.go
@@ -1,0 +1,108 @@
+package service_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// captureLog redirects the standard logger for the duration of fn and returns
+// what was written to it.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// osvServerWithOneVuln serves a single HIGH finding for any query.
+func osvServerWithOneVuln(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"vulns": []map[string]any{
+				{"id": "CVE-2021-9999", "summary": "Prototype pollution",
+					"database_specific": map[string]any{"severity": "HIGH"}},
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// A scan that cannot be written back leaves the dashboard showing stale data for
+// the component. The scan still succeeds for the caller — but it must not be the
+// only place the failure is ever visible.
+func TestScanService_LogsWhenResultNotPersistedToComponent(t *testing.T) {
+	comp := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "lodash", Version: "4.17.20"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+	comps.UpdateExtraErr = errors.New("connection reset by peer")
+
+	svc := service.NewScanService(comps, "")
+	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
+
+	var result *domain.ScanResult
+	var err error
+	out := captureLog(t, func() {
+		result, err = svc.Scan(context.Background(), comp.ID, "")
+	})
+
+	if err != nil {
+		t.Fatalf("a failed write must not fail the scan: %v", err)
+	}
+	if result.Summary.High != 1 {
+		t.Errorf("the caller still gets the findings, got %#v", result.Summary)
+	}
+	for _, want := range []string{comp.ID, "osv", "connection reset by peer"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log %q does not mention %q", out, want)
+		}
+	}
+}
+
+// Same defect on the other write: the scan_results history row the org-wide
+// dashboard aggregates from.
+func TestScanService_LogsWhenHistoryRowNotInserted(t *testing.T) {
+	comp := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "lodash", Version: "4.17.20"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	scanRepo := testutil.NewScanResultRepo()
+	scanRepo.InsertErr = errors.New("deadlock detected")
+
+	svc := service.NewScanService(comps, "").WithScanResults(scanRepo)
+	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
+
+	var err error
+	out := captureLog(t, func() {
+		_, err = svc.Scan(context.Background(), comp.ID, "")
+	})
+
+	if err != nil {
+		t.Fatalf("a failed write must not fail the scan: %v", err)
+	}
+	for _, want := range []string{comp.ID, "osv", "deadlock detected"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log %q does not mention %q", out, want)
+		}
+	}
+}

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/robfig/cron/v3"
+
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 )
@@ -116,7 +118,22 @@ type ScanService struct {
 	// trivyMu serializes Trivy CLI runs. Trivy's on-disk cache (BoltDB) is not safe for concurrent
 	// processes; parallel scans caused "cache may be in use by another process: timeout".
 	trivyMu sync.Mutex
+
+	// queue carries component ids awaiting an automatic scan. It is buffered and
+	// dropped-on-full: an upload must never wait on a scanner, and must never be
+	// refused because one is behind. What the queue drops, the daily bulk scan
+	// picks up.
+	queue chan string
 }
+
+// autoScanQueueSize bounds the outstanding automatic scans. Past this, uploads
+// keep succeeding and the overflow waits for the next bulk scan.
+const autoScanQueueSize = 256
+
+// defaultScanSchedule re-scans everything nightly, so components uploaded before
+// auto-scan existed — or dropped by a full queue — are still checked, and
+// already-scanned ones are re-checked against newly published CVEs.
+const defaultScanSchedule = "0 3 * * *"
 
 // NewScanService constructs a vulnerability scanning service backed by Trivy and OSV.dev.
 func NewScanService(components repository.ComponentRepo, httpBaseURL string) *ScanService {
@@ -126,6 +143,92 @@ func NewScanService(components repository.ComponentRepo, httpBaseURL string) *Sc
 		TrivyBin:     "trivy",
 		TrivyTimeout: 10 * time.Minute,
 		OSVClient:    NewOSVClient(),
+		queue:        make(chan string, autoScanQueueSize),
+	}
+}
+
+// TriggerAsync requests a background scan of componentID and returns immediately.
+//
+// It is the seam the storage layer uses after an artifact is stored, so it is on
+// the upload path and must behave like it: never block, never fail the caller.
+// A full queue drops the request rather than applying backpressure to an upload
+// — the nightly bulk scan covers what is dropped.
+func (s *ScanService) TriggerAsync(componentID string) {
+	if componentID == "" || s.queue == nil {
+		return
+	}
+	select {
+	case s.queue <- componentID:
+	default:
+		log.Printf("nexor: auto-scan queue full, skipping component=%s (next bulk scan will cover it)", componentID)
+	}
+}
+
+// StartScheduler drains the automatic-scan queue and runs a full bulk re-scan on
+// the given cron schedule, until ctx is done. Run it as a goroutine.
+//
+// A blank schedule keeps the queue worker but disables the periodic scan; an
+// invalid one disables the periodic scan with a log line rather than taking the
+// server down over a config typo.
+//
+// The queue is drained by this single goroutine, one component at a time. That
+// is not a throughput compromise: Trivy's on-disk cache tolerates only one
+// process at a time anyway (see trivyMu), so a wider pool would serialize on
+// the same lock while holding more scans in flight.
+func (s *ScanService) StartScheduler(ctx context.Context, schedule string) {
+	if strings.TrimSpace(schedule) == "" {
+		s.drainQueue(ctx)
+		return
+	}
+
+	c := cron.New()
+	if _, err := c.AddFunc(schedule, func() {
+		scanned, failed, err := s.BulkScan(ctx, "")
+		if err != nil {
+			log.Printf("nexor: scheduled bulk scan failed: %v", err)
+			return
+		}
+		log.Printf("nexor: scheduled bulk scan done scanned=%d failed=%d", scanned, failed)
+	}); err != nil {
+		log.Printf("nexor: scan scheduler disabled, invalid schedule %q: %v", schedule, err)
+		s.drainQueue(ctx)
+		return
+	}
+	c.Start()
+	defer c.Stop()
+
+	s.drainQueue(ctx)
+}
+
+// skipAutoScan reports whether a queued component is not worth a scanner run.
+//
+// A component that cannot be read is left to Scan to report — this only filters
+// what is knowably pointless.
+func (s *ScanService) skipAutoScan(ctx context.Context, componentID string) bool {
+	comp, err := s.Components.Get(ctx, componentID)
+	if err != nil || comp == nil {
+		return false
+	}
+	return isDigestAlias(comp.Version)
+}
+
+// drainQueue scans queued components sequentially until ctx is done.
+func (s *ScanService) drainQueue(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case componentID := <-s.queue:
+			if s.skipAutoScan(ctx, componentID) {
+				continue
+			}
+			// An unscannable format is a normal upload, not a failure: every
+			// artifact is queued because the storage layer does not know which
+			// formats have a scanner, and Scan is the thing that does.
+			if _, err := s.Scan(ctx, componentID, ""); err != nil {
+				log.Printf("nexor: auto-scan skipped component=%s: %v", componentID, err)
+			}
+		}
 	}
 }
 
@@ -235,8 +338,7 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 			log.Printf("nexor: trivy scan failed component=%s imageRef=%q: %s", componentID, ref, msg)
 			result.Status = domain.ScanStatusFailed
 			result.Error = truncateScanError(msg)
-			_ = s.persistResult(ctx, comp, result)
-			s.persistScanRow(ctx, comp, result, "trivy")
+			s.persist(ctx, comp, result, "trivy")
 			return result, nil
 		}
 	}
@@ -244,8 +346,7 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 	result.Findings, result.Summary = parseTrivyJSON(out)
 	result.Status = domain.ScanStatusOK
 
-	_ = s.persistResult(ctx, comp, result)
-	s.persistScanRow(ctx, comp, result, "trivy")
+	s.persist(ctx, comp, result, "trivy")
 	return result, nil
 }
 
@@ -280,6 +381,25 @@ func (s *ScanService) persistResult(ctx context.Context, comp *domain.Component,
 	return s.Components.UpdateExtra(ctx, comp.ID, map[string]any{"scan_result": raw})
 }
 
+// persist stores a finished scan in both places it lives: the component's cached
+// scan_result and the scan_results history row the dashboard aggregates.
+//
+// Both writes are best-effort — the result is already on its way back to the
+// caller, and a failed write must not turn a successful scan into an error. It
+// must not be invisible either: a dropped write leaves the dashboard showing
+// stale or missing data for that component, so each failure is logged with the
+// component and the scanner that produced the result.
+//
+// Deliberately no retry: Scan runs inside the request that asked for it, and
+// blocking that request to retry a cache write costs the caller more than the
+// stale row does. The daily bulk re-scan is what eventually repairs it.
+func (s *ScanService) persist(ctx context.Context, comp *domain.Component, result *domain.ScanResult, scanner string) {
+	if err := s.persistResult(ctx, comp, result); err != nil {
+		log.Printf("nexor: scan result not persisted to component component=%s scanner=%s: %v", comp.ID, scanner, err)
+	}
+	s.persistScanRow(ctx, comp, result, scanner)
+}
+
 func (s *ScanService) scanOSV(ctx context.Context, comp *domain.Component) (*domain.ScanResult, error) {
 	ecosystem := FormatToEcosystem(comp.Format)
 	if ecosystem == "" {
@@ -295,8 +415,7 @@ func (s *ScanService) scanOSV(ctx context.Context, comp *domain.Component) (*dom
 	if err != nil {
 		result.Status = domain.ScanStatusFailed
 		result.Error = err.Error()
-		_ = s.persistResult(ctx, comp, result)
-		s.persistScanRow(ctx, comp, result, "osv")
+		s.persist(ctx, comp, result, "osv")
 		return result, nil //nolint:nilerr // best-effort scan: OSV query failure is recorded in result.Error and returned as a failed-status result; propagating the error would break the UI scan response
 	}
 
@@ -309,6 +428,8 @@ func (s *ScanService) scanOSV(ctx context.Context, comp *domain.Component) (*dom
 			Title:    v.Summary,
 		})
 		switch v.Severity {
+		case SeverityMalicious:
+			summary.Malicious++
 		case "CRITICAL":
 			summary.Critical++
 		case "HIGH":
@@ -325,8 +446,7 @@ func (s *ScanService) scanOSV(ctx context.Context, comp *domain.Component) (*dom
 	result.Findings = findings
 	result.Summary = summary
 
-	_ = s.persistResult(ctx, comp, result)
-	s.persistScanRow(ctx, comp, result, "osv")
+	s.persist(ctx, comp, result, "osv")
 	return result, nil
 }
 
@@ -338,6 +458,7 @@ func (s *ScanService) persistScanRow(ctx context.Context, comp *domain.Component
 		ComponentID: comp.ID,
 		Scanner:     scanner,
 		Status:      result.Status,
+		Malicious:   result.Summary.Malicious,
 		Critical:    result.Summary.Critical,
 		High:        result.Summary.High,
 		Medium:      result.Summary.Medium,
@@ -347,7 +468,21 @@ func (s *ScanService) persistScanRow(ctx context.Context, comp *domain.Component
 		ScannedAt:   result.ScannedAt,
 		Error:       result.Error,
 	}
-	_ = s.ScanResults.Insert(ctx, row)
+	if err := s.ScanResults.Insert(ctx, row); err != nil {
+		log.Printf("nexor: scan result row not inserted component=%s scanner=%s: %v", comp.ID, scanner, err)
+	}
+}
+
+// isDigestAlias reports whether a component version is a content digest rather
+// than a release.
+//
+// An OCI push registers every layer and the manifest's digest alias as their own
+// components, versioned by digest. They duplicate the tagged image: scanning
+// them means one scanner run per layer against a reference that is not an image,
+// and — on the bounded auto-scan queue — that wasted work would crowd out the
+// manifest scan that actually says something.
+func isDigestAlias(version string) bool {
+	return strings.HasPrefix(version, "sha256:")
 }
 
 // BulkScan scans every component in a repository (skipping SHA digest aliases),
@@ -358,8 +493,7 @@ func (s *ScanService) BulkScan(ctx context.Context, repoName string) (scanned in
 		return 0, 0, err
 	}
 	for _, comp := range page.Items {
-		// Skip SHA digest aliases — they duplicate the tagged image and clutter the dashboard.
-		if strings.HasPrefix(comp.Version, "sha256:") {
+		if isDigestAlias(comp.Version) {
 			continue
 		}
 		_, scanErr := s.Scan(ctx, comp.ID, "")

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -130,11 +130,6 @@ type ScanService struct {
 // keep succeeding and the overflow waits for the next bulk scan.
 const autoScanQueueSize = 256
 
-// defaultScanSchedule re-scans everything nightly, so components uploaded before
-// auto-scan existed — or dropped by a full queue — are still checked, and
-// already-scanned ones are re-checked against newly published CVEs.
-const defaultScanSchedule = "0 3 * * *"
-
 // NewScanService constructs a vulnerability scanning service backed by Trivy and OSV.dev.
 func NewScanService(components repository.ComponentRepo, httpBaseURL string) *ScanService {
 	return &ScanService{
@@ -181,7 +176,11 @@ func (s *ScanService) StartScheduler(ctx context.Context, schedule string) {
 		return
 	}
 
-	c := cron.New()
+	// SkipIfStillRunning, unlike the other schedulers: a full re-scan re-queries
+	// OSV.dev per component and re-runs Trivy per image, so on a large registry
+	// it can outlast its own interval. Overlapping runs would queue up behind
+	// trivyMu and never catch up.
+	c := cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DiscardLogger)))
 	if _, err := c.AddFunc(schedule, func() {
 		scanned, failed, err := s.BulkScan(ctx, "")
 		if err != nil {

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -329,6 +329,9 @@ type ComponentRepo struct {
 	components map[string]*domain.Component
 	nextID     int
 	Err        error // when non-nil, ListByRepoNames/Get/Search/Delete/SetTags return it (500-branch seam)
+	// UpdateExtraErr is returned by UpdateExtra when set — the seam for a write
+	// that fails after the work producing it already succeeded.
+	UpdateExtraErr error
 	// DockerRowsByRepo maps repoName→browse rows; ListDockerBrowseRows returns the
 	// union of rows for the requested repo names (mirrors the SQL WHERE rep.name IN (...)).
 	// A row's ArtifactType stands for the SQL's extra->>'oci_artifact_type': the
@@ -530,6 +533,9 @@ func (c *ComponentRepo) DeleteOrphans(_ context.Context, repoName string) error 
 func (c *ComponentRepo) UpdateExtra(_ context.Context, id string, extra map[string]any) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.UpdateExtraErr != nil {
+		return c.UpdateExtraErr
+	}
 	comp := c.components[id]
 	if comp == nil {
 		return nil
@@ -2123,6 +2129,9 @@ type ScanResultRepo struct {
 	mu   sync.Mutex
 	rows []*domain.ScanResultRow
 	Err  error // when set, Aggregate/List return it (500-branch seam)
+	// InsertErr is returned by Insert when set — the seam for a scan whose history
+	// row cannot be written.
+	InsertErr error
 	// VulnRows is returned by List (with len as total) when non-nil; lets tests assert
 	// the Vulnerabilities handler's success body without a live DB.
 	VulnRows []*domain.VulnRow
@@ -2133,6 +2142,9 @@ func NewScanResultRepo() *ScanResultRepo { return &ScanResultRepo{} }
 func (r *ScanResultRepo) Insert(_ context.Context, row *domain.ScanResultRow) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.InsertErr != nil {
+		return r.InsertErr
+	}
 	cp := *row
 	r.rows = append(r.rows, &cp)
 	return nil

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -2185,6 +2185,7 @@ func (r *ScanResultRepo) Aggregate(_ context.Context) (*domain.SecuritySummary, 
 	}
 	s := &domain.SecuritySummary{ScannedTotal: len(latest)}
 	for _, row := range latest {
+		s.Malicious += row.Malicious
 		s.Critical += row.Critical
 		s.High += row.High
 		s.Medium += row.Medium


### PR DESCRIPTION
Closes #157, #158, #159, #160.

## What changed

**Automatic scanning (#160).** Scanning existed but had to be asked for by hand, per component. Every stored artifact is now queued for a background scan through a one-method `formats.ScanTrigger`, hooked into `RegisterStoredBlob` — the waist that both uploads and proxy-cache writes pass through. The queue is buffered (256) and drops rather than blocks, so an upload is never delayed or refused because the scanner is behind; a nightly bulk re-scan (`scan.schedule`, default 03:00) covers what it drops and re-checks everything else against newly published CVEs. `scan.enabled: false` returns to on-demand-only.

**MALICIOUS severity tier (#159).** OSV.dev already returned the `MAL-…` reports for compromised releases — the detection worked, the visibility did not. Those reports carry no CVSS severity, so they landed in "Unknown", a column the org-wide dashboard did not render at all. They now get their own counter end to end (client → service → `scan_results.malicious` → API → UI), keep their `MAL-` id instead of being displayed under a CVE alias, lead the severity order, and are matched by every minimum-severity filter — a `?severity=HIGH` query must not lose a compromised package that has no CVEs.

**Silently dropped errors (#157, #158).** Nine JSONB reads discarded their decode error, so a corrupt column produced a zero value with no trace — including the rbac `actions` array, where it turned a privilege into one that grants nothing. Both post-scan writes were fire-and-forget with the error discarded, so a failed write left the dashboard stale and invisible. All of them stay non-fatal; none of them stay silent.

## Notes

- Background lifecycle: `api.NewRouter` now takes a context and threads it into all five schedulers. They were started on `context.Background()` while the SIGTERM handler only shut down the HTTP server, so none of them ever stopped before the process did. `main` cancels it before `srv.Shutdown` so background jobs wind down while requests drain.
- New migration `025_scan_results_malicious.sql`. Existing rows keep 0 rather than being backfilled — that would mean re-querying OSV.dev per component, which is what the nightly re-scan does anyway.
- The promotion quality gate now refuses a malicious component. It read `Critical > 0 || High > 0`, which would have promoted a compromised release with a spotless CVE record straight to production.
- OCI layer blobs are filtered at enqueue: a push sends every layer before the manifest, and scanning digest-versioned components means one scanner run per layer against a reference that is not an image.

## Verification

Test-first throughout; each test was watched fail before its implementation. `go build`, full `go test` (1979 pass), integration tests against a real Postgres (420 pass), `-race -count=2` on the touched packages, `make lint`, `vitest` (497 pass), `tsc`, `eslint` — all clean.

Two pre-existing failures unrelated to this branch, both confirmed on `main`: `TestWebhookHandler_Test_200` (needs outbound network) and a `-race -count=2` flake in `TestExtraCleanup_ReloadPolicy_DisabledRemovesEntry`. `internal/integration/integration_test.go` also does not compile on `main` (stale `db.Connect` and `NewRouter` arity) and is left alone here.