### PR TITLE
feat(scan): export vulnerability results as CSV and JSON

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -453,6 +453,22 @@ export const nexspenceApi = {
       body ?? {},
     ),
 
+  // Scan-result exports — same endpoints, ?export= switches them to a file
+  // download of the whole filtered set rather than a page.
+  exportVulnerabilities: (
+    filters: { repo?: string; severity?: string; format?: string },
+    as: 'csv' | 'json',
+  ) =>
+    apiClient.get(`/api/v1/security/vulnerabilities`, {
+      params: { ...filters, export: as },
+      responseType: 'blob',
+    }),
+  exportScanResult: (componentId: string, as: 'csv' | 'json') =>
+    apiClient.get(`/api/v1/components/${encodeURIComponent(componentId)}/scan`, {
+      params: { export: as },
+      responseType: 'blob',
+    }),
+
   // Replication rules
   listReplicationRules: () =>
     apiClient.get<ReplicationRule[]>('/api/v1/replication/rules'),

--- a/frontend/src/api/download.ts
+++ b/frontend/src/api/download.ts
@@ -1,0 +1,22 @@
+/**
+ * saveBlob hands a downloaded response to the browser as a file.
+ *
+ * These endpoints require an Authorization header, so the file cannot simply be
+ * an <a href> the browser fetches on its own — the response has to be requested
+ * through the API client and then handed over as an object URL.
+ */
+export function saveBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+/** exportFilename builds the dated name a downloaded export is saved under. */
+export function exportFilename(kind: string, as: 'csv' | 'json'): string {
+  return `nexspence-${kind}-${new Date().toISOString().slice(0, 10)}.${as}`
+}

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
-import { Shield, RefreshCw, Webhook, AlertTriangle, CheckCircle, Loader, Trash2, Plus, Bug, Zap, Pencil } from 'lucide-react'
+import { Shield, RefreshCw, Webhook, AlertTriangle, CheckCircle, Loader, Trash2, Plus, Bug, Zap, Pencil, Download } from 'lucide-react'
 import { nexusApi, nexspenceApi, apiClient, apiErrorMessage } from '@/api/client'
+import { saveBlob, exportFilename } from '@/api/download'
 import { UsersTab } from './UsersPage'
 import { useAuthStore } from '@/store/authStore'
 import { Select } from '../components/Select'
@@ -581,6 +582,19 @@ function ScanTab() {
     } finally { setScanning(false) }
   }
 
+  // Exports the component's full finding list, not the severity slice on
+  // screen: this is one artifact's record, and a partial one is a claim about
+  // the artifact that isn't true.
+  async function exportFindings(as: 'csv' | 'json') {
+    setError('')
+    try {
+      const res = await nexspenceApi.exportScanResult(componentId.trim(), as)
+      saveBlob(res.data as Blob, exportFilename(`scan-${componentId.trim()}`, as))
+    } catch (e: unknown) {
+      if (axios.isAxiosError(e)) setError(e.response?.data?.error ?? e.message)
+    }
+  }
+
   const findings = result?.findings ?? []
   const filtered = severityFilter === 'ALL' ? findings : findings.filter(f => f.severity === severityFilter)
 
@@ -633,6 +647,15 @@ function ScanTab() {
             <span>Scanned {new Date(result.scannedAt).toLocaleString()}</span>
             <span>·</span>
             <span>{result.summary.total} total CVEs</span>
+            <span style={{ flex: 1 }} />
+            <HoloButton onClick={() => exportFindings('csv')} title="Download these findings as CSV">
+              <Download size={14} />
+              Export CSV
+            </HoloButton>
+            <HoloButton onClick={() => exportFindings('json')} title="Download these findings as JSON">
+              <Download size={14} />
+              Export JSON
+            </HoloButton>
           </div>
 
           {/* Severity filter */}
@@ -731,6 +754,21 @@ function VulnDashTab() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [repoFilter, severityFilter])
 
+  // The export carries the filters that are on screen: a report that quietly
+  // covers something other than what the user is looking at is worse than none.
+  async function exportVulns(as: 'csv' | 'json') {
+    setError('')
+    try {
+      const res = await nexspenceApi.exportVulnerabilities(
+        { repo: repoFilter || undefined, severity: severityFilter || undefined },
+        as,
+      )
+      saveBlob(res.data as Blob, exportFilename('vulnerabilities', as))
+    } catch (e: unknown) {
+      if (axios.isAxiosError(e)) setError(e.response?.data?.error ?? e.message)
+    }
+  }
+
   async function rescanAll() {
     setScanning(true)
     setError('')
@@ -789,6 +827,14 @@ function VulnDashTab() {
             <option key={s} value={s}>{s}</option>
           ))}
         </select>
+        <HoloButton onClick={() => exportVulns('csv')} title="Download the filtered results as CSV">
+          <Download size={14} />
+          Export CSV
+        </HoloButton>
+        <HoloButton onClick={() => exportVulns('json')} title="Download the filtered results as JSON">
+          <Download size={14} />
+          Export JSON
+        </HoloButton>
         <HoloButton variant="primary" onClick={rescanAll} disabled={scanning}>
           {scanning ? <Loader size={14} className="spin" /> : <Shield size={14} />}
           {scanning ? 'Scanning…' : 'Rescan All'}

--- a/frontend/src/pages/SecurityPageExport.test.tsx
+++ b/frontend/src/pages/SecurityPageExport.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import SecurityPage from './SecurityPage'
+import { renderWithProviders, seedAuthAsAdmin } from '@/test/renderUtils'
+import { server } from '@/test/msw/server'
+import { fixtures } from '@/test/fixtures'
+
+/**
+ * Exporting the scan results (#162). The value is a file someone can hand on,
+ * so what these pin is: the request carries the filters that are on screen, and
+ * a download actually happens.
+ */
+
+function seedBaseline() {
+  server.use(
+    http.get('/service/rest/v1/security/roles', () => HttpResponse.json([
+      { id: 'role-1', name: 'nx-admin', description: 'Admin role', privileges: [], roles: [], readOnly: true },
+    ])),
+    http.get('/service/rest/v1/security/privileges', () => HttpResponse.json([])),
+    http.get('/service/rest/v1/security/content-selectors', () => HttpResponse.json([])),
+    http.get('/api/v1/security/privilege-role-map', () => HttpResponse.json({})),
+    http.get('/service/rest/v1/repositories', () => HttpResponse.json([fixtures.repository()])),
+    http.get('/service/rest/v1/security/users', () => HttpResponse.json([fixtures.user()])),
+    http.get('/api/v1/webhooks', () => HttpResponse.json([])),
+    http.get('/api/v1/security/summary', () =>
+      HttpResponse.json({ malicious: 1, critical: 0, high: 0, medium: 0, low: 0, unknown: 0, scanned_total: 1 }),
+    ),
+  )
+}
+
+/** Records every /security/vulnerabilities request and returns one row. */
+function captureVulnRequests(): string[] {
+  const urls: string[] = []
+  server.use(
+    http.get('/api/v1/security/vulnerabilities', ({ request }) => {
+      urls.push(request.url)
+      if (new URL(request.url).searchParams.get('export')) {
+        return HttpResponse.text('repository,format\nnpm-hosted,npm\n', {
+          headers: { 'Content-Type': 'text/csv' },
+        })
+      }
+      return HttpResponse.json({
+        total: 1,
+        items: [{
+          repoName: 'npm-hosted', format: 'npm', componentId: 'c1', name: 'debug', version: '4.4.2',
+          malicious: 1, critical: 0, high: 0, medium: 0, low: 0, unknown: 0,
+          scannedAt: '2026-08-06T00:00:00Z',
+        }],
+      })
+    }),
+  )
+  return urls
+}
+
+async function openDashboard() {
+  const user = userEvent.setup()
+  renderWithProviders(<SecurityPage />)
+  await screen.findByText('nx-admin')
+  await user.click(screen.getByRole('button', { name: 'Vulnerability Dashboard' }))
+  await screen.findByText('debug')
+  return user
+}
+
+describe('SecurityPage — exporting scan results', () => {
+  let clickSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    seedAuthAsAdmin()
+    seedBaseline()
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: vi.fn(() => 'blob:x') })
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: vi.fn() })
+    clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('downloads the dashboard as CSV', async () => {
+    const urls = captureVulnRequests()
+    const user = await openDashboard()
+
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }))
+
+    await waitFor(() => {
+      expect(urls.some((u) => new URL(u).searchParams.get('export') === 'csv')).toBe(true)
+    })
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+  })
+
+  it('downloads the dashboard as JSON', async () => {
+    const urls = captureVulnRequests()
+    const user = await openDashboard()
+
+    await user.click(screen.getByRole('button', { name: /Export JSON/i }))
+
+    await waitFor(() => {
+      expect(urls.some((u) => new URL(u).searchParams.get('export') === 'json')).toBe(true)
+    })
+  })
+
+  // The other view that shows findings: a single component's CVE list.
+  it('downloads a single component scan as CSV', async () => {
+    let exportedAs: string | null = null
+    server.use(
+      http.post('/api/v1/components/:id/scan', () =>
+        HttpResponse.json({
+          scannedAt: '2026-08-06T00:00:00Z', imageRef: 'debug:4.4.2', status: 'ok',
+          summary: { malicious: 1, critical: 0, high: 0, medium: 0, low: 0, unknown: 0, total: 1 },
+          findings: [{ id: 'MAL-2025-46974', severity: 'MALICIOUS', pkgName: 'debug', installedVersion: '4.4.2', title: 'Malicious code' }],
+        }),
+      ),
+      http.get('/api/v1/components/:id/scan', ({ request }) => {
+        exportedAs = new URL(request.url).searchParams.get('export')
+        return HttpResponse.text('id,severity\nMAL-2025-46974,MALICIOUS\n', {
+          headers: { 'Content-Type': 'text/csv' },
+        })
+      }),
+    )
+
+    const user = userEvent.setup()
+    renderWithProviders(<SecurityPage />)
+    await screen.findByText('nx-admin')
+    await user.click(screen.getByRole('button', { name: 'CVE Scan' }))
+    await screen.findByText('Trivy Vulnerability Scan')
+
+    await user.type(screen.getByPlaceholderText(/component id/i), 'comp-1')
+    await user.click(screen.getByRole('button', { name: 'Scan' }))
+    await screen.findByText('MAL-2025-46974')
+
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }))
+    await waitFor(() => expect(exportedAs).toBe('csv'))
+    await waitFor(() => expect(clickSpy).toHaveBeenCalled())
+  })
+
+  // An export that ignores the filters on screen is a different report from the
+  // one the user is looking at.
+  it('exports what is on screen, filters included', async () => {
+    const urls = captureVulnRequests()
+    const user = await openDashboard()
+
+    await user.selectOptions(screen.getByRole('combobox'), 'MALICIOUS')
+    await screen.findByText('debug')
+    await user.click(screen.getByRole('button', { name: /Export CSV/i }))
+
+    await waitFor(() => {
+      const exportURL = urls.map((u) => new URL(u)).find((u) => u.searchParams.get('export') === 'csv')
+      expect(exportURL?.searchParams.get('severity')).toBe('MALICIOUS')
+    })
+  })
+})

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -46,7 +46,14 @@ func (h *ScanHandler) Scan(c *gin.Context) {
 
 // GetScanResult returns the cached scan result for a component.
 // GET /api/v1/components/:id/scan
+// With ?export=csv|json it returns the finding list as a downloadable file.
 func (h *ScanHandler) GetScanResult(c *gin.Context) {
+	export, invalid := exportFormat(c)
+	if invalid {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `export must be "csv" or "json"`})
+		return
+	}
+
 	id := c.Param("id")
 	result, err := h.svc.GetResult(c.Request.Context(), id)
 	if err != nil {
@@ -55,7 +62,13 @@ func (h *ScanHandler) GetScanResult(c *gin.Context) {
 	}
 	if result == nil {
 		// No cached scan yet — not an error (avoid 404 in logs / monitoring).
+		// Nothing to download either: an empty file would read as "scanned,
+		// nothing found", which is a different and much more reassuring claim.
 		c.Status(http.StatusNoContent)
+		return
+	}
+	if export != "" {
+		h.exportScanResult(c, export, result)
 		return
 	}
 	c.JSON(http.StatusOK, result)
@@ -74,7 +87,16 @@ func (h *ScanHandler) Summary(c *gin.Context) {
 
 // Vulnerabilities returns a paginated list of vulnerability rows.
 // GET /api/v1/security/vulnerabilities?repo=&severity=&format=&limit=&offset=
+//
+// With ?export=csv|json it returns the whole filtered set as a downloadable
+// file instead of a page.
 func (h *ScanHandler) Vulnerabilities(c *gin.Context) {
+	export, invalid := exportFormat(c)
+	if invalid {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `export must be "csv" or "json"`})
+		return
+	}
+
 	limit := 50
 	offset := 0
 	if v := c.Query("limit"); v != "" {
@@ -93,6 +115,10 @@ func (h *ScanHandler) Vulnerabilities(c *gin.Context) {
 		Format:   c.Query("format"),
 		Limit:    limit,
 		Offset:   offset,
+	}
+	if export != "" {
+		h.exportVulnerabilities(c, export, f)
+		return
 	}
 	items, total, err := h.svc.ListVulnerabilities(c.Request.Context(), f)
 	if err != nil {

--- a/internal/api/handlers/scan_export.go
+++ b/internal/api/handlers/scan_export.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"encoding/csv"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// exportMaxRows caps a single export. An export is one response assembled in
+// memory, so it needs a bound; this one is set well past any registry that
+// would fit on a dashboard, and a truncated export says so in a header rather
+// than quietly handing over a partial report.
+const exportMaxRows = 50000
+
+// exportTruncatedHeader marks an export that hit exportMaxRows.
+const exportTruncatedHeader = "X-Export-Truncated"
+
+// exportFormat reads the ?export= parameter.
+//
+// It is a parameter on the existing endpoints rather than a route of its own so
+// that an export is authorized exactly as the data it exports already is —
+// there is no second path to get the access rules right on.
+//
+// Returns ("", false) when no export was asked for, and ("", true) for a format
+// that does not exist.
+func exportFormat(c *gin.Context) (format string, invalid bool) {
+	switch v := c.Query("export"); v {
+	case "":
+		return "", false
+	case "csv", "json":
+		return v, false
+	default:
+		return "", true
+	}
+}
+
+// exportFilename builds a dated, self-describing download name.
+func exportFilename(kind, format string) string {
+	return fmt.Sprintf("nexspence-%s-%s.%s", kind, time.Now().UTC().Format("2006-01-02"), format)
+}
+
+func setExportHeaders(c *gin.Context, kind, format string) {
+	contentType := "text/csv; charset=utf-8"
+	if format == "json" {
+		contentType = "application/json; charset=utf-8"
+	}
+	c.Header("Content-Type", contentType)
+	c.Header("Content-Disposition", `attachment; filename="`+exportFilename(kind, format)+`"`)
+}
+
+// writeCSV streams a header row and the given rows to the response.
+func writeCSV(c *gin.Context, header []string, rows [][]string) {
+	w := csv.NewWriter(c.Writer)
+	if err := w.Write(header); err != nil {
+		return
+	}
+	for _, row := range rows {
+		if err := w.Write(row); err != nil {
+			return
+		}
+	}
+	w.Flush()
+}
+
+// vulnExportHeader names the columns of a vulnerability-dashboard export.
+// Malicious leads the counts, as it does everywhere else: a report that buries
+// the most severe class of finding is the problem the tier was added to fix.
+var vulnExportHeader = []string{
+	"repository", "format", "component", "version",
+	"malicious", "critical", "high", "medium", "low", "unknown",
+	"scanned_at",
+}
+
+func vulnExportRows(items []*domain.VulnRow) [][]string {
+	rows := make([][]string, 0, len(items))
+	for _, v := range items {
+		rows = append(rows, []string{
+			v.RepoName, v.Format, v.Name, v.Version,
+			strconv.Itoa(v.Malicious), strconv.Itoa(v.Critical), strconv.Itoa(v.High),
+			strconv.Itoa(v.Medium), strconv.Itoa(v.Low), strconv.Itoa(v.Unknown),
+			v.ScannedAt.UTC().Format(time.RFC3339),
+		})
+	}
+	return rows
+}
+
+// exportVulnerabilities answers GET /api/v1/security/vulnerabilities?export=…
+// with the whole filtered set as a downloadable file.
+//
+// Paging is deliberately ignored: the paged response exists to render a screen,
+// while an export of a single page would be a report that is quietly wrong.
+func (h *ScanHandler) exportVulnerabilities(c *gin.Context, format string, f domain.VulnFilter) {
+	f.Limit = exportMaxRows
+	f.Offset = 0
+
+	items, _, err := h.svc.ListVulnerabilities(c.Request.Context(), f)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if items == nil {
+		items = []*domain.VulnRow{}
+	}
+	if len(items) >= exportMaxRows {
+		c.Header(exportTruncatedHeader, strconv.Itoa(exportMaxRows))
+	}
+
+	setExportHeaders(c, "vulnerabilities", format)
+	if format == "json" {
+		// A bare array, not the endpoint's {items,total} envelope: this is the
+		// same row-oriented data the CSV carries, and a file a script reads is
+		// easier to consume without unwrapping it.
+		c.JSON(http.StatusOK, items)
+		return
+	}
+	writeCSV(c, vulnExportHeader, vulnExportRows(items))
+}
+
+// findingExportHeader names the columns of a single component's export.
+var findingExportHeader = []string{"id", "severity", "package", "installed_version", "fixed_version", "title"}
+
+func findingExportRows(findings []domain.CVEFinding) [][]string {
+	rows := make([][]string, 0, len(findings))
+	for _, f := range findings {
+		rows = append(rows, []string{
+			f.ID, f.Severity, f.PkgName, f.InstalledVer, f.FixedVersion, f.Title,
+		})
+	}
+	return rows
+}
+
+// exportScanResult answers GET /api/v1/components/:id/scan?export=… with that
+// component's findings as a downloadable file.
+func (h *ScanHandler) exportScanResult(c *gin.Context, format string, result *domain.ScanResult) {
+	setExportHeaders(c, "scan-"+c.Param("id"), format)
+	if format == "json" {
+		findings := result.Findings
+		if findings == nil {
+			findings = []domain.CVEFinding{}
+		}
+		c.JSON(http.StatusOK, findings)
+		return
+	}
+	writeCSV(c, findingExportHeader, findingExportRows(result.Findings))
+}

--- a/internal/api/handlers/scan_export_test.go
+++ b/internal/api/handlers/scan_export_test.go
@@ -1,0 +1,185 @@
+package handlers_test
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// The export is the report someone hands to somebody else, so what matters is
+// that it arrives as a file, carries every filtered row rather than one page,
+// and does not omit the most severe class of finding.
+
+func exportVulnRows() []*domain.VulnRow {
+	scanned := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	return []*domain.VulnRow{
+		{
+			RepoName: "npm-hosted", Format: "npm", ComponentID: "c1", Name: "debug", Version: "4.4.2",
+			Malicious: 1, ScannedAt: scanned,
+		},
+		{
+			RepoName: "maven-hosted", Format: "maven2", ComponentID: "c2", Name: "log4j-core", Version: "2.14.1",
+			Critical: 2, High: 1, ScannedAt: scanned,
+		},
+	}
+}
+
+func TestScanHandler_Vulnerabilities_ExportCSV(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	scanRepo.VulnRows = exportVulnRows()
+
+	rec := do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities?export=csv", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/csv")
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "attachment")
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), ".csv")
+
+	records, err := csv.NewReader(strings.NewReader(rec.Body.String())).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 3, "header + one row per finding")
+
+	header := records[0]
+	assert.Equal(t, "repository", header[0])
+	assert.Contains(t, header, "malicious", "an export that omits malware is worse than none")
+
+	assert.Equal(t, "npm-hosted", records[1][0])
+	assert.Equal(t, "debug", records[1][2])
+	malCol := indexOf(header, "malicious")
+	require.GreaterOrEqual(t, malCol, 0)
+	assert.Equal(t, "1", records[1][malCol])
+}
+
+// indexOf returns the position of col in header, or -1.
+func indexOf(header []string, col string) int {
+	for i, h := range header {
+		if h == col {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestScanHandler_Vulnerabilities_ExportJSON(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	scanRepo.VulnRows = exportVulnRows()
+
+	rec := do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities?export=json", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), ".json")
+
+	// A bare array: the same row-oriented data CSV carries, without an envelope
+	// a script would have to unwrap.
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rows))
+	require.Len(t, rows, 2)
+	assert.Equal(t, float64(1), rows[0]["malicious"])
+}
+
+// An export of one page would be a quietly wrong report.
+func TestScanHandler_Vulnerabilities_ExportIgnoresPaging(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	scanRepo.VulnRows = exportVulnRows()
+
+	rec := do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities?export=csv&limit=1&offset=10", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Greater(t, scanRepo.LastFilter.Limit, 1, "export must not request a single page")
+	assert.Equal(t, 0, scanRepo.LastFilter.Offset, "export starts at the beginning")
+}
+
+// The export shows what the screen shows.
+func TestScanHandler_Vulnerabilities_ExportKeepsFilters(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	scanRepo.VulnRows = exportVulnRows()
+
+	rec := do(t, r, http.MethodGet,
+		"/api/v1/security/vulnerabilities?export=csv&repo=npm-hosted&severity=MALICIOUS&format=npm", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	assert.Equal(t, "npm-hosted", scanRepo.LastFilter.Repo)
+	assert.Equal(t, "MALICIOUS", scanRepo.LastFilter.Severity)
+	assert.Equal(t, "npm", scanRepo.LastFilter.Format)
+}
+
+func TestScanHandler_Vulnerabilities_ExportUnknownFormat_400(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	scanRepo.VulnRows = exportVulnRows()
+
+	rec := do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities?export=pdf", nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+// Without export=, the endpoint answers exactly as it did before.
+func TestScanHandler_Vulnerabilities_NoExportStillPaginatedJSON(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	scanRepo.VulnRows = exportVulnRows()
+
+	rec := do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Empty(t, rec.Header().Get("Content-Disposition"))
+
+	var body struct {
+		Items []domain.VulnRow `json:"items"`
+		Total int              `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, 2, body.Total)
+}
+
+// ── Single component ──────────────────────────────────────────────────────────
+
+func TestScanHandler_GetScanResult_ExportCSV(t *testing.T) {
+	r, comps, _, _ := mountScan(t)
+	c := seedComponent(t, comps, "npm", "debug", "4.4.2")
+
+	// Produce a cached result via a real scan (the OSV stub returns one HIGH).
+	require.Equal(t, http.StatusOK,
+		do(t, r, http.MethodPost, "/api/v1/components/"+c.ID+"/scan", nil).Code)
+
+	rec := do(t, r, http.MethodGet, "/api/v1/components/"+c.ID+"/scan?export=csv", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/csv")
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), "attachment")
+
+	records, err := csv.NewReader(strings.NewReader(rec.Body.String())).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 2, "header + one finding")
+	assert.Equal(t, "id", records[0][0])
+	assert.Equal(t, "GHSA-xxxx", records[1][0])
+	assert.Equal(t, "HIGH", records[1][1])
+}
+
+func TestScanHandler_GetScanResult_ExportJSON(t *testing.T) {
+	r, comps, _, _ := mountScan(t)
+	c := seedComponent(t, comps, "npm", "debug", "4.4.2")
+	require.Equal(t, http.StatusOK,
+		do(t, r, http.MethodPost, "/api/v1/components/"+c.ID+"/scan", nil).Code)
+
+	rec := do(t, r, http.MethodGet, "/api/v1/components/"+c.ID+"/scan?export=json", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Disposition"), ".json")
+
+	var findings []domain.CVEFinding
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &findings))
+	require.Len(t, findings, 1)
+	assert.Equal(t, "GHSA-xxxx", findings[0].ID)
+}
+
+// A component that has never been scanned has nothing to export — and an empty
+// file would read as "scanned, nothing found".
+func TestScanHandler_GetScanResult_ExportWithoutScan_204(t *testing.T) {
+	r, comps, _, _ := mountScan(t)
+	c := seedComponent(t, comps, "npm", "never-scanned", "1.0.0")
+
+	rec := do(t, r, http.MethodGet, "/api/v1/components/"+c.ID+"/scan?export=csv", nil)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -2135,6 +2135,10 @@ type ScanResultRepo struct {
 	// VulnRows is returned by List (with len as total) when non-nil; lets tests assert
 	// the Vulnerabilities handler's success body without a live DB.
 	VulnRows []*domain.VulnRow
+	// LastFilter records the filter of the most recent List call, so a test can
+	// assert what the handler asked for — paging in particular, which the mock
+	// does not itself apply.
+	LastFilter domain.VulnFilter
 }
 
 func NewScanResultRepo() *ScanResultRepo { return &ScanResultRepo{} }
@@ -2195,9 +2199,10 @@ func (r *ScanResultRepo) Aggregate(_ context.Context) (*domain.SecuritySummary, 
 	return s, nil
 }
 
-func (r *ScanResultRepo) List(_ context.Context, _ domain.VulnFilter) ([]*domain.VulnRow, int, error) {
+func (r *ScanResultRepo) List(_ context.Context, f domain.VulnFilter) ([]*domain.VulnRow, int, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.LastFilter = f
 	if r.Err != nil {
 		return nil, 0, r.Err
 	}


### PR DESCRIPTION
Closes #162. Requested by @ladserg in #160.

## What changed

Both views that show findings now export, in both formats:

- `GET /api/v1/security/vulnerabilities?export=csv|json` — the org-wide table, honouring the existing `repo` / `severity` / `format` filters so the file matches what is on screen.
- `GET /api/v1/components/:id/scan?export=csv|json` — one component's CVE list.

Plus **Export CSV** / **Export JSON** buttons on the dashboard toolbar and on a component's scan result.

## Decisions worth flagging

- **`export=` on the existing endpoints, not new routes.** Each export is then authorized exactly as the data it exports already is (`admin` for the dashboard, `authed` for a single component) rather than needing the access rules re-applied correctly on two new paths.
- **Paging is ignored.** The paged response exists to render a screen; an export of one page would be a report that is quietly wrong. Capped at 50k rows since one response is assembled in memory, and a truncated export sets `X-Export-Truncated` rather than silently returning a partial answer.
- **JSON is a bare array**, not the endpoint's `{items,total}` envelope — the same row-oriented data the CSV carries, without something a script has to unwrap.
- **Malicious leads the CSV counts**, as it does everywhere else. An export that omits the most severe class of finding is the failure #159 was written to fix.
- **204, not an empty file**, for a component that has never been scanned — an empty CSV reads as "scanned, nothing found", which is a much more reassuring claim than the truth.
- The endpoints need an `Authorization` header, so the download goes through the API client as a blob rather than a plain `<a href>`.

## Verification

Test-first; each test watched fail first. Backend: 10 new handler tests covering both formats on both endpoints, filter pass-through, paging override, unknown format, the unscanned case, and that the non-export response is unchanged. Frontend: 4 tests asserting the request carries the on-screen filters and that a download fires.

`go build`, `go test ./...` (2000 pass), `make lint`, `vitest` (500 pass), `tsc`, `eslint` — clean. The one failure, `TestWebhookHandler_Test_200`, is the pre-existing sandbox network restriction confirmed on `main`.