### PR TITLE
docs: correct the architecture description where it drifted from the code

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,10 +16,11 @@ Nexspence follows a clean layered architecture. Each layer depends only on the l
 │  /repository/:name/*     /service/rest/v1/*     /api/v1/*             │
 │       Format Router        Nexus-compat API       Native API           │
 │                                                                        │
-│  Middleware stack (in order):                                          │
-│    Recovery → RequestLogger → CORS → MetricsMiddleware                │
-│    → AuditMiddleware → AuthMiddleware / OptionalAuth                   │
-│    → [future: RateLimitMiddleware, OTelTraceMiddleware]               │
+│  Global middleware (in order, internal/api/router.go):                 │
+│    Recovery → requestLogger → CORS → securityHeaders → bodyLimit      │
+│    → MetricsMiddleware → AuditMiddleware → RateLimitMiddleware        │
+│  Auth is per route group, not global:                                  │
+│    AuthMiddleware / AdminRequired / RBACMiddleware                     │
 └──────────────┬──────────────────────────────┬──────────────────────────┘
                │                              │
 ┌──────────────▼───────────┐   ┌──────────────▼──────────────────────────┐
@@ -28,27 +29,30 @@ Nexspence follows a clean layered architecture. Each layer depends only on the l
 │  │ MavenHandler        │ │   │  RepositoryService   CleanupService      │
 │  │ NpmHandler          │ │   │  UserService         BackupService       │
 │  │ PypiHandler         │ │   │  TokenService        WebhookService      │
-│  │ DockerHandler       │ │   │  ContentSelectorSvc  ScanService (Trivy) │
-│  │ GoModHandler        │ │   │  RoutingRuleService                      │
-│  │ NugetHandler        │ │   │                                          │
-│  │ HelmHandler         │ │   │  [Phase 8+]                              │
-│  │ CargoHandler        │ │   │  OIDCService         LDAPService         │
-│  │ AptHandler          │ │   │  SBOMService         AnalyticsService    │
-│  │ YumHandler          │ │   │  BlobGCService       ReplicationService  │
+│  │ OCIHandler          │ │   │  ContentSelectorSvc  ScanService         │
+│  │  (docker + oci)     │ │   │  RoutingRuleService  RBACService         │
+│  │ GoModHandler        │ │   │  PromotionService    ReplicationService  │
+│  │ NugetHandler        │ │   │  BlobGCService       DownloadCounter     │
+│  │ HelmHandler         │ │   │  BlobStoreMigrationService               │
+│  │ CargoHandler        │ │   │                                          │
+│  │ AptHandler          │ │   │  Authenticators (internal/auth):         │
+│  │ YumHandler          │ │   │  LDAP · OIDC · SAML                      │
 │  │ ConanHandler        │ │   │                                          │
 │  │ CondaHandler        │ │   │                                          │
 │  │ TerraformHandler    │ │   │                                          │
 │  │ RawHandler          │ │   └────────────────┬─────────────────────────┘
 │  │ GroupHandler        │ │                    │
-│  │ ReproxyHandler      │ │   ┌────────────────▼─────────────────────────┐
-│  └─────────────────────┘ │   │          Repository Layer                │
-└──────────────────────────┘   │                                          │
-          │                    │  RepositoryRepo   ComponentRepo           │
-          │                    │  AssetRepo        UserRepo                │
-          │                    │  BlobStoreRepo    RoleRepo                │
-          │                    │  AuditRepo        CleanupPolicyRepo       │
+│  └─────────────────────┘ │   ┌────────────────▼─────────────────────────┐
+│                          │   │          Repository Layer                │
+│  repoproxy is a shared   │   │                                          │
+│  proxy layer the handlers│   │  RepositoryRepo   ComponentRepo           │
+│  call — not an entry in  │   │  AssetRepo        UserRepo                │
+│  the registry            │   │  BlobStoreRepo    RoleRepo                │
+└──────────────────────────┘   │  AuditRepo        CleanupPolicyRepo       │
           │                    │  UserTokenRepo    ContentSelectorRepo     │
           │                    │  WebhookRepo      RoutingRuleRepo         │
+          │                    │  ScanResultRepo   PromotionRepo           │
+          │                    │  ReplicationRepo  PrivilegeRepo           │
           │                    │                                          │
           │                    │  All interfaces in repository/interfaces.go│
           │                    │  Implementations in repository/postgres/  │
@@ -57,17 +61,17 @@ Nexspence follows a clean layered architecture. Each layer depends only on the l
               ┌─────────────────────────────────▼──────────────────────┐
               │                    Data Tier                            │
               │                                                        │
-              │  ┌───────────────┐   ┌────────────────┐               │
-              │  │  PostgreSQL   │   │   BlobStore     │               │
-              │  │               │   │                 │               │
-              │  │  Metadata     │   │  LocalBlobStore │               │
-              │  │  Users/Roles  │   │  S3BlobStore    │               │
-              │  │  Audit log    │   │  (MinIO/AWS/    │               │
-              │  │  (partitioned)│   │   Ceph/B2/GCS)  │               │
-              │  │  Full-text    │   │                 │               │
-              │  │  tsvector     │   │  [Phase 10+]    │               │
-              │  │  search       │   │  AzureBlob      │               │
-              │  └───────────────┘   └────────────────┘               │
+              │  ┌───────────────┐  ┌──────────────┐  ┌─────────────┐ │
+              │  │  PostgreSQL   │  │  BlobStore   │  │   Redis     │ │
+              │  │               │  │              │  │  (optional) │ │
+              │  │  Metadata     │  │  local       │  │             │ │
+              │  │  Users/Roles  │  │  s3 (MinIO / │  │  dist locks │ │
+              │  │  Audit log    │  │  AWS / Ceph /│  │  proxy cache│ │
+              │  │  (partitioned)│  │  B2 / GCS)   │  │  login      │ │
+              │  │  Scan results │  │  group (fan  │  │  throttle   │ │
+              │  │  Full-text    │  │  out over    │  │             │ │
+              │  │  tsvector     │  │  members)    │  │  Enables HA │ │
+              │  └───────────────┘  └──────────────┘  └─────────────┘ │
               └────────────────────────────────────────────────────────┘
 ```
 
@@ -86,7 +90,9 @@ Nexspence follows a clean layered architecture. Each layer depends only on the l
   - `OptionalAuth` variant for artifact endpoints — anonymous reads allowed per repo config
 - **Audit middleware** — goroutine write after POST/PUT/DELETE/PATCH on key paths; login events use `action=LOGIN`, `entityName=username` (set by Login handler via `c.Set("username", ...)` before returning)
 - **Metrics middleware** — atomic counter increments (requests, errors); cumulative counters (`ArtifactsStored`, `BytesStored`, `DownloadsTotal`) seeded from DB on startup
-- **[Phase 8]** Rate limiting — token bucket per `userID`; 429 with `Retry-After`
+- **Security headers** — CSP built from config (`cspPolicy`), plus the usual frame/content-type/referrer set
+- **Body limit** — `http.max_body_mb`, skipped for the artifact upload paths that stream
+- **Rate limiting** — token bucket; enabled by `auth.rate_limit_enabled` (`auth.rate_limit_rps` / `_burst`)
 - **[Phase 9]** OTel trace middleware — span per request with format/repo labels
 
 ### Format Handlers
@@ -175,13 +181,17 @@ Pure business logic; no HTTP concerns; depend only on repository interfaces.
 | `BackupService` | Full tar.gz export (metadata + blobs); non-destructive restore with UUID remapping |
 | `ContentSelectorService` | CEL program compilation + cache; Variant B gate evaluation |
 | `WebhookService` | Async delivery with HMAC-SHA256; retry; inactive hook skip |
-| `ScanService` | Trivy invocation; result cache in `components.extra`; Phase 8 wiring |
-| **[Phase 8]** `OIDCService` | Exchange OIDC id_token for Nexspence JWT; group → role mapping |
-| **[Phase 8]** `LDAPService` | Bind + search; group sync → Nexspence roles |
-| **[Phase 8]** `SBOMService` | Generate SPDX / CycloneDX from component + asset metadata |
-| **[Phase 9]** `AnalyticsService` | Daily download buckets (PostgreSQL date_trunc); top-N packages; bandwidth |
-| **[Phase 9]** `ReplicationService` | Push-on-publish to secondary instance via webhook + streaming blob copy |
-| **[Phase 10]** `BlobGCService` | `ListAllBlobKeys` vs `BlobStore.ListKeys` → delete orphan blobs; dry-run |
+| `ScanService` | Trivy for `docker`/`oci`, OSV.dev for `maven`/`npm`/`pypi`/`cargo`; auto-scan queued on upload plus a nightly bulk re-scan; results cached in `components.extra` and persisted to `scan_results`; CSV/JSON export |
+| `RBACService` | Role → privilege → content-selector evaluation for a caller, path and action |
+| `RoutingRuleService` | Path allow/block rules applied to group-repository fan-out |
+| `PromotionService` | Staging → production promotion with a scan-pass gate and optional manual approval |
+| `ReplicationService` | Push-on-publish to a secondary instance via streaming blob copy; per-rule cron |
+| `BlobGCService` | `ListAllBlobKeys` vs `BlobStore.ListKeys` → delete orphan blobs; dry-run |
+| `BlobStoreMigrationService` | Move a repository's blobs between stores, resumable after a restart |
+| `DownloadCounter` | In-memory download aggregation, flushed to the DB every 10s |
+| Authenticators (`internal/auth`) | `LDAPService` bind + group sync · `OIDCService` id_token exchange + PKCE · `SAMLService` |
+| **[Phase 8]** `SBOMService` | Not built. Would generate SPDX / CycloneDX from component + asset metadata |
+| **[Phase 9]** `AnalyticsService` | Not built. Would give daily download buckets, top-N packages, bandwidth |
 
 ### Repository Layer
 
@@ -258,24 +268,20 @@ API routes:
 
 ### Phase 8 — Security & Compliance
 
-```
-                    ┌───────────────────────────────────┐
-                    │         Auth Extensions            │
-                    │                                    │
-                    │  OIDCService  ←→  Keycloak/GitHub  │
-                    │  LDAPService  ←→  AD / OpenLDAP    │
-                    │  K8s SA Token ←→  kube-apiserver   │
-                    │  RateLimiter  ←  token bucket      │
-                    └───────────────────────────────────┘
+Shipped: OIDC (with PKCE), SAML, LDAP bind + group sync, rate limiting, and
+vulnerability scanning — Trivy for `docker`/`oci` images and OSV.dev for
+`maven`/`npm`/`pypi`/`cargo`, queued automatically on upload with a nightly bulk
+re-scan, results in `components.extra` and the `scan_results` table.
 
+Still outstanding:
+
+```
                     ┌───────────────────────────────────┐
                     │       Supply Chain Security        │
                     │                                    │
-                    │  ScanService   →  Trivy (sidecar)  │
+                    │  K8s SA Token ←→  kube-apiserver   │
                     │  SBOMService   →  SPDX / CycloneDX │
-                    │  CosignVerify  →  Sigstore PKI      │
-                    │                                    │
-                    │  Stored in components.extra        │
+                    │  CosignVerify  →  Sigstore PKI     │
                     └───────────────────────────────────┘
 ```
 

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -185,11 +185,13 @@ type ContentSelector struct {
 
 // ── Blob Store ───────────────────────────────────────────────
 
-// BlobStore is a named storage backend (local filesystem or S3) with an optional quota.
+// BlobStore is a named storage backend with an optional quota: a local
+// filesystem, an S3-compatible bucket, or a group that fans writes out over
+// other stores.
 type BlobStore struct {
 	ID         string         `json:"id"`
 	Name       string         `json:"name"`
-	Type       string         `json:"type"` // "local" | "s3"
+	Type       string         `json:"type"` // "local" | "s3" | "group"
 	Config     map[string]any `json:"config,omitempty"`
 	QuotaBytes *int64         `json:"quotaBytes,omitempty"`
 	UsedBytes  int64          `json:"usedBytes"`

--- a/website/index.html
+++ b/website/index.html
@@ -707,10 +707,11 @@ resource <span style="color:#7dd3fc">"nexspence_repository"</span> <span style="
       </div>
       <div class="card rev-r" style="padding:24px">
         <div style="font-size:.9rem;font-weight:700;margin-bottom:8px">CVE Scanning + Audit Logs</div>
-        <div style="font-size:.8rem;color:var(--dim);margin-bottom:14px;line-height:1.6">Trivy-based Docker image scanning. 90-day audit trail with NDJSON export.</div>
+        <div style="font-size:.8rem;color:var(--dim);margin-bottom:14px;line-height:1.6">Trivy for Docker/OCI images, OSV.dev for Maven/npm/PyPI/Cargo. 90-day audit trail with NDJSON export.</div>
         <ul class="cl">
-          <li>Scan on-demand via <code style="font-family:'JetBrains Mono',monospace;font-size:.7rem;background:var(--glasm);padding:1px 5px;border-radius:4px">GET /api/v1/components/:id/scan</code></li>
-          <li>Results cached in component.extra JSON</li>
+          <li>Scanned automatically on upload, plus a nightly re-scan against newly published CVEs</li>
+          <li>Malicious-package reports (OSV <code style="font-family:'JetBrains Mono',monospace;font-size:.7rem;background:var(--glasm);padding:1px 5px;border-radius:4px">MAL-*</code>) get their own severity tier, above Critical</li>
+          <li>On-demand via <code style="font-family:'JetBrains Mono',monospace;font-size:.7rem;background:var(--glasm);padding:1px 5px;border-radius:4px">GET /api/v1/components/:id/scan</code>; export the dashboard as CSV or JSON</li>
           <li>Audit log: date/user filters, NDJSON streaming export</li>
           <li>90-day retention via monthly partition rotation</li>
         </ul>
@@ -1064,7 +1065,7 @@ resource <span style="color:#7dd3fc">"nexspence_repository"</span> <span style="
           <tr><td>LDAP Authentication</td><td class="y">Built-in</td><td class="y">Built-in</td></tr>
           <tr><td>Docker OCI v2</td><td class="y">Full spec</td><td class="y">Full spec</td></tr>
           <tr><td>S3 Blob Store</td><td class="y">Any S3-compatible</td><td class="n">Paid tier only</td></tr>
-          <tr><td>Vulnerability Scanning</td><td class="y">Trivy (built-in)</td><td class="n">Paid add-on</td></tr>
+          <tr><td>Vulnerability Scanning</td><td class="y">Trivy + OSV.dev (built-in)</td><td class="n">Paid add-on</td></tr>
           <tr><td>Webhooks</td><td class="y">Built-in async</td><td class="n">Paid tier only</td></tr>
           <tr><td>Per-repo Export / Import</td><td class="y">Streaming tar.gz</td><td>Admin UI</td></tr>
           <tr><td>Go Modules (GOPROXY)</td><td class="y">Native</td><td class="n">Community plugin</td></tr>


### PR DESCRIPTION
Follow-up to #164. Building that diagram from `internal/api/router.go` rather than from prose surfaced places where the written description no longer matches the code — which is worse than having no description, since a reader has no way to tell which half to trust.

## Corrected

| Claim | Reality |
|---|---|
| `ReproxyHandler` is a registered format handler | `repoproxy` is a shared proxy layer the handlers call; not an entry in `formatRegistry` |
| `SBOMService`, `AnalyticsService` sit in the service layer | Neither exists. They are roadmap items and now say so |
| Middleware: `Recovery → RequestLogger → CORS → Metrics → Audit → Auth`, rate limiting `[future]` | Missing `securityHeaders` and `bodyLimit`; audit runs *before* auth in the list but auth is per route group, not global; rate limiting ships behind `auth.rate_limit_enabled` |
| Scanning is Trivy-only, results cached in `components.extra` | OSV.dev covers maven/npm/pypi/cargo; scans are queued automatically on upload with a nightly bulk re-scan; results also persist to `scan_results` |
| `BlobStore.Type` is `"local" \| "s3"` | `"group"` is fully supported — validated on create, resolved with round-robin or fill-first member selection |

Also filled in what the diagrams were missing: RBAC, promotion, replication, blob GC, blob-store migration and the download counter in the service layer; Redis and the group store in the data tier; the OCI handler serving both `docker` and `oci`.

The Phase 8 roadmap block now lists only what is genuinely still outstanding there — K8s SA tokens, SBOM generation, Cosign verification — instead of things that shipped.

## Website

`website/index.html`: the security card repeated the Trivy-only and `component.extra` claims. It now describes both scanners, auto-scan, the `MAL-*` severity tier, and CSV/JSON export; the comparison table row reads "Trivy + OSV.dev (built-in)".

Left alone deliberately: "SBOM + Trivy image vulnerability scanning on every release" in the *Hardened by default* card. That is about Nexspence's own release pipeline (`release.yml` sets `sbom: true`), not a product feature, and it is accurate.

## Verification

Only a comment changed in Go (`domain.BlobStore.Type`); `go build`, `go test`, `make lint` clean apart from the pre-existing sandbox-network webhook failure. Website change is copy only — will confirm the deploy after merge.