### PR TITLE
fix(ui): primary button label was below AA contrast, and disabled rendered as mud

### DIFF
--- a/frontend/src/components/holo/holo.css
+++ b/frontend/src/components/holo/holo.css
@@ -32,9 +32,17 @@
   --holo-radius-pill:   999px;
 
   --holo-ring: 0 0 0 3px rgba(124,92,255,0.30);
-  --holo-shadow-glow: 0 8px 30px rgba(124,92,255,0.35);
 
   --holo-gradient: linear-gradient(110deg, #7c5cff 0%, #22d3ee 35%, #ff5cf0 70%, #7c5cff 100%);
+
+  /* Primary action fill.
+     Deliberately not --holo-gradient: that one runs through cyan and magenta,
+     which puts white label text at roughly 2:1 and, animated on every primary
+     button at once, makes the page restless. These two stops stay in the brand
+     purple and hold >=4.6:1 across the whole face of the button. If you lighten
+     them, re-check that first. */
+  --holo-primary:       linear-gradient(180deg, #7554f0, #5a37d6);
+  --holo-primary-hover: linear-gradient(180deg, #7a5af2, #6440dd);
 }
 
 @keyframes holoShift {
@@ -168,19 +176,32 @@
 .holo-btn:focus-visible { outline: none; box-shadow: var(--holo-ring); }
 .holo-btn:disabled { opacity: 0.45; cursor: not-allowed; }
 
+/* Solid brand fill. The holographic gradient stays where it reads as identity —
+   headings, the active tab rule, card hairlines — rather than on every action
+   button, where an always-animating fill and a permanent 30px glow competed
+   with the content for attention. */
 .holo-btn--primary {
   color: #fff;
-  background: var(--holo-gradient);
-  background-size: 200% 200%;
-  animation: holoShift 5s ease infinite;
-  border-color: rgba(124,92,255,0.5);
-  box-shadow: var(--holo-shadow-glow);
+  background: var(--holo-primary);
+  border-color: rgba(160,140,255,0.55);
+  box-shadow: 0 2px 10px rgba(124,92,255,0.20);
 }
 @media (hover: hover) and (pointer: fine) {
   .holo-btn--primary:not(:disabled):hover {
+    background: var(--holo-primary-hover);
+    border-color: rgba(180,165,255,0.75);
     transform: translateY(-1px);
-    box-shadow: 0 12px 40px rgba(124,92,255,0.6), 0 4px 14px rgba(0,0,0,0.2);
+    box-shadow: 0 6px 20px rgba(124,92,255,0.30), 0 4px 14px rgba(0,0,0,0.2);
   }
+}
+/* A gradient under opacity:0.45 turns to mud — the button stopped looking
+   disabled and started looking broken. Disabled drops the fill entirely. */
+.holo-btn--primary:disabled {
+  background: var(--holo-bg-3);
+  color: var(--holo-text-dim);
+  border-color: rgba(255,255,255,0.10);
+  box-shadow: none;
+  opacity: 1;
 }
 .holo-btn--danger {
   color: var(--holo-red);


### PR DESCRIPTION
## Why

`.holo-btn--primary` carried the full holographic gradient — purple → cyan → magenta → purple — on a 5s `holoShift` loop that never stops, plus `0 8px 30px` of glow that was always on. On a page with several primary buttons, the chrome was the loudest thing on screen and the motion never settled, because nothing triggered it and nothing ended it.

Chosen after comparing six treatments live in the running app.

## What

A solid two-stop purple fill. The holographic gradient stays where it reads as identity — headings (`.holo-text`), the active tab rule, card and modal hairlines — rather than being spent on every action button.

Two problems fixed while in there:

**Contrast.** White label text over the old gradient sat at roughly 2:1 where it crossed the cyan stop — well under AA for 13px text. The new stops hold ≥4.6:1 across the whole face of the button. The token comment says so, because "just lighten it slightly" is the obvious future edit that would quietly undo it.

**Disabled.** `opacity: 0.45` over a gradient produced a muddy smear; the button read as broken rather than unavailable. Disabled now drops the fill for a flat neutral surface.

Also removes `--holo-shadow-glow`, which nothing else referenced.

## Correction to an earlier version of this description

This body previously said the login screen's **Sign in** button was deliberately left on the animated gradient. That was wrong: it is a `HoloButton variant="primary"` like every other primary action — `LoginPage.module.css` styles the card and a hairline, not the button — so it changed with the rest, verified in the running app. There is no separate login treatment to follow up on.

## Verification

Built the image and looked at it in the running app: the Backup & Restore card, the Security roles tab, the vulnerability dashboard and the login screen, in `rest / hover / disabled / next-to-secondary`. `tsc`, `vitest` (500 pass) and `eslint` clean.

No test asserts the new values. Vitest runs under jsdom, which does not apply an imported stylesheet, so any such test would pass regardless of what the CSS says — a check that cannot fail is worse than none. The verification here is visual.