### PR TITLE
ci: let the tag workflow take an explicit version

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,8 +3,12 @@ name: Tag Release
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "Explicit version, e.g. v1.31.1. Leave empty to derive it from the commits since the last tag."
+        type: string
+        default: ""
       dry_run:
-        description: "Show the next version without creating a tag"
+        description: "Show the version without creating a tag"
         type: boolean
         default: false
 
@@ -29,23 +33,56 @@ jobs:
       - name: Install svu
         run: go install github.com/caarlos0/svu/v2@v2.2.0   # pinned: svu drives release versioning
 
+      # svu derives the bump from conventional-commit types, and only feat/fix
+      # move it. That is the right default, but it makes a release impossible for
+      # a batch of docs/style/refactor work — and the only way out was to
+      # mislabel a commit as a fix, which corrupts the history the versioning
+      # itself depends on. The explicit input is the honest escape hatch.
       - name: Compute next version
         id: ver
+        env:
+          EXPLICIT: ${{ inputs.version }}
         run: |
-          NEXT="$(svu next)"
+          set -euo pipefail
+          if [ -n "$EXPLICIT" ]; then
+            NEXT="$EXPLICIT"
+            SOURCE="explicit input"
+            if ! printf '%s' "$NEXT" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+              echo "::error::\"$NEXT\" is not a version like v1.31.1"
+              exit 1
+            fi
+            # A typo that goes backwards would publish a release older than one
+            # already out there, which no downstream tool expects.
+            LATEST="$(git tag --sort=-v:refname | head -n1)"
+            if [ -n "$LATEST" ] && [ "$NEXT" = "$(printf '%s\n%s\n' "$NEXT" "$LATEST" | sort -V | head -n1)" ]; then
+              echo "::error::$NEXT is not newer than the latest tag $LATEST"
+              exit 1
+            fi
+          else
+            NEXT="$(svu next)"
+            SOURCE="derived from commits"
+          fi
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "Next version: $NEXT"
-          echo "### Next version: \`$NEXT\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "source=$SOURCE" >> "$GITHUB_OUTPUT"
+          echo "Next version: $NEXT ($SOURCE)"
+          echo "### Next version: \`$NEXT\` — $SOURCE" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Create and push tag
         if: ${{ !inputs.dry_run }}
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+          SOURCE: ${{ steps.ver.outputs.source }}
         run: |
-          NEXT="${{ steps.ver.outputs.next }}"
-          # svu returns the current tag when there are no feat/fix commits since the
-          # last release — there is nothing new to release, so fail with a clear message
-          # instead of a raw "tag already exists" git error.
+          set -euo pipefail
           if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
-            echo "::error::svu computed $NEXT, which already exists — no feat/fix commits since the last release. Merge a feat/fix PR before tagging."
+            if [ "$SOURCE" = "explicit input" ]; then
+              echo "::error::$NEXT already exists — pick a version that has not been released."
+            else
+              # svu returns the current tag when nothing since the last release
+              # bumps it. Say so, rather than letting git fail with a bare
+              # "tag already exists".
+              echo "::error::svu computed $NEXT, which already exists — no feat/fix commits since the last release. Merge a feat/fix PR, or re-run with an explicit version."
+            fi
             exit 1
           fi
           git config user.name  "github-actions[bot]"


### PR DESCRIPTION
## Why

`svu` derives the bump from conventional-commit types, and only `feat` and `fix` move it. Good default — but it means a batch of `docs:` / `style:` / `refactor:` work can never be released at all. The workflow's own failure message said *"Merge a feat/fix PR before tagging"*, which is, in effect, advice to mislabel a commit in order to get a release out.

That is a bad trade. Mislabelling corrupts the very history the versioning derives from, so the shortcut costs more than it saves. This came up for real: #166 fixes a sub-AA contrast bug and a broken disabled state, but landed on `main` as `style(ui):` (GitHub's squash used the single commit's subject rather than the PR title), and there is now no way to ship it.

## What

The dispatch takes an optional `version`. Leaving it empty keeps today's behaviour byte for byte.

Because an explicit version is a hand-typed string, it is guarded:

- **Shape** — must match `v1.2.3` or `v1.2.3-rc.1`, so a typo cannot reach `git tag`.
- **Direction** — must be strictly newer than the newest existing tag, compared with `sort -V` so `v1.9.0` is not mistaken for newer than `v1.31.0`. A version that goes backwards would publish a release older than one already out, which nothing downstream expects.
- **Collision** — the existing "tag already exists" check stays, and now explains itself differently depending on which path produced the version; the "merge a feat/fix PR" advice is no longer the only way out it offers.

The input reaches the script through `env:` rather than `${{ }}` interpolation, so its contents are data and never shell.

## Verification

Both guards exercised locally against a table of inputs before committing:

- ordering — `v1.31.1`/`v1.32.0`/`v2.0.0` over `v1.31.0` accepted; `v1.31.0` (equal), `v1.30.0` (older) and `v1.9.0` (lexically larger, numerically smaller) rejected; empty tag list accepted.
- shape — `v1.31.1` and `v1.31.1-rc.1` accepted; `1.31.1`, `v1.31`, empty, and shell-metacharacter strings rejected.

YAML parses and the job still has its five steps. A dry run against `main` after merge will confirm the derived path is unchanged before any real tag is cut.