### PR TITLE
feat(ui): reveal clipped text on hover, only where it does not fit

### DIFF
--- a/frontend/src/components/Layout.module.css
+++ b/frontend/src/components/Layout.module.css
@@ -235,9 +235,8 @@
   font-size: 11.5px;
   font-weight: 600;
   color: var(--holo-text);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  /* Clipping comes from <Truncated>, which also decides whether the value is
+     worth a tooltip. Re-adding it here would clip without ever revealing. */
   display: block;
 }
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,6 +13,7 @@ import { apiClient } from '@/api/client'
 import logo from '@/assets/logo.png'
 import miniLogo from '@/assets/mini_logo.png'
 import { HoloApp, HoloModal, HoloButton, HoloInput } from '@/components/holo'
+import { Truncated } from '@/components/Truncated'
 
 const navItems = [
   { to: '/repositories', icon: Home,       label: 'Repositories' },
@@ -94,7 +95,7 @@ function ProfileModal({ onClose }: { onClose: () => void }) {
     tokenList: { maxHeight: 240, overflowY: 'auto' as const, display: 'flex', flexDirection: 'column' as const },
     row:       { display: 'flex', alignItems: 'flex-start', gap: 10, padding: '10px 0', borderBottom: '1px solid rgba(255,255,255,0.06)', minWidth: 0 },
     rowMeta:   { flex: 1, minWidth: 0 },
-    rowName:   { fontWeight: 600, fontSize: 13, color: 'var(--holo-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const },
+    rowName:   { fontWeight: 600, fontSize: 13, color: 'var(--holo-text)' },
     rowDates:  { fontSize: 11, color: 'var(--holo-text-dim)', marginTop: 2, lineHeight: 1.4 },
     empty:     { color: 'var(--holo-text-dim)', fontSize: 13, padding: '12px 0' },
     mono:      { fontFamily: 'ui-monospace,monospace' },
@@ -196,7 +197,7 @@ function ProfileModal({ onClose }: { onClose: () => void }) {
                     <div key={t.id} style={S.row}>
                       <Key size={13} style={{ color: 'var(--holo-a)', flexShrink: 0, marginTop: 2 }} />
                       <div style={S.rowMeta}>
-                        <div style={S.rowName}>{t.name}</div>
+                        <Truncated text={t.name} style={S.rowName} />
                         <div style={S.rowDates}>
                           Created {new Date(t.createdAt).toLocaleDateString()}
                           {t.lastUsedAt && ` · Last used ${new Date(t.lastUsedAt).toLocaleDateString()}`}
@@ -319,9 +320,7 @@ export default function Layout() {
               {(user.firstName || user.username || '?')[0].toUpperCase()}
             </button>
             <div className={styles.commandBarUser}>
-              <span className={styles.commandBarUserName}>
-                {user.firstName || user.username}
-              </span>
+              <Truncated as="span" className={styles.commandBarUserName} text={user.firstName || user.username} />
             </div>
             <button
               className={styles.commandBarAction}

--- a/frontend/src/components/Truncated.test.tsx
+++ b/frontend/src/components/Truncated.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { Truncated } from './Truncated'
+
+function stubWidths(scrollWidth: number, clientWidth: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, value: scrollWidth })
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: clientWidth })
+}
+
+afterEach(() => {
+  // @ts-expect-error — removing the stub restores jsdom's zero-width getters
+  delete HTMLElement.prototype.scrollWidth
+  // @ts-expect-error — same
+  delete HTMLElement.prototype.clientWidth
+})
+
+describe('Truncated', () => {
+  // A hook cannot be called per row inside a .map(), which is where nearly
+  // every clipped value in this UI lives. That is what the component is for.
+  it('reveals the value on overflow, row by row', () => {
+    stubWidths(300, 100)
+    const rows = ['first overlong value', 'second overlong value']
+    render(<div>{rows.map(r => <Truncated key={r} text={r} />)}</div>)
+
+    expect(screen.getByText('first overlong value')).toHaveAttribute('title', 'first overlong value')
+    expect(screen.getByText('second overlong value')).toHaveAttribute('title', 'second overlong value')
+  })
+
+  it('stays quiet when the value fits', () => {
+    stubWidths(100, 100)
+    render(<Truncated text="fits" />)
+    expect(screen.getByText('fits')).not.toHaveAttribute('title')
+  })
+
+  // Owning the clipping styles is the point: the three properties were copied
+  // by hand at every site, and a site that forgets one does not clip at all.
+  it('applies the clipping styles itself', () => {
+    stubWidths(100, 100)
+    render(<Truncated text="v" data-testid="t" />)
+
+    const el = screen.getByTestId('t')
+    expect(el).toHaveStyle({ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })
+  })
+
+  it('lets the call site add its own styles', () => {
+    stubWidths(100, 100)
+    render(<Truncated text="v" data-testid="t" style={{ maxWidth: 200, color: 'rgb(239, 68, 68)' }} />)
+
+    const el = screen.getByTestId('t')
+    expect(el).toHaveStyle({ maxWidth: '200px', color: 'rgb(239, 68, 68)', overflow: 'hidden' })
+  })
+
+  it('renders as the requested element, for table cells', () => {
+    stubWidths(100, 100)
+    render(<table><tbody><tr><Truncated as="td" text="cell" /></tr></tbody></table>)
+
+    expect(screen.getByText('cell').tagName).toBe('TD')
+  })
+
+  // Some sites decorate the value — an arrow, a badge — while the title should
+  // still be the value alone.
+  it('titles with text even when children render something else', () => {
+    stubWidths(300, 100)
+    render(
+      <Truncated text="https://registry.npmjs.org" data-testid="t">
+        <span aria-hidden="true">↗ </span>
+        <span>https://registry.npmjs.org</span>
+      </Truncated>,
+    )
+
+    expect(screen.getByTestId('t')).toHaveAttribute('title', 'https://registry.npmjs.org')
+  })
+})

--- a/frontend/src/components/Truncated.tsx
+++ b/frontend/src/components/Truncated.tsx
@@ -1,0 +1,50 @@
+import type { CSSProperties, HTMLAttributes, ReactNode, Ref } from 'react'
+import { useOverflowTitle } from './useOverflowTitle'
+
+/** The elements that clip text in this UI. */
+type TruncatedTag = 'div' | 'span' | 'td'
+
+interface TruncatedProps extends Omit<HTMLAttributes<HTMLElement>, 'title' | 'children'> {
+  /** The value to clip, and to reveal on hover when it does not fit. */
+  text: string
+  /** Rendered instead of `text` when the value needs decoration. `text` still supplies the title. */
+  children?: ReactNode
+  as?: TruncatedTag
+  style?: CSSProperties
+}
+
+const clip: CSSProperties = {
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+}
+
+/**
+ * Truncated clips a value to its container and reveals the whole of it on hover
+ * — but only when it is actually cut off. See useOverflowTitle for why the
+ * "only when" matters.
+ *
+ * It owns the three clipping properties rather than leaving them to the call
+ * site. They were being copied by hand at every site, and a site that copies
+ * two of the three does not clip at all — it just overflows.
+ *
+ * A component rather than a bare hook because nearly every clipped value here
+ * is inside a `.map()`, and a hook cannot be called per row.
+ */
+export function Truncated({ text, children, as: Tag = 'div', style, ...rest }: TruncatedProps) {
+  const { ref, title } = useOverflowTitle<HTMLElement>(text)
+
+  return (
+    <Tag
+      // One cast, here: the tag is chosen at the call site, so no single
+      // element type describes it. The hook only ever reads scrollWidth and
+      // clientWidth, which every element has.
+      ref={ref as Ref<HTMLDivElement & HTMLSpanElement & HTMLTableCellElement>}
+      title={title}
+      style={{ ...clip, ...style }}
+      {...rest}
+    >
+      {children ?? text}
+    </Tag>
+  )
+}

--- a/frontend/src/components/useOverflowTitle.test.tsx
+++ b/frontend/src/components/useOverflowTitle.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { useOverflowTitle } from './useOverflowTitle'
+
+/**
+ * jsdom performs no layout, so scrollWidth and clientWidth are always 0. The
+ * hook exists precisely to compare them, so the test has to supply them —
+ * stubbing the prototype is the only place they can come from here.
+ */
+function stubWidths(scrollWidth: number, clientWidth: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', { configurable: true, value: scrollWidth })
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, value: clientWidth })
+}
+
+function restoreWidths() {
+  // @ts-expect-error — removing the stub restores jsdom's own zero-width getters
+  delete HTMLElement.prototype.scrollWidth
+  // @ts-expect-error — same
+  delete HTMLElement.prototype.clientWidth
+}
+
+function Probe({ text }: { text?: string | null }) {
+  const { ref, title } = useOverflowTitle<HTMLDivElement>(text)
+  return <div ref={ref} title={title} data-testid="cell">{text}</div>
+}
+
+afterEach(() => {
+  restoreWidths()
+  vi.unstubAllGlobals()
+})
+
+describe('useOverflowTitle', () => {
+  // The whole point: a tooltip only where something is actually unreadable.
+  it('exposes the full text when it is clipped', () => {
+    stubWidths(300, 120)
+    render(<Probe text="a replication error far too long to fit in the cell" />)
+
+    expect(screen.getByTestId('cell')).toHaveAttribute(
+      'title',
+      'a replication error far too long to fit in the cell',
+    )
+  })
+
+  // An unconditional title turns every row into a popup on the way past.
+  it('sets no title when the text fits', () => {
+    stubWidths(120, 120)
+    render(<Probe text="short" />)
+
+    expect(screen.getByTestId('cell')).not.toHaveAttribute('title')
+  })
+
+  it('sets no title when there is no text to reveal', () => {
+    stubWidths(300, 120)
+    render(<Probe text="" />)
+
+    expect(screen.getByTestId('cell')).not.toHaveAttribute('title')
+  })
+
+  // A column that was wide enough a moment ago may not be after a resize.
+  it('re-measures when the element resizes', () => {
+    let trigger: (() => void) | undefined
+    vi.stubGlobal('ResizeObserver', class {
+      constructor(cb: () => void) { trigger = cb }
+      observe() {}
+      disconnect() {}
+    })
+
+    stubWidths(120, 120)
+    render(<Probe text="a value that only overflows once the column narrows" />)
+    expect(screen.getByTestId('cell')).not.toHaveAttribute('title')
+
+    stubWidths(300, 120)
+    act(() => { trigger?.() })
+
+    expect(screen.getByTestId('cell')).toHaveAttribute(
+      'title',
+      'a value that only overflows once the column narrows',
+    )
+  })
+
+  // MiniChart already guards for this: jsdom, and any environment without the
+  // API, must not throw.
+  it('works where ResizeObserver does not exist', () => {
+    vi.stubGlobal('ResizeObserver', undefined)
+    stubWidths(300, 120)
+
+    expect(() => render(<Probe text="still measured once on mount" />)).not.toThrow()
+    expect(screen.getByTestId('cell')).toHaveAttribute('title', 'still measured once on mount')
+  })
+})

--- a/frontend/src/components/useOverflowTitle.ts
+++ b/frontend/src/components/useOverflowTitle.ts
@@ -1,0 +1,46 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+
+/**
+ * useOverflowTitle reveals text that CSS has clipped, and only then.
+ *
+ * The UI truncates with `text-overflow: ellipsis` in a dozen places, and in
+ * almost all of them the clipped part was simply unrecoverable. The obvious fix
+ * — a `title` on everything that might overflow — is worse than it looks: the
+ * tooltip then fires on rows that are perfectly readable, turning a list into a
+ * field of popups. So the title exists only while `scrollWidth > clientWidth`,
+ * which is the browser's own answer to "is there text you cannot see".
+ *
+ * Attach `ref` to the element that does the clipping — the one carrying
+ * `overflow: hidden` — not to a wrapper, or the comparison measures the wrong
+ * box.
+ *
+ * Accessibility note: this is for sighted mouse users. Screen readers already
+ * read the full string, because ellipsis is a visual effect and the text is
+ * intact in the DOM. Sighted keyboard-only users are the group still left out —
+ * `title` does not open on focus — and the fix for that is not `tabIndex` on
+ * every table cell, which would bury real controls in tab order. It needs a
+ * real tooltip component, which is a separate decision.
+ */
+export function useOverflowTitle<T extends HTMLElement>(text: string | null | undefined) {
+  const ref = useRef<T>(null)
+  const [overflowing, setOverflowing] = useState(false)
+
+  // Layout effect, not effect: measuring after paint would show one frame with
+  // the wrong answer on every mount.
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+
+    const measure = () => setOverflowing(el.scrollWidth > el.clientWidth)
+    measure()
+
+    // Absent in jsdom, and in any environment old enough to lack it. The mount
+    // measurement above still stands; only the response to resizing is lost.
+    if (typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [text])
+
+  return { ref, title: overflowing && text ? text : undefined }
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -5,6 +5,7 @@ import { Activity, Archive, ArrowRightLeft, ArrowUpCircle, CheckCircle, Database
 import { nexusApi, nexspenceApi, apiClient, apiErrorMessage, ImportRepoStats, ServiceStatus, RoutingRule, RoutingRuleInput, ReplicationRule, ReplicationHistory, ReplicationRuleInput, AuthConfig } from '@/api/client'
 const MonitoringView = lazy(() => import('@/pages/MonitoringPage').then(m => ({ default: m.MonitoringView })))
 import { Select } from '@/components/Select'
+import { Truncated } from '@/components/Truncated'
 import { HoloButton, HoloInput, HoloModal, HoloTabs, HoloCard, HoloTabItem, Wizard } from '@/components/holo'
 
 interface BlobStore {
@@ -528,7 +529,7 @@ function ReplicationTab() {
                         <td style={{ padding: '4px 8px' }}>{h.skipped_count}</td>
                         <td style={{ padding: '4px 8px', color: h.failed_count > 0 ? '#ef4444' : '#94a3b8' }}>{h.failed_count}</td>
                         <td style={{ padding: '4px 8px' }}>{fmtBytes(h.transferred_bytes)}</td>
-                        <td style={{ padding: '4px 8px', color: '#ef4444', maxWidth: 200, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{h.error || '—'}</td>
+                        <Truncated as="td" text={h.error || '—'} style={{ padding: '4px 8px', color: '#ef4444', maxWidth: 200 }} />
                       </tr>
                     ))}
                   </tbody>
@@ -1228,7 +1229,7 @@ export default function AdminPage() {
                           <span style={{ fontSize: 10, padding: '1px 6px', borderRadius: 4, background: 'rgba(245,158,11,0.15)', color: '#f59e0b', fontWeight: 700 }}>S3</span>
                         )}
                       </div>
-                      <div style={{ fontSize: 11, color: 'var(--holo-text-faint)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>{svc.detail}</div>
+                      <Truncated text={svc.detail} style={{ fontSize: 11, color: 'var(--holo-text-faint)', marginTop: 2 }} />
                     </div>
                     <div style={{ textAlign: 'right' as const, fontSize: 11, color: 'var(--holo-text-faint)', whiteSpace: 'nowrap' as const }}>
                       {svc.latency_ms != null && <span style={{ color: svc.latency_ms < 50 ? 'var(--holo-green)' : svc.latency_ms < 200 ? 'var(--holo-amber)' : 'var(--holo-red)' }}>{svc.latency_ms}ms</span>}
@@ -1354,7 +1355,7 @@ export default function AdminPage() {
                 {importFile ? (
                   <span style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'var(--holo-text-faint)', maxWidth: 320, overflow: 'hidden' }}>
                     <Archive size={12} style={{ flexShrink: 0 }} />
-                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>{importFile.name}</span>
+                    <Truncated as="span" text={importFile.name} />
                     <button
                       onClick={() => { setImportFile(null); if (importFileRef.current) importFileRef.current.value = '' }}
                       style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--holo-text-dim)', padding: '0 2px', lineHeight: 1, fontSize: 16, flexShrink: 0 }}
@@ -2208,7 +2209,7 @@ function MigrationTab() {
                   return (
                     <div key={job.id} style={{ display: 'grid', gridTemplateColumns: '3fr 1fr 1fr 1fr 1fr', padding: '11px 16px', borderBottom: '1px solid rgba(255,255,255,0.04)', fontSize: 13, color: 'var(--holo-text)', alignItems: 'center' }}>
                       <div>
-                        <div style={{ fontFamily: 'monospace', fontSize: 12, fontWeight: 600, color: 'var(--holo-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{job.sourceUrl}</div>
+                        <Truncated text={job.sourceUrl} style={{ fontFamily: 'monospace', fontSize: 12, fontWeight: 600, color: 'var(--holo-text)' }} />
                         {job.sourceUser && <div style={{ fontSize: 11, color: 'var(--holo-text-faint)', marginTop: 2 }}>{job.sourceUser}</div>}
                       </div>
                       <div>

--- a/frontend/src/pages/AuditPage.tsx
+++ b/frontend/src/pages/AuditPage.tsx
@@ -4,6 +4,7 @@ import { FileText, RefreshCw, ChevronLeft, ChevronRight, Download } from 'lucide
 import { nexusApi } from '@/api/client'
 import { Select } from '../components/Select'
 import { HoloButton, HoloInput, HoloCard, HoloPill } from '@/components/holo'
+import { Truncated } from '@/components/Truncated'
 
 interface AuditEvent {
   id: number
@@ -208,7 +209,7 @@ export default function AuditPage() {
                     </td>
                     <td style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--holo-text-dim)', maxWidth: 320 }}>
                       {e.context?.path
-                        ? <span title={String(e.context.path)} style={{ display: 'inline-block', maxWidth: '100%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{String(e.context.path)}</span>
+                        ? <Truncated as="span" text={String(e.context.path)} style={{ display: 'inline-block', maxWidth: '100%' }} />
                         : '—'}
                     </td>
                     <td style={{ fontFamily: 'monospace', fontSize: 12, color: 'var(--holo-text-dim)' }}>{e.remoteIp || '—'}</td>

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { HoloButton, HoloInput, HoloModal } from '@/components/holo'
+import { Truncated } from '@/components/Truncated'
 import {
   BookOpen,
   ChevronDown,
@@ -364,19 +365,11 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
                           {row.installedVersion}
                         </td>
                         <td style={{ padding: '6px 6px', fontFamily: 'monospace', color: '#86efac' }}>{row.fixedVersion || '—'}</td>
-                        <td
-                          style={{
-                            padding: '6px 6px',
-                            color: 'var(--holo-text-dim)',
-                            maxWidth: 200,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap' as const,
-                          }}
-                          title={row.title || undefined}
-                        >
-                          {row.title || '—'}
-                        </td>
+                        <Truncated
+                          as="td"
+                          text={row.title || '—'}
+                          style={{ padding: '6px 6px', color: 'var(--holo-text-dim)', maxWidth: 200 }}
+                        />
                       </tr>
                     ))}
                   </tbody>
@@ -922,9 +915,7 @@ function RawTreeRows({
         }}
       >
         <FileText size={13} style={{ color: '#4ade80', flexShrink: 0 }} />
-        <span style={{ fontFamily: 'monospace', fontSize: 12, flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
-          {node.label}
-        </span>
+        <Truncated as="span" text={node.label} style={{ fontFamily: 'monospace', fontSize: 12, flex: 1 }} />
         {node.size != null && (
           <span style={{ fontSize: 11, color: 'var(--holo-text-faint)', flexShrink: 0 }}>
             {formatBytes(node.size)}

--- a/frontend/src/pages/CleanupPage.tsx
+++ b/frontend/src/pages/CleanupPage.tsx
@@ -5,6 +5,7 @@ import { nexusApi, apiErrorMessage } from '@/api/client'
 import type { CleanupPreviewResponse } from '@/api/client'
 import { Select } from '../components/Select'
 import { HoloButton, HoloInput, HoloModal, HoloPill, Wizard } from '@/components/holo'
+import { Truncated } from '@/components/Truncated'
 
 interface CleanupScope {
   repositoryName?: string
@@ -232,9 +233,7 @@ function PreviewModal({ policyId, policyName, onClose, onRun }: {
               <tbody>
                 {data.assets.map((a, i) => (
                   <tr key={i}>
-                    <td style={{ fontFamily: 'monospace', fontSize: 11, color: 'var(--holo-b)', maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                      {a.path}
-                    </td>
+                    <Truncated as="td" text={a.path} style={{ fontFamily: 'monospace', fontSize: 11, color: 'var(--holo-b)', maxWidth: 240 }} />
                     <td style={{ fontSize: 12, color: 'var(--holo-text-dim)' }}>{a.repository}</td>
                     <td style={{ fontSize: 12, color: 'var(--holo-amber)', whiteSpace: 'nowrap' }}>{fmtBytes(a.sizeBytes)}</td>
                     <td>
@@ -836,9 +835,7 @@ export default function CleanupPage() {
 
                 {/* Name + meta */}
                 <div style={{ minWidth: 0 }}>
-                  <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--holo-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                    {p.name}
-                  </div>
+                  <Truncated text={p.name} style={{ fontWeight: 600, fontSize: 13, color: 'var(--holo-text)' }} />
                   <div style={{ display: 'flex', gap: 6, marginTop: 3, flexWrap: 'wrap', alignItems: 'center' }}>
                     {criteria.length > 0 ? criteria.map(c => (
                       <span key={c} style={{ fontSize: 10, padding: '1px 6px', borderRadius: 4, background: 'rgba(124,92,255,0.1)', color: 'var(--holo-a)', fontFamily: 'monospace', whiteSpace: 'nowrap' }}>{c}</span>
@@ -856,7 +853,7 @@ export default function CleanupPage() {
                       </span>
                     )}
                     {p.description && criteria.length > 0 && (
-                      <span style={{ fontSize: 11, color: 'var(--holo-text-faint)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{p.description}</span>
+                      <Truncated as="span" text={p.description} style={{ fontSize: 11, color: 'var(--holo-text-faint)' }} />
                     )}
                   </div>
                 </div>

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '@/store/authStore'
 import styles from './RepositoriesPage.module.css'
 import { Select } from '../components/Select'
 import { HoloButton, HoloInput, HoloPill, HoloModal, Wizard } from '@/components/holo'
+import { Truncated } from '@/components/Truncated'
 
 interface Repository {
   id: string
@@ -313,22 +314,21 @@ function RepoRow({
         {repo.format}
       </span>
       <div style={{ minWidth: 0 }}>
-        <div style={{ fontWeight: 600, fontSize: 13, color: 'var(--holo-text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
-          {repo.name}
-        </div>
+        <Truncated text={repo.name} style={{ fontWeight: 600, fontSize: 13, color: 'var(--holo-text)' }} />
         {(repo.description || storeName) && (
-          <div style={{ fontSize: 11, color: 'var(--holo-text-faint)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>
-            {repo.description || (storeName ? `on ${storeName}` : '')}
-          </div>
+          <Truncated
+            text={repo.description || (storeName ? `on ${storeName}` : '')}
+            style={{ fontSize: 11, color: 'var(--holo-text-faint)', marginTop: 2 }}
+          />
         )}
         {repo.type === 'proxy' && cfgString(repo.proxyConfig, 'remote_url') && (
-          <div
-            title={cfgString(repo.proxyConfig, 'remote_url')}
-            style={{ fontSize: 11, color: 'var(--holo-text-faint)', fontFamily: 'ui-monospace,monospace', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}
+          <Truncated
+            text={cfgString(repo.proxyConfig, 'remote_url')}
+            style={{ fontSize: 11, color: 'var(--holo-text-faint)', fontFamily: 'ui-monospace,monospace', marginTop: 2 }}
           >
             <span aria-hidden="true">↗ </span>
             <span>{cfgString(repo.proxyConfig, 'remote_url')}</span>
-          </div>
+          </Truncated>
         )}
       </div>
       <HoloPill tone={repo.type === 'hosted' ? 'success' : repo.type === 'proxy' ? 'default' : 'warn'}>

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -8,6 +8,7 @@ import { UsersTab } from './UsersPage'
 import { useAuthStore } from '@/store/authStore'
 import { Select } from '../components/Select'
 import { HoloButton, HoloInput, HoloModal, HoloTabs, HoloPill, HoloCard, HoloTabItem } from '@/components/holo'
+import { Truncated } from '@/components/Truncated'
 
 /* ─── Types ─────────────────────────────────────────────── */
 interface Role { id: string; name: string; description: string; privileges: string[]; roles: string[]; readOnly: boolean; source?: string }
@@ -693,7 +694,7 @@ function ScanTab() {
                       <td style={{ padding: '8px 8px 8px 0', color: 'var(--holo-text)' }}>{f.pkgName}</td>
                       <td style={{ padding: '8px 8px 8px 0', ...monoStyle, color: 'var(--holo-text-dim)' }}>{f.installedVersion}</td>
                       <td style={{ padding: '8px 8px 8px 0', ...monoStyle, color: '#22c55e' }}>{f.fixedVersion || '—'}</td>
-                      <td style={{ padding: '8px 0', color: 'var(--holo-text-dim)', maxWidth: 280, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' as const }}>{f.title || '—'}</td>
+                      <Truncated as="td" text={f.title || '—'} style={{ padding: '8px 0', color: 'var(--holo-text-dim)', maxWidth: 280 }} />
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
Closes #167.

## Why

Text was clipped with `text-overflow: ellipsis` in fifteen places, and in all but two the clipped part was simply unrecoverable. The worst is `AdminPage` — the replication error cell, capped at 200px. An error message you cannot read is not an error message.

The obvious fix is worse than it looks: a `title` on everything that *might* overflow fires a tooltip on rows that are perfectly readable, turning a list into a field of popups. So the title exists only while `scrollWidth > clientWidth` — the browser's own answer to "is there text you cannot see".

## What

- `useOverflowTitle` — measures on mount (layout effect, so no wrong-answer frame) and on resize via `ResizeObserver`, guarded for environments without it.
- `Truncated` — a component around the hook, because nearly every clipped value here lives inside a `.map()` and a hook cannot be called per row. It also owns the three clipping properties rather than leaving them to each call site: they were copied by hand, and a site that copies two of the three does not clip at all, it silently overflows.

All fifteen sites converted, across `AdminPage`, `AuditPage`, `BrowsePage`, `CleanupPage`, `RepositoriesPage`, `SecurityPage` and `Layout`. That includes the two that already had an *unconditional* title (`AuditPage` path, `RepositoriesPage` proxy URL) — those now stay quiet when the value fits.

## Accessibility, stated rather than claimed

Screen readers were never affected: ellipsis is a visual effect and the full text is in the DOM. Sighted keyboard-only users still cannot reach a `title`, and the fix for that is a real tooltip component — not `tabIndex` on every table cell, which would bury real controls in tab order. Left as a follow-up and written into the hook's doc comment.

## Verification

11 new unit tests: clipped→title, fits→no title, empty text, re-measure when the observer fires, and no-throw where `ResizeObserver` is absent. jsdom performs no layout, so the widths are stubbed on the prototype — noted in the test, since a reader will rightly ask.

Full suite green: 511 tests, `tsc` and `eslint` clean.

Checked in the running app as well. The real element carries the expected props (`ref`, `title`, `style`), and with a narrow width forced, a freshly-mounted row measured as clipped and got its title while short rows stayed untouched.

One honest gap in that live check: the automated tab never becomes visible, and Chrome freezes `requestAnimationFrame` and `ResizeObserver` in a hidden tab, so the *resize* path could not be exercised there — it is covered by the unit test that drives the observer directly. An earlier run of mine looked like a bug for exactly this reason before I checked `document.visibilityState`.

## Found but not touched

`SecurityPage.module.css` is imported by nothing at all, and `.cell` in `UsersPage.module.css` is unused. Both contain clipping rules, which is how they surfaced. Separate cleanup rather than smuggled in here.