### PR TITLE
feat(migration): give the Nexus migration a runner that actually runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Published on the [Terraform Registry](https://registry.terraform.io/providers/ne
 - High Availability — stateless nodes, Redis distributed locks, `/healthz` + `/readyz`
 - Cleanup policies — by age, last-downloaded, retain-N-versions; cron scheduler; dry-run
 - Per-repository export / import (streaming `.tar.gz`); full system backup / restore
-- Live migration from a running Nexus OSS/Pro instance
+- Live migration from a running Nexus instance — repositories, artifacts, container images, privileges/roles/users, routing rules; pausable, resumable, restart-safe ([guide](docs/nexus-migration.md))
 - Vulnerability scanning — Trivy (Docker) + OSV.dev (Maven/npm/PyPI/Cargo)
 - Audit log — every action logged; NDJSON streaming export; 90-day partition rotation
 - Webhooks — HMAC-SHA256 signed; `artifact.published`, `artifact.deleted`, repo events

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -221,20 +221,31 @@ components:
 
     MigrationJob:
       type: object
+      description: |
+        A Nexus → Nexspence migration. The source password is stored sealed and
+        is never part of this response.
       properties:
-        id:             { type: string }
-        sourceUrl:      { type: string }
-        status:         { type: string, enum: [pending, running, paused, done, error] }
-        totalRepos:     { type: integer }
-        doneRepos:      { type: integer }
-        totalAssets:    { type: integer }
-        doneAssets:     { type: integer }
-        totalBytes:     { type: integer }
-        doneBytes:      { type: integer }
-        errorCount:     { type: integer }
-        lastError:      { type: string, nullable: true }
-        startedAt:      { type: string, format: date-time, nullable: true }
-        finishedAt:     { type: string, format: date-time, nullable: true }
+        id:                  { type: string }
+        sourceUrl:           { type: string }
+        sourceUser:          { type: string }
+        status:              { type: string, enum: [pending, running, paused, done, error] }
+        migrateRepos:        { type: boolean }
+        migrateUsers:        { type: boolean }
+        migrateBlobs:        { type: boolean }
+        migratePolicies:     { type: boolean, description: "Legacy umbrella; the default the three security scopes fall back to." }
+        migratePrivileges:   { type: boolean }
+        migrateRoles:        { type: boolean }
+        migrateRoutingRules: { type: boolean }
+        repositoriesTotal:   { type: integer }
+        repositoriesDone:    { type: integer }
+        assetsTotal:         { type: integer }
+        assetsDone:          { type: integer }
+        errorCount:          { type: integer, description: "Per-item failures; a run continues past them." }
+        lastError:           { type: string, nullable: true }
+        startedAt:           { type: string, format: date-time, nullable: true }
+        finishedAt:          { type: string, format: date-time, nullable: true }
+        createdAt:           { type: string, format: date-time }
+        updatedAt:           { type: string, format: date-time }
 
 security:
   - basicAuth: []
@@ -1077,37 +1088,73 @@ paths:
                 items: { $ref: '#/components/schemas/MigrationJob' }
     post:
       tags: [Migration]
-      summary: Start a new migration from Nexus source
+      summary: Create a migration from a Nexus source and start it
       operationId: createMigrationJob
       description: |
-        Connects to a live Nexus/Pro instance and pulls:
-        - Repository definitions
-        - User accounts and roles
-        - Cleanup policies
-        - Artifact metadata and blobs (streamed)
+        Creates the job and starts running it immediately. Each stage is gated
+        by its own scope flag and runs in this order:
+
+        1. Repositories — hosted, then proxy, then group, so a group's members
+           exist before the group naming them.
+        2. Artifacts — hosted repositories only; a proxy re-fetches from its own
+           upstream, so its cache is not copied. For a registry repository
+           (docker/oci) the blobs are read out of each manifest rather than out
+           of the component listing, which reports only the manifest and names
+           blobs under a placeholder image; blobs are stored before the manifest
+           that references them, and a tagged manifest also gets its digest
+           alias, so a migrated image is pullable.
+        3. Privileges, then roles (nested roles are flattened into the parent),
+           then users, then routing rules.
+
+        Anything already present is skipped, which is what makes a resumed or
+        repeated job cheap rather than destructive. A per-item failure is counted
+        in `errorCount` and named in `lastError`; the run continues.
+
+        Migrated local users get a random temporary password and
+        `mustResetPassword`; externally-authenticated users get no local
+        credential.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [sourceUrl, sourceUsername, sourcePassword]
+              required: [sourceUrl]
               properties:
-                sourceUrl:        { type: string, example: "https://nexus.example.com" }
-                sourceUsername:   { type: string }
-                sourcePassword:   { type: string }
-                migrateRepos:     { type: boolean, default: true }
-                migrateUsers:     { type: boolean, default: true }
-                migrateBlobs:     { type: boolean, default: true }
-                migratePolicies:  { type: boolean, default: true }
-                repoFilter:       { type: array, items: { type: string }, description: "Only migrate these repos. Empty = all." }
-                concurrency:      { type: integer, default: 4, description: "Parallel blob download workers" }
+                sourceUrl:
+                  type: string
+                  example: "https://nexus.example.com"
+                  description: Absolute http(s) URL of the source Nexus.
+                credentials:
+                  type: object
+                  properties:
+                    username: { type: string }
+                    password: { type: string, description: "Stored sealed; never returned." }
+                options:
+                  type: object
+                  properties:
+                    concurrency: { type: integer, default: 4 }
+                scope:
+                  type: object
+                  description: |
+                    Every flag defaults to true. `migratePolicies` is the older,
+                    coarser switch and is the default the three security scopes
+                    fall back to when a request does not name them.
+                  properties:
+                    migrateRepos:        { type: boolean, default: true }
+                    migrateBlobs:        { type: boolean, default: true }
+                    migrateUsers:        { type: boolean, default: true }
+                    migratePolicies:     { type: boolean, default: true }
+                    migratePrivileges:   { type: boolean }
+                    migrateRoles:        { type: boolean }
+                    migrateRoutingRules: { type: boolean }
       responses:
         '201':
-          description: Job created
+          description: Job created and started
           content:
             application/json:
               schema: { $ref: '#/components/schemas/MigrationJob' }
+        '400': { description: Malformed body, or a sourceUrl that is not an absolute http(s) URL }
 
   /api/v1/migration/jobs/{id}:
     get:
@@ -1117,97 +1164,90 @@ paths:
       parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
       responses:
         '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/MigrationJob' } } } }
+        '404': { description: No such job }
+    delete:
+      tags: [Migration]
+      summary: Delete a migration job
+      operationId: deleteMigrationJob
+      description: Stops the run if one is in flight, then removes the job record.
+      parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
+      responses:
+        '204': { description: Deleted }
+        '404': { description: No such job }
 
   /api/v1/migration/jobs/{id}/pause:
     post:
       tags: [Migration]
-      summary: Pause migration (resumes from last cursor)
+      summary: Pause a migration
       operationId: pauseMigrationJob
+      description: |
+        Stops the run and parks the job where it stands. Progress already
+        recorded is kept, and resuming picks up only the work that is left.
       parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
       responses:
         '204': { description: Paused }
+        '400': { description: The job has already finished }
+        '404': { description: No such job }
 
   /api/v1/migration/jobs/{id}/resume:
     post:
       tags: [Migration]
-      summary: Resume paused migration
+      summary: Resume a paused migration
       operationId: resumeMigrationJob
+      description: Starts a fresh pass that skips everything already migrated.
       parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
       responses:
         '204': { description: Resumed }
-
-  /api/v1/migration/jobs/{id}/cancel:
-    post:
-      tags: [Migration]
-      summary: Cancel migration job
-      operationId: cancelMigrationJob
-      parameters: [{ name: id, in: path, required: true, schema: { type: string } }]
-      responses:
-        '204': { description: Cancelled }
-
-  /api/v1/migration/jobs/{id}/errors:
-    get:
-      tags: [Migration]
-      summary: Get migration errors log
-      operationId: getMigrationErrors
-      parameters:
-        - { name: id, in: path, required: true, schema: { type: string } }
-        - { name: limit, in: query, schema: { type: integer, default: 100 } }
-      responses:
-        '200':
-          description: Error list
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    time:       { type: string, format: date-time }
-                    repository: { type: string }
-                    path:       { type: string }
-                    error:      { type: string }
+        '404': { description: No such job }
 
   /api/v1/migration/preview:
     post:
       tags: [Migration]
-      summary: Preview what would be migrated (dry-run)
+      summary: Test the connection to a Nexus source
       operationId: previewMigration
+      description: |
+        Reads the repository list from the source instance. Creates nothing, so
+        it is safe to call as often as an operator edits the form.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               type: object
-              required: [sourceUrl, sourceUsername, sourcePassword]
+              required: [sourceUrl]
               properties:
-                sourceUrl:      { type: string }
-                sourceUsername: { type: string }
-                sourcePassword: { type: string }
+                sourceUrl: { type: string }
+                username:  { type: string }
+                password:  { type: string }
       responses:
         '200':
-          description: Migration preview
+          description: The source answered
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  repositories:  { type: array, items: { $ref: '#/components/schemas/Repository' } }
-                  userCount:     { type: integer }
-                  roleCount:     { type: integer }
-                  totalAssets:   { type: integer }
-                  totalBytes:    { type: integer }
-                  formatBreakdown:
-                    type: object
-                    additionalProperties: { type: integer }
-                  conflicts:
+                  reachable: { type: boolean }
+                  repoCount: { type: integer }
+                  repos:
                     type: array
                     items:
                       type: object
                       properties:
-                        type:    { type: string }
-                        name:    { type: string }
-                        message: { type: string }
+                        name:   { type: string }
+                        format: { type: string }
+                        type:   { type: string }
+        '400': { description: Malformed body }
+        '422': { description: sourceUrl missing, or not an absolute http(s) URL }
+        '502':
+          description: The source could not be reached or returned an error; `error` carries the reason.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reachable: { type: boolean, example: false }
+                  error:     { type: string }
 
   # ── System info ──────────────────────────────────────────────
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,6 +188,7 @@ Pure business logic; no HTTP concerns; depend only on repository interfaces.
 | `ReplicationService` | Push-on-publish to a secondary instance via streaming blob copy; per-rule cron |
 | `BlobGCService` | `ListAllBlobKeys` vs `BlobStore.ListKeys` → delete orphan blobs; dry-run |
 | `BlobStoreMigrationService` | Move a repository's blobs between stores, resumable after a restart |
+| `NexusMigrationService` | Import a live Nexus OSS instance over its REST API — repositories, artifacts, privileges, roles, users, routing rules — one goroutine per job, pausable, and re-attached on startup |
 | `DownloadCounter` | In-memory download aggregation, flushed to the DB every 10s |
 | Authenticators (`internal/auth`) | `LDAPService` bind + group sync · `OIDCService` id_token exchange + PKCE · `SAMLService` |
 | **[Phase 8]** `SBOMService` | Not built. Would generate SPDX / CycloneDX from component + asset metadata |
@@ -442,7 +443,7 @@ user_roles          — user_id, role_id
 blob_stores         — name, type (local|s3), config JSONB, used_bytes, quota_bytes
 cleanup_policies    — name, format, criteria JSONB (age_days, last_downloaded_days), schedule_cron
 audit_events        — partitioned by month; user_id, domain, action, entity_type, entity_name, result
-migration_jobs      — source_url, status, progress JSONB
+migration_jobs      — source_url, source_user, sealed source_password, status, per-scope flags, repo/asset progress, error_count
 routing_rules       — name, mode (ALLOW|BLOCK), matchers[]
 content_selectors   — name, expression (CEL)
 webhooks            — name, url, events[], secret, active

--- a/docs/nexus-migration.md
+++ b/docs/nexus-migration.md
@@ -1,0 +1,138 @@
+# Migration from Nexus
+
+Nexspence imports a live **Sonatype Nexus Repository 3 (OSS / Community)** instance over its REST API: repository definitions, the artifacts inside them, container images, and the security model that governs access to all of it. The source instance keeps serving traffic throughout — nothing is written back to it.
+
+A migration is a **job**. You create one, it runs in the background, and you watch it from **Admin → Migration**. It can be paused, resumed, and it survives a restart of Nexspence.
+
+## What gets migrated
+
+| Item | Detail |
+|------|--------|
+| Repositories | Hosted, proxy and group definitions — format, type, group membership, proxy remote URL |
+| Artifacts | Every component in each **hosted** repository, streamed through the same storage path an upload takes |
+| Container images | Manifests, image indexes and the blobs they reference, re-created so the image is pullable byte-for-byte |
+| Privileges | Everything except Nexus built-ins, which this instance ships its own copies of |
+| Roles | Including nested roles, flattened (see below) |
+| Users | Local accounts with a temporary password; LDAP/OIDC/SAML accounts as external references |
+| Routing rules | `ALLOW` / `BLOCK` rules with their regex matchers |
+
+**Not migrated:** cleanup policies and task schedules — Nexus OSS does not expose either through its REST API. Proxy repository *caches* are not copied either: a proxy re-fetches from its own upstream, so copying its cache would only duplicate bytes that Nexspence would fetch anyway.
+
+## Running a migration
+
+### 1. Test the connection
+
+In **Admin → Migration → New Migration**, enter the Nexus URL and admin credentials and press **Test connection**. This is a pure read — no job is created, so it is safe to press as often as you edit the form. On success it lists the repositories it can see; on failure it shows the reason the source gave.
+
+The equivalent API call:
+
+```bash
+curl -X POST https://nexspence.example.com/api/v1/migration/preview \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"sourceUrl":"https://nexus.example.com","username":"admin","password":"…"}'
+```
+
+`200` with `{"reachable":true,"repoCount":N,"repos":[…]}`, `422` if the URL is missing or is not an absolute `http(s)` URL, `502` if the source could not be reached — with the underlying error, not a generic failure.
+
+### 2. Choose the scope
+
+Every stage is an independent flag. A repositories-only run touches nothing else; a security-only run creates no repositories.
+
+```bash
+curl -X POST https://nexspence.example.com/api/v1/migration/jobs \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{
+    "sourceUrl": "https://nexus.example.com",
+    "credentials": {"username": "admin", "password": "…"},
+    "scope": {
+      "migrateRepos": true,
+      "migrateBlobs": true,
+      "migratePrivileges": true,
+      "migrateRoles": true,
+      "migrateUsers": true,
+      "migrateRoutingRules": true
+    }
+  }'
+```
+
+Every flag defaults to `true`. `migratePolicies` is the older, coarser switch kept for API compatibility: when a request does not name the three security scopes, they fall back to it.
+
+### 3. Watch it
+
+The job card shows repositories done, assets done, and an error count. `GET /api/v1/migration/jobs/{id}` returns the same numbers.
+
+## The order things happen in
+
+The sequence is fixed, because each stage depends on the one before it.
+
+1. **Repositories** — hosted, then proxy, then group, so a group's members already exist when the group naming them is created. A member that was not migrated is left out of the group rather than blocking it.
+2. **Artifacts** — hosted repositories only.
+3. **Privileges** → **Roles** → **Users** — a role references privileges by name and a user references roles by name, so each must exist before the thing that names it.
+4. **Routing rules** — independent of everything above.
+
+## Container images
+
+Nexus stores registry blobs content-addressed, lists them under a placeholder image name (`/v2/-/blobs/<digest>`), and its component listing reports only the manifest. Copying what that listing reports would produce an image nobody can pull.
+
+So for a `docker` or `oci` repository the migration reads each manifest and uses it as the index of what to fetch:
+
+- an **image index** (multi-platform) is followed into each child manifest first;
+- the manifest's config and layer blobs are fetched from `/v2/<image>/blobs/<digest>` — the path the image actually references them under — and stored **before** the manifest, so the registry never serves a manifest whose layers are still missing;
+- a **tagged** manifest also gets its content-digest alias registered, because a client that pulls by tag immediately re-fetches the same manifest by digest.
+
+Shared layers are transferred once: a blob already present for an image is skipped.
+
+## Nested roles
+
+Nexspence has no nested-role table, so a Nexus role that nests another is **flattened**: the parent takes the union of its own privileges and everything it inherits. The role graph is topologically sorted first, so one pass is enough.
+
+A cycle in the role graph is reported in `errorCount` and `lastError`. The roles involved are still created — each keeping only its own privileges — because dropping a role silently is worse than migrating a flatter version of it.
+
+## Migrated users and passwords
+
+A Nexus password hash cannot come across. A **local** account is therefore created with a random temporary password and `mustResetPassword`, and an **externally-authenticated** account (LDAP, OIDC, SAML) is created with no local credential at all — its identity provider still owns it.
+
+Migrated users log in normally; the flag drives the prompt to choose a new password, and clears the moment one is set. Blocking login until reset was considered and rejected: it strands every migrated user at once, which is the opposite of what an admin bootstrapping a hundred accounts needs.
+
+## Re-running, pausing, restarting
+
+Everything the migration creates is matched by its logical name — repository name, privilege name, role name, username, rule name, asset path. Anything already present is **skipped, not overwritten**. A repository an operator has since reconfigured is left exactly as it is.
+
+That single property is what makes the three lifecycle operations cheap:
+
+- **Re-running** a finished job costs only whatever was not there the first time.
+- **Pause** (`POST /api/v1/migration/jobs/{id}/pause`) stops the run where it stands and keeps its progress. **Resume** starts a fresh pass that skips what is done.
+- **A restart** of Nexspence re-attaches to every job that was still running, on startup. The source credential is persisted for exactly this reason — sealed with the instance encryption key, the same way replication target passwords are, and never returned by the API.
+
+## Failures
+
+A migration copies thousands of independent things, so one that will not come across is counted in `errorCount`, named in `lastError`, and the run continues. Only a failure that makes the rest impossible — the source becoming unreachable, credentials being rejected — ends the job as `error`.
+
+Common entries:
+
+| `lastError` | Meaning |
+|-------------|---------|
+| `format "rubygems" has no Nexspence equivalent` | The source has a repository of a format Nexspence does not serve. It is skipped; everything else still migrates. |
+| `member "x" was not migrated and is left out` | A group named a member that could not be created (usually an unsupported format). |
+| `matcher "…" does not compile` | A routing rule is stored whole or not at all — a half-applied `ALLOW` rule would quietly change what the source permitted. |
+
+## Requirements and limits
+
+- **Nexus admin credentials.** The security endpoints (`/service/rest/v1/security/*`) are admin-only.
+- **Network reachability.** Migration targets are user-supplied URLs, so they go through the same SSRF guard as webhooks and proxy upstreams. A Nexus on an internal address needs that range in `outbound.allowed_internal_cidrs`.
+- **Full repository configuration** comes from `/service/rest/v1/repositorySettings`. An instance that does not expose it — an older version, or credentials without admin rights — falls back to the basic repository listing, which still names every repository but cannot describe group membership or proxy remotes.
+- Regex matchers are copied verbatim. Nexus and Nexspence both use Go-compatible syntax; an implementation on a different engine should re-check them.
+
+## API reference
+
+Full request and response shapes are in [`docs/api-spec.yaml`](api-spec.yaml) under the **Migration** tag.
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/api/v1/migration/preview` | Test the connection; creates nothing |
+| `GET` | `/api/v1/migration/jobs` | List jobs |
+| `POST` | `/api/v1/migration/jobs` | Create a job and start it |
+| `GET` | `/api/v1/migration/jobs/{id}` | Job status and progress |
+| `POST` | `/api/v1/migration/jobs/{id}/pause` | Stop the run, keep the progress |
+| `POST` | `/api/v1/migration/jobs/{id}/resume` | Start a fresh pass |
+| `DELETE` | `/api/v1/migration/jobs/{id}` | Stop the run and delete the record |

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -179,6 +179,10 @@ CREATE TABLE users (
                         CHECK (source IN ('local', 'ldap', 'saml')),
     -- External identity (LDAP DN, SAML NameID)
     external_id     TEXT,
+    -- Set for an account whose password was chosen for it rather than by it —
+    -- a migrated Nexus user given a random temporary one. Cleared on the next
+    -- password change.
+    must_reset_password BOOLEAN NOT NULL DEFAULT FALSE,
     last_login      TIMESTAMPTZ,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -440,13 +444,21 @@ CREATE TABLE migration_jobs (
     id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     source_url      TEXT NOT NULL,
     source_user     TEXT NOT NULL,
+    -- Sealed with the instance encryption key. Kept because a migration must
+    -- survive a restart: the runner re-attaches to jobs left running, long
+    -- after the request that supplied the credential is gone.
+    source_password TEXT NOT NULL DEFAULT '',
     status          TEXT NOT NULL DEFAULT 'pending'
                         CHECK (status IN ('pending','running','paused','done','error')),
-    -- Which parts to migrate
+    -- Which parts to migrate. migrate_policies is the older, coarser switch and
+    -- is the default the three security scopes fall back to.
     migrate_repos   BOOLEAN NOT NULL DEFAULT TRUE,
     migrate_users   BOOLEAN NOT NULL DEFAULT TRUE,
     migrate_blobs   BOOLEAN NOT NULL DEFAULT TRUE,
     migrate_policies BOOLEAN NOT NULL DEFAULT TRUE,
+    migrate_privileges    BOOLEAN NOT NULL DEFAULT TRUE,
+    migrate_roles         BOOLEAN NOT NULL DEFAULT TRUE,
+    migrate_routing_rules BOOLEAN NOT NULL DEFAULT TRUE,
     -- Progress tracking
     total_repos     INT NOT NULL DEFAULT 0,
     done_repos      INT NOT NULL DEFAULT 0,
@@ -463,6 +475,9 @@ CREATE TABLE migration_jobs (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- Read on every startup, to re-attach to jobs a restart interrupted.
+CREATE INDEX idx_migration_jobs_status ON migration_jobs(status);
 
 -- ============================================================
 -- SEED DATA — built-in roles and privileges

--- a/frontend/src/pages/MigrationPage.test.tsx
+++ b/frontend/src/pages/MigrationPage.test.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import MigrationPage from './MigrationPage'
+import { shouldPollJobs } from './migrationJobs'
 import { renderWithProviders, seedAuthAsAdmin } from '@/test/renderUtils'
 import { server } from '@/test/msw/server'
 
@@ -148,5 +149,157 @@ describe('MigrationPage', () => {
     const initial = calls
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
     await waitFor(() => expect(calls).toBeGreaterThan(initial))
+  })
+})
+
+describe('MigrationPage — job status from the engine', () => {
+  beforeEach(() => {
+    seedAuthAsAdmin()
+  })
+
+  it('renders the terminal statuses the API actually returns', async () => {
+    server.use(
+      http.get('/api/v1/migration/jobs', () =>
+        HttpResponse.json([
+          job({ id: 'j-done', status: 'done' }),
+          job({ id: 'j-error', status: 'error', lastError: 'connection refused' }),
+        ]),
+      ),
+    )
+    renderWithProviders(<MigrationPage />)
+    expect(await screen.findByText('done')).toBeInTheDocument()
+    expect(screen.getByText('error')).toBeInTheDocument()
+    // A finished job offers neither Pause nor Resume.
+    expect(screen.queryByRole('button', { name: /Pause/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Resume/ })).not.toBeInTheDocument()
+  })
+
+  it('shows the last error reported by a job', async () => {
+    server.use(
+      http.get('/api/v1/migration/jobs', () =>
+        HttpResponse.json([job({ status: 'error', lastError: 'nexus returned 401' })]),
+      ),
+    )
+    renderWithProviders(<MigrationPage />)
+    expect(await screen.findByText(/nexus returned 401/)).toBeInTheDocument()
+  })
+
+  it('keeps polling while a job is pending or running, and stops once it settles', () => {
+    expect(shouldPollJobs([{ status: 'pending' }])).toBe(3000)
+    expect(shouldPollJobs([{ status: 'running' }])).toBe(3000)
+    expect(shouldPollJobs([{ status: 'done' }, { status: 'paused' }])).toBe(false)
+    expect(shouldPollJobs([])).toBe(false)
+    expect(shouldPollJobs(undefined)).toBe(false)
+  })
+})
+
+describe('MigrationPage — test connection', () => {
+  beforeEach(() => {
+    seedAuthAsAdmin()
+  })
+
+  const openModal = async (user: ReturnType<typeof userEvent.setup>) => {
+    renderWithProviders(<MigrationPage />)
+    await screen.findByText('No migration jobs yet')
+    await user.click(screen.getByRole('button', { name: /New Migration/ }))
+    await screen.findByRole('heading', { name: 'New Migration Job' })
+  }
+
+  it('reports a reachable Nexus with the repositories it found', async () => {
+    const user = userEvent.setup()
+    let sent: unknown = null
+    server.use(
+      http.post('/api/v1/migration/preview', async ({ request }) => {
+        sent = await request.json()
+        return HttpResponse.json({
+          reachable: true,
+          repoCount: 2,
+          repos: [
+            { name: 'raw-hosted', format: 'raw', type: 'hosted' },
+            { name: 'maven-central', format: 'maven2', type: 'proxy' },
+          ],
+        })
+      }),
+    )
+    await openModal(user)
+
+    await user.type(screen.getByPlaceholderText('https://nexus.example.com'), 'https://src.example.com')
+    const pwd = document.querySelector('input[type="password"]') as HTMLInputElement
+    await user.type(pwd, 'secret')
+    await user.click(screen.getByRole('button', { name: /Test connection/ }))
+
+    expect(await screen.findByText(/Connected — 2 repositories/)).toBeInTheDocument()
+    expect(screen.getByText(/raw-hosted/)).toBeInTheDocument()
+    expect(sent).toEqual({
+      sourceUrl: 'https://src.example.com',
+      username: 'admin',
+      password: 'secret',
+    })
+  })
+
+  it('shows the underlying reason when the Nexus cannot be reached', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/v1/migration/preview', () =>
+        HttpResponse.json({ error: 'dial tcp: connection refused', reachable: false }, { status: 502 }),
+      ),
+    )
+    await openModal(user)
+
+    await user.type(screen.getByPlaceholderText('https://nexus.example.com'), 'https://bad.invalid')
+    await user.click(screen.getByRole('button', { name: /Test connection/ }))
+
+    expect(await screen.findByText(/connection refused/)).toBeInTheDocument()
+  })
+
+  it('drops a stale result as soon as the connection details change', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.post('/api/v1/migration/preview', () =>
+        HttpResponse.json({ reachable: true, repoCount: 1, repos: [{ name: 'raw-hosted', format: 'raw', type: 'hosted' }] }),
+      ),
+    )
+    await openModal(user)
+
+    const url = screen.getByPlaceholderText('https://nexus.example.com')
+    await user.type(url, 'https://src.example.com')
+    await user.click(screen.getByRole('button', { name: /Test connection/ }))
+    expect(await screen.findByText(/Connected — 1 repositor/)).toBeInTheDocument()
+
+    await user.type(url, '/extra')
+    await waitFor(() =>
+      expect(screen.queryByText(/Connected — 1 repositor/)).not.toBeInTheDocument(),
+    )
+  })
+
+  it('sends the scopes the operator selected', async () => {
+    const user = userEvent.setup()
+    let posted: { scope?: Record<string, boolean> } | null = null
+    server.use(
+      http.post('/api/v1/migration/jobs', async ({ request }) => {
+        posted = (await request.json()) as { scope?: Record<string, boolean> }
+        return HttpResponse.json({ id: 'new-job' }, { status: 201 })
+      }),
+    )
+    await openModal(user)
+
+    await user.type(screen.getByPlaceholderText('https://nexus.example.com'), 'https://src.example.com')
+    const pwd = document.querySelector('input[type="password"]') as HTMLInputElement
+    await user.type(pwd, 'secret')
+    await user.click(screen.getByRole('checkbox', { name: /Users/ }))
+    await user.click(screen.getByRole('checkbox', { name: /Routing rules/ }))
+
+    const submit = pwd.closest('form')!.querySelector('button[type="submit"]') as HTMLButtonElement
+    await user.click(submit)
+
+    await waitFor(() => expect(posted).toBeTruthy())
+    expect(posted!.scope).toEqual({
+      migrateRepos: true,
+      migrateBlobs: true,
+      migrateUsers: false,
+      migratePrivileges: true,
+      migrateRoles: true,
+      migrateRoutingRules: false,
+    })
   })
 })

--- a/frontend/src/pages/MigrationPage.tsx
+++ b/frontend/src/pages/MigrationPage.tsx
@@ -1,26 +1,17 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { ArrowRightLeft, Play, Pause, RefreshCw, Plus } from 'lucide-react'
+import { ArrowRightLeft, Play, Pause, RefreshCw, Plus, PlugZap } from 'lucide-react'
 import { nexspenceApi, apiErrorMessage } from '@/api/client'
 import { HoloCard, HoloButton, HoloPill, HoloInput, HoloModal } from '@/components/holo'
-
-interface MigrationJob {
-  id: string
-  status: 'pending' | 'running' | 'paused' | 'completed' | 'failed'
-  sourceUrl: string
-  repositoriesTotal: number
-  repositoriesDone: number
-  assetsTotal: number
-  assetsDone: number
-  errorCount: number
-  createdAt: string
-  updatedAt: string
-}
+import { type MigrationJob, shouldPollJobs } from './migrationJobs'
 
 const STATUS_STYLE: Record<string, { bg: string; color: string }> = {
   pending:   { bg: 'rgba(245,158,11,0.15)',  color: '#f59e0b' },
   running:   { bg: 'rgba(59,130,246,0.15)',  color: '#3b82f6' },
   paused:    { bg: 'rgba(107,114,128,0.15)', color: '#9ca3af' },
+  done:      { bg: 'rgba(34,197,94,0.15)',   color: '#22c55e' },
+  error:     { bg: 'rgba(239,68,68,0.15)',   color: '#ef4444' },
+  // Kept for jobs recorded by older builds, which used these two labels.
   completed: { bg: 'rgba(34,197,94,0.15)',   color: '#22c55e' },
   failed:    { bg: 'rgba(239,68,68,0.15)',   color: '#ef4444' },
 }
@@ -32,10 +23,7 @@ export default function MigrationPage() {
   const { data: jobs = [], isLoading, refetch } = useQuery<MigrationJob[]>({
     queryKey: ['migrationJobs'],
     queryFn: () => nexspenceApi.listMigrationJobs().then(r => r.data),
-    refetchInterval: (q) => {
-      const list = q.state.data as MigrationJob[] | undefined
-      return list?.some(j => j.status === 'running') ? 3000 : false
-    },
+    refetchInterval: (q) => shouldPollJobs(q.state.data as MigrationJob[] | undefined),
   })
 
   const pauseMut = useMutation({
@@ -115,6 +103,12 @@ export default function MigrationPage() {
                   </div>
                 </div>
 
+                {job.lastError && (
+                  <div style={{ background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.2)', borderRadius: 8, padding: '8px 12px', fontSize: 12, color: '#fca5a5', wordBreak: 'break-word' }}>
+                    {job.lastError}
+                  </div>
+                )}
+
                 <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                   <span style={{ fontSize: 12, color: 'var(--holo-text-faint)' }}>Started {new Date(job.createdAt).toLocaleString()}</span>
                   <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
@@ -145,13 +139,59 @@ export default function MigrationPage() {
   )
 }
 
+interface PreviewRepo { name: string; format: string; type: string }
+interface PreviewResult { reachable: boolean; repoCount: number; repos: PreviewRepo[] }
+
+/** The stages a job can run, in the order the engine runs them. */
+const SCOPES = [
+  { key: 'migrateRepos',        label: 'Repositories' },
+  { key: 'migrateBlobs',        label: 'Artifacts' },
+  { key: 'migratePrivileges',   label: 'Privileges' },
+  { key: 'migrateRoles',        label: 'Roles' },
+  { key: 'migrateUsers',        label: 'Users' },
+  { key: 'migrateRoutingRules', label: 'Routing rules' },
+] as const
+
+type ScopeKey = (typeof SCOPES)[number]['key']
+
 function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
   const [form, setForm] = useState({ sourceUrl: '', username: 'admin', password: '', concurrency: '4' })
+  const [scope, setScope] = useState<Record<ScopeKey, boolean>>(
+    () => Object.fromEntries(SCOPES.map(s => [s.key, true])) as Record<ScopeKey, boolean>,
+  )
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [preview, setPreview] = useState<PreviewResult | null>(null)
+  const [previewError, setPreviewError] = useState('')
 
-  const set = (k: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) =>
+  const set = (k: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    // A connection result belongs to the details it was tested with. Once any
+    // of them changes it is stale, and a stale green banner is worse than none.
+    setPreview(null)
+    setPreviewError('')
     setForm(f => ({ ...f, [k]: e.target.value }))
+  }
+
+  const toggleScope = (k: ScopeKey) => () => setScope(s => ({ ...s, [k]: !s[k] }))
+
+  const handleTest = async () => {
+    setPreview(null)
+    setPreviewError('')
+    setTesting(true)
+    try {
+      const { data } = await nexspenceApi.previewMigration({
+        sourceUrl: form.sourceUrl,
+        username: form.username,
+        password: form.password,
+      })
+      setPreview(data as PreviewResult)
+    } catch (err) {
+      setPreviewError(apiErrorMessage(err, 'Could not reach that Nexus'))
+    } finally {
+      setTesting(false)
+    }
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -162,6 +202,7 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
         sourceUrl: form.sourceUrl,
         credentials: { username: form.username, password: form.password },
         options: { concurrency: parseInt(form.concurrency) || 4 },
+        scope,
       })
       onCreated()
     } catch (err) {
@@ -177,8 +218,33 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
       <form style={{ display: 'flex', flexDirection: 'column', gap: 14 }} onSubmit={handleSubmit}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
           <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Nexus URL *</label>
-          <HoloInput placeholder="https://nexus.example.com" value={form.sourceUrl} onChange={set('sourceUrl')} required />
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <HoloInput style={{ flex: 1 }} placeholder="https://nexus.example.com" value={form.sourceUrl} onChange={set('sourceUrl')} required />
+            <HoloButton type="button" onClick={handleTest} disabled={testing || !form.sourceUrl}>
+              <PlugZap size={14} /> {testing ? 'Testing…' : 'Test connection'}
+            </HoloButton>
+          </div>
         </div>
+
+        {preview && (
+          <div style={{ background: 'rgba(34,197,94,0.1)', border: '1px solid rgba(34,197,94,0.25)', borderRadius: 8, padding: '10px 12px', color: '#86efac', fontSize: 13 }}>
+            <div style={{ fontWeight: 600 }}>
+              Connected — {preview.repoCount} {preview.repoCount === 1 ? 'repository' : 'repositories'} found
+            </div>
+            {preview.repos.length > 0 && (
+              <div style={{ marginTop: 6, fontFamily: 'monospace', fontSize: 12, maxHeight: 120, overflowY: 'auto', lineHeight: 1.6 }}>
+                {preview.repos.map(r => (
+                  <div key={r.name}>{r.name} <span style={{ opacity: 0.7 }}>({r.format}/{r.type})</span></div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        {previewError && (
+          <div style={{ background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.25)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13, wordBreak: 'break-word' }}>
+            {previewError}
+          </div>
+        )}
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
             <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Username</label>
@@ -192,6 +258,17 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
         <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
           <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Concurrency</label>
           <HoloInput type="number" min={1} max={16} value={form.concurrency} onChange={set('concurrency')} />
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>What to migrate</label>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px 12px' }}>
+            {SCOPES.map(s => (
+              <label key={s.key} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--holo-text)', cursor: 'pointer' }}>
+                <input type="checkbox" checked={scope[s.key]} onChange={toggleScope(s.key)} />
+                {s.label}
+              </label>
+            ))}
+          </div>
         </div>
         {error && <div style={{ background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.25)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13 }}>{error}</div>}
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 8 }}>

--- a/frontend/src/pages/migrationJobs.ts
+++ b/frontend/src/pages/migrationJobs.ts
@@ -1,0 +1,26 @@
+/** A Nexus → Nexspence migration job, as the API reports it. */
+export interface MigrationJob {
+  id: string
+  status: 'pending' | 'running' | 'paused' | 'done' | 'error'
+  sourceUrl: string
+  repositoriesTotal: number
+  repositoriesDone: number
+  assetsTotal: number
+  assetsDone: number
+  errorCount: number
+  lastError?: string
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * How often to re-read the job list, or false to stop.
+ *
+ * A pending job counts as live: it is one the runner has picked up but not yet
+ * reported on, and it is exactly the state that used to sit there forever.
+ * A paused job is parked by an operator and changes nothing on its own.
+ */
+export function shouldPollJobs(jobs?: { status: string }[]): number | false {
+  const live = jobs?.some(j => j.status === 'pending' || j.status === 'running')
+  return live ? 3000 : false
+}

--- a/internal/api/handlers/migration.go
+++ b/internal/api/handlers/migration.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 
@@ -8,57 +9,70 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/service"
 )
 
-// MigrationHandler serves the Nexus-migration job REST endpoints.
+// MigrationHandler serves the Nexus-migration job REST endpoints. Reads come
+// straight from the job repository; anything that starts, stops or inspects a
+// live migration goes through the runner.
 type MigrationHandler struct {
 	repo repository.MigrationRepo
+	svc  *service.NexusMigrationService
 }
 
-// NewMigrationHandler constructs a MigrationHandler backed by the given migration repository.
-func NewMigrationHandler(repo repository.MigrationRepo) *MigrationHandler {
-	return &MigrationHandler{repo: repo}
+// NewMigrationHandler constructs a MigrationHandler over the job repository and
+// the migration runner.
+func NewMigrationHandler(repo repository.MigrationRepo, svc *service.NexusMigrationService) *MigrationHandler {
+	return &MigrationHandler{repo: repo, svc: svc}
 }
 
 type migrationJobResp struct {
-	ID                string  `json:"id"`
-	SourceURL         string  `json:"sourceUrl"`
-	SourceUser        string  `json:"sourceUser"`
-	Status            string  `json:"status"`
-	MigrateRepos      bool    `json:"migrateRepos"`
-	MigrateUsers      bool    `json:"migrateUsers"`
-	MigrateBlobs      bool    `json:"migrateBlobs"`
-	MigratePolicies   bool    `json:"migratePolicies"`
-	RepositoriesTotal int     `json:"repositoriesTotal"`
-	RepositoriesDone  int     `json:"repositoriesDone"`
-	AssetsTotal       int64   `json:"assetsTotal"`
-	AssetsDone        int64   `json:"assetsDone"`
-	ErrorCount        int     `json:"errorCount"`
-	LastError         *string `json:"lastError,omitempty"`
-	StartedAt         *string `json:"startedAt,omitempty"`
-	FinishedAt        *string `json:"finishedAt,omitempty"`
-	CreatedAt         string  `json:"createdAt"`
-	UpdatedAt         string  `json:"updatedAt"`
+	ID                  string  `json:"id"`
+	SourceURL           string  `json:"sourceUrl"`
+	SourceUser          string  `json:"sourceUser"`
+	Status              string  `json:"status"`
+	MigrateRepos        bool    `json:"migrateRepos"`
+	MigrateUsers        bool    `json:"migrateUsers"`
+	MigrateBlobs        bool    `json:"migrateBlobs"`
+	MigratePolicies     bool    `json:"migratePolicies"`
+	MigratePrivileges   bool    `json:"migratePrivileges"`
+	MigrateRoles        bool    `json:"migrateRoles"`
+	MigrateRoutingRules bool    `json:"migrateRoutingRules"`
+	RepositoriesTotal   int     `json:"repositoriesTotal"`
+	RepositoriesDone    int     `json:"repositoriesDone"`
+	AssetsTotal         int64   `json:"assetsTotal"`
+	AssetsDone          int64   `json:"assetsDone"`
+	ErrorCount          int     `json:"errorCount"`
+	LastError           *string `json:"lastError,omitempty"`
+	StartedAt           *string `json:"startedAt,omitempty"`
+	FinishedAt          *string `json:"finishedAt,omitempty"`
+	CreatedAt           string  `json:"createdAt"`
+	UpdatedAt           string  `json:"updatedAt"`
 }
 
+// toJobResp maps a job onto its API shape. SourcePassword is deliberately
+// absent: it is stored sealed and never leaves the process.
 func toJobResp(j domain.MigrationJob) migrationJobResp {
 	r := migrationJobResp{
-		ID:                j.ID,
-		SourceURL:         j.SourceURL,
-		SourceUser:        j.SourceUser,
-		Status:            string(j.Status),
-		MigrateRepos:      j.MigrateRepos,
-		MigrateUsers:      j.MigrateUsers,
-		MigrateBlobs:      j.MigrateBlobs,
-		MigratePolicies:   j.MigratePolicies,
-		RepositoriesTotal: j.TotalRepos,
-		RepositoriesDone:  j.DoneRepos,
-		AssetsTotal:       j.TotalAssets,
-		AssetsDone:        j.DoneAssets,
-		ErrorCount:        j.ErrorCount,
-		LastError:         j.LastError,
-		CreatedAt:         j.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
-		UpdatedAt:         j.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		ID:                  j.ID,
+		SourceURL:           j.SourceURL,
+		SourceUser:          j.SourceUser,
+		Status:              string(j.Status),
+		MigrateRepos:        j.MigrateRepos,
+		MigrateUsers:        j.MigrateUsers,
+		MigrateBlobs:        j.MigrateBlobs,
+		MigratePolicies:     j.MigratePolicies,
+		MigratePrivileges:   j.MigratePrivileges,
+		MigrateRoles:        j.MigrateRoles,
+		MigrateRoutingRules: j.MigrateRoutingRules,
+		RepositoriesTotal:   j.TotalRepos,
+		RepositoriesDone:    j.DoneRepos,
+		AssetsTotal:         j.TotalAssets,
+		AssetsDone:          j.DoneAssets,
+		ErrorCount:          j.ErrorCount,
+		LastError:           j.LastError,
+		CreatedAt:           j.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:           j.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
 	if j.StartedAt != nil {
 		s := j.StartedAt.Format("2006-01-02T15:04:05Z07:00")
@@ -89,11 +103,7 @@ func (h *MigrationHandler) ListJobs(c *gin.Context) {
 func (h *MigrationHandler) GetJob(c *gin.Context) {
 	job, err := h.repo.Get(c.Request.Context(), c.Param("id"))
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondMigrationErr(c, err)
 		return
 	}
 	c.JSON(http.StatusOK, toJobResp(*job))
@@ -109,10 +119,13 @@ type createJobReq struct {
 		Concurrency int `json:"concurrency"`
 	} `json:"options"`
 	Scope struct {
-		MigrateRepos    *bool `json:"migrateRepos"`
-		MigrateUsers    *bool `json:"migrateUsers"`
-		MigrateBlobs    *bool `json:"migrateBlobs"`
-		MigratePolicies *bool `json:"migratePolicies"`
+		MigrateRepos        *bool `json:"migrateRepos"`
+		MigrateUsers        *bool `json:"migrateUsers"`
+		MigrateBlobs        *bool `json:"migrateBlobs"`
+		MigratePolicies     *bool `json:"migratePolicies"`
+		MigratePrivileges   *bool `json:"migratePrivileges"`
+		MigrateRoles        *bool `json:"migrateRoles"`
+		MigrateRoutingRules *bool `json:"migrateRoutingRules"`
 	} `json:"scope"`
 }
 
@@ -123,7 +136,7 @@ func boolDefault(b *bool, def bool) bool {
 	return *b
 }
 
-// CreateJob handles POST /api/v1/migration/jobs — creates a pending migration job.
+// CreateJob handles POST /api/v1/migration/jobs — creates the job and starts it.
 func (h *MigrationHandler) CreateJob(c *gin.Context) {
 	var req createJobReq
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -131,54 +144,102 @@ func (h *MigrationHandler) CreateJob(c *gin.Context) {
 		return
 	}
 
+	// migratePolicies used to be the single switch for the security model. It
+	// stays the default the finer-grained scopes fall back to, so a client
+	// written against the older shape still gets what it asked for.
+	policies := boolDefault(req.Scope.MigratePolicies, true)
+
 	job := &domain.MigrationJob{
-		SourceURL:       req.SourceURL,
-		SourceUser:      req.Credentials.Username,
-		Status:          domain.MigrationPending,
-		MigrateRepos:    boolDefault(req.Scope.MigrateRepos, true),
-		MigrateUsers:    boolDefault(req.Scope.MigrateUsers, true),
-		MigrateBlobs:    boolDefault(req.Scope.MigrateBlobs, true),
-		MigratePolicies: boolDefault(req.Scope.MigratePolicies, true),
+		SourceURL:           req.SourceURL,
+		SourceUser:          req.Credentials.Username,
+		MigrateRepos:        boolDefault(req.Scope.MigrateRepos, true),
+		MigrateUsers:        boolDefault(req.Scope.MigrateUsers, true),
+		MigrateBlobs:        boolDefault(req.Scope.MigrateBlobs, true),
+		MigratePolicies:     policies,
+		MigratePrivileges:   boolDefault(req.Scope.MigratePrivileges, policies),
+		MigrateRoles:        boolDefault(req.Scope.MigrateRoles, policies),
+		MigrateRoutingRules: boolDefault(req.Scope.MigrateRoutingRules, policies),
 	}
 
-	if err := h.repo.Create(c.Request.Context(), job); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.svc.Create(c.Request.Context(), job, req.Credentials.Password); err != nil {
+		respondMigrationErr(c, err)
 		return
 	}
 	c.JSON(http.StatusCreated, toJobResp(*job))
 }
 
-// PauseJob handles the pause action, setting the job status to paused.
+// PauseJob handles POST /api/v1/migration/jobs/:id/pause — stops the run and
+// parks the job where it stands.
 func (h *MigrationHandler) PauseJob(c *gin.Context) {
-	h.setStatus(c, domain.MigrationPaused)
+	if err := h.svc.Pause(c.Request.Context(), c.Param("id")); err != nil {
+		respondMigrationErr(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
-// ResumeJob handles the resume action, setting the job status back to running.
+// ResumeJob handles POST /api/v1/migration/jobs/:id/resume — starts a fresh
+// pass that skips everything already migrated.
 func (h *MigrationHandler) ResumeJob(c *gin.Context) {
-	h.setStatus(c, domain.MigrationRunning)
+	if err := h.svc.Resume(c.Request.Context(), c.Param("id")); err != nil {
+		respondMigrationErr(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
 }
 
 // DeleteJob handles DELETE /api/v1/migration/jobs/:id — removes a migration job.
 func (h *MigrationHandler) DeleteJob(c *gin.Context) {
-	if err := h.repo.Delete(c.Request.Context(), c.Param("id")); err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	id := c.Param("id")
+	// Stop the runner first: deleting the row under a live goroutine would
+	// leave it writing progress to a job that no longer exists.
+	_ = h.svc.Pause(c.Request.Context(), id)
+	if err := h.repo.Delete(c.Request.Context(), id); err != nil {
+		respondMigrationErr(c, err)
 		return
 	}
 	c.Status(http.StatusNoContent)
 }
 
-func (h *MigrationHandler) setStatus(c *gin.Context, status domain.MigrationJobStatus) {
-	if err := h.repo.UpdateStatus(c.Request.Context(), c.Param("id"), status); err != nil {
-		if strings.Contains(err.Error(), "not found") {
-			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+type previewReq struct {
+	SourceURL string `json:"sourceUrl"`
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+}
+
+// Preview handles POST /api/v1/migration/preview — a read-only reachability
+// check against a Nexus instance. It creates nothing, so it is safe to call as
+// often as an operator edits the form.
+func (h *MigrationHandler) Preview(c *gin.Context) {
+	var req previewReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	c.Status(http.StatusNoContent)
+
+	res, err := h.svc.Preview(c.Request.Context(), req.SourceURL, req.Username, req.Password)
+	if errors.Is(err, service.ErrInvalidInput) {
+		// The request was understood and rejected on its content, not its shape.
+		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error(), "reachable": false})
+		return
+	}
+	if err != nil {
+		// The failure is upstream: the operator needs the underlying reason,
+		// not a generic 500 that reads like a bug here.
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error(), "reachable": false})
+		return
+	}
+	c.JSON(http.StatusOK, res)
+}
+
+// respondMigrationErr maps a service or repository error onto a status code.
+func respondMigrationErr(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrInvalidInput):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	case errors.Is(err, repository.ErrNotFound), strings.Contains(err.Error(), "not found"):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
 }

--- a/internal/api/handlers/migration_test.go
+++ b/internal/api/handlers/migration_test.go
@@ -1,100 +1,77 @@
 package handlers_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
-// migrationRepoMock is a minimal in-memory repository.MigrationRepo for handler tests.
-// No MigrationRepo mock exists in internal/testutil, so we define a local one here.
-type migrationRepoMock struct {
-	jobs map[string]*domain.MigrationJob
-	// listErr/getErr/createErr/updateErr/deleteErr force the corresponding 500 branches.
-	listErr   error
-	getErr    error
-	createErr error
-	updateErr error
-	deleteErr error
+// stubRoundTrip answers every outbound request from the migration runner, so a
+// handler test never depends on a reachable Nexus.
+type stubRoundTrip func(*http.Request) (*http.Response, error)
+
+func (f stubRoundTrip) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// emptyNexus answers every REST call with an empty list: a job created in a
+// handler test runs to completion immediately and touches nothing.
+func emptyNexus() stubRoundTrip {
+	return func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`[]`)),
+		}, nil
+	}
 }
 
-func newMigrationRepoMock() *migrationRepoMock {
-	return &migrationRepoMock{jobs: make(map[string]*domain.MigrationJob)}
+func mountMigration(t *testing.T) (*gin.Engine, *testutil.MigrationRepo) {
+	return mountMigrationWith(t, emptyNexus())
 }
 
-func (m *migrationRepoMock) List(_ context.Context) ([]domain.MigrationJob, error) {
-	if m.listErr != nil {
-		return nil, m.listErr
-	}
-	out := make([]domain.MigrationJob, 0, len(m.jobs))
-	for _, j := range m.jobs {
-		out = append(out, *j)
-	}
-	return out, nil
-}
-
-func (m *migrationRepoMock) Get(_ context.Context, id string) (*domain.MigrationJob, error) {
-	if m.getErr != nil {
-		return nil, m.getErr
-	}
-	j, ok := m.jobs[id]
-	if !ok {
-		return nil, errors.New("migration job not found")
-	}
-	return j, nil
-}
-
-func (m *migrationRepoMock) Create(_ context.Context, job *domain.MigrationJob) error {
-	if m.createErr != nil {
-		return m.createErr
-	}
-	if job.ID == "" {
-		job.ID = "job-" + job.SourceURL
-	}
-	now := time.Now()
-	job.CreatedAt = now
-	job.UpdatedAt = now
-	m.jobs[job.ID] = job
-	return nil
-}
-
-func (m *migrationRepoMock) UpdateStatus(_ context.Context, id string, status domain.MigrationJobStatus) error {
-	if m.updateErr != nil {
-		return m.updateErr
-	}
-	j, ok := m.jobs[id]
-	if !ok {
-		return errors.New("migration job not found")
-	}
-	j.Status = status
-	return nil
-}
-
-func (m *migrationRepoMock) Delete(_ context.Context, id string) error {
-	if m.deleteErr != nil {
-		return m.deleteErr
-	}
-	if _, ok := m.jobs[id]; !ok {
-		return errors.New("migration job not found")
-	}
-	delete(m.jobs, id)
-	return nil
-}
-
-func mountMigration(t *testing.T) (*gin.Engine, *migrationRepoMock) {
+func mountMigrationWith(t *testing.T, rt stubRoundTrip) (*gin.Engine, *testutil.MigrationRepo) {
 	t.Helper()
-	repo := newMigrationRepoMock()
-	h := handlers.NewMigrationHandler(repo)
+	repo := testutil.NewMigrationRepo()
+
+	repoRepo := testutil.NewRepoRepo()
+	blobRepo := testutil.NewBlobStoreRepo()
+	blobStore := testutil.NewBlobStore()
+
+	svc := service.NewNexusMigrationService(service.NexusMigrationConfig{
+		Jobs:         repo,
+		Repos:        service.NewRepositoryService(repoRepo, blobRepo, blobStore, testutil.NewCleanupPolicyRepo()),
+		Users:        &noopUserStore{},
+		Roles:        testutil.NewRoleRepo(),
+		Privileges:   testutil.NewPrivilegeRepo(),
+		RoutingRules: testutil.NewRoutingRuleRepo(),
+		Deps: formats.Deps{
+			Repos: repoRepo, Components: testutil.NewComponentRepo(),
+			Assets: testutil.NewAssetRepo(), Blobs: blobRepo, BlobStore: blobStore,
+		},
+		JWTSecret: "handler-test-secret",
+		Log:       zap.NewNop().Sugar(),
+		HTTPClientFor: func(timeout time.Duration) *http.Client {
+			return &http.Client{Timeout: timeout, Transport: rt}
+		},
+	})
+
+	h := handlers.NewMigrationHandler(repo, svc)
 	r := gin.New()
 	r.GET("/api/v1/migration/jobs", h.ListJobs)
 	r.GET("/api/v1/migration/jobs/:id", h.GetJob)
@@ -102,7 +79,41 @@ func mountMigration(t *testing.T) (*gin.Engine, *migrationRepoMock) {
 	r.POST("/api/v1/migration/jobs/:id/pause", h.PauseJob)
 	r.POST("/api/v1/migration/jobs/:id/resume", h.ResumeJob)
 	r.DELETE("/api/v1/migration/jobs/:id", h.DeleteJob)
+	r.POST("/api/v1/migration/preview", h.Preview)
 	return r, repo
+}
+
+// noopUserStore stands in for user management the handler tests never exercise.
+type noopUserStore struct{}
+
+func (noopUserStore) Get(_ context.Context, _ string) (*domain.User, error) {
+	return nil, service.ErrNotFound
+}
+func (noopUserStore) Create(_ context.Context, _ *domain.User, _ string) error { return nil }
+
+// jobStatus reads the job back, failing the test if it is gone.
+func jobStatus(t *testing.T, repo *testutil.MigrationRepo, id string) domain.MigrationJobStatus {
+	t.Helper()
+	j, err := repo.Get(testContext(), id)
+	require.NoError(t, err)
+	return j.Status
+}
+
+// waitForJob polls until pred holds, which is how a test observes a runner
+// goroutine without guessing at timings.
+func waitForJob(t *testing.T, repo *testutil.MigrationRepo, id string, pred func(domain.MigrationJob) bool) domain.MigrationJob {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		j, err := repo.Get(testContext(), id)
+		require.NoError(t, err)
+		if pred(*j) {
+			return *j
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("job %s never reached the expected state", id)
+	return domain.MigrationJob{}
 }
 
 // ── ListJobs ────────────────────────────────────────────────────────────────
@@ -132,9 +143,21 @@ func TestMigration_ListJobs_WithJob(t *testing.T) {
 	assert.Equal(t, "pending", got[0]["status"])
 }
 
+func TestMigration_ListJobs_NeverLeaksTheSourcePassword(t *testing.T) {
+	r, repo := mountMigration(t)
+	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{
+		ID: "j1", SourceURL: "https://nexus.example.com", SourceUser: "admin",
+		SourcePassword: "sealed-secret-value", Status: domain.MigrationPending,
+	}))
+	rec := do(t, r, http.MethodGet, "/api/v1/migration/jobs", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "sealed-secret-value")
+	assert.NotContains(t, strings.ToLower(rec.Body.String()), "password")
+}
+
 func TestMigration_ListJobs_RepoError_500(t *testing.T) {
 	r, repo := mountMigration(t)
-	repo.listErr = errors.New("db down")
+	repo.ListErr = errors.New("db down")
 	rec := do(t, r, http.MethodGet, "/api/v1/migration/jobs", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
@@ -143,22 +166,19 @@ func TestMigration_ListJobs_RepoError_500(t *testing.T) {
 
 func TestMigration_GetJob_OK(t *testing.T) {
 	r, repo := mountMigration(t)
-	started := time.Now()
-	finished := started.Add(time.Hour)
-	errMsg := "boom"
+	started := time.Now().UTC()
 	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{
-		ID: "g1", SourceURL: "https://src", Status: domain.MigrationDone,
-		StartedAt: &started, FinishedAt: &finished, LastError: &errMsg, ErrorCount: 2,
+		ID: "g1", SourceURL: "https://nexus.example.com", Status: domain.MigrationRunning,
+		TotalRepos: 4, DoneRepos: 2, TotalAssets: 100, DoneAssets: 40, StartedAt: &started,
 	}))
 	rec := do(t, r, http.MethodGet, "/api/v1/migration/jobs/g1", nil)
 	require.Equal(t, http.StatusOK, rec.Code)
 	var got map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
-	assert.Equal(t, "g1", got["id"])
-	assert.Equal(t, "done", got["status"])
+	assert.Equal(t, "running", got["status"])
+	assert.InDelta(t, 4, got["repositoriesTotal"], 0.001)
+	assert.InDelta(t, 40, got["assetsDone"], 0.001)
 	assert.NotEmpty(t, got["startedAt"])
-	assert.NotEmpty(t, got["finishedAt"])
-	assert.Equal(t, "boom", got["lastError"])
 }
 
 func TestMigration_GetJob_NotFound_404(t *testing.T) {
@@ -169,14 +189,12 @@ func TestMigration_GetJob_NotFound_404(t *testing.T) {
 
 func TestMigration_GetJob_RepoError_500(t *testing.T) {
 	r, repo := mountMigration(t)
-	repo.getErr = errors.New("db down")
+	repo.GetErr = errors.New("db down")
 	rec := do(t, r, http.MethodGet, "/api/v1/migration/jobs/any", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
-// ── CreateJob ─────────────────────────────────────────────────────────────────
-// CreateJob only persists the job record and returns it; the handler does not
-// start any background migration worker, so the full create path is reachable.
+// ── CreateJob ───────────────────────────────────────────────────────────────
 
 func TestMigration_CreateJob_OK_DefaultScope(t *testing.T) {
 	r, _ := mountMigration(t)
@@ -190,11 +208,13 @@ func TestMigration_CreateJob_OK_DefaultScope(t *testing.T) {
 	assert.Equal(t, "https://nexus.example.com", got["sourceUrl"])
 	assert.Equal(t, "admin", got["sourceUser"])
 	assert.Equal(t, "pending", got["status"])
-	// scope omitted → all four flags default to true
-	assert.Equal(t, true, got["migrateRepos"])
-	assert.Equal(t, true, got["migrateUsers"])
-	assert.Equal(t, true, got["migrateBlobs"])
-	assert.Equal(t, true, got["migratePolicies"])
+	// scope omitted → every stage is on
+	for _, key := range []string{
+		"migrateRepos", "migrateUsers", "migrateBlobs", "migratePolicies",
+		"migratePrivileges", "migrateRoles", "migrateRoutingRules",
+	} {
+		assert.Equal(t, true, got[key], key)
+	}
 }
 
 func TestMigration_CreateJob_OK_ExplicitScope(t *testing.T) {
@@ -202,10 +222,11 @@ func TestMigration_CreateJob_OK_ExplicitScope(t *testing.T) {
 	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs", map[string]any{
 		"sourceUrl": "https://nexus.example.com",
 		"scope": map[string]any{
-			"migrateRepos":    false,
-			"migrateUsers":    true,
-			"migrateBlobs":    false,
-			"migratePolicies": false,
+			"migrateRepos":        false,
+			"migrateUsers":        true,
+			"migrateBlobs":        false,
+			"migratePolicies":     false,
+			"migrateRoutingRules": true,
 		},
 	})
 	require.Equal(t, http.StatusCreated, rec.Code)
@@ -215,6 +236,27 @@ func TestMigration_CreateJob_OK_ExplicitScope(t *testing.T) {
 	assert.Equal(t, true, got["migrateUsers"])
 	assert.Equal(t, false, got["migrateBlobs"])
 	assert.Equal(t, false, got["migratePolicies"])
+	// unnamed security scopes follow migratePolicies; a named one wins
+	assert.Equal(t, false, got["migratePrivileges"])
+	assert.Equal(t, false, got["migrateRoles"])
+	assert.Equal(t, true, got["migrateRoutingRules"])
+}
+
+// This is the reported bug: a job could be created and then nothing ever ran it.
+func TestMigration_CreateJob_StartsTheRun(t *testing.T) {
+	r, repo := mountMigration(t)
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs", map[string]any{
+		"sourceUrl":   "https://nexus.example.com",
+		"credentials": map[string]any{"username": "admin", "password": "secret"},
+	})
+	require.Equal(t, http.StatusCreated, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+
+	final := waitForJob(t, repo, got["id"].(string), func(j domain.MigrationJob) bool {
+		return j.Status == domain.MigrationDone
+	})
+	assert.NotNil(t, final.StartedAt, "the run stamps started_at instead of sitting pending")
 }
 
 func TestMigration_CreateJob_BadJSON_400(t *testing.T) {
@@ -231,31 +273,59 @@ func TestMigration_CreateJob_MissingSourceURL_400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestMigration_CreateJob_MalformedSourceURL_400(t *testing.T) {
+	r, repo := mountMigration(t)
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs", map[string]any{
+		"sourceUrl": "nexus.example.com",
+	})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	jobs, err := repo.List(testContext())
+	require.NoError(t, err)
+	assert.Empty(t, jobs, "a rejected job leaves no row behind")
+}
+
 func TestMigration_CreateJob_RepoError_500(t *testing.T) {
 	r, repo := mountMigration(t)
-	repo.createErr = errors.New("db down")
+	repo.CreateErr = errors.New("db down")
 	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs", map[string]any{
 		"sourceUrl": "https://nexus.example.com",
 	})
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
-// ── PauseJob / ResumeJob (setStatus) ──────────────────────────────────────────
+// ── PauseJob / ResumeJob ────────────────────────────────────────────────────
 
 func TestMigration_PauseJob_OK(t *testing.T) {
 	r, repo := mountMigration(t)
-	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{ID: "p1", SourceURL: "s", Status: domain.MigrationRunning}))
+	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{
+		ID: "p1", SourceURL: "https://nexus.example.com", Status: domain.MigrationRunning,
+	}))
 	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs/p1/pause", nil)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Equal(t, domain.MigrationPaused, repo.jobs["p1"].Status)
+	assert.Equal(t, domain.MigrationPaused, jobStatus(t, repo, "p1"))
+}
+
+func TestMigration_PauseJob_AlreadyFinished_400(t *testing.T) {
+	r, repo := mountMigration(t)
+	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{
+		ID: "p2", SourceURL: "https://nexus.example.com", Status: domain.MigrationDone,
+	}))
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs/p2/pause", nil)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
 func TestMigration_ResumeJob_OK(t *testing.T) {
 	r, repo := mountMigration(t)
-	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{ID: "r1", SourceURL: "s", Status: domain.MigrationPaused}))
+	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{
+		ID: "r1", SourceURL: "https://nexus.example.com", Status: domain.MigrationPaused,
+	}))
 	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs/r1/resume", nil)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	assert.Equal(t, domain.MigrationRunning, repo.jobs["r1"].Status)
+
+	waitForJob(t, repo, "r1", func(j domain.MigrationJob) bool {
+		return j.Status != domain.MigrationPaused
+	})
 }
 
 func TestMigration_PauseJob_NotFound_404(t *testing.T) {
@@ -264,22 +334,28 @@ func TestMigration_PauseJob_NotFound_404(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
+func TestMigration_ResumeJob_NotFound_404(t *testing.T) {
+	r, _ := mountMigration(t)
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs/ghost/resume", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 func TestMigration_ResumeJob_RepoError_500(t *testing.T) {
 	r, repo := mountMigration(t)
-	repo.updateErr = errors.New("db down")
+	repo.GetErr = errors.New("db down")
 	rec := do(t, r, http.MethodPost, "/api/v1/migration/jobs/any/resume", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
-// ── DeleteJob ─────────────────────────────────────────────────────────────────
+// ── DeleteJob ───────────────────────────────────────────────────────────────
 
 func TestMigration_DeleteJob_OK(t *testing.T) {
 	r, repo := mountMigration(t)
 	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{ID: "d1", SourceURL: "s"}))
 	rec := do(t, r, http.MethodDelete, "/api/v1/migration/jobs/d1", nil)
 	assert.Equal(t, http.StatusNoContent, rec.Code)
-	_, ok := repo.jobs["d1"]
-	assert.False(t, ok)
+	_, err := repo.Get(testContext(), "d1")
+	assert.Error(t, err)
 }
 
 func TestMigration_DeleteJob_NotFound_404(t *testing.T) {
@@ -290,7 +366,86 @@ func TestMigration_DeleteJob_NotFound_404(t *testing.T) {
 
 func TestMigration_DeleteJob_RepoError_500(t *testing.T) {
 	r, repo := mountMigration(t)
-	repo.deleteErr = errors.New("db down")
+	require.NoError(t, repo.Create(testContext(), &domain.MigrationJob{ID: "any", SourceURL: "s"}))
+	repo.DeleteErr = errors.New("db down")
 	rec := do(t, r, http.MethodDelete, "/api/v1/migration/jobs/any", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// ── Preview ─────────────────────────────────────────────────────────────────
+
+func TestMigration_Preview_OK(t *testing.T) {
+	rt := stubRoundTrip(func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "/service/rest/v1/repositories", req.URL.Path)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`[{"name":"raw-hosted","format":"raw","type":"hosted"}]`)),
+		}, nil
+	})
+	r, repo := mountMigrationWith(t, rt)
+
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/preview", map[string]any{
+		"sourceUrl": "https://nexus.example.com", "username": "admin", "password": "s3cret",
+	})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, true, got["reachable"])
+	assert.InDelta(t, 1, got["repoCount"], 0.001)
+
+	jobs, err := repo.List(testContext())
+	require.NoError(t, err)
+	assert.Empty(t, jobs, "a preview creates no job")
+}
+
+func TestMigration_Preview_MissingURL_422(t *testing.T) {
+	r, _ := mountMigration(t)
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/preview", map[string]any{
+		"username": "admin",
+	})
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, false, got["reachable"])
+}
+
+func TestMigration_Preview_Unreachable_502(t *testing.T) {
+	rt := stubRoundTrip(func(_ *http.Request) (*http.Response, error) {
+		return nil, errors.New("dial tcp: connection refused")
+	})
+	r, _ := mountMigrationWith(t, rt)
+
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/preview", map[string]any{
+		"sourceUrl": "https://this-nexus-does-not-exist.invalid",
+	})
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, false, got["reachable"])
+	assert.Contains(t, got["error"], "connection refused")
+}
+
+func TestMigration_Preview_BadCredentials_502(t *testing.T) {
+	rt := stubRoundTrip(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header:     http.Header{},
+			Body:       io.NopCloser(bytes.NewReader(nil)),
+		}, nil
+	})
+	r, _ := mountMigrationWith(t, rt)
+
+	rec := do(t, r, http.MethodPost, "/api/v1/migration/preview", map[string]any{
+		"sourceUrl": "https://nexus.example.com", "username": "admin", "password": "wrong",
+	})
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Contains(t, rec.Body.String(), "401")
+}
+
+func TestMigration_Preview_BadJSON_400(t *testing.T) {
+	r, _ := mountMigration(t)
+	rec := doRaw(t, r, http.MethodPost, "/api/v1/migration/preview", []byte(`{bad`))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -289,7 +289,23 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	rrSvc := service.NewRoutingRuleService(rrRepo)
 	rrH := handlers.NewRoutingRuleHandler(rrSvc)
 	systemH := handlers.NewSystemHandler(cfg, pool, ldapSvc, oidcSvc).WithBlobStores(blobRepo).WithSAML(samlSvc)
-	migrationH := handlers.NewMigrationHandler(migrationRepo)
+	nexusMigSvc := service.NewNexusMigrationService(service.NexusMigrationConfig{
+		Jobs:          migrationRepo,
+		Repos:         repoSvc,
+		Users:         userSvc,
+		Roles:         roleRepo,
+		Privileges:    privilegeRepo,
+		RoutingRules:  rrRepo,
+		Deps:          formatDeps,
+		JWTSecret:     cfg.Auth.JWTSecret,
+		EncryptionKey: cfg.Auth.EncryptionKeyBytes(),
+		Log:           log,
+	})
+	// Re-attach to migrations interrupted by a restart. Without this a job left
+	// running when the process stopped sits in "running" with nothing behind it —
+	// which is exactly how a migration used to look even on a healthy server.
+	go func() { _ = nexusMigSvc.ResumeAll(ctx) }()
+	migrationH := handlers.NewMigrationHandler(migrationRepo, nexusMigSvc)
 	ldapH := handlers.NewLDAPHandler(cfg.LDAP, ldapSvc)
 	tasksH := handlers.NewTasksHandler(cleanupTaskAdapter{repo: cleanupRepo, svc: cleanupSvc}, replSvc)
 	blobMigrationRepo := postgres.NewBlobStoreMigrationRepo(pool)
@@ -599,6 +615,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		admin.DELETE("/service/rest/v1/routing-rules/:id", rrH.Delete)
 
 		// Migration
+		admin.POST("/api/v1/migration/preview", migrationH.Preview)
 		admin.GET("/api/v1/migration/jobs", migrationH.ListJobs)
 		admin.POST("/api/v1/migration/jobs", migrationH.CreateJob)
 		admin.GET("/api/v1/migration/jobs/:id", migrationH.GetJob)

--- a/internal/db/migrations/026_nexus_migration_engine.sql
+++ b/internal/db/migrations/026_nexus_migration_engine.sql
@@ -1,0 +1,38 @@
+-- The Nexus migration jobs table was written for a runner that did not exist:
+-- a job could be created, but nothing ever read it back to do the work. Giving
+-- it a runner needs three things the row could not hold.
+--
+-- 1. The source credential. A migration is a long transfer that has to survive
+--    a restart, so the runner re-attaches to jobs left running — which means it
+--    needs the Nexus password again, after the request that supplied it is long
+--    gone. It is sealed with the same AES-256-GCM key replication targets use,
+--    never stored in the clear, and never leaves the process in an API response.
+--
+-- 2. Per-scope flags for the security data. `migrate_policies` was one coarse
+--    switch; privileges, roles and routing rules are three independent stages
+--    and get a flag each. The old column stays as the default those three fall
+--    back to, so a job created against the previous API keeps its meaning.
+--
+-- 3. `users.must_reset_password`. A migrated local user cannot bring its Nexus
+--    password hash along, so it gets a random temporary one. The account logs in
+--    normally — blocking it would strand every migrated user at once — and the
+--    flag is what asks for a change afterwards.
+
+-- +goose Up
+ALTER TABLE migration_jobs ADD COLUMN IF NOT EXISTS source_password TEXT NOT NULL DEFAULT '';
+ALTER TABLE migration_jobs ADD COLUMN IF NOT EXISTS migrate_privileges BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE migration_jobs ADD COLUMN IF NOT EXISTS migrate_roles BOOLEAN NOT NULL DEFAULT TRUE;
+ALTER TABLE migration_jobs ADD COLUMN IF NOT EXISTS migrate_routing_rules BOOLEAN NOT NULL DEFAULT TRUE;
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS must_reset_password BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- ListActive is polled on every startup and reads only the unfinished jobs.
+CREATE INDEX IF NOT EXISTS idx_migration_jobs_status ON migration_jobs (status);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_migration_jobs_status;
+ALTER TABLE users DROP COLUMN IF EXISTS must_reset_password;
+ALTER TABLE migration_jobs DROP COLUMN IF EXISTS migrate_routing_rules;
+ALTER TABLE migration_jobs DROP COLUMN IF EXISTS migrate_roles;
+ALTER TABLE migration_jobs DROP COLUMN IF EXISTS migrate_privileges;
+ALTER TABLE migration_jobs DROP COLUMN IF EXISTS source_password;

--- a/internal/domain/migration.go
+++ b/internal/domain/migration.go
@@ -14,27 +14,46 @@ const (
 	MigrationError   MigrationJobStatus = "error"
 )
 
-// MigrationJob tracks an import from a live Nexus instance, including selected
-// scopes (repos/users/blobs/policies) and per-asset transfer progress.
+// MigrationJob tracks an import from a live Nexus instance, including the
+// selected scopes and per-asset transfer progress.
+//
+// Each Migrate* flag gates one stage of the run independently, so a job can
+// copy everything or just a slice of it. MigratePolicies is the older, coarser
+// flag kept for API compatibility: it is the default the three security scopes
+// (privileges, roles, routing rules) fall back to when a request does not name
+// them, and drives no stage of its own.
 type MigrationJob struct {
-	ID              string
-	SourceURL       string
-	SourceUser      string
-	Status          MigrationJobStatus
-	MigrateRepos    bool
-	MigrateUsers    bool
-	MigrateBlobs    bool
-	MigratePolicies bool
-	TotalRepos      int
-	DoneRepos       int
-	TotalAssets     int64
-	DoneAssets      int64
-	TotalBytes      int64
-	DoneBytes       int64
-	ErrorCount      int
-	LastError       *string
-	StartedAt       *time.Time
-	FinishedAt      *time.Time
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	ID         string
+	SourceURL  string
+	SourceUser string
+	// SourcePassword is the Nexus password sealed with the instance encryption
+	// key. It is persisted so a job can resume after a process restart, and is
+	// never included in an API response.
+	SourcePassword      string
+	Status              MigrationJobStatus
+	MigrateRepos        bool
+	MigrateUsers        bool
+	MigrateBlobs        bool
+	MigratePolicies     bool
+	MigratePrivileges   bool
+	MigrateRoles        bool
+	MigrateRoutingRules bool
+	TotalRepos          int
+	DoneRepos           int
+	TotalAssets         int64
+	DoneAssets          int64
+	TotalBytes          int64
+	DoneBytes           int64
+	ErrorCount          int
+	LastError           *string
+	StartedAt           *time.Time
+	FinishedAt          *time.Time
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
+}
+
+// IsActive reports whether the job is one the runner owns — created but not
+// yet finished, and not deliberately parked by an operator.
+func (j MigrationJob) IsActive() bool {
+	return j.Status == MigrationPending || j.Status == MigrationRunning
 }

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -377,7 +377,11 @@ type User struct {
 	Source       UserSource `json:"source"`
 	ExternalID   string     `json:"-"`
 	Roles        []string   `json:"roles"` // role names
-	LastLogin    *time.Time `json:"lastLogin,omitempty"`
+	// MustResetPassword marks an account whose password was set for it rather
+	// than by it — a migrated Nexus user given a random temporary password.
+	// The account logs in normally; the flag drives the prompt to change it.
+	MustResetPassword bool       `json:"mustResetPassword,omitempty"`
+	LastLogin         *time.Time `json:"lastLogin,omitempty"`
 	// TokensValidAfter is the cutoff for JWT validity: a token whose `iat` is
 	// before this instant is rejected. Bumped on disable, password change, and
 	// role change so previously-issued JWTs are revoked. Zero value (distant

--- a/internal/nexusclient/client.go
+++ b/internal/nexusclient/client.go
@@ -1,0 +1,483 @@
+// Package nexusclient is a read-only HTTP client for the Sonatype Nexus OSS 3
+// REST API. It is the source side of a Nexus → Nexspence migration: it lists
+// what a Nexus instance holds and streams the bytes back, and never writes
+// anything to the instance it is pointed at.
+package nexusclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/netguard"
+)
+
+// maxErrorBody caps how much of a failing response is quoted back in an error.
+const maxErrorBody = 512
+
+// Repository is a repository as configured on the source Nexus.
+// MemberNames and RemoteURL are only populated when the instance exposes the
+// admin repositorySettings endpoint; the basic listing carries neither.
+type Repository struct {
+	Name        string
+	Format      string
+	Type        string
+	URL         string
+	Online      bool
+	RemoteURL   string
+	MemberNames []string
+	// BlobStoreName is informational: Nexspence resolves its own store.
+	BlobStoreName string
+}
+
+// Asset is one downloadable file belonging to a component.
+type Asset struct {
+	Path        string
+	DownloadURL string
+	ContentType string
+	SizeBytes   int64
+	SHA256      string
+	SHA1        string
+	MD5         string
+}
+
+// Component is one artifact (a coordinate) with its files.
+type Component struct {
+	Name    string
+	Version string
+	Group   string
+	Format  string
+	Assets  []Asset
+}
+
+// User is a security user as defined on the source Nexus.
+type User struct {
+	UserID    string
+	FirstName string
+	LastName  string
+	Email     string
+	Source    string
+	Status    string
+	Roles     []string
+}
+
+// Role is a security role, which may nest other roles.
+type Role struct {
+	ID          string
+	Name        string
+	Description string
+	Privileges  []string
+	Roles       []string
+	ReadOnly    bool
+}
+
+// Privilege is a security privilege. Attrs holds the type-specific fields
+// (format, repository, actions, domain, …) that Nexus returns flattened
+// alongside the identity fields.
+type Privilege struct {
+	Name        string
+	Description string
+	Type        string
+	ReadOnly    bool
+	Attrs       map[string]any
+}
+
+// RoutingRule is a request routing rule (ALLOW or BLOCK plus regex matchers).
+type RoutingRule struct {
+	Name        string
+	Description string
+	Mode        string
+	Matchers    []string
+}
+
+// Client talks to one Nexus instance with one set of credentials.
+type Client struct {
+	baseURL  string
+	username string
+	password string
+	http     *http.Client
+}
+
+// New returns a client for baseURL authenticating with the given credentials.
+// The default HTTP client is SSRF-guarded, because the URL comes from an
+// operator-supplied migration job rather than from configuration.
+func New(baseURL, username, password string, timeout time.Duration) *Client {
+	return &Client{
+		baseURL:  strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		username: username,
+		password: password,
+		http:     netguard.Client(timeout),
+	}
+}
+
+// WithHTTPClient replaces the HTTP client. Intended for tests that need to
+// reach loopback servers the SSRF guard blocks.
+func (c *Client) WithHTTPClient(h *http.Client) *Client {
+	c.http = h
+	return c
+}
+
+// BaseURL returns the normalised base URL the client was built with.
+func (c *Client) BaseURL() string { return c.baseURL }
+
+func (c *Client) do(ctx context.Context, rawURL string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 300 {
+		defer func() { _ = resp.Body.Close() }()
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+		return nil, fmt.Errorf("nexus %s: %d %s: %s",
+			rawURL, resp.StatusCode, http.StatusText(resp.StatusCode), strings.TrimSpace(string(body)))
+	}
+	return resp, nil
+}
+
+// getJSON fetches path (relative to the base URL) and decodes it into out.
+func (c *Client) getJSON(ctx context.Context, path string, out any) error {
+	resp, err := c.do(ctx, c.baseURL+path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// ── Repositories ────────────────────────────────────────────────────────────
+
+type basicRepoDTO struct {
+	Name       string `json:"name"`
+	Format     string `json:"format"`
+	Type       string `json:"type"`
+	URL        string `json:"url"`
+	Attributes struct {
+		Proxy struct {
+			RemoteURL string `json:"remoteUrl"`
+		} `json:"proxy"`
+	} `json:"attributes"`
+}
+
+// ListRepositories returns the repositories visible to the credentials, using
+// the endpoint every Nexus 3 exposes. It carries no group membership and no
+// online flag — use ListRepositoriesWithConfig when the full config matters.
+func (c *Client) ListRepositories(ctx context.Context) ([]Repository, error) {
+	var dto []basicRepoDTO
+	if err := c.getJSON(ctx, "/service/rest/v1/repositories", &dto); err != nil {
+		return nil, err
+	}
+	out := make([]Repository, 0, len(dto))
+	for _, d := range dto {
+		out = append(out, Repository{
+			Name:      d.Name,
+			Format:    d.Format,
+			Type:      d.Type,
+			URL:       d.URL,
+			Online:    true, // not reported here; assume usable
+			RemoteURL: d.Attributes.Proxy.RemoteURL,
+		})
+	}
+	return out, nil
+}
+
+type settingsRepoDTO struct {
+	Name    string `json:"name"`
+	Format  string `json:"format"`
+	Type    string `json:"type"`
+	URL     string `json:"url"`
+	Online  bool   `json:"online"`
+	Storage struct {
+		BlobStoreName string `json:"blobStoreName"`
+	} `json:"storage"`
+	Group struct {
+		MemberNames []string `json:"memberNames"`
+	} `json:"group"`
+	Proxy struct {
+		RemoteURL string `json:"remoteUrl"`
+	} `json:"proxy"`
+}
+
+// ListRepositoriesWithConfig returns repositories including group membership
+// and proxy remote URLs, read from the admin repositorySettings endpoint.
+// Instances that do not expose it — older versions, or credentials without
+// admin rights — fall back to the basic listing, which still names every
+// repository but cannot describe how the groups are wired.
+func (c *Client) ListRepositoriesWithConfig(ctx context.Context) ([]Repository, error) {
+	var dto []settingsRepoDTO
+	err := c.getJSON(ctx, "/service/rest/v1/repositorySettings", &dto)
+	if err != nil {
+		return c.ListRepositories(ctx)
+	}
+	out := make([]Repository, 0, len(dto))
+	for _, d := range dto {
+		out = append(out, Repository{
+			Name:          d.Name,
+			Format:        d.Format,
+			Type:          d.Type,
+			URL:           d.URL,
+			Online:        d.Online,
+			RemoteURL:     d.Proxy.RemoteURL,
+			MemberNames:   d.Group.MemberNames,
+			BlobStoreName: d.Storage.BlobStoreName,
+		})
+	}
+	return out, nil
+}
+
+// ── Components and assets ───────────────────────────────────────────────────
+
+type componentPageDTO struct {
+	Items []struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+		Group   string `json:"group"`
+		Format  string `json:"format"`
+		Assets  []struct {
+			Path        string `json:"path"`
+			DownloadURL string `json:"downloadUrl"`
+			ContentType string `json:"contentType"`
+			FileSize    int64  `json:"fileSize"`
+			Checksum    struct {
+				SHA256 string `json:"sha256"`
+				SHA1   string `json:"sha1"`
+				MD5    string `json:"md5"`
+			} `json:"checksum"`
+		} `json:"assets"`
+	} `json:"items"`
+	ContinuationToken string `json:"continuationToken"`
+}
+
+// ListComponents returns one page of components in repo. Pass the token
+// returned by the previous call to get the next page; an empty returned token
+// means the listing is exhausted.
+func (c *Client) ListComponents(ctx context.Context, repo, continuationToken string) ([]Component, string, error) {
+	reqURL := c.baseURL + "/service/rest/v1/components?repository=" + url.QueryEscape(repo)
+	if continuationToken != "" {
+		reqURL += "&continuationToken=" + url.QueryEscape(continuationToken)
+	}
+	resp, err := c.do(ctx, reqURL)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var page componentPageDTO
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, "", err
+	}
+	out := make([]Component, 0, len(page.Items))
+	for _, it := range page.Items {
+		comp := Component{Name: it.Name, Version: it.Version, Group: it.Group, Format: it.Format}
+		for _, a := range it.Assets {
+			comp.Assets = append(comp.Assets, Asset{
+				Path:        a.Path,
+				DownloadURL: a.DownloadURL,
+				ContentType: a.ContentType,
+				SizeBytes:   a.FileSize,
+				SHA256:      a.Checksum.SHA256,
+				SHA1:        a.Checksum.SHA1,
+				MD5:         a.Checksum.MD5,
+			})
+		}
+		out = append(out, comp)
+	}
+	return out, page.ContinuationToken, nil
+}
+
+// DownloadAsset streams an asset from its absolute download URL. The caller
+// closes the returned reader.
+func (c *Client) DownloadAsset(ctx context.Context, downloadURL string) (io.ReadCloser, error) {
+	resp, err := c.do(ctx, downloadURL)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
+
+// ── OCI registry surface ────────────────────────────────────────────────────
+
+// manifestAccept lists every manifest media type worth asking for. A registry
+// that is not told what the caller understands is free to convert, and would
+// hand back a document whose digest is not the one being recorded.
+const manifestAccept = "application/vnd.docker.distribution.manifest.v2+json," +
+	"application/vnd.docker.distribution.manifest.list.v2+json," +
+	"application/vnd.oci.image.manifest.v1+json," +
+	"application/vnd.oci.image.index.v1+json"
+
+// maxManifestBytes caps a manifest read. The OCI spec caps manifests at 4 MiB;
+// reading one byte past it is what makes an oversized document visible instead
+// of silently truncated.
+const maxManifestBytes = 4 << 20
+
+// RepositoryURL returns the absolute URL of a path inside a repository's own
+// content surface — the same URL a docker or maven client would fetch.
+func (c *Client) RepositoryURL(repo, path string) string {
+	return c.baseURL + "/repository/" + repo + "/" + strings.TrimPrefix(path, "/")
+}
+
+// DownloadManifest fetches an image manifest by tag or digest and returns its
+// bytes along with the media type the registry served it as.
+//
+// Manifests are read whole rather than streamed because the migration has to
+// look inside one: a manifest names the blobs that must come across with it,
+// and Nexus does not list those blobs under the image they belong to.
+func (c *Client) DownloadManifest(ctx context.Context, repo, image, reference string) ([]byte, string, error) {
+	rawURL := c.RepositoryURL(repo, "/v2/"+image+"/manifests/"+reference)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+	req.Header.Set("Accept", manifestAccept)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+		return nil, "", fmt.Errorf("nexus %s: %d %s: %s",
+			rawURL, resp.StatusCode, http.StatusText(resp.StatusCode), strings.TrimSpace(string(body)))
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestBytes+1))
+	if err != nil {
+		return nil, "", err
+	}
+	if len(body) > maxManifestBytes {
+		return nil, "", fmt.Errorf("nexus %s: manifest exceeds the 4MiB limit", rawURL)
+	}
+	return body, resp.Header.Get("Content-Type"), nil
+}
+
+// DownloadBlob streams a registry blob by digest from the image's own path.
+// Nexus stores blobs content-addressed and lists them under a placeholder image
+// name, but serves them under whichever image references them.
+func (c *Client) DownloadBlob(ctx context.Context, repo, image, digest string) (io.ReadCloser, error) {
+	return c.DownloadAsset(ctx, c.RepositoryURL(repo, "/v2/"+image+"/blobs/"+digest))
+}
+
+// ── Security ────────────────────────────────────────────────────────────────
+
+type userDTO struct {
+	UserID    string   `json:"userId"`
+	FirstName string   `json:"firstName"`
+	LastName  string   `json:"lastName"`
+	Email     string   `json:"emailAddress"`
+	Source    string   `json:"source"`
+	Status    string   `json:"status"`
+	Roles     []string `json:"roles"`
+}
+
+// ListUsers returns every security user. Requires admin credentials; Nexus OSS
+// returns the full list unpaginated.
+func (c *Client) ListUsers(ctx context.Context) ([]User, error) {
+	var dto []userDTO
+	if err := c.getJSON(ctx, "/service/rest/v1/security/users", &dto); err != nil {
+		return nil, err
+	}
+	out := make([]User, 0, len(dto))
+	for _, d := range dto {
+		out = append(out, User(d))
+	}
+	return out, nil
+}
+
+type roleDTO struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Privileges  []string `json:"privileges"`
+	Roles       []string `json:"roles"`
+	ReadOnly    bool     `json:"readOnly"`
+}
+
+// ListRoles returns every security role, including its nested role references.
+func (c *Client) ListRoles(ctx context.Context) ([]Role, error) {
+	var dto []roleDTO
+	if err := c.getJSON(ctx, "/service/rest/v1/security/roles", &dto); err != nil {
+		return nil, err
+	}
+	out := make([]Role, 0, len(dto))
+	for _, d := range dto {
+		out = append(out, Role(d))
+	}
+	return out, nil
+}
+
+// privilegeIdentityFields are decoded into the struct proper; everything else
+// Nexus returns is type-specific and kept in Attrs.
+var privilegeIdentityFields = map[string]bool{
+	"name": true, "description": true, "type": true, "readOnly": true,
+}
+
+// ListPrivileges returns every security privilege with its type-specific
+// attributes preserved.
+func (c *Client) ListPrivileges(ctx context.Context) ([]Privilege, error) {
+	var raw []map[string]any
+	if err := c.getJSON(ctx, "/service/rest/v1/security/privileges", &raw); err != nil {
+		return nil, err
+	}
+	out := make([]Privilege, 0, len(raw))
+	for _, m := range raw {
+		p := Privilege{
+			Name:        stringField(m, "name"),
+			Description: stringField(m, "description"),
+			Type:        stringField(m, "type"),
+			Attrs:       map[string]any{},
+		}
+		if b, ok := m["readOnly"].(bool); ok {
+			p.ReadOnly = b
+		}
+		for k, v := range m {
+			if !privilegeIdentityFields[k] {
+				p.Attrs[k] = v
+			}
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+type routingRuleDTO struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Mode        string   `json:"mode"`
+	Matchers    []string `json:"matchers"`
+}
+
+// ListRoutingRules returns every routing rule defined on the instance.
+func (c *Client) ListRoutingRules(ctx context.Context) ([]RoutingRule, error) {
+	var dto []routingRuleDTO
+	if err := c.getJSON(ctx, "/service/rest/v1/routing-rules", &dto); err != nil {
+		return nil, err
+	}
+	out := make([]RoutingRule, 0, len(dto))
+	for _, d := range dto {
+		out = append(out, RoutingRule(d))
+	}
+	return out, nil
+}
+
+func stringField(m map[string]any, key string) string {
+	if s, ok := m[key].(string); ok {
+		return s
+	}
+	return ""
+}

--- a/internal/nexusclient/client_test.go
+++ b/internal/nexusclient/client_test.go
@@ -1,0 +1,338 @@
+package nexusclient_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/nexusclient"
+)
+
+// newClient points a client at srv and lets it dial loopback, which the
+// SSRF-guarded default client refuses.
+func newClient(t *testing.T, srv *httptest.Server) *nexusclient.Client {
+	t.Helper()
+	return nexusclient.New(srv.URL, "admin", "s3cret", 5*time.Second).
+		WithHTTPClient(srv.Client())
+}
+
+func TestListRepositories_ParsesBasicListing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/service/rest/v1/repositories", r.URL.Path)
+		user, pass, ok := r.BasicAuth()
+		assert.True(t, ok)
+		assert.Equal(t, "admin", user)
+		assert.Equal(t, "s3cret", pass)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"name":"maven-central","format":"maven2","type":"proxy","url":"http://n/repository/maven-central",
+			 "attributes":{"proxy":{"remoteUrl":"https://repo1.maven.org/maven2"}}},
+			{"name":"raw-hosted","format":"raw","type":"hosted","url":"http://n/repository/raw-hosted"}
+		]`)
+	}))
+	defer srv.Close()
+
+	repos, err := newClient(t, srv).ListRepositories(context.Background())
+	require.NoError(t, err)
+	require.Len(t, repos, 2)
+	assert.Equal(t, "maven-central", repos[0].Name)
+	assert.Equal(t, "maven2", repos[0].Format)
+	assert.Equal(t, "proxy", repos[0].Type)
+	assert.Equal(t, "https://repo1.maven.org/maven2", repos[0].RemoteURL)
+	assert.Equal(t, "raw-hosted", repos[1].Name)
+	assert.Equal(t, "hosted", repos[1].Type)
+}
+
+func TestListRepositories_SurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "bad credentials")
+	}))
+	defer srv.Close()
+
+	_, err := newClient(t, srv).ListRepositories(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "401")
+}
+
+func TestListRepositoriesWithConfig_UsesRepositorySettings(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/service/rest/v1/repositorySettings", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"name":"maven-releases","format":"maven2","type":"hosted","online":true,
+			 "storage":{"blobStoreName":"default"}},
+			{"name":"maven-public","format":"maven2","type":"group","online":true,
+			 "group":{"memberNames":["maven-releases","maven-central"]}},
+			{"name":"maven-central","format":"maven2","type":"proxy","online":false,
+			 "proxy":{"remoteUrl":"https://repo1.maven.org/maven2"}}
+		]`)
+	}))
+	defer srv.Close()
+
+	repos, err := newClient(t, srv).ListRepositoriesWithConfig(context.Background())
+	require.NoError(t, err)
+	require.Len(t, repos, 3)
+	assert.True(t, repos[0].Online)
+	assert.Equal(t, []string{"maven-releases", "maven-central"}, repos[1].MemberNames)
+	assert.Equal(t, "https://repo1.maven.org/maven2", repos[2].RemoteURL)
+	assert.False(t, repos[2].Online)
+}
+
+func TestListRepositoriesWithConfig_FallsBackWhenSettingsForbidden(t *testing.T) {
+	var settingsHits, basicHits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/service/rest/v1/repositorySettings":
+			settingsHits++
+			w.WriteHeader(http.StatusForbidden)
+		case "/service/rest/v1/repositories":
+			basicHits++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"name":"raw-hosted","format":"raw","type":"hosted"}]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	repos, err := newClient(t, srv).ListRepositoriesWithConfig(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, settingsHits)
+	assert.Equal(t, 1, basicHits)
+	require.Len(t, repos, 1)
+	assert.Equal(t, "raw-hosted", repos[0].Name)
+	// The basic listing carries no online flag; a repository is assumed usable.
+	assert.True(t, repos[0].Online)
+}
+
+func TestListComponents_FollowsContinuationToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/service/rest/v1/components", r.URL.Path)
+		require.Equal(t, "raw-hosted", r.URL.Query().Get("repository"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("continuationToken") == "" {
+			_, _ = io.WriteString(w, `{"items":[
+				{"name":"a.txt","version":null,"group":"/","format":"raw","assets":[
+					{"path":"a.txt","downloadUrl":"http://n/repository/raw-hosted/a.txt",
+					 "contentType":"text/plain","fileSize":3,"checksum":{"sha256":"aa"}}]}
+			],"continuationToken":"tok2"}`)
+			return
+		}
+		require.Equal(t, "tok2", r.URL.Query().Get("continuationToken"))
+		_, _ = io.WriteString(w, `{"items":[
+			{"name":"b.txt","version":null,"group":"/","format":"raw","assets":[
+				{"path":"b.txt","downloadUrl":"http://n/repository/raw-hosted/b.txt","fileSize":4}]}
+		],"continuationToken":null}`)
+	}))
+	defer srv.Close()
+
+	c := newClient(t, srv)
+	first, tok, err := c.ListComponents(context.Background(), "raw-hosted", "")
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "a.txt", first[0].Name)
+	require.Len(t, first[0].Assets, 1)
+	assert.Equal(t, "a.txt", first[0].Assets[0].Path)
+	assert.Equal(t, "text/plain", first[0].Assets[0].ContentType)
+	assert.Equal(t, int64(3), first[0].Assets[0].SizeBytes)
+	assert.Equal(t, "aa", first[0].Assets[0].SHA256)
+	require.Equal(t, "tok2", tok)
+
+	second, tok, err := c.ListComponents(context.Background(), "raw-hosted", tok)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, "b.txt", second[0].Name)
+	assert.Empty(t, tok)
+}
+
+func TestDownloadAsset_StreamsBytes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, _, ok := r.BasicAuth()
+		assert.True(t, ok)
+		assert.Equal(t, "admin", user)
+		_, _ = io.WriteString(w, "hello")
+	}))
+	defer srv.Close()
+
+	rc, err := newClient(t, srv).DownloadAsset(context.Background(), srv.URL+"/repository/raw-hosted/a.txt")
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(body))
+}
+
+func TestDownloadAsset_ErrorsOnNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := newClient(t, srv).DownloadAsset(context.Background(), srv.URL+"/missing")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestListUsers_ParsesSecurityUsers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/service/rest/v1/security/users", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"userId":"jdoe","firstName":"Jane","lastName":"Doe","emailAddress":"j@example.com",
+			 "source":"default","status":"active","roles":["nx-admin"]},
+			{"userId":"ldapuser","firstName":"L","lastName":"U","emailAddress":"l@example.com",
+			 "source":"LDAP","status":"disabled","roles":[]}
+		]`)
+	}))
+	defer srv.Close()
+
+	users, err := newClient(t, srv).ListUsers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, users, 2)
+	assert.Equal(t, "jdoe", users[0].UserID)
+	assert.Equal(t, "Jane", users[0].FirstName)
+	assert.Equal(t, "j@example.com", users[0].Email)
+	assert.Equal(t, "default", users[0].Source)
+	assert.Equal(t, "active", users[0].Status)
+	assert.Equal(t, []string{"nx-admin"}, users[0].Roles)
+	assert.Equal(t, "LDAP", users[1].Source)
+}
+
+func TestListRoles_ParsesNestedRoles(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/service/rest/v1/security/roles", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"id":"dev","name":"dev","description":"Developers","readOnly":false,
+			 "privileges":["nx-repository-view-maven2-*-read"],"roles":["base"]},
+			{"id":"base","name":"base","description":"","readOnly":false,"privileges":[],"roles":[]}
+		]`)
+	}))
+	defer srv.Close()
+
+	roles, err := newClient(t, srv).ListRoles(context.Background())
+	require.NoError(t, err)
+	require.Len(t, roles, 2)
+	assert.Equal(t, "dev", roles[0].ID)
+	assert.Equal(t, "Developers", roles[0].Description)
+	assert.Equal(t, []string{"base"}, roles[0].Roles)
+	assert.Equal(t, []string{"nx-repository-view-maven2-*-read"}, roles[0].Privileges)
+}
+
+func TestListPrivileges_KeepsTypeSpecificAttributes(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/service/rest/v1/security/privileges", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[
+			{"type":"repository-view","name":"view-maven","description":"d","readOnly":false,
+			 "format":"maven2","repository":"maven-central","actions":["READ","BROWSE"]},
+			{"type":"application","name":"nx-all","description":"","readOnly":true,
+			 "domain":"*","actions":["*"]}
+		]`)
+	}))
+	defer srv.Close()
+
+	privs, err := newClient(t, srv).ListPrivileges(context.Background())
+	require.NoError(t, err)
+	require.Len(t, privs, 2)
+	assert.Equal(t, "view-maven", privs[0].Name)
+	assert.Equal(t, "repository-view", privs[0].Type)
+	assert.False(t, privs[0].ReadOnly)
+	assert.Equal(t, "maven2", privs[0].Attrs["format"])
+	assert.Equal(t, "maven-central", privs[0].Attrs["repository"])
+	assert.True(t, privs[1].ReadOnly)
+	// Identity fields are not duplicated into the attribute bag.
+	assert.NotContains(t, privs[0].Attrs, "name")
+	assert.NotContains(t, privs[0].Attrs, "type")
+}
+
+func TestListRoutingRules_ParsesMatchers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/service/rest/v1/routing-rules", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"name":"block-com","description":"no com","mode":"BLOCK",
+			"matchers":["^/com/.*"]}]`)
+	}))
+	defer srv.Close()
+
+	rules, err := newClient(t, srv).ListRoutingRules(context.Background())
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "block-com", rules[0].Name)
+	assert.Equal(t, "BLOCK", rules[0].Mode)
+	assert.Equal(t, []string{"^/com/.*"}, rules[0].Matchers)
+}
+
+func TestNew_TrimsTrailingSlashFromBaseURL(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = io.WriteString(w, `[]`)
+	}))
+	defer srv.Close()
+
+	c := nexusclient.New(srv.URL+"/", "admin", "s3cret", time.Second).WithHTTPClient(srv.Client())
+	_, err := c.ListRepositories(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "/service/rest/v1/repositories", gotPath)
+}
+
+// ── OCI registry surface ────────────────────────────────────────────────────
+
+func TestRepositoryURL_ComposesTheContentPath(t *testing.T) {
+	c := nexusclient.New("https://nexus.example.com/", "admin", "pw", time.Second)
+	assert.Equal(t,
+		"https://nexus.example.com/repository/docker-hosted/v2/demo/alpine/blobs/sha256:abc",
+		c.RepositoryURL("docker-hosted", "/v2/demo/alpine/blobs/sha256:abc"))
+	// A path without its leading slash composes to the same URL.
+	assert.Equal(t,
+		"https://nexus.example.com/repository/docker-hosted/v2/demo/alpine/manifests/3.20",
+		c.RepositoryURL("docker-hosted", "v2/demo/alpine/manifests/3.20"))
+}
+
+func TestDownloadManifest_AsksForEveryManifestMediaType(t *testing.T) {
+	var gotAccept, gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAccept = r.Header.Get("Accept")
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+		_, _ = io.WriteString(w, `{"schemaVersion":2}`)
+	}))
+	defer srv.Close()
+
+	body, contentType, err := newClient(t, srv).DownloadManifest(
+		context.Background(), "docker-hosted", "demo/alpine", "3.20")
+	require.NoError(t, err)
+	assert.Equal(t, `{"schemaVersion":2}`, string(body))
+	assert.Equal(t, "application/vnd.oci.image.manifest.v1+json", contentType)
+	assert.Equal(t, "/repository/docker-hosted/v2/demo/alpine/manifests/3.20", gotPath)
+
+	// Without these, a registry is free to hand back a different variant than
+	// the one whose digest the client is about to record.
+	for _, want := range []string{
+		"application/vnd.docker.distribution.manifest.v2+json",
+		"application/vnd.docker.distribution.manifest.list.v2+json",
+		"application/vnd.oci.image.manifest.v1+json",
+		"application/vnd.oci.image.index.v1+json",
+	} {
+		assert.Contains(t, gotAccept, want)
+	}
+}
+
+func TestDownloadManifest_SurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, _, err := newClient(t, srv).DownloadManifest(context.Background(), "r", "img", "tag")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -198,6 +198,8 @@ type UserRepo interface {
 type RoleRepo interface {
 	List(ctx context.Context) ([]domain.Role, error)
 	Get(ctx context.Context, id string) (*domain.Role, error)
+	// GetByName resolves a role by its unique name.
+	GetByName(ctx context.Context, name string) (*domain.Role, error)
 	Create(ctx context.Context, r *domain.Role) error
 	Update(ctx context.Context, r *domain.Role) error
 	Delete(ctx context.Context, id string) error
@@ -265,6 +267,22 @@ type MigrationRepo interface {
 	Create(ctx context.Context, job *domain.MigrationJob) error
 	UpdateStatus(ctx context.Context, id string, status domain.MigrationJobStatus) error
 	Delete(ctx context.Context, id string) error
+	// ListActive returns pending|running jobs — the ones the runner re-attaches
+	// to on startup after a process restart.
+	ListActive(ctx context.Context) ([]domain.MigrationJob, error)
+	// SetSourcePassword stores the sealed Nexus credential for the job.
+	SetSourcePassword(ctx context.Context, id, sealed string) error
+	// SetStarted marks the job running and stamps started_at (once — a resumed
+	// job keeps the timestamp of its first run).
+	SetStarted(ctx context.Context, id string, at time.Time) error
+	// SetTotals records how much work the run discovered.
+	SetTotals(ctx context.Context, id string, totalRepos int, totalAssets int64) error
+	// UpdateProgress records how much of that work is done, along with the
+	// running error tally and the most recent per-item failure.
+	UpdateProgress(ctx context.Context, id string, doneRepos int, doneAssets int64,
+		errorCount int, lastError *string) error
+	// FinishJob stamps finished_at and sets the terminal status.
+	FinishJob(ctx context.Context, id string, status domain.MigrationJobStatus, errMsg *string) error
 }
 
 // BlobStoreRepo manages blob store configuration.

--- a/internal/repository/postgres/migration_repo.go
+++ b/internal/repository/postgres/migration_repo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -19,8 +20,9 @@ func NewMigrationRepo(pool *pgxpool.Pool) *MigrationRepo {
 	return &MigrationRepo{pool: pool}
 }
 
-const migrationCols = `id, source_url, source_user, status,
+const migrationCols = `id, source_url, source_user, source_password, status,
 	migrate_repos, migrate_users, migrate_blobs, migrate_policies,
+	migrate_privileges, migrate_roles, migrate_routing_rules,
 	total_repos, done_repos, total_assets, done_assets,
 	total_bytes, done_bytes, error_count, last_error,
 	started_at, finished_at, created_at, updated_at`
@@ -28,8 +30,9 @@ const migrationCols = `id, source_url, source_user, status,
 func scanJob(row pgx.Row) (*domain.MigrationJob, error) {
 	var j domain.MigrationJob
 	err := row.Scan(
-		&j.ID, &j.SourceURL, &j.SourceUser, &j.Status,
+		&j.ID, &j.SourceURL, &j.SourceUser, &j.SourcePassword, &j.Status,
 		&j.MigrateRepos, &j.MigrateUsers, &j.MigrateBlobs, &j.MigratePolicies,
+		&j.MigratePrivileges, &j.MigrateRoles, &j.MigrateRoutingRules,
 		&j.TotalRepos, &j.DoneRepos, &j.TotalAssets, &j.DoneAssets,
 		&j.TotalBytes, &j.DoneBytes, &j.ErrorCount, &j.LastError,
 		&j.StartedAt, &j.FinishedAt, &j.CreatedAt, &j.UpdatedAt,
@@ -72,14 +75,102 @@ func (r *MigrationRepo) Get(ctx context.Context, id string) (*domain.MigrationJo
 
 // Create inserts a new migration job and populates its generated fields.
 func (r *MigrationRepo) Create(ctx context.Context, job *domain.MigrationJob) error {
+	status := job.Status
+	if status == "" {
+		status = domain.MigrationPending
+	}
 	return r.pool.QueryRow(ctx, `
 		INSERT INTO migration_jobs
-			(source_url, source_user, migrate_repos, migrate_users, migrate_blobs, migrate_policies)
-		VALUES ($1, $2, $3, $4, $5, $6)
+			(source_url, source_user, source_password, status,
+			 migrate_repos, migrate_users, migrate_blobs, migrate_policies,
+			 migrate_privileges, migrate_roles, migrate_routing_rules)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING id, created_at, updated_at`,
-		job.SourceURL, job.SourceUser,
+		job.SourceURL, job.SourceUser, job.SourcePassword, status,
 		job.MigrateRepos, job.MigrateUsers, job.MigrateBlobs, job.MigratePolicies,
+		job.MigratePrivileges, job.MigrateRoles, job.MigrateRoutingRules,
 	).Scan(&job.ID, &job.CreatedAt, &job.UpdatedAt)
+}
+
+// ListActive returns pending and running jobs, oldest first, so a restart
+// re-attaches to them in the order they were created.
+func (r *MigrationRepo) ListActive(ctx context.Context) ([]domain.MigrationJob, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT `+migrationCols+` FROM migration_jobs
+		 WHERE status IN ('pending', 'running') ORDER BY created_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []domain.MigrationJob
+	for rows.Next() {
+		j, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *j)
+	}
+	return out, rows.Err()
+}
+
+// SetSourcePassword stores the sealed Nexus credential for the job.
+func (r *MigrationRepo) SetSourcePassword(ctx context.Context, id, sealed string) error {
+	return r.exec(ctx, id,
+		`UPDATE migration_jobs SET source_password = $1, updated_at = NOW() WHERE id = $2`,
+		sealed, id)
+}
+
+// SetStarted marks the job running and stamps started_at the first time only,
+// so a resumed job still reports when the transfer originally began.
+func (r *MigrationRepo) SetStarted(ctx context.Context, id string, at time.Time) error {
+	return r.exec(ctx, id, `
+		UPDATE migration_jobs
+		SET status = 'running',
+		    started_at = COALESCE(started_at, $1),
+		    finished_at = NULL,
+		    updated_at = NOW()
+		WHERE id = $2`, at, id)
+}
+
+// SetTotals records how much work the run discovered.
+func (r *MigrationRepo) SetTotals(ctx context.Context, id string, totalRepos int, totalAssets int64) error {
+	return r.exec(ctx, id, `
+		UPDATE migration_jobs SET total_repos = $1, total_assets = $2, updated_at = NOW()
+		WHERE id = $3`, totalRepos, totalAssets, id)
+}
+
+// UpdateProgress records completed work along with the running error tally.
+func (r *MigrationRepo) UpdateProgress(ctx context.Context, id string, doneRepos int, doneAssets int64,
+	errorCount int, lastError *string,
+) error {
+	return r.exec(ctx, id, `
+		UPDATE migration_jobs
+		SET done_repos = $1, done_assets = $2, error_count = $3,
+		    last_error = COALESCE($4, last_error), updated_at = NOW()
+		WHERE id = $5`, doneRepos, doneAssets, errorCount, lastError, id)
+}
+
+// FinishJob stamps finished_at and sets the terminal status.
+func (r *MigrationRepo) FinishJob(ctx context.Context, id string,
+	status domain.MigrationJobStatus, errMsg *string,
+) error {
+	return r.exec(ctx, id, `
+		UPDATE migration_jobs
+		SET status = $1, last_error = COALESCE($2, last_error),
+		    finished_at = NOW(), updated_at = NOW()
+		WHERE id = $3`, status, errMsg, id)
+}
+
+// exec runs a single-row update and reports a missing job as a not-found error.
+func (r *MigrationRepo) exec(ctx context.Context, id, sql string, args ...any) error {
+	tag, err := r.pool.Exec(ctx, sql, args...)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("migration job not found: %s", id)
+	}
+	return nil
 }
 
 // UpdateStatus sets the status of the migration job with the given id.

--- a/internal/repository/postgres/migration_repo_integration_test.go
+++ b/internal/repository/postgres/migration_repo_integration_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
@@ -95,5 +96,149 @@ func TestMigrationRepo_List_Empty(t *testing.T) {
 	}
 	if len(list) != 0 {
 		t.Fatalf("expected empty, got %d", len(list))
+	}
+}
+
+func TestMigrationRepo_RunnerLifecycle(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "migration_jobs")
+	ctx := context.Background()
+	repo := NewMigrationRepo(pool)
+
+	job := &domain.MigrationJob{
+		SourceURL:           "https://nexus.example.com",
+		SourceUser:          "admin",
+		SourcePassword:      "sealed-blob",
+		MigrateRepos:        true,
+		MigrateBlobs:        true,
+		MigratePrivileges:   true,
+		MigrateRoles:        true,
+		MigrateRoutingRules: false,
+	}
+	if err := repo.Create(ctx, job); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := repo.Get(ctx, job.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.SourcePassword != "sealed-blob" {
+		t.Fatalf("source password not round-tripped: %q", got.SourcePassword)
+	}
+	if !got.MigratePrivileges || !got.MigrateRoles || got.MigrateRoutingRules {
+		t.Fatalf("scope flags mismatch: %+v", got)
+	}
+	if got.Status != domain.MigrationPending {
+		t.Fatalf("new job should be pending, got %s", got.Status)
+	}
+
+	// A pending job is one the runner must re-attach to after a restart.
+	active, err := repo.ListActive(ctx)
+	if err != nil {
+		t.Fatalf("ListActive: %v", err)
+	}
+	if len(active) != 1 || active[0].ID != job.ID {
+		t.Fatalf("ListActive mismatch: %+v", active)
+	}
+
+	started := time.Now().UTC().Truncate(time.Millisecond)
+	if err := repo.SetStarted(ctx, job.ID, started); err != nil {
+		t.Fatalf("SetStarted: %v", err)
+	}
+	got, _ = repo.Get(ctx, job.ID)
+	if got.Status != domain.MigrationRunning || got.StartedAt == nil {
+		t.Fatalf("SetStarted did not take: %+v", got)
+	}
+	first := *got.StartedAt
+
+	// Resuming must not rewrite when the transfer originally began.
+	if err := repo.SetStarted(ctx, job.ID, started.Add(time.Hour)); err != nil {
+		t.Fatalf("SetStarted (resume): %v", err)
+	}
+	got, _ = repo.Get(ctx, job.ID)
+	if !got.StartedAt.Equal(first) {
+		t.Fatalf("resume moved started_at from %v to %v", first, *got.StartedAt)
+	}
+
+	if err := repo.SetTotals(ctx, job.ID, 4, 120); err != nil {
+		t.Fatalf("SetTotals: %v", err)
+	}
+	msg := "asset raw-hosted/a.txt: 404"
+	if err := repo.UpdateProgress(ctx, job.ID, 2, 55, 1, &msg); err != nil {
+		t.Fatalf("UpdateProgress: %v", err)
+	}
+	got, _ = repo.Get(ctx, job.ID)
+	if got.TotalRepos != 4 || got.TotalAssets != 120 || got.DoneRepos != 2 || got.DoneAssets != 55 {
+		t.Fatalf("progress mismatch: %+v", got)
+	}
+	if got.ErrorCount != 1 || got.LastError == nil || *got.LastError != msg {
+		t.Fatalf("error tally mismatch: %+v", got)
+	}
+
+	// A later progress write with no new message keeps the one already recorded.
+	if err := repo.UpdateProgress(ctx, job.ID, 3, 90, 1, nil); err != nil {
+		t.Fatalf("UpdateProgress (no message): %v", err)
+	}
+	got, _ = repo.Get(ctx, job.ID)
+	if got.LastError == nil || *got.LastError != msg {
+		t.Fatalf("last_error was cleared by a progress write: %+v", got.LastError)
+	}
+
+	if err := repo.FinishJob(ctx, job.ID, domain.MigrationDone, nil); err != nil {
+		t.Fatalf("FinishJob: %v", err)
+	}
+	got, _ = repo.Get(ctx, job.ID)
+	if got.Status != domain.MigrationDone || got.FinishedAt == nil {
+		t.Fatalf("FinishJob did not take: %+v", got)
+	}
+
+	// A finished job is no longer the runner's to pick up.
+	active, _ = repo.ListActive(ctx)
+	if len(active) != 0 {
+		t.Fatalf("finished job still listed as active: %+v", active)
+	}
+}
+
+func TestMigrationRepo_SetSourcePassword(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "migration_jobs")
+	ctx := context.Background()
+	repo := NewMigrationRepo(pool)
+
+	job := &domain.MigrationJob{SourceURL: "https://nexus.example.com"}
+	if err := repo.Create(ctx, job); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.SetSourcePassword(ctx, job.ID, "sealed-v2"); err != nil {
+		t.Fatalf("SetSourcePassword: %v", err)
+	}
+	got, _ := repo.Get(ctx, job.ID)
+	if got.SourcePassword != "sealed-v2" {
+		t.Fatalf("password not updated: %q", got.SourcePassword)
+	}
+}
+
+func TestMigrationRepo_RunnerUpdates_NotFound(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "migration_jobs")
+	ctx := context.Background()
+	repo := NewMigrationRepo(pool)
+
+	const missing = "00000000-0000-0000-0000-000000000000"
+	if err := repo.SetStarted(ctx, missing, time.Now()); err == nil {
+		t.Fatal("SetStarted(missing) should error")
+	}
+	if err := repo.SetTotals(ctx, missing, 1, 1); err == nil {
+		t.Fatal("SetTotals(missing) should error")
+	}
+	if err := repo.UpdateProgress(ctx, missing, 1, 1, 0, nil); err == nil {
+		t.Fatal("UpdateProgress(missing) should error")
+	}
+	if err := repo.FinishJob(ctx, missing, domain.MigrationDone, nil); err == nil {
+		t.Fatal("FinishJob(missing) should error")
+	}
+	if err := repo.SetSourcePassword(ctx, missing, "x"); err == nil {
+		t.Fatal("SetSourcePassword(missing) should error")
 	}
 }

--- a/internal/repository/postgres/role_repo.go
+++ b/internal/repository/postgres/role_repo.go
@@ -60,6 +60,17 @@ func (r *roleRepo) Get(ctx context.Context, id string) (*domain.Role, error) {
 	return ro, err
 }
 
+func (r *roleRepo) GetByName(ctx context.Context, name string) (*domain.Role, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, name, description, source, builtin, created_at, updated_at
+		FROM roles WHERE name = $1`, name)
+	ro, err := scanRole(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, repository.ErrNotFound
+	}
+	return ro, err
+}
+
 func (r *roleRepo) Create(ctx context.Context, ro *domain.Role) error {
 	return r.db.QueryRow(ctx, `
 		INSERT INTO roles (name, description, source, builtin)

--- a/internal/repository/postgres/role_repo_integration_test.go
+++ b/internal/repository/postgres/role_repo_integration_test.go
@@ -660,3 +660,43 @@ func TestRoleRepo_Delete_CascadesRolePrivileges(t *testing.T) {
 		t.Errorf("role_privileges not cascade-deleted: %v", ids)
 	}
 }
+
+// ── GetByName ─────────────────────────────────────────────────────────────────
+
+func TestRoleRepo_GetByName_HappyPath(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "roles", "privileges", "content_selectors")
+	ctx := context.Background()
+	repo := NewRoleRepo(pool)
+
+	created := makeRole("getbyname_dev", "migrated")
+	if err := repo.Create(ctx, created); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := repo.GetByName(ctx, "getbyname_dev")
+	if err != nil {
+		t.Fatalf("GetByName: %v", err)
+	}
+	if got.ID != created.ID || got.Name != "getbyname_dev" {
+		t.Fatalf("GetByName mismatch: %+v", got)
+	}
+	if got.Description != created.Description {
+		t.Fatalf("description not round-tripped: %q", got.Description)
+	}
+}
+
+func TestRoleRepo_GetByName_NotFound_ReturnsErrNotFound(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "roles", "privileges", "content_selectors")
+	ctx := context.Background()
+	repo := NewRoleRepo(pool)
+
+	got, err := repo.GetByName(ctx, "no_such_role")
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("GetByName(missing): want ErrNotFound, got %v", err)
+	}
+	if got != nil {
+		t.Fatalf("GetByName(missing): expected nil, got %+v", got)
+	}
+}

--- a/internal/repository/postgres/user_repo.go
+++ b/internal/repository/postgres/user_repo.go
@@ -22,7 +22,8 @@ func NewUserRepo(db *pgxpool.Pool) *userRepo {
 
 const userSelect = `
 	SELECT id, username, COALESCE(email,''), COALESCE(password_hash,''), first_name, last_name,
-	       status, source, COALESCE(external_id,''), last_login, tokens_valid_after, created_at, updated_at
+	       status, source, COALESCE(external_id,''), must_reset_password,
+	       last_login, tokens_valid_after, created_at, updated_at
 	FROM users`
 
 func (r *userRepo) List(ctx context.Context, source string) ([]domain.User, error) {
@@ -83,11 +84,12 @@ func (r *userRepo) GetByID(ctx context.Context, id string) (*domain.User, error)
 
 func (r *userRepo) Create(ctx context.Context, u *domain.User) error {
 	return r.db.QueryRow(ctx, `
-		INSERT INTO users (username, email, password_hash, first_name, last_name, status, source)
-		VALUES ($1,$2,$3,$4,$5,$6,$7)
+		INSERT INTO users (username, email, password_hash, first_name, last_name, status, source,
+		                   must_reset_password)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
 		RETURNING id, created_at, updated_at`,
 		u.Username, nilIfEmpty(u.Email), nilIfEmpty(u.PasswordHash),
-		u.FirstName, u.LastName, u.Status, u.Source,
+		u.FirstName, u.LastName, u.Status, u.Source, u.MustResetPassword,
 	).Scan(&u.ID, &u.CreatedAt, &u.UpdatedAt)
 }
 
@@ -100,8 +102,12 @@ func (r *userRepo) Update(ctx context.Context, u *domain.User) error {
 	return err
 }
 
+// UpdatePassword sets a new hash and clears must_reset_password: choosing a
+// password is what the flag was asking for, so the prompt retires with it.
 func (r *userRepo) UpdatePassword(ctx context.Context, username, hash string) error {
-	_, err := r.db.Exec(ctx, `UPDATE users SET password_hash=$1, updated_at=NOW() WHERE username=$2`, hash, username)
+	_, err := r.db.Exec(ctx, `
+		UPDATE users SET password_hash=$1, must_reset_password=FALSE, updated_at=NOW()
+		WHERE username=$2`, hash, username)
 	return err
 }
 
@@ -152,7 +158,7 @@ func scanUser(row scanner) (*domain.User, error) {
 	err := row.Scan(
 		&u.ID, &u.Username, &u.Email, &u.PasswordHash,
 		&u.FirstName, &u.LastName, &u.Status, &u.Source,
-		&u.ExternalID, &u.LastLogin, &u.TokensValidAfter,
+		&u.ExternalID, &u.MustResetPassword, &u.LastLogin, &u.TokensValidAfter,
 		&u.CreatedAt, &u.UpdatedAt,
 	)
 	if err != nil {

--- a/internal/repository/postgres/user_repo_integration_test.go
+++ b/internal/repository/postgres/user_repo_integration_test.go
@@ -887,3 +887,67 @@ func TestUserRepo_Delete_CascadesUserRoles(t *testing.T) {
 		t.Errorf("GetUserRoles after Delete: got %v, want empty", userRoles)
 	}
 }
+
+// ── must_reset_password ───────────────────────────────────────────────────────
+
+func TestUserRepo_MustResetPassword_RoundTrips(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "users", "roles")
+	ctx := context.Background()
+	repo := NewUserRepo(pool)
+
+	u := makeUser("migrated_user", "migrated@test.com")
+	u.MustResetPassword = true
+	if err := repo.Create(ctx, u); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := repo.Get(ctx, "migrated_user")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.MustResetPassword {
+		t.Fatal("must_reset_password did not survive the round trip")
+	}
+}
+
+func TestUserRepo_MustResetPassword_DefaultsFalse(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "users", "roles")
+	ctx := context.Background()
+	repo := NewUserRepo(pool)
+
+	u := makeUser("ordinary_user", "ordinary@test.com")
+	if err := repo.Create(ctx, u); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	got, _ := repo.Get(ctx, "ordinary_user")
+	if got.MustResetPassword {
+		t.Fatal("an ordinary account should not be asked to reset its password")
+	}
+}
+
+// Setting a password is what the flag was asking for, so it retires with it.
+func TestUserRepo_UpdatePassword_ClearsMustReset(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "users", "roles")
+	ctx := context.Background()
+	repo := NewUserRepo(pool)
+
+	u := makeUser("reset_user", "reset@test.com")
+	u.MustResetPassword = true
+	if err := repo.Create(ctx, u); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := repo.UpdatePassword(ctx, "reset_user", "new_hash"); err != nil {
+		t.Fatalf("UpdatePassword: %v", err)
+	}
+
+	got, _ := repo.Get(ctx, "reset_user")
+	if got.MustResetPassword {
+		t.Fatal("must_reset_password should be cleared once a password is set")
+	}
+	if got.PasswordHash != "new_hash" {
+		t.Fatalf("password hash not updated: %q", got.PasswordHash)
+	}
+}

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -1,0 +1,1235 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/logger"
+	"github.com/nexspence-oss/nexspence/internal/netguard"
+	"github.com/nexspence-oss/nexspence/internal/nexusclient"
+	"github.com/nexspence-oss/nexspence/internal/repository"
+)
+
+// errMigrationPaused unwinds a run that an operator parked. It is not a
+// failure: the job keeps its progress and can be resumed.
+var errMigrationPaused = errors.New("migration paused")
+
+const (
+	// migrationHTTPTimeout bounds a single request to the source Nexus. Asset
+	// downloads share it, so it is generous rather than snappy.
+	migrationHTTPTimeout = 5 * time.Minute
+	// previewTimeout bounds the read-only reachability check, which runs inside
+	// an operator's request and must answer quickly either way.
+	previewTimeout = 10 * time.Second
+)
+
+// nexusFormats maps a Nexus repository format onto the Nexspence format that
+// speaks the same protocol. A format absent from this map has no handler here,
+// so its repository is reported and skipped rather than created half-working.
+var nexusFormats = map[string]domain.RepoFormat{
+	"maven2":    domain.FormatMaven2,
+	"npm":       domain.FormatNPM,
+	"docker":    domain.FormatDocker,
+	"pypi":      domain.FormatPyPI,
+	"go":        domain.FormatGo,
+	"nuget":     domain.FormatNuGet,
+	"helm":      domain.FormatHelm,
+	"raw":       domain.FormatRaw,
+	"apt":       domain.FormatApt,
+	"yum":       domain.FormatYum,
+	"cargo":     "cargo",
+	"conan":     "conan",
+	"conda":     "conda",
+	"terraform": "terraform",
+}
+
+// nexusPrivilegeTypes maps Nexus privilege types onto the Nexspence ones. The
+// two products share the model, so this is a rename rather than a translation.
+var nexusPrivilegeTypes = map[string]domain.PrivilegeType{
+	"wildcard":                    domain.PrivilegeTypeWildcard,
+	"repository-view":             domain.PrivilegeTypeRepositoryView,
+	"repository-admin":            domain.PrivilegeTypeRepositoryAdmin,
+	"application":                 domain.PrivilegeTypeApplication,
+	"script":                      domain.PrivilegeTypeScript,
+	"repository-content-selector": domain.PrivilegeTypeRepositoryContentSelector,
+}
+
+// MigrationUserStore is the slice of user management a migration needs:
+// look an account up, and create one with a password. *UserService satisfies it.
+type MigrationUserStore interface {
+	Get(ctx context.Context, username string) (*domain.User, error)
+	Create(ctx context.Context, u *domain.User, plainPassword string) error
+}
+
+// NexusMigrationConfig holds the collaborators of a NexusMigrationService.
+type NexusMigrationConfig struct {
+	Jobs         repository.MigrationRepo
+	Repos        *RepositoryService
+	Users        MigrationUserStore
+	Roles        repository.RoleRepo
+	Privileges   repository.PrivilegeRepo
+	RoutingRules repository.RoutingRuleRepo
+	// Deps is the storage waist every format handler writes through; the
+	// migration ingests assets the same way an upload does.
+	Deps formats.Deps
+	// JWTSecret and EncryptionKey seal the stored source credential, exactly as
+	// they do for replication targets.
+	JWTSecret     string
+	EncryptionKey []byte
+	Log           logger.Logger
+	// HTTPClientFor builds the client used to reach the source Nexus. Defaults
+	// to the SSRF-guarded netguard client; tests override it for loopback.
+	HTTPClientFor func(timeout time.Duration) *http.Client
+}
+
+// NexusMigrationService runs Nexus → Nexspence migration jobs: it reads a
+// source instance over its REST API and re-creates its repositories, artifacts,
+// security model and routing rules here.
+//
+// One job runs in one goroutine. Pausing cancels it; resuming starts a fresh
+// pass that skips whatever is already present, which is also what makes a job
+// survive a process restart — ResumeAll re-attaches to jobs left running.
+type NexusMigrationService struct {
+	jobs         repository.MigrationRepo
+	repos        *RepositoryService
+	users        MigrationUserStore
+	roles        repository.RoleRepo
+	privileges   repository.PrivilegeRepo
+	routingRules repository.RoutingRuleRepo
+	deps         formats.Deps
+	log          logger.Logger
+
+	primaryKey []byte
+	legacyKey  []byte
+
+	newClient func(timeout time.Duration) *http.Client
+
+	mu      sync.Mutex
+	cancels map[string]context.CancelFunc
+}
+
+// NewNexusMigrationService constructs the migration runner.
+func NewNexusMigrationService(cfg NexusMigrationConfig) *NexusMigrationService {
+	s := &NexusMigrationService{
+		jobs:         cfg.Jobs,
+		repos:        cfg.Repos,
+		users:        cfg.Users,
+		roles:        cfg.Roles,
+		privileges:   cfg.Privileges,
+		routingRules: cfg.RoutingRules,
+		deps:         cfg.Deps,
+		log:          cfg.Log,
+		newClient:    cfg.HTTPClientFor,
+		cancels:      make(map[string]context.CancelFunc),
+	}
+	if s.newClient == nil {
+		s.newClient = netguard.Client
+	}
+	legacy := deriveKey(cfg.JWTSecret)
+	if len(cfg.EncryptionKey) == 32 {
+		s.primaryKey = cfg.EncryptionKey
+		s.legacyKey = legacy
+	} else {
+		s.primaryKey = legacy
+	}
+	return s
+}
+
+// SealPassword encrypts a Nexus password for storage on the job row.
+func (s *NexusMigrationService) SealPassword(plain string) string {
+	if plain == "" {
+		return ""
+	}
+	sealed, err := sealWithKey(s.primaryKey, plain)
+	if err != nil {
+		return ""
+	}
+	return sealed
+}
+
+// OpenPassword decrypts a stored source credential, falling back to the legacy
+// jwt-derived key for rows sealed before a dedicated key was configured.
+func (s *NexusMigrationService) OpenPassword(sealed string) (string, error) {
+	if sealed == "" {
+		return "", nil
+	}
+	plain, err := openWithKey(s.primaryKey, sealed)
+	if err == nil {
+		return plain, nil
+	}
+	if s.legacyKey != nil {
+		if lp, lerr := openWithKey(s.legacyKey, sealed); lerr == nil {
+			return lp, nil
+		}
+	}
+	return "", err
+}
+
+// ── lifecycle ───────────────────────────────────────────────────────────────
+
+// Create validates the job, seals its credential, persists it and starts the
+// run. The job row exists before the run begins, so a source that turns out to
+// be unreachable is reported on the job rather than swallowed by the request.
+func (s *NexusMigrationService) Create(ctx context.Context, job *domain.MigrationJob, password string) error {
+	if err := validateNexusURL(job.SourceURL); err != nil {
+		return err
+	}
+	job.SourceURL = strings.TrimRight(strings.TrimSpace(job.SourceURL), "/")
+	job.Status = domain.MigrationPending
+	job.SourcePassword = s.SealPassword(password)
+
+	if err := s.jobs.Create(ctx, job); err != nil {
+		return err
+	}
+	s.launch(job.ID)
+	return nil
+}
+
+// Pause stops the run and parks the job. A job that is not running is parked
+// where it stands, so an operator can stop one before it ever starts.
+func (s *NexusMigrationService) Pause(ctx context.Context, id string) error {
+	job, err := s.jobs.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	cancel, running := s.cancels[id]
+	s.mu.Unlock()
+	if running {
+		// The runner writes the paused status when it unwinds, so progress
+		// recorded between here and there is not lost.
+		cancel()
+		return nil
+	}
+	if !job.IsActive() {
+		return fmt.Errorf("%w: migration job is already %s", ErrInvalidInput, job.Status)
+	}
+	return s.jobs.UpdateStatus(ctx, id, domain.MigrationPaused)
+}
+
+// Resume starts a fresh pass over the job. Everything already migrated is
+// skipped, so resuming costs only the work that is left.
+func (s *NexusMigrationService) Resume(ctx context.Context, id string) error {
+	if _, err := s.jobs.Get(ctx, id); err != nil {
+		return err
+	}
+	s.launch(id)
+	return nil
+}
+
+// ResumeAll re-attaches to every job that was still active when the process
+// stopped. Called once on startup: without it a migration interrupted by a
+// restart would sit in "running" forever with nothing behind it.
+func (s *NexusMigrationService) ResumeAll(ctx context.Context) error {
+	active, err := s.jobs.ListActive(ctx)
+	if err != nil {
+		return err
+	}
+	for _, job := range active {
+		s.launch(job.ID)
+	}
+	return nil
+}
+
+// launch starts the runner unless this process is already running the job.
+func (s *NexusMigrationService) launch(id string) {
+	s.mu.Lock()
+	if _, busy := s.cancels[id]; busy {
+		s.mu.Unlock()
+		return
+	}
+	//nolint:gosec // the run must outlive the request; cancel is stored below and always invoked in run's defer
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancels[id] = cancel
+	s.mu.Unlock()
+
+	go s.run(ctx, id)
+}
+
+// ── preview ─────────────────────────────────────────────────────────────────
+
+// NexusPreviewRepo is one repository as reported by a preflight check.
+type NexusPreviewRepo struct {
+	Name   string `json:"name"`
+	Format string `json:"format"`
+	Type   string `json:"type"`
+}
+
+// NexusPreview is the result of a preflight "can we reach this Nexus" check.
+type NexusPreview struct {
+	Reachable bool               `json:"reachable"`
+	RepoCount int                `json:"repoCount"`
+	Repos     []NexusPreviewRepo `json:"repos"`
+}
+
+// Preview reads the repository list from a Nexus instance without creating
+// anything. It is the "Test connection" path: pure read, safe to repeat.
+func (s *NexusMigrationService) Preview(ctx context.Context, sourceURL, username, password string) (*NexusPreview, error) {
+	if err := validateNexusURL(sourceURL); err != nil {
+		return nil, err
+	}
+	client := s.clientFor(sourceURL, username, password, previewTimeout)
+	repos, err := client.ListRepositories(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := &NexusPreview{Reachable: true, RepoCount: len(repos), Repos: make([]NexusPreviewRepo, 0, len(repos))}
+	for _, r := range repos {
+		out.Repos = append(out.Repos, NexusPreviewRepo{Name: r.Name, Format: r.Format, Type: r.Type})
+	}
+	return out, nil
+}
+
+func (s *NexusMigrationService) clientFor(sourceURL, username, password string, timeout time.Duration) *nexusclient.Client {
+	return nexusclient.New(sourceURL, username, password, timeout).
+		WithHTTPClient(s.newClient(timeout))
+}
+
+func validateNexusURL(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("%w: sourceUrl is required", ErrInvalidInput)
+	}
+	u, err := url.Parse(trimmed)
+	if err != nil || u.Host == "" || (u.Scheme != "http" && u.Scheme != "https") {
+		return fmt.Errorf("%w: sourceUrl must be an absolute http(s) URL", ErrInvalidInput)
+	}
+	return nil
+}
+
+// ── the run ─────────────────────────────────────────────────────────────────
+
+// progress accumulates what a run has done and writes it through to the job row.
+// Every counter update goes through here, so the numbers an operator watches and
+// the numbers the runner acts on are the same numbers.
+type progress struct {
+	jobs  repository.MigrationRepo
+	jobID string
+
+	totalRepos  int
+	doneRepos   int
+	totalAssets int64
+	doneAssets  int64
+	errorCount  int
+	lastError   *string
+}
+
+func (p *progress) setTotals(ctx context.Context, totalRepos int, totalAssets int64) {
+	p.totalRepos, p.totalAssets = totalRepos, totalAssets
+	_ = p.jobs.SetTotals(ctx, p.jobID, totalRepos, totalAssets)
+}
+
+func (p *progress) flush(ctx context.Context) {
+	_ = p.jobs.UpdateProgress(ctx, p.jobID, p.doneRepos, p.doneAssets, p.errorCount, p.lastError)
+}
+
+// fail records one non-fatal problem. A migration copies thousands of
+// independent things; one that will not come across is counted and named, and
+// the rest of the run continues.
+func (p *progress) fail(ctx context.Context, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	p.errorCount++
+	p.lastError = &msg
+	p.flush(ctx)
+}
+
+func (s *NexusMigrationService) run(ctx context.Context, jobID string) {
+	defer func() {
+		s.mu.Lock()
+		if cancel, ok := s.cancels[jobID]; ok {
+			cancel()
+			delete(s.cancels, jobID)
+		}
+		s.mu.Unlock()
+	}()
+
+	// Progress and status are written on a background context: a paused or
+	// canceled run still has to record where it stopped.
+	bg := context.Background()
+
+	job, err := s.jobs.Get(bg, jobID)
+	if err != nil {
+		s.logf("migration: cannot load job %s: %v", jobID, err)
+		return
+	}
+	password, err := s.OpenPassword(job.SourcePassword)
+	if err != nil {
+		s.finish(bg, jobID, domain.MigrationError,
+			fmt.Sprintf("cannot decrypt the stored Nexus credential: %v", err))
+		return
+	}
+	if err := s.jobs.SetStarted(bg, jobID, time.Now().UTC()); err != nil {
+		s.logf("migration: cannot mark job %s started: %v", jobID, err)
+		return
+	}
+
+	client := s.clientFor(job.SourceURL, job.SourceUser, password, migrationHTTPTimeout)
+	p := &progress{jobs: s.jobs, jobID: jobID}
+
+	runErr := s.runStages(ctx, client, job, p)
+	switch {
+	case errors.Is(runErr, errMigrationPaused):
+		_ = s.jobs.UpdateStatus(bg, jobID, domain.MigrationPaused)
+	case runErr != nil:
+		s.finish(bg, jobID, domain.MigrationError, runErr.Error())
+	default:
+		_ = s.jobs.FinishJob(bg, jobID, domain.MigrationDone, nil)
+	}
+}
+
+func (s *NexusMigrationService) finish(ctx context.Context, jobID string, status domain.MigrationJobStatus, msg string) {
+	_ = s.jobs.FinishJob(ctx, jobID, status, &msg)
+}
+
+// runStages walks the fixed sequence. Each stage is gated by its own scope
+// flag, and each returns an error only when it cannot proceed at all —
+// per-item problems are counted on the job instead.
+func (s *NexusMigrationService) runStages(ctx context.Context, client *nexusclient.Client,
+	job *domain.MigrationJob, p *progress,
+) error {
+	bg := context.Background()
+
+	if job.MigrateRepos {
+		hosted, err := s.migrateRepositories(ctx, client, p)
+		if err != nil {
+			return err
+		}
+		if job.MigrateBlobs {
+			if err := s.migrateAssets(ctx, client, hosted, p); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Privileges first: a role references them by name, so they must exist
+	// before the roles that name them are wired up.
+	if job.MigratePrivileges {
+		if err := s.migratePrivileges(ctx, client, p); err != nil {
+			return err
+		}
+	}
+	if job.MigrateRoles {
+		if err := s.migrateRoles(ctx, client, p); err != nil {
+			return err
+		}
+	}
+	if job.MigrateUsers {
+		if err := s.migrateUsers(ctx, client, p); err != nil {
+			return err
+		}
+	}
+	if job.MigrateRoutingRules {
+		if err := s.migrateRoutingRules(ctx, client, p); err != nil {
+			return err
+		}
+	}
+	p.flush(bg)
+	return checkPaused(ctx)
+}
+
+func checkPaused(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return errMigrationPaused
+	}
+	return nil
+}
+
+// ── repositories ────────────────────────────────────────────────────────────
+
+// migrateRepositories re-creates the source repositories here and returns the
+// hosted ones, which are the only ones holding artifacts worth transferring.
+func (s *NexusMigrationService) migrateRepositories(ctx context.Context, client *nexusclient.Client,
+	p *progress,
+) ([]nexusclient.Repository, error) {
+	bg := context.Background()
+
+	source, err := client.ListRepositoriesWithConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list repositories on the source Nexus: %w", err)
+	}
+	p.setTotals(bg, len(source), p.totalAssets)
+
+	// hosted → proxy → group, so a group's members already exist when the
+	// group naming them is created.
+	ordered := make([]nexusclient.Repository, 0, len(source))
+	for _, want := range []string{"hosted", "proxy", "group"} {
+		for _, r := range source {
+			if r.Type == want {
+				ordered = append(ordered, r)
+			}
+		}
+	}
+
+	var hosted []nexusclient.Repository
+	for _, src := range ordered {
+		if err := checkPaused(ctx); err != nil {
+			return nil, err
+		}
+		format, ok := nexusFormats[src.Format]
+		if !ok {
+			p.fail(bg, "repository %q: format %q has no Nexspence equivalent", src.Name, src.Format)
+			continue
+		}
+		if err := s.ensureRepository(ctx, src, format, p); err != nil {
+			p.fail(bg, "repository %q: %v", src.Name, err)
+			continue
+		}
+		p.doneRepos++
+		p.flush(bg)
+		if src.Type == "hosted" {
+			hosted = append(hosted, src)
+		}
+	}
+	return hosted, nil
+}
+
+// ensureRepository creates the repository unless one of that name is already
+// here. An existing repository is left exactly as it is: a re-run must not
+// rewrite configuration an operator has since changed.
+func (s *NexusMigrationService) ensureRepository(ctx context.Context, src nexusclient.Repository,
+	format domain.RepoFormat, p *progress,
+) error {
+	existing, err := s.deps.Repos.Get(ctx, src.Name)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
+	repo := &domain.Repository{
+		Name:        src.Name,
+		Format:      format,
+		Type:        domain.RepoType(src.Type),
+		Online:      true,
+		Description: "Migrated from Nexus",
+	}
+	switch src.Type {
+	case "proxy":
+		if src.RemoteURL == "" {
+			return fmt.Errorf("proxy repository has no remote URL on the source")
+		}
+		repo.ProxyConfig = map[string]any{"remote_url": src.RemoteURL}
+	case "group":
+		members := make([]string, 0, len(src.MemberNames))
+		for _, name := range src.MemberNames {
+			if _, err := s.deps.Repos.Get(ctx, name); err == nil {
+				members = append(members, name)
+				continue
+			}
+			p.fail(context.Background(),
+				"group %q: member %q was not migrated and is left out", src.Name, name)
+		}
+		repo.FormatConfig = map[string]any{"member_names": members}
+	}
+	return s.repos.Create(ctx, repo)
+}
+
+// ── assets ──────────────────────────────────────────────────────────────────
+
+// plannedAsset is one unit to transfer.
+//
+// For an ordinary format that is one file. For an OCI registry it is one
+// manifest, which brings the blobs it names along with it — see
+// transferOCIManifest for why those cannot be planned from the listing.
+type plannedAsset struct {
+	repo        string
+	path        string // Nexspence asset path, leading slash
+	downloadURL string
+	contentType string
+	size        int64
+	coords      base.Coords
+	// isOCIManifest marks a registry manifest: image is coords.Name and the tag
+	// or digest is coords.Version.
+	isOCIManifest bool
+}
+
+func (s *NexusMigrationService) migrateAssets(ctx context.Context, client *nexusclient.Client,
+	hosted []nexusclient.Repository, p *progress,
+) error {
+	bg := context.Background()
+
+	for _, src := range hosted {
+		if err := checkPaused(ctx); err != nil {
+			return err
+		}
+		planned, err := s.planAssets(ctx, client, src, p)
+		if err != nil {
+			p.fail(bg, "repository %q: listing components: %v", src.Name, err)
+			continue
+		}
+		p.setTotals(bg, p.totalRepos, p.totalAssets+int64(len(planned)))
+
+		for _, a := range planned {
+			if err := checkPaused(ctx); err != nil {
+				return err
+			}
+			if err := s.transferAsset(ctx, client, a); err != nil {
+				p.fail(bg, "asset %s%s: %v", a.repo, a.path, err)
+				continue
+			}
+			p.doneAssets++
+			p.flush(bg)
+		}
+	}
+	return nil
+}
+
+// planAssets lists every component in the repository and turns it into the set
+// of files to transfer, ordered so a manifest never lands before its blobs.
+func (s *NexusMigrationService) planAssets(ctx context.Context, client *nexusclient.Client,
+	src nexusclient.Repository, _ *progress,
+) ([]plannedAsset, error) {
+	isOCI := nexusFormats[src.Format].IsOCIRegistry()
+
+	var planned []plannedAsset
+	token := ""
+	for {
+		if err := checkPaused(ctx); err != nil {
+			return nil, err
+		}
+		components, next, err := client.ListComponents(ctx, src.Name, token)
+		if err != nil {
+			return nil, err
+		}
+		for _, comp := range components {
+			for _, a := range comp.Assets {
+				pa := plannedAsset{
+					repo:        src.Name,
+					downloadURL: a.DownloadURL,
+					contentType: a.ContentType,
+					size:        a.SizeBytes,
+					coords:      base.Coords{Group: comp.Group, Name: comp.Name, Version: comp.Version},
+				}
+				if isOCI {
+					translated, ok := ociManifestPath(a.Path)
+					if !ok {
+						// Every other registry path is a blob, and Nexus lists
+						// those under a placeholder image name that no client
+						// could pull them from. They come across with the
+						// manifest that names them instead.
+						continue
+					}
+					pa.path = translated.path
+					pa.isOCIManifest = true
+					pa.coords = base.Coords{Name: translated.image, Version: translated.reference}
+				} else {
+					pa.path = normalizeAssetPath(a.Path)
+				}
+				if pa.contentType == "" {
+					pa.contentType = "application/octet-stream"
+				}
+				planned = append(planned, pa)
+			}
+		}
+		if next == "" {
+			break
+		}
+		token = next
+	}
+
+	return planned, nil
+}
+
+// transferAsset brings one planned unit across, skipping whatever is already
+// here — which is what makes a resumed or repeated job cheap instead of
+// destructive.
+func (s *NexusMigrationService) transferAsset(ctx context.Context, client *nexusclient.Client, a plannedAsset) error {
+	if a.isOCIManifest {
+		return s.transferOCIManifest(ctx, client, a.repo, a.coords.Name, a.coords.Version, 0)
+	}
+
+	existing, err := s.deps.Assets.GetByPath(ctx, a.repo, a.path)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
+	body, err := client.DownloadAsset(ctx, a.downloadURL)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = body.Close() }()
+
+	_, err = base.StoreArtifact(ctx, s.deps, a.repo, a.path, a.contentType, a.coords, body, a.size)
+	return err
+}
+
+// maxManifestDepth bounds index → manifest recursion. One level is what the
+// spec describes; the bound is there so a source that points an index at
+// itself cannot spin this forever.
+const maxManifestDepth = 4
+
+// ociManifest is the slice of a manifest document the migration reads: what it
+// references, and what kind of document it is.
+type ociManifestDoc struct {
+	MediaType string `json:"mediaType"`
+	Config    struct {
+		Digest string `json:"digest"`
+	} `json:"config"`
+	Layers []struct {
+		Digest string `json:"digest"`
+	} `json:"layers"`
+	// Manifests is non-empty on an index (a multi-platform image), whose
+	// children are manifests rather than blobs.
+	Manifests []struct {
+		Digest string `json:"digest"`
+	} `json:"manifests"`
+}
+
+// transferOCIManifest brings one image manifest across along with everything it
+// names, in that order: blobs first, then the manifest, so the registry never
+// serves a manifest whose layers are still missing.
+//
+// The blobs cannot be taken from the component listing. Nexus stores registry
+// blobs content-addressed and lists them under a placeholder image name
+// ("/v2/-/blobs/<digest>"), which is not a path any client can pull from — and
+// its component listing reports only the manifest in the first place. The
+// manifest is therefore read, parsed, and used as the index of what to fetch.
+func (s *NexusMigrationService) transferOCIManifest(ctx context.Context, client *nexusclient.Client,
+	repoName, image, reference string, depth int,
+) error {
+	if depth > maxManifestDepth {
+		return fmt.Errorf("manifest %s/%s nests deeper than %d levels", image, reference, maxManifestDepth)
+	}
+
+	body, contentType, err := client.DownloadManifest(ctx, repoName, image, reference)
+	if err != nil {
+		return err
+	}
+
+	var doc ociManifestDoc
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return fmt.Errorf("parse manifest %s:%s: %w", image, reference, err)
+	}
+	if contentType == "" {
+		contentType = doc.MediaType
+	}
+	if contentType == "" {
+		contentType = "application/vnd.docker.distribution.manifest.v2+json"
+	}
+
+	// An index names manifests; a manifest names blobs. Either way the things
+	// it points at are stored before it is.
+	for _, child := range doc.Manifests {
+		if child.Digest == "" {
+			continue
+		}
+		if err := s.transferOCIManifest(ctx, client, repoName, image, child.Digest, depth+1); err != nil {
+			return err
+		}
+	}
+	digests := make([]string, 0, len(doc.Layers)+1)
+	if doc.Config.Digest != "" {
+		digests = append(digests, doc.Config.Digest)
+	}
+	for _, l := range doc.Layers {
+		if l.Digest != "" {
+			digests = append(digests, l.Digest)
+		}
+	}
+	for _, digest := range digests {
+		if err := s.ensureOCIBlob(ctx, client, repoName, image, digest); err != nil {
+			return err
+		}
+	}
+
+	manifestPath := "/manifests/" + image + "/" + reference
+	existing, err := s.deps.Assets.GetByPath(ctx, repoName, manifestPath)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
+	coords := base.Coords{Name: image, Version: reference}
+	res, err := base.StoreArtifact(ctx, s.deps, repoName, manifestPath, contentType, coords,
+		bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return err
+	}
+	s.registerManifestDigestAlias(ctx, plannedAsset{
+		repo: repoName, contentType: contentType, coords: coords,
+	}, res)
+	return nil
+}
+
+// ensureOCIBlob copies one blob unless the image already has it. Layers are
+// shared between images, so this check is what keeps a repository-wide
+// migration from re-transferring the same base layer for every tag.
+func (s *NexusMigrationService) ensureOCIBlob(ctx context.Context, client *nexusclient.Client,
+	repoName, image, digest string,
+) error {
+	blobPath := "/blobs/" + image + "/" + digest
+	existing, err := s.deps.Assets.GetByPath(ctx, repoName, blobPath)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
+	body, err := client.DownloadBlob(ctx, repoName, image, digest)
+	if err != nil {
+		return fmt.Errorf("blob %s: %w", digest, err)
+	}
+	defer func() { _ = body.Close() }()
+
+	_, err = base.StoreArtifact(ctx, s.deps, repoName, blobPath, "application/octet-stream",
+		base.Coords{Name: image, Version: digest}, body, 0)
+	return err
+}
+
+// registerManifestDigestAlias points the manifest's content digest at the same
+// stored bytes, the way a registry push does: a client that pulls by tag
+// immediately re-fetches the manifest by digest, and gets a 404 without this.
+func (s *NexusMigrationService) registerManifestDigestAlias(ctx context.Context, a plannedAsset, res *base.StoreResult) {
+	digestRef := "sha256:" + res.SHA256
+	if a.coords.Version == digestRef {
+		return // already stored under its digest
+	}
+	repo, err := s.deps.Repos.Get(ctx, a.repo)
+	if err != nil || repo == nil {
+		return
+	}
+	aliasPath := "/manifests/" + a.coords.Name + "/" + digestRef
+	if _, err := base.RegisterStoredBlob(ctx, s.deps, repo,
+		aliasPath, a.contentType,
+		base.Coords{Name: a.coords.Name, Version: digestRef},
+		res.Asset.BlobKey,
+		res.SHA256, res.SHA1, res.MD5, res.Size,
+		res.Asset.BlobStoreID, "",
+	); err != nil {
+		s.logf("migration: cannot register digest alias %s%s: %v", a.repo, aliasPath, err)
+	}
+}
+
+// normalizeAssetPath gives a Nexus asset path the leading slash every path
+// stored here carries.
+func normalizeAssetPath(p string) string {
+	p = strings.TrimSpace(p)
+	if !strings.HasPrefix(p, "/") {
+		return "/" + p
+	}
+	return p
+}
+
+type ociPath struct {
+	path      string
+	image     string
+	reference string
+}
+
+// ociManifestPath rewrites a Nexus registry manifest path —
+// "/v2/<image>/manifests/<tag-or-digest>" — into the layout the OCI handler
+// here reads. Anything else, including a blob path, is not a manifest and is
+// reported as such.
+func ociManifestPath(raw string) (ociPath, bool) {
+	p := strings.TrimPrefix(normalizeAssetPath(raw), "/")
+	p = strings.TrimPrefix(p, "v2/")
+
+	i := strings.LastIndex(p, "/manifests/")
+	if i <= 0 {
+		return ociPath{}, false
+	}
+	image, reference := p[:i], p[i+len("/manifests/"):]
+	if image == "" || reference == "" {
+		return ociPath{}, false
+	}
+	return ociPath{
+		path:      "/manifests/" + image + "/" + reference,
+		image:     image,
+		reference: reference,
+	}, true
+}
+
+// ── privileges ──────────────────────────────────────────────────────────────
+
+func (s *NexusMigrationService) migratePrivileges(ctx context.Context, client *nexusclient.Client, p *progress) error {
+	bg := context.Background()
+
+	source, err := client.ListPrivileges(ctx)
+	if err != nil {
+		return fmt.Errorf("list privileges on the source Nexus: %w", err)
+	}
+	for _, src := range source {
+		if err := checkPaused(ctx); err != nil {
+			return err
+		}
+		if src.ReadOnly {
+			continue // a Nexus built-in; this instance ships its own
+		}
+		if existing, _ := s.privileges.GetByName(ctx, src.Name); existing != nil {
+			continue
+		}
+		privType, ok := nexusPrivilegeTypes[src.Type]
+		if !ok {
+			p.fail(bg, "privilege %q: unknown type %q", src.Name, src.Type)
+			continue
+		}
+		priv := &domain.Privilege{
+			Name:        src.Name,
+			Description: src.Description,
+			Type:        privType,
+			Attrs:       normalizePrivilegeAttrs(src.Attrs),
+		}
+		if err := s.privileges.Create(ctx, priv); err != nil {
+			p.fail(bg, "privilege %q: %v", src.Name, err)
+		}
+	}
+	return nil
+}
+
+// normalizePrivilegeAttrs lowercases the action names. Nexus reports them
+// uppercase ("READ"); every check here compares against lowercase.
+func normalizePrivilegeAttrs(attrs map[string]any) map[string]any {
+	out := make(map[string]any, len(attrs))
+	for k, v := range attrs {
+		if k != "actions" {
+			out[k] = v
+			continue
+		}
+		raw, ok := v.([]any)
+		if !ok {
+			out[k] = v
+			continue
+		}
+		actions := make([]string, 0, len(raw))
+		for _, item := range raw {
+			if s, ok := item.(string); ok {
+				actions = append(actions, strings.ToLower(s))
+			}
+		}
+		out[k] = actions
+	}
+	return out
+}
+
+// ── roles ───────────────────────────────────────────────────────────────────
+
+func (s *NexusMigrationService) migrateRoles(ctx context.Context, client *nexusclient.Client, p *progress) error {
+	bg := context.Background()
+
+	source, err := client.ListRoles(ctx)
+	if err != nil {
+		return fmt.Errorf("list roles on the source Nexus: %w", err)
+	}
+
+	byName := make(map[string]nexusclient.Role, len(source))
+	for _, r := range source {
+		if r.ReadOnly {
+			continue // a Nexus built-in; this instance ships its own
+		}
+		byName[roleKey(r)] = r
+	}
+
+	ordered, cyclic := topoSortRoles(byName)
+	if len(cyclic) > 0 {
+		p.fail(bg, "roles %s reference each other in a cycle; each keeps only its own privileges",
+			strings.Join(cyclic, ", "))
+	}
+
+	// Nexspence has no nested-role table, so a nested role is flattened: the
+	// parent takes the union of its own privileges and everything it inherits.
+	// Dependency order is what makes one pass enough.
+	effective := make(map[string]map[string]bool, len(ordered))
+	for _, name := range ordered {
+		src := byName[name]
+		own := make(map[string]bool, len(src.Privileges))
+		for _, priv := range src.Privileges {
+			own[priv] = true
+		}
+		for _, nested := range src.Roles {
+			for priv := range effective[nested] {
+				own[priv] = true
+			}
+		}
+		effective[name] = own
+
+		if err := checkPaused(ctx); err != nil {
+			return err
+		}
+		if err := s.ensureRole(ctx, src, own); err != nil {
+			p.fail(bg, "role %q: %v", src.Name, err)
+		}
+	}
+	return nil
+}
+
+// roleKey is the name a nested reference resolves against. Nexus nests roles by
+// id, and for every role it creates the id and the name are the same string;
+// the id is what a reference carries, so it is the key.
+func roleKey(r nexusclient.Role) string {
+	if r.ID != "" {
+		return r.ID
+	}
+	return r.Name
+}
+
+// ensureRole creates the role unless one of that name is already here, then
+// attaches the privileges it resolves to.
+func (s *NexusMigrationService) ensureRole(ctx context.Context, src nexusclient.Role, privilegeNames map[string]bool) error {
+	role, err := s.roles.GetByName(ctx, src.Name)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		return err
+	}
+	if role == nil {
+		role = &domain.Role{
+			Name:        src.Name,
+			Description: src.Description,
+			Source:      "migrated",
+		}
+		if err := s.roles.Create(ctx, role); err != nil {
+			return err
+		}
+	}
+
+	ids := make([]string, 0, len(privilegeNames))
+	for name := range privilegeNames {
+		priv, err := s.privileges.GetByName(ctx, name)
+		if err != nil || priv == nil {
+			continue // a built-in this instance does not carry, or one that failed to migrate
+		}
+		ids = append(ids, priv.ID)
+	}
+	sort.Strings(ids)
+	if len(ids) == 0 {
+		return nil
+	}
+	return s.roles.SetPrivileges(ctx, role.ID, ids)
+}
+
+// topoSortRoles orders roles so every role follows the roles it nests, and
+// reports the ones caught in a cycle. Cyclic roles are still returned — last,
+// and without their inherited privileges — because dropping a role silently is
+// worse than migrating a flatter version of it.
+func topoSortRoles(byName map[string]nexusclient.Role) (ordered []string, cyclic []string) {
+	const (
+		unvisited = 0
+		active    = 1
+		done      = 2
+	)
+	state := make(map[string]int, len(byName))
+	inCycle := map[string]bool{}
+
+	var visit func(name string)
+	visit = func(name string) {
+		switch state[name] {
+		case done:
+			return
+		case active:
+			inCycle[name] = true
+			return
+		}
+		state[name] = active
+		for _, nested := range byName[name].Roles {
+			if _, known := byName[nested]; known {
+				visit(nested)
+			}
+		}
+		state[name] = done
+		ordered = append(ordered, name)
+	}
+
+	for _, name := range sortedKeys(byName) {
+		visit(name)
+	}
+	for _, name := range sortedKeys(byName) {
+		if inCycle[name] {
+			cyclic = append(cyclic, name)
+		}
+	}
+	return ordered, cyclic
+}
+
+func sortedKeys(m map[string]nexusclient.Role) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// ── users ───────────────────────────────────────────────────────────────────
+
+func (s *NexusMigrationService) migrateUsers(ctx context.Context, client *nexusclient.Client, p *progress) error {
+	bg := context.Background()
+
+	source, err := client.ListUsers(ctx)
+	if err != nil {
+		return fmt.Errorf("list users on the source Nexus: %w", err)
+	}
+	for _, src := range source {
+		if err := checkPaused(ctx); err != nil {
+			return err
+		}
+		if src.UserID == "" {
+			continue
+		}
+		existing, err := s.users.Get(ctx, src.UserID)
+		if err != nil && !isNotFound(err) {
+			p.fail(bg, "user %q: %v", src.UserID, err)
+			continue
+		}
+		if existing != nil {
+			continue // an account of that name is already here; it is not overwritten
+		}
+		if err := s.createMigratedUser(ctx, src); err != nil {
+			p.fail(bg, "user %q: %v", src.UserID, err)
+		}
+	}
+	return nil
+}
+
+func (s *NexusMigrationService) createMigratedUser(ctx context.Context, src nexusclient.User) error {
+	source := mapUserSource(src.Source)
+	status := domain.UserStatusDisabled
+	if strings.EqualFold(src.Status, "active") {
+		status = domain.UserStatusActive
+	}
+
+	user := &domain.User{
+		Username:  src.UserID,
+		Email:     src.Email,
+		FirstName: src.FirstName,
+		LastName:  src.LastName,
+		Status:    status,
+		Source:    source,
+	}
+
+	// A Nexus password hash cannot come across, so a local account gets a random
+	// one it cannot know and is asked to change it. Externally-authenticated
+	// accounts get no local credential at all — their identity provider still
+	// owns them.
+	password := ""
+	if source == domain.UserSourceLocal {
+		generated, err := randomPassword()
+		if err != nil {
+			return err
+		}
+		password = generated
+		user.MustResetPassword = true
+	}
+
+	if err := s.users.Create(ctx, user, password); err != nil {
+		return err
+	}
+
+	roleIDs := make([]string, 0, len(src.Roles))
+	for _, name := range src.Roles {
+		role, err := s.roles.GetByName(ctx, name)
+		if err != nil || role == nil {
+			continue // a role that was not migrated cannot be granted
+		}
+		roleIDs = append(roleIDs, role.ID)
+	}
+	if len(roleIDs) == 0 {
+		return nil
+	}
+	return s.roles.SetUserRoles(ctx, user.ID, roleIDs)
+}
+
+// mapUserSource translates a Nexus realm name. An unrecognized realm becomes a
+// local account: it keeps the person able to sign in, which is the point of
+// migrating them at all.
+func mapUserSource(source string) domain.UserSource {
+	switch strings.ToLower(strings.TrimSpace(source)) {
+	case "ldap":
+		return domain.UserSourceLDAP
+	case "oidc", "openid", "openid connect":
+		return domain.UserSourceOIDC
+	case "saml":
+		return domain.UserSourceSAML
+	default:
+		return domain.UserSourceLocal
+	}
+}
+
+func randomPassword() (string, error) {
+	buf := make([]byte, 24)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+// ── routing rules ───────────────────────────────────────────────────────────
+
+func (s *NexusMigrationService) migrateRoutingRules(ctx context.Context, client *nexusclient.Client, p *progress) error {
+	bg := context.Background()
+
+	source, err := client.ListRoutingRules(ctx)
+	if err != nil {
+		return fmt.Errorf("list routing rules on the source Nexus: %w", err)
+	}
+	for _, src := range source {
+		if err := checkPaused(ctx); err != nil {
+			return err
+		}
+		if existing, _ := s.routingRules.GetByName(ctx, src.Name); existing != nil {
+			continue
+		}
+		mode := strings.ToUpper(strings.TrimSpace(src.Mode))
+		if mode != "ALLOW" && mode != "BLOCK" {
+			p.fail(bg, "routing rule %q: unknown mode %q", src.Name, src.Mode)
+			continue
+		}
+		if bad, err := firstInvalidMatcher(src.Matchers); err != nil {
+			p.fail(bg, "routing rule %q: matcher %q does not compile: %v", src.Name, bad, err)
+			continue
+		}
+		rule := &domain.RoutingRule{
+			Name:        src.Name,
+			Description: src.Description,
+			Mode:        mode,
+			Matchers:    src.Matchers,
+		}
+		if err := s.routingRules.Create(ctx, rule); err != nil {
+			p.fail(bg, "routing rule %q: %v", src.Name, err)
+		}
+	}
+	return nil
+}
+
+// firstInvalidMatcher reports the first pattern that will not compile. A rule
+// is stored whole or not at all: a half-applied ALLOW rule would quietly widen
+// or narrow what the source instance permitted.
+func firstInvalidMatcher(matchers []string) (string, error) {
+	for _, m := range matchers {
+		if _, err := regexp.Compile(m); err != nil {
+			return m, err
+		}
+	}
+	return "", nil
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+func isNotFound(err error) bool {
+	return errors.Is(err, repository.ErrNotFound) || errors.Is(err, ErrNotFound)
+}
+
+func (s *NexusMigrationService) logf(format string, args ...any) {
+	if s.log != nil {
+		s.log.Warnf(format, args...)
+	}
+}

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -1,0 +1,1010 @@
+package service_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// ── fake Nexus ───────────────────────────────────────────────────────────────
+
+// fakeNexus serves the slice of the Nexus OSS REST API the migration reads.
+// Every field is a raw JSON body; empty means "endpoint returns an empty list".
+type fakeNexus struct {
+	settings     string            // /service/rest/v1/repositorySettings
+	settingsCode int               // non-zero forces this status instead of settings
+	repositories string            // /service/rest/v1/repositories
+	components   map[string]string // repository name → one full component page
+	files        map[string]string // /repository/... path → body
+	users        string
+	roles        string
+	privileges   string
+	routingRules string
+	// onFile, when set, runs before an artifact byte is served. It lets a test
+	// hold the run inside a download and act while it is demonstrably in flight.
+	onFile func()
+
+	mu   sync.Mutex
+	hits map[string]int
+}
+
+func (f *fakeNexus) hit(path string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.hits == nil {
+		f.hits = map[string]int{}
+	}
+	f.hits[path]++
+}
+
+func (f *fakeNexus) count(path string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.hits[path]
+}
+
+func (f *fakeNexus) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.hit(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/service/rest/v1/repositorySettings":
+			if f.settingsCode != 0 {
+				w.WriteHeader(f.settingsCode)
+				return
+			}
+			_, _ = io.WriteString(w, orEmptyList(f.settings))
+		case r.URL.Path == "/service/rest/v1/repositories":
+			_, _ = io.WriteString(w, orEmptyList(f.repositories))
+		case r.URL.Path == "/service/rest/v1/components":
+			body := f.components[r.URL.Query().Get("repository")]
+			if body == "" {
+				body = `{"items":[],"continuationToken":null}`
+			}
+			_, _ = io.WriteString(w, body)
+		case r.URL.Path == "/service/rest/v1/security/users":
+			_, _ = io.WriteString(w, orEmptyList(f.users))
+		case r.URL.Path == "/service/rest/v1/security/roles":
+			_, _ = io.WriteString(w, orEmptyList(f.roles))
+		case r.URL.Path == "/service/rest/v1/security/privileges":
+			_, _ = io.WriteString(w, orEmptyList(f.privileges))
+		case r.URL.Path == "/service/rest/v1/routing-rules":
+			_, _ = io.WriteString(w, orEmptyList(f.routingRules))
+		case strings.HasPrefix(r.URL.Path, "/repository/"):
+			if f.onFile != nil {
+				f.onFile()
+			}
+			body, ok := f.files[r.URL.Path]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = io.WriteString(w, body)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func orEmptyList(s string) string {
+	if s == "" {
+		return "[]"
+	}
+	return s
+}
+
+// ── harness ──────────────────────────────────────────────────────────────────
+
+// fakeUserStore is the slice of user management the migration needs.
+type fakeUserStore struct {
+	mu        sync.Mutex
+	users     map[string]*domain.User
+	passwords map[string]string
+	createErr error
+	nextID    int
+}
+
+func newFakeUserStore(existing ...*domain.User) *fakeUserStore {
+	s := &fakeUserStore{users: map[string]*domain.User{}, passwords: map[string]string{}}
+	for _, u := range existing {
+		s.users[u.Username] = u
+	}
+	return s
+}
+
+func (s *fakeUserStore) Get(_ context.Context, username string) (*domain.User, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	u, ok := s.users[username]
+	if !ok {
+		return nil, service.ErrNotFound
+	}
+	return u, nil
+}
+
+func (s *fakeUserStore) Create(_ context.Context, u *domain.User, plainPassword string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.createErr != nil {
+		return s.createErr
+	}
+	s.nextID++
+	u.ID = fmt.Sprintf("user-%d", s.nextID)
+	s.users[u.Username] = u
+	s.passwords[u.Username] = plainPassword
+	return nil
+}
+
+func (s *fakeUserStore) get(username string) *domain.User {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.users[username]
+}
+
+func (s *fakeUserStore) password(username string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.passwords[username]
+}
+
+type migHarness struct {
+	svc        *service.NexusMigrationService
+	jobs       *testutil.MigrationRepo
+	repos      *testutil.RepoRepo
+	assets     *testutil.AssetRepo
+	components *testutil.ComponentRepo
+	blobs      *testutil.BlobStore
+	users      *fakeUserStore
+	roles      *testutil.RoleRepo
+	privileges *testutil.PrivilegeRepo
+	rules      *testutil.RoutingRuleRepo
+	nexus      *httptest.Server
+}
+
+func newMigHarness(t *testing.T, fake *fakeNexus, existingUsers ...*domain.User) *migHarness {
+	t.Helper()
+	srv := fake.start(t)
+
+	repoRepo := testutil.NewRepoRepo()
+	blobStore := testutil.NewBlobStore()
+	blobRepo := testutil.NewBlobStoreRepo()
+	assetRepo := testutil.NewAssetRepo()
+	componentRepo := testutil.NewComponentRepo()
+
+	deps := formats.Deps{
+		Repos:      repoRepo,
+		Components: componentRepo,
+		Assets:     assetRepo,
+		Blobs:      blobRepo,
+		BlobStore:  blobStore,
+		// Registry is left nil: per-blob-store routing is not what these tests
+		// are about, and without it every write lands in the store they read.
+		BaseURL: "http://nexspence.test",
+	}
+
+	h := &migHarness{
+		jobs:       testutil.NewMigrationRepo(),
+		repos:      repoRepo,
+		assets:     assetRepo,
+		components: componentRepo,
+		blobs:      blobStore,
+		users:      newFakeUserStore(existingUsers...),
+		roles:      testutil.NewRoleRepo(),
+		privileges: testutil.NewPrivilegeRepo(),
+		rules:      testutil.NewRoutingRuleRepo(),
+		nexus:      srv,
+	}
+
+	h.svc = service.NewNexusMigrationService(service.NexusMigrationConfig{
+		Jobs:          h.jobs,
+		Repos:         service.NewRepositoryService(repoRepo, blobRepo, blobStore, testutil.NewCleanupPolicyRepo()),
+		Users:         h.users,
+		Roles:         h.roles,
+		Privileges:    h.privileges,
+		RoutingRules:  h.rules,
+		Deps:          deps,
+		JWTSecret:     "unit-test-secret",
+		Log:           zap.NewNop().Sugar(),
+		HTTPClientFor: func(time.Duration) *http.Client { return srv.Client() },
+	})
+	return h
+}
+
+// startJob creates a job with all scopes on and runs it to completion.
+func (h *migHarness) startJob(t *testing.T, mutate ...func(*domain.MigrationJob)) *domain.MigrationJob {
+	t.Helper()
+	job := &domain.MigrationJob{
+		SourceURL:           h.nexus.URL,
+		SourceUser:          "admin",
+		Status:              domain.MigrationPending,
+		MigrateRepos:        true,
+		MigrateBlobs:        true,
+		MigrateUsers:        true,
+		MigratePrivileges:   true,
+		MigrateRoles:        true,
+		MigrateRoutingRules: true,
+	}
+	for _, m := range mutate {
+		m(job)
+	}
+	require.NoError(t, h.svc.Create(context.Background(), job, "s3cret"))
+	return job
+}
+
+// waitForStatus polls until the job reaches want, failing the test on timeout.
+func (h *migHarness) waitForStatus(t *testing.T, id string, want domain.MigrationJobStatus) *domain.MigrationJob {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last *domain.MigrationJob
+	for time.Now().Before(deadline) {
+		j, err := h.jobs.Get(context.Background(), id)
+		require.NoError(t, err)
+		last = j
+		if j.Status == want {
+			return j
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	lastErr := ""
+	if last != nil && last.LastError != nil {
+		lastErr = *last.LastError
+	}
+	t.Fatalf("job %s never reached %q (status=%q lastError=%q)", id, want, last.Status, lastErr)
+	return nil
+}
+
+// ── the bug: a created job never runs ────────────────────────────────────────
+
+func TestNexusMigration_CreatedJobRunsToCompletion(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"raw-hosted": `{"items":[{"name":"a.txt","version":null,"group":"/","format":"raw","assets":[
+				{"path":"a.txt","downloadUrl":"%BASE%/repository/raw-hosted/a.txt",
+				 "contentType":"text/plain","fileSize":5}]}],"continuationToken":null}`,
+		},
+		files: map[string]string{"/repository/raw-hosted/a.txt": "hello"},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["raw-hosted"] = strings.ReplaceAll(fake.components["raw-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	assert.Equal(t, 1, done.TotalRepos)
+	assert.Equal(t, 1, done.DoneRepos)
+	assert.Equal(t, int64(1), done.TotalAssets)
+	assert.Equal(t, int64(1), done.DoneAssets)
+	assert.Zero(t, done.ErrorCount)
+	require.NotNil(t, done.StartedAt)
+	require.NotNil(t, done.FinishedAt)
+
+	created, err := h.repos.Get(context.Background(), "raw-hosted")
+	require.NoError(t, err)
+	assert.Equal(t, domain.FormatRaw, created.Format)
+	assert.Equal(t, domain.TypeHosted, created.Type)
+
+	stored, err := h.assets.GetByPath(context.Background(), "raw-hosted", "/a.txt")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	body, err := h.blobs.Read(base.BlobKey("raw-hosted", "/a.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", body)
+}
+
+func TestNexusMigration_UnreachableSourceFailsJobWithError(t *testing.T) {
+	fake := &fakeNexus{}
+	h := newMigHarness(t, fake)
+	// Point the job at a URL that will never answer.
+	job := h.startJob(t, func(j *domain.MigrationJob) {
+		j.SourceURL = "http://127.0.0.1:1/nexus"
+	})
+
+	failed := h.waitForStatus(t, job.ID, domain.MigrationError)
+	require.NotNil(t, failed.LastError)
+	assert.NotEmpty(t, *failed.LastError)
+	require.NotNil(t, failed.FinishedAt)
+}
+
+// ── repository creation ──────────────────────────────────────────────────────
+
+func TestNexusMigration_CreatesGroupAfterItsMembers(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[
+			{"name":"maven-public","format":"maven2","type":"group","online":true,
+			 "group":{"memberNames":["maven-releases","maven-central"]}},
+			{"name":"maven-central","format":"maven2","type":"proxy","online":true,
+			 "proxy":{"remoteUrl":"https://repo1.maven.org/maven2"}},
+			{"name":"maven-releases","format":"maven2","type":"hosted","online":true}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Equal(t, 3, done.DoneRepos)
+
+	ctx := context.Background()
+	group, err := h.repos.Get(ctx, "maven-public")
+	require.NoError(t, err)
+	assert.Equal(t, domain.TypeGroup, group.Type)
+	assert.Equal(t, []string{"maven-releases", "maven-central"}, domain.GroupMemberNames(group))
+
+	proxy, err := h.repos.Get(ctx, "maven-central")
+	require.NoError(t, err)
+	assert.Equal(t, "https://repo1.maven.org/maven2", proxy.ProxyConfig["remote_url"])
+}
+
+func TestNexusMigration_SkipsUnsupportedFormatAndCountsIt(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[
+			{"name":"gems","format":"rubygems","type":"hosted","online":true},
+			{"name":"raw-hosted","format":"raw","type":"hosted","online":true}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	assert.Equal(t, 1, done.DoneRepos, "only the supported repository is created")
+	assert.Equal(t, 1, done.ErrorCount)
+	require.NotNil(t, done.LastError)
+	assert.Contains(t, *done.LastError, "rubygems")
+
+	_, err := h.repos.Get(context.Background(), "gems")
+	assert.Error(t, err)
+}
+
+func TestNexusMigration_ExistingRepositoryIsReused(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+	}
+	h := newMigHarness(t, fake)
+	require.NoError(t, h.repos.Create(context.Background(), &domain.Repository{
+		Name: "raw-hosted", Format: domain.FormatRaw, Type: domain.TypeHosted, Online: true,
+		Description: "pre-existing",
+	}))
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount)
+
+	got, err := h.repos.Get(context.Background(), "raw-hosted")
+	require.NoError(t, err)
+	assert.Equal(t, "pre-existing", got.Description, "an existing repository is left untouched")
+}
+
+// ── assets ───────────────────────────────────────────────────────────────────
+
+func TestNexusMigration_SkipsAssetsThatAlreadyExist(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"raw-hosted": `{"items":[{"name":"a.txt","version":null,"group":"/","format":"raw","assets":[
+				{"path":"a.txt","downloadUrl":"%BASE%/repository/raw-hosted/a.txt","fileSize":5}]}],
+				"continuationToken":null}`,
+		},
+		files: map[string]string{"/repository/raw-hosted/a.txt": "hello"},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["raw-hosted"] = strings.ReplaceAll(fake.components["raw-hosted"], "%BASE%", h.nexus.URL)
+
+	first := h.startJob(t)
+	h.waitForStatus(t, first.ID, domain.MigrationDone)
+	downloadsAfterFirst := fake.count("/repository/raw-hosted/a.txt")
+	require.Equal(t, 1, downloadsAfterFirst)
+
+	second := h.startJob(t)
+	done := h.waitForStatus(t, second.ID, domain.MigrationDone)
+	assert.Equal(t, 1, fake.count("/repository/raw-hosted/a.txt"),
+		"a re-run must not re-download an asset that is already present")
+	assert.Equal(t, int64(1), done.DoneAssets, "skipped assets still count as done")
+	assert.Zero(t, done.ErrorCount)
+}
+
+func TestNexusMigration_AssetFailureIsCountedNotFatal(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"raw-hosted": `{"items":[{"name":"c","version":null,"group":"/","format":"raw","assets":[
+				{"path":"gone.txt","downloadUrl":"%BASE%/repository/raw-hosted/gone.txt","fileSize":1},
+				{"path":"ok.txt","downloadUrl":"%BASE%/repository/raw-hosted/ok.txt","fileSize":2}]}],
+				"continuationToken":null}`,
+		},
+		files: map[string]string{"/repository/raw-hosted/ok.txt": "ok"},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["raw-hosted"] = strings.ReplaceAll(fake.components["raw-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	assert.Equal(t, 1, done.ErrorCount)
+	assert.Equal(t, int64(1), done.DoneAssets)
+	require.NotNil(t, done.LastError)
+	assert.Contains(t, *done.LastError, "gone.txt")
+
+	ok, err := h.assets.GetByPath(context.Background(), "raw-hosted", "/ok.txt")
+	require.NoError(t, err)
+	assert.NotNil(t, ok, "the good asset is still transferred")
+}
+
+func TestNexusMigration_ProxyRepositoriesTransferNoAssets(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"maven-central","format":"maven2","type":"proxy","online":true,
+			"proxy":{"remoteUrl":"https://repo1.maven.org/maven2"}}]`,
+		components: map[string]string{
+			"maven-central": `{"items":[{"name":"cached","version":"1","group":"c","format":"maven2","assets":[
+				{"path":"c/cached/1/cached-1.jar","downloadUrl":"%BASE%/repository/maven-central/x","fileSize":1}]}],
+				"continuationToken":null}`,
+		},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["maven-central"] = strings.ReplaceAll(fake.components["maven-central"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Equal(t, int64(0), done.TotalAssets,
+		"a proxy repository re-fetches from its own upstream; its cache is not migrated")
+	assert.Zero(t, fake.count("/service/rest/v1/components"))
+}
+
+// ── OCI registry transfer ────────────────────────────────────────────────────
+
+// Nexus stores registry blobs content-addressed under a placeholder image name
+// ("/v2/-/blobs/<digest>") and its component listing names only the manifest.
+// Copying what the listing reports would migrate an image nobody can pull, so
+// the blobs are read out of the manifest instead.
+const (
+	ociConfigDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	ociLayerDigest  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+)
+
+func ociManifest() string {
+	return `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json",` +
+		`"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"` + ociConfigDigest + `","size":6},` +
+		`"layers":[{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"` + ociLayerDigest + `","size":5}]}`
+}
+
+// dockerFake builds a source whose docker repository behaves like the real one.
+func dockerFake() *fakeNexus {
+	return &fakeNexus{
+		settings: `[{"name":"docker-hosted","format":"docker","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"docker-hosted": `{"items":[{"name":"demo/alpine","version":"3.20","group":"","format":"docker","assets":[
+				{"path":"/v2/demo/alpine/manifests/3.20",
+				 "downloadUrl":"%BASE%/repository/docker-hosted/v2/demo/alpine/manifests/3.20",
+				 "contentType":"application/vnd.oci.image.manifest.v1+json","fileSize":300}]}],
+				"continuationToken":null}`,
+		},
+		files: map[string]string{
+			"/repository/docker-hosted/v2/demo/alpine/manifests/3.20":           ociManifest(),
+			"/repository/docker-hosted/v2/demo/alpine/blobs/" + ociConfigDigest: "config",
+			"/repository/docker-hosted/v2/demo/alpine/blobs/" + ociLayerDigest:  "layer",
+		},
+	}
+}
+
+func TestNexusMigration_OCIBlobsComeFromTheManifestNotTheListing(t *testing.T) {
+	fake := dockerFake()
+	h := newMigHarness(t, fake)
+	fake.components["docker-hosted"] = strings.ReplaceAll(fake.components["docker-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount)
+
+	ctx := context.Background()
+	for _, tc := range []struct{ digest, want string }{
+		{ociConfigDigest, "config"},
+		{ociLayerDigest, "layer"},
+	} {
+		asset, err := h.assets.GetByPath(ctx, "docker-hosted", "/blobs/demo/alpine/"+tc.digest)
+		require.NoError(t, err, "blob %s must be stored under the image that references it", tc.digest)
+		require.NotNil(t, asset)
+		body, err := h.blobs.Read(base.BlobKey("docker-hosted", "/blobs/demo/alpine/"+tc.digest))
+		require.NoError(t, err)
+		assert.Equal(t, tc.want, body)
+	}
+
+	manifest, err := h.assets.GetByPath(ctx, "docker-hosted", "/manifests/demo/alpine/3.20")
+	require.NoError(t, err)
+	require.NotNil(t, manifest)
+
+	// A client that pulls by tag re-fetches the manifest by digest immediately.
+	alias, err := h.assets.GetByPath(ctx, "docker-hosted",
+		"/manifests/demo/alpine/sha256:"+manifest.SHA256)
+	require.NoError(t, err)
+	assert.NotNil(t, alias)
+}
+
+func TestNexusMigration_OCIManifestIsRegisteredAfterItsBlobs(t *testing.T) {
+	fake := dockerFake()
+	h := newMigHarness(t, fake)
+	fake.components["docker-hosted"] = strings.ReplaceAll(fake.components["docker-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	order := h.assets.CreatedPaths()
+	lastBlob, firstManifest := -1, len(order)
+	for i, p := range order {
+		if strings.HasPrefix(p, "/blobs/") {
+			lastBlob = i
+		}
+		if strings.HasPrefix(p, "/manifests/") && i < firstManifest {
+			firstManifest = i
+		}
+	}
+	require.NotEqual(t, -1, lastBlob)
+	require.NotEqual(t, len(order), firstManifest)
+	assert.Less(t, lastBlob, firstManifest,
+		"a manifest must never be servable before the blobs it names")
+}
+
+// A listing that does name blobs names them under a placeholder image, which is
+// not an image anything here could serve them under.
+func TestNexusMigration_OCIPlaceholderBlobEntriesAreIgnored(t *testing.T) {
+	fake := dockerFake()
+	fake.components["docker-hosted"] = `{"items":[{"name":"demo/alpine","version":"3.20","group":"","format":"docker","assets":[
+		{"path":"/v2/demo/alpine/manifests/3.20",
+		 "downloadUrl":"%BASE%/repository/docker-hosted/v2/demo/alpine/manifests/3.20",
+		 "contentType":"application/vnd.oci.image.manifest.v1+json","fileSize":300},
+		{"path":"/v2/-/blobs/` + ociLayerDigest + `",
+		 "downloadUrl":"%BASE%/repository/docker-hosted/v2/-/blobs/` + ociLayerDigest + `","fileSize":5}]}],
+		"continuationToken":null}`
+	h := newMigHarness(t, fake)
+	fake.components["docker-hosted"] = strings.ReplaceAll(fake.components["docker-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount)
+
+	ctx := context.Background()
+	_, err := h.assets.GetByPath(ctx, "docker-hosted", "/blobs/-/"+ociLayerDigest)
+	assert.Error(t, err, "the placeholder image name is not a path anything can pull from")
+
+	_, err = h.assets.GetByPath(ctx, "docker-hosted", "/blobs/demo/alpine/"+ociLayerDigest)
+	assert.NoError(t, err, "the blob still arrives, under the image that references it")
+}
+
+func TestNexusMigration_OCIIndexBringsItsChildManifests(t *testing.T) {
+	const childDigest = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	index := `{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[` +
+		`{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + childDigest + `","size":300,` +
+		`"platform":{"architecture":"arm64","os":"linux"}}]}`
+
+	fake := dockerFake()
+	fake.files["/repository/docker-hosted/v2/demo/alpine/manifests/3.20"] = index
+	fake.files["/repository/docker-hosted/v2/demo/alpine/manifests/"+childDigest] = ociManifest()
+
+	h := newMigHarness(t, fake)
+	fake.components["docker-hosted"] = strings.ReplaceAll(fake.components["docker-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount)
+
+	ctx := context.Background()
+	child, err := h.assets.GetByPath(ctx, "docker-hosted", "/manifests/demo/alpine/"+childDigest)
+	require.NoError(t, err, "a child manifest of an index is migrated too")
+	require.NotNil(t, child)
+
+	_, err = h.assets.GetByPath(ctx, "docker-hosted", "/blobs/demo/alpine/"+ociLayerDigest)
+	require.NoError(t, err, "and so are the blobs that child names")
+
+	_, err = h.assets.GetByPath(ctx, "docker-hosted", "/manifests/demo/alpine/3.20")
+	require.NoError(t, err, "the index itself is stored under its tag")
+}
+
+// ── security data ────────────────────────────────────────────────────────────
+
+func TestNexusMigration_MigratesPrivilegesSkippingBuiltins(t *testing.T) {
+	fake := &fakeNexus{
+		privileges: `[
+			{"type":"repository-view","name":"view-maven","description":"d","readOnly":false,
+			 "format":"maven2","repository":"maven-central","actions":["READ"]},
+			{"type":"application","name":"nx-all","description":"","readOnly":true,"domain":"*","actions":["*"]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	ctx := context.Background()
+	got, err := h.privileges.GetByName(ctx, "view-maven")
+	require.NoError(t, err)
+	assert.Equal(t, domain.PrivilegeTypeRepositoryView, got.Type)
+	assert.Equal(t, "maven-central", got.Attrs["repository"])
+
+	_, err = h.privileges.GetByName(ctx, "nx-all")
+	assert.Error(t, err, "Nexus built-in privileges are not copied")
+}
+
+func TestNexusMigration_MigratesRolesInDependencyOrderAndFlattensNesting(t *testing.T) {
+	fake := &fakeNexus{
+		privileges: `[
+			{"type":"application","name":"p-base","description":"","readOnly":false,"domain":"users","actions":["read"]},
+			{"type":"application","name":"p-dev","description":"","readOnly":false,"domain":"repos","actions":["read"]}
+		]`,
+		roles: `[
+			{"id":"dev","name":"dev","description":"Developers","readOnly":false,
+			 "privileges":["p-dev"],"roles":["base"]},
+			{"id":"base","name":"base","description":"Base","readOnly":false,
+			 "privileges":["p-base"],"roles":[]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	ctx := context.Background()
+	baseRole, err := h.roles.GetByName(ctx, "base")
+	require.NoError(t, err)
+	dev, err := h.roles.GetByName(ctx, "dev")
+	require.NoError(t, err)
+
+	pBase, err := h.privileges.GetByName(ctx, "p-base")
+	require.NoError(t, err)
+	pDev, err := h.privileges.GetByName(ctx, "p-dev")
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{pBase.ID}, h.roles.PrivilegesOf(baseRole.ID))
+	assert.ElementsMatch(t, []string{pDev.ID, pBase.ID}, h.roles.PrivilegesOf(dev.ID),
+		"a nested role's privileges are flattened into the parent")
+}
+
+func TestNexusMigration_RoleCycleDoesNotHangTheJob(t *testing.T) {
+	fake := &fakeNexus{
+		roles: `[
+			{"id":"a","name":"a","description":"","readOnly":false,"privileges":[],"roles":["b"]},
+			{"id":"b","name":"b","description":"","readOnly":false,"privileges":[],"roles":["a"]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	ctx := context.Background()
+	_, errA := h.roles.GetByName(ctx, "a")
+	_, errB := h.roles.GetByName(ctx, "b")
+	assert.NoError(t, errA)
+	assert.NoError(t, errB)
+	assert.Positive(t, done.ErrorCount, "a role cycle is reported rather than silently dropped")
+}
+
+func TestNexusMigration_MigratesLocalUserWithTemporaryPassword(t *testing.T) {
+	fake := &fakeNexus{
+		roles: `[{"id":"dev","name":"dev","description":"","readOnly":false,"privileges":[],"roles":[]}]`,
+		users: `[{"userId":"jdoe","firstName":"Jane","lastName":"Doe","emailAddress":"j@example.com",
+			"source":"default","status":"active","roles":["dev"]}]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	u := h.users.get("jdoe")
+	require.NotNil(t, u)
+	assert.Equal(t, "Jane", u.FirstName)
+	assert.Equal(t, "j@example.com", u.Email)
+	assert.Equal(t, domain.UserSourceLocal, u.Source)
+	assert.Equal(t, domain.UserStatusActive, u.Status)
+	assert.True(t, u.MustResetPassword, "a migrated local user must reset the temporary password")
+	assert.NotEmpty(t, h.users.password("jdoe"), "a local user gets a random temporary password")
+
+	dev, err := h.roles.GetByName(context.Background(), "dev")
+	require.NoError(t, err)
+	assert.Equal(t, []string{dev.ID}, h.roles.UserRoleIDs(u.ID))
+}
+
+func TestNexusMigration_MigratesExternalUserWithoutCredentials(t *testing.T) {
+	fake := &fakeNexus{
+		users: `[{"userId":"ldapuser","firstName":"L","lastName":"U","emailAddress":"l@example.com",
+			"source":"LDAP","status":"disabled","roles":[]}]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	u := h.users.get("ldapuser")
+	require.NotNil(t, u)
+	assert.Equal(t, domain.UserSourceLDAP, u.Source)
+	assert.Equal(t, domain.UserStatusDisabled, u.Status)
+	assert.False(t, u.MustResetPassword)
+	assert.Empty(t, h.users.password("ldapuser"), "an external user gets no local credential")
+}
+
+func TestNexusMigration_ExistingUserIsSkipped(t *testing.T) {
+	existing := &domain.User{ID: "u-existing", Username: "jdoe", Email: "old@example.com"}
+	fake := &fakeNexus{
+		users: `[{"userId":"jdoe","firstName":"Jane","lastName":"Doe","emailAddress":"new@example.com",
+			"source":"default","status":"active","roles":[]}]`,
+	}
+	h := newMigHarness(t, fake, existing)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	assert.Equal(t, "old@example.com", h.users.get("jdoe").Email)
+}
+
+func TestNexusMigration_MigratesRoutingRules(t *testing.T) {
+	fake := &fakeNexus{
+		routingRules: `[
+			{"name":"block-com","description":"no com","mode":"BLOCK","matchers":["^/com/.*"]},
+			{"name":"bad-regex","description":"","mode":"ALLOW","matchers":["^/[unclosed"]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	ctx := context.Background()
+	rule, err := h.rules.GetByName(ctx, "block-com")
+	require.NoError(t, err)
+	assert.Equal(t, "BLOCK", rule.Mode)
+	assert.Equal(t, []string{"^/com/.*"}, rule.Matchers)
+
+	_, err = h.rules.GetByName(ctx, "bad-regex")
+	assert.Error(t, err, "a matcher that does not compile is rejected, not stored")
+	assert.Positive(t, done.ErrorCount)
+}
+
+// ── scope flags ──────────────────────────────────────────────────────────────
+
+func TestNexusMigration_ScopeFlagsGateEachStage(t *testing.T) {
+	fake := &fakeNexus{
+		settings:     `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		users:        `[{"userId":"jdoe","source":"default","status":"active","roles":[]}]`,
+		privileges:   `[{"type":"application","name":"p","description":"","readOnly":false,"domain":"d","actions":["read"]}]`,
+		roles:        `[{"id":"r","name":"r","description":"","readOnly":false,"privileges":[],"roles":[]}]`,
+		routingRules: `[{"name":"rr","description":"","mode":"BLOCK","matchers":["^/x"]}]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t, func(j *domain.MigrationJob) {
+		j.MigrateRepos = true
+		j.MigrateBlobs = false
+		j.MigrateUsers = false
+		j.MigratePrivileges = false
+		j.MigrateRoles = false
+		j.MigrateRoutingRules = false
+	})
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	ctx := context.Background()
+	_, err := h.repos.Get(ctx, "raw-hosted")
+	assert.NoError(t, err, "the repository scope was on")
+
+	assert.Nil(t, h.users.get("jdoe"))
+	_, err = h.privileges.GetByName(ctx, "p")
+	assert.Error(t, err)
+	_, err = h.roles.GetByName(ctx, "r")
+	assert.Error(t, err)
+	_, err = h.rules.GetByName(ctx, "rr")
+	assert.Error(t, err)
+	assert.Zero(t, fake.count("/service/rest/v1/security/users"))
+	assert.Zero(t, fake.count("/service/rest/v1/routing-rules"))
+}
+
+func TestNexusMigration_BlobsOffStillCreatesRepositories(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"raw-hosted": `{"items":[{"name":"a.txt","version":null,"group":"/","format":"raw","assets":[
+				{"path":"a.txt","downloadUrl":"http://unused/","fileSize":5}]}],"continuationToken":null}`,
+		},
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t, func(j *domain.MigrationJob) { j.MigrateBlobs = false })
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	_, err := h.repos.Get(context.Background(), "raw-hosted")
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), done.TotalAssets)
+	assert.Zero(t, fake.count("/service/rest/v1/components"))
+}
+
+// ── lifecycle ────────────────────────────────────────────────────────────────
+
+func TestNexusMigration_PauseStopsTheRunAndResumeFinishesIt(t *testing.T) {
+	var items []string
+	files := map[string]string{}
+	for i := range 40 {
+		p := fmt.Sprintf("f%02d.txt", i)
+		items = append(items, fmt.Sprintf(
+			`{"name":"%s","version":null,"group":"/","format":"raw","assets":[
+				{"path":"%s","downloadUrl":"%%BASE%%/repository/raw-hosted/%s","fileSize":4}]}`, p, p, p))
+		files["/repository/raw-hosted/"+p] = "data"
+	}
+	fake := &fakeNexus{
+		settings:   `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{"raw-hosted": `{"items":[` + strings.Join(items, ",") + `],"continuationToken":null}`},
+		files:      files,
+	}
+	// Hold the run inside its first download so Pause provably lands mid-transfer.
+	inFlight := make(chan struct{})
+	release := make(chan struct{})
+	firstCall := make(chan struct{}, 1)
+	firstCall <- struct{}{}
+	fake.onFile = func() {
+		select {
+		case <-firstCall:
+			close(inFlight)
+			<-release
+		default:
+		}
+	}
+
+	h := newMigHarness(t, fake)
+	fake.components["raw-hosted"] = strings.ReplaceAll(fake.components["raw-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	<-inFlight
+	require.NoError(t, h.svc.Pause(context.Background(), job.ID))
+	close(release)
+
+	paused := h.waitForStatus(t, job.ID, domain.MigrationPaused)
+	assert.Nil(t, paused.FinishedAt, "a paused job is not finished")
+	assert.Less(t, paused.DoneAssets, int64(40), "the run stopped before transferring everything")
+
+	fake.onFile = nil
+	require.NoError(t, h.svc.Resume(context.Background(), job.ID))
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Equal(t, int64(40), done.DoneAssets)
+	assert.Zero(t, done.ErrorCount)
+}
+
+func TestNexusMigration_PauseOnAPendingJobIsAccepted(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	ctx := context.Background()
+	job := &domain.MigrationJob{SourceURL: h.nexus.URL, Status: domain.MigrationPending}
+	require.NoError(t, h.jobs.Create(ctx, job))
+
+	require.NoError(t, h.svc.Pause(ctx, job.ID))
+	got, err := h.jobs.Get(ctx, job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.MigrationPaused, got.Status)
+}
+
+func TestNexusMigration_ResumeAllRestartsInterruptedJobs(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+	}
+	h := newMigHarness(t, fake)
+	ctx := context.Background()
+
+	// A job left "running" by a process that died mid-transfer.
+	job := &domain.MigrationJob{
+		SourceURL: h.nexus.URL, SourceUser: "admin", Status: domain.MigrationRunning,
+		MigrateRepos: true,
+	}
+	require.NoError(t, h.jobs.Create(ctx, job))
+	require.NoError(t, h.jobs.SetSourcePassword(ctx, job.ID, h.svc.SealPassword("s3cret")))
+
+	require.NoError(t, h.svc.ResumeAll(ctx))
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	_, err := h.repos.Get(ctx, "raw-hosted")
+	assert.NoError(t, err)
+}
+
+func TestNexusMigration_ResumeAllLeavesPausedJobsAlone(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	ctx := context.Background()
+	job := &domain.MigrationJob{SourceURL: h.nexus.URL, Status: domain.MigrationPaused}
+	require.NoError(t, h.jobs.Create(ctx, job))
+
+	require.NoError(t, h.svc.ResumeAll(ctx))
+	time.Sleep(50 * time.Millisecond)
+
+	got, err := h.jobs.Get(ctx, job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.MigrationPaused, got.Status)
+}
+
+func TestNexusMigration_CreateStoresCredentialsEncrypted(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	stored, err := h.jobs.Get(context.Background(), job.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, stored.SourcePassword)
+	assert.NotContains(t, stored.SourcePassword, "s3cret", "the password is not stored in the clear")
+
+	plain, err := h.svc.OpenPassword(stored.SourcePassword)
+	require.NoError(t, err)
+	assert.Equal(t, "s3cret", plain)
+}
+
+// ── preview ──────────────────────────────────────────────────────────────────
+
+func TestNexusMigration_PreviewListsRepositories(t *testing.T) {
+	fake := &fakeNexus{
+		repositories: `[{"name":"raw-hosted","format":"raw","type":"hosted"},
+			{"name":"maven-central","format":"maven2","type":"proxy"}]`,
+	}
+	h := newMigHarness(t, fake)
+
+	res, err := h.svc.Preview(context.Background(), h.nexus.URL, "admin", "s3cret")
+	require.NoError(t, err)
+	assert.True(t, res.Reachable)
+	assert.Equal(t, 2, res.RepoCount)
+	require.Len(t, res.Repos, 2)
+	assert.Equal(t, "raw-hosted", res.Repos[0].Name)
+	assert.Equal(t, "hosted", res.Repos[0].Type)
+}
+
+func TestNexusMigration_PreviewRejectsEmptyURL(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	_, err := h.svc.Preview(context.Background(), "   ", "admin", "s3cret")
+	require.ErrorIs(t, err, service.ErrInvalidInput)
+}
+
+func TestNexusMigration_PreviewSurfacesUnreachableSource(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	_, err := h.svc.Preview(context.Background(), "http://127.0.0.1:1/nexus", "admin", "s3cret")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, service.ErrInvalidInput)
+}
+
+func TestNexusMigration_PreviewDoesNotCreateAJob(t *testing.T) {
+	fake := &fakeNexus{repositories: `[{"name":"raw-hosted","format":"raw","type":"hosted"}]`}
+	h := newMigHarness(t, fake)
+
+	_, err := h.svc.Preview(context.Background(), h.nexus.URL, "admin", "s3cret")
+	require.NoError(t, err)
+
+	jobs, err := h.jobs.List(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, jobs)
+}
+
+// ── validation ───────────────────────────────────────────────────────────────
+
+func TestNexusMigration_CreateRejectsEmptySourceURL(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	err := h.svc.Create(context.Background(), &domain.MigrationJob{SourceURL: " "}, "pw")
+	require.ErrorIs(t, err, service.ErrInvalidInput)
+}
+
+func TestNexusMigration_CreateRejectsMalformedSourceURL(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	err := h.svc.Create(context.Background(), &domain.MigrationJob{SourceURL: "nexus.example.com"}, "pw")
+	require.ErrorIs(t, err, service.ErrInvalidInput)
+}
+
+func TestNexusMigration_ResumeUnknownJobIsNotFound(t *testing.T) {
+	h := newMigHarness(t, &fakeNexus{})
+	err := h.svc.Resume(context.Background(), "nope")
+	require.Error(t, err)
+}
+
+// jsonRoundTrip guards the fixtures above against silent typos.
+func TestFakeNexusFixturesAreValidJSON(t *testing.T) {
+	for _, doc := range []string{
+		`[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+	} {
+		var v any
+		require.NoError(t, json.Unmarshal([]byte(doc), &v))
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -38,6 +38,7 @@ var (
 	_ repository.ScanResultRepo         = (*ScanResultRepo)(nil)
 	_ repository.ReplicationRepo        = (*ReplicationRepo)(nil)
 	_ repository.PromotionRepo          = (*PromotionRepo)(nil)
+	_ repository.MigrationRepo          = (*MigrationRepo)(nil)
 	_ storage.BlobStore                 = (*BlobStore)(nil)
 )
 
@@ -602,6 +603,8 @@ type AssetRepo struct {
 	GetByPathErr error
 	// DownloadIncrements records aggregated counts passed to IncrementDownloads.
 	DownloadIncrements map[string]int64
+	// createdPaths records the order Create was called in; read via CreatedPaths.
+	createdPaths []string
 }
 
 func NewAssetRepo() *AssetRepo {
@@ -731,7 +734,17 @@ func (a *AssetRepo) Create(_ context.Context, asset *domain.Asset) error {
 	// Index by repo name (for GetByPath) — matches what postgres impl does via JOIN
 	a.assets[key] = asset
 	a.byID[asset.ID] = asset
+	a.createdPaths = append(a.createdPaths, asset.Path)
 	return nil
+}
+
+// CreatedPaths returns the asset paths passed to Create, in call order. Tests
+// that care about write ordering — a manifest must not be registered before the
+// blobs it names — read it.
+func (a *AssetRepo) CreatedPaths() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.createdPaths...)
 }
 
 // TouchLastModified sets the asset's LastModified to now (mirrors the postgres
@@ -1467,6 +1480,7 @@ type RoleRepo struct {
 	mu               sync.Mutex
 	roles            map[string]*domain.Role
 	userRoles        map[string][]string // userID → roleIDs
+	rolePrivileges   map[string][]string // roleID → privilegeIDs
 	nextID           int
 	Err              error // when non-nil, mutating/listing methods return this error
 	SetPrivilegesErr error // when non-nil, SetPrivileges returns this error (independent of Err)
@@ -1474,8 +1488,9 @@ type RoleRepo struct {
 
 func NewRoleRepo(roles ...*domain.Role) *RoleRepo {
 	r := &RoleRepo{
-		roles:     make(map[string]*domain.Role),
-		userRoles: make(map[string][]string),
+		roles:          make(map[string]*domain.Role),
+		userRoles:      make(map[string][]string),
+		rolePrivileges: make(map[string][]string),
 	}
 	for _, role := range roles {
 		r.roles[role.ID] = role
@@ -1503,6 +1518,16 @@ func (r *RoleRepo) Get(_ context.Context, id string) (*domain.Role, error) {
 		return nil, repository.ErrNotFound
 	}
 	return v, nil
+}
+func (r *RoleRepo) GetByName(_ context.Context, name string) (*domain.Role, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, v := range r.roles {
+		if v.Name == name {
+			return v, nil
+		}
+	}
+	return nil, repository.ErrNotFound
 }
 func (r *RoleRepo) Create(_ context.Context, role *domain.Role) error {
 	r.mu.Lock()
@@ -1559,18 +1584,37 @@ func (r *RoleRepo) SetUserRoles(_ context.Context, userID string, roleIDs []stri
 	return nil
 }
 
-func (r *RoleRepo) SetPrivileges(_ context.Context, _ string, _ []string) error {
+func (r *RoleRepo) SetPrivileges(_ context.Context, roleID string, privilegeIDs []string) error {
 	if r.SetPrivilegesErr != nil {
 		return r.SetPrivilegesErr
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.Err != nil {
 		return r.Err
 	}
+	r.rolePrivileges[roleID] = append([]string(nil), privilegeIDs...)
 	return nil
 }
 
-func (r *RoleRepo) ListPrivilegeIDsByRole(_ context.Context, _ string) ([]string, error) {
-	return []string{}, nil
+func (r *RoleRepo) ListPrivilegeIDsByRole(_ context.Context, roleID string) ([]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string{}, r.rolePrivileges[roleID]...), nil
+}
+
+// PrivilegesOf returns the privilege IDs last assigned to the role.
+func (r *RoleRepo) PrivilegesOf(roleID string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.rolePrivileges[roleID]...)
+}
+
+// UserRoleIDs returns the role IDs last assigned to the user.
+func (r *RoleRepo) UserRoleIDs(userID string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.userRoles[userID]...)
 }
 
 // ── ContentSelectorRepo ───────────────────────────────────────
@@ -2448,4 +2492,175 @@ func (r *PromotionRepo) UpdateRequestStatus(_ context.Context, id string, status
 // PutBytes is a test helper that stores raw bytes under key in the BlobStore mock.
 func (b *BlobStore) PutBytes(ctx context.Context, key string, data []byte) error {
 	return b.Put(ctx, key, bytes.NewReader(data), int64(len(data)))
+}
+
+// ── MigrationRepo ─────────────────────────────────────────────
+
+// MigrationRepo is an in-memory repository.MigrationRepo. Every job is stored
+// by value and handed back as a copy, so a test reading progress never races
+// with the runner goroutine writing it.
+type MigrationRepo struct {
+	mu     sync.Mutex
+	jobs   map[string]*domain.MigrationJob
+	order  []string
+	nextID int
+
+	ListErr   error
+	GetErr    error
+	CreateErr error
+	UpdateErr error
+	DeleteErr error
+}
+
+func NewMigrationRepo(jobs ...*domain.MigrationJob) *MigrationRepo {
+	m := &MigrationRepo{jobs: make(map[string]*domain.MigrationJob)}
+	for _, j := range jobs {
+		m.jobs[j.ID] = j
+		m.order = append(m.order, j.ID)
+	}
+	return m
+}
+
+func (m *MigrationRepo) List(_ context.Context) ([]domain.MigrationJob, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ListErr != nil {
+		return nil, m.ListErr
+	}
+	out := make([]domain.MigrationJob, 0, len(m.order))
+	for _, id := range m.order {
+		if j, ok := m.jobs[id]; ok {
+			out = append(out, *j)
+		}
+	}
+	return out, nil
+}
+
+func (m *MigrationRepo) Get(_ context.Context, id string) (*domain.MigrationJob, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.GetErr != nil {
+		return nil, m.GetErr
+	}
+	j, ok := m.jobs[id]
+	if !ok {
+		return nil, fmt.Errorf("migration job not found: %s", id)
+	}
+	cp := *j
+	return &cp, nil
+}
+
+func (m *MigrationRepo) Create(_ context.Context, job *domain.MigrationJob) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	if job.ID == "" {
+		m.nextID++
+		job.ID = fmt.Sprintf("mig-%d", m.nextID)
+	}
+	if job.Status == "" {
+		job.Status = domain.MigrationPending
+	}
+	now := time.Now()
+	job.CreatedAt, job.UpdatedAt = now, now
+	stored := *job
+	m.jobs[job.ID] = &stored
+	m.order = append(m.order, job.ID)
+	return nil
+}
+
+func (m *MigrationRepo) UpdateStatus(_ context.Context, id string, status domain.MigrationJobStatus) error {
+	return m.mutate(id, m.UpdateErr, func(j *domain.MigrationJob) { j.Status = status })
+}
+
+func (m *MigrationRepo) Delete(_ context.Context, id string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.DeleteErr != nil {
+		return m.DeleteErr
+	}
+	if _, ok := m.jobs[id]; !ok {
+		return fmt.Errorf("migration job not found: %s", id)
+	}
+	delete(m.jobs, id)
+	return nil
+}
+
+func (m *MigrationRepo) ListActive(_ context.Context) ([]domain.MigrationJob, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.ListErr != nil {
+		return nil, m.ListErr
+	}
+	var out []domain.MigrationJob
+	for _, id := range m.order {
+		if j, ok := m.jobs[id]; ok && j.IsActive() {
+			out = append(out, *j)
+		}
+	}
+	return out, nil
+}
+
+func (m *MigrationRepo) SetSourcePassword(_ context.Context, id, sealed string) error {
+	return m.mutate(id, m.UpdateErr, func(j *domain.MigrationJob) { j.SourcePassword = sealed })
+}
+
+func (m *MigrationRepo) SetStarted(_ context.Context, id string, at time.Time) error {
+	return m.mutate(id, m.UpdateErr, func(j *domain.MigrationJob) {
+		j.Status = domain.MigrationRunning
+		if j.StartedAt == nil {
+			stamp := at
+			j.StartedAt = &stamp
+		}
+		j.FinishedAt = nil
+	})
+}
+
+func (m *MigrationRepo) SetTotals(_ context.Context, id string, totalRepos int, totalAssets int64) error {
+	return m.mutate(id, m.UpdateErr, func(j *domain.MigrationJob) {
+		j.TotalRepos, j.TotalAssets = totalRepos, totalAssets
+	})
+}
+
+func (m *MigrationRepo) UpdateProgress(_ context.Context, id string, doneRepos int, doneAssets int64,
+	errorCount int, lastError *string,
+) error {
+	return m.mutate(id, m.UpdateErr, func(j *domain.MigrationJob) {
+		j.DoneRepos, j.DoneAssets, j.ErrorCount = doneRepos, doneAssets, errorCount
+		if lastError != nil {
+			msg := *lastError
+			j.LastError = &msg
+		}
+	})
+}
+
+func (m *MigrationRepo) FinishJob(_ context.Context, id string,
+	status domain.MigrationJobStatus, errMsg *string,
+) error {
+	return m.mutate(id, m.UpdateErr, func(j *domain.MigrationJob) {
+		j.Status = status
+		now := time.Now()
+		j.FinishedAt = &now
+		if errMsg != nil {
+			msg := *errMsg
+			j.LastError = &msg
+		}
+	})
+}
+
+func (m *MigrationRepo) mutate(id string, forced error, fn func(*domain.MigrationJob)) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if forced != nil {
+		return forced
+	}
+	j, ok := m.jobs[id]
+	if !ok {
+		return fmt.Errorf("migration job not found: %s", id)
+	}
+	fn(j)
+	j.UpdatedAt = time.Now()
+	return nil
 }

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -1230,24 +1230,34 @@ def verify(secret: str, body: bytes, header: str) -&gt; bool:
       </section>
       <section id="sec-migration" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="mig.title">Migration from Nexus</div>
-  <div class="doc-section-sub" data-i18n="mig.sub">Migrate repositories, users, roles, and artifacts from a live Nexus OSS or Pro instance without downtime.</div>
+  <div class="doc-section-sub" data-i18n="mig.sub">Import a live Nexus Repository 3 instance over its REST API — repositories, artifacts, container images and the security model. The source keeps serving traffic; nothing is written back to it.</div>
 
   <div class="inst-sep" data-i18n="mig.what.sep">What Gets Migrated</div>
   <table class="doc-table">
     <thead><tr><th data-i18n="mig.th.item">Item</th><th data-i18n="mig.th.detail">Detail</th></tr></thead>
     <tbody>
-      <tr><td data-i18n="mig.repos.label">Repositories</td><td data-i18n="mig.repos.desc">Hosted, proxy, and group repo definitions (format, type, configuration)</td></tr>
-      <tr><td data-i18n="mig.users.label">Users &amp; Roles</td><td data-i18n="mig.users.desc">Local Nexus users, roles, and privileges</td></tr>
-      <tr><td data-i18n="mig.blobs.label">Artifacts</td><td data-i18n="mig.blobs.desc">All components streamed via Nexus REST API — large repos pause/resume</td></tr>
-      <tr><td data-i18n="mig.cleanup.label">Cleanup policies</td><td data-i18n="mig.cleanup.desc">Imported and attached to the corresponding repositories</td></tr>
+      <tr><td data-i18n="mig.repos.label">Repositories</td><td data-i18n="mig.repos.desc">Hosted, proxy and group definitions — format, type, group membership, proxy remote URL</td></tr>
+      <tr><td data-i18n="mig.blobs.label">Artifacts</td><td data-i18n="mig.blobs.desc">Every component in each hosted repository, streamed through the same storage path an upload takes</td></tr>
+      <tr><td data-i18n="mig.docker.label">Container images</td><td data-i18n="mig.docker.desc">Manifests, image indexes and the blobs they reference — re-created so the image is pullable byte-for-byte</td></tr>
+      <tr><td data-i18n="mig.users.label">Privileges, roles, users</td><td data-i18n="mig.users.desc">Nexus built-ins skipped; nested roles flattened; local users get a temporary password, external ones no credential</td></tr>
+      <tr><td data-i18n="mig.rules.label">Routing rules</td><td data-i18n="mig.rules.desc">ALLOW / BLOCK rules with their regex matchers, stored whole or not at all</td></tr>
     </tbody>
   </table>
+  <div class="alert-info" data-i18n="mig.notmig"><strong>Not migrated:</strong> cleanup policies and task schedules — Nexus OSS exposes neither through its REST API. Proxy caches are skipped too: a proxy re-fetches from its own upstream.</div>
+
   <div class="step-list">
-    <div class="step-item"><div class="step-num">01</div><div><div class="step-title" data-i18n="mig.s1.title">Open the Migration tab</div><div class="step-desc" data-i18n="mig.s1.desc">Go to <strong>Admin → System → Migration</strong>. Enter the source Nexus URL, admin username, and password.</div></div></div>
-    <div class="step-item"><div class="step-num">02</div><div><div class="step-title" data-i18n="mig.s2.title">Select scope</div><div class="step-desc" data-i18n="mig.s2.desc">Choose what to migrate: Repositories, Users, Cleanup Policies, Artifacts (blobs). You can run each separately.</div></div></div>
-    <div class="step-item"><div class="step-num">03</div><div><div class="step-title" data-i18n="mig.s3.title">Start and monitor</div><div class="step-desc" data-i18n="mig.s3.desc">Click <strong>Start Migration</strong>. Progress is shown in the job history table. Large artifact migrations can be paused and resumed.</div></div></div>
+    <div class="step-item"><div class="step-num">01</div><div><div class="step-title" data-i18n="mig.s1.title">Test the connection</div><div class="step-desc" data-i18n="mig.s1.desc">Go to <strong>Admin &rarr; Migration &rarr; New Migration</strong>, enter the Nexus URL and admin credentials, then press <strong>Test connection</strong>. It is a pure read — no job is created — and it lists the repositories it can see, or the exact reason the source refused.</div></div></div>
+    <div class="step-item"><div class="step-num">02</div><div><div class="step-title" data-i18n="mig.s2.title">Choose the scope</div><div class="step-desc" data-i18n="mig.s2.desc">Every stage is an independent flag: repositories, artifacts, privileges, roles, users, routing rules. A repositories-only run touches nothing else. All are on by default.</div></div></div>
+    <div class="step-item"><div class="step-num">03</div><div><div class="step-title" data-i18n="mig.s3.title">Start and watch</div><div class="step-desc" data-i18n="mig.s3.desc">The job runs in the background and reports repositories done, assets done and an error count. One artifact that will not come across is counted and named; the run continues.</div></div></div>
   </div>
-  <div class="alert-info" data-i18n="mig.note"><strong>No downtime:</strong> Migration reads from a live Nexus instance via its REST API. Your existing Nexus continues serving traffic during migration. Switch DNS/clients to Nexspence when ready.</div>
+
+  <div class="inst-sep" data-i18n="mig.order.sep">Order of Operations</div>
+  <div class="doc-section-sub" data-i18n="mig.order.sub">Repositories are created hosted &rarr; proxy &rarr; group, so a group&rsquo;s members exist before the group naming them. Then artifacts, then privileges &rarr; roles &rarr; users — each references the previous one by name — and finally routing rules.</div>
+
+  <div class="inst-sep" data-i18n="mig.resume.sep">Pause, Resume, Restart</div>
+  <div class="doc-section-sub" data-i18n="mig.resume.sub">Everything is matched by its logical name — repository, privilege, role, username, asset path — and anything already present is skipped rather than overwritten. That is what makes re-running cheap: <strong>Pause</strong> stops the run and keeps its progress, <strong>Resume</strong> starts a fresh pass over what is left, and a restart of Nexspence re-attaches to jobs that were still running. The source credential is persisted for that, sealed with the instance encryption key and never returned by the API.</div>
+
+  <div class="alert-info" data-i18n="mig.note"><strong>No downtime.</strong> Migration only reads from the source. Requires Nexus admin credentials for the security endpoints; a Nexus on an internal address needs that range in <code>outbound.allowed_internal_cidrs</code>.</div>
       </section>
       <section id="sec-monitoring" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="mon.title">Monitoring</div>
@@ -1706,16 +1716,22 @@ const TRANSLATIONS={
     'wh.s2.title':'Test delivery','wh.s2.desc':'Click the ⚡ button on the webhook card to send a test event.',
     'wh.s3.title':'Verify the signature','wh.s3.desc':'If a secret is set, each request carries an <code>X-Nexspence-Signature</code> header (HMAC-SHA256 of body).',
     'wh.retry.note':'<strong>Delivery:</strong> Webhooks are fired asynchronously. Events are not retried if your endpoint is unavailable.',
-    'mig.title':'Migration from Nexus','mig.sub':'Migrate repositories, users, roles, and artifacts from a live Nexus OSS or Pro instance without downtime.',
+    'mig.title':'Migration from Nexus','mig.sub':'Import a live Nexus Repository 3 instance over its REST API — repositories, artifacts, container images and the security model. The source keeps serving traffic; nothing is written back to it.',
     'mig.what.sep':'What Gets Migrated','mig.th.item':'Item','mig.th.detail':'Detail',
-    'mig.repos.label':'Repositories','mig.repos.desc':'Hosted, proxy, and group repo definitions',
-    'mig.users.label':'Users & Roles','mig.users.desc':'Local Nexus users, roles, and privileges',
-    'mig.blobs.label':'Artifacts','mig.blobs.desc':'All components streamed via Nexus REST API — large repos pause/resume',
-    'mig.cleanup.label':'Cleanup policies','mig.cleanup.desc':'Imported and attached to corresponding repositories',
-    'mig.s1.title':'Open the Migration tab','mig.s1.desc':'Go to <strong>Admin → System → Migration</strong>. Enter the source Nexus URL, admin username, and password.',
-    'mig.s2.title':'Select scope','mig.s2.desc':'Choose what to migrate: Repositories, Users, Cleanup Policies, Artifacts. Run each separately.',
-    'mig.s3.title':'Start and monitor','mig.s3.desc':'Click <strong>Start Migration</strong>. Large artifact migrations can be paused and resumed.',
-    'mig.note':'<strong>No downtime:</strong> Migration reads from a live Nexus via its REST API. Switch clients to Nexspence when ready.',
+    'mig.repos.label':'Repositories','mig.repos.desc':'Hosted, proxy and group definitions — format, type, group membership, proxy remote URL',
+    'mig.blobs.label':'Artifacts','mig.blobs.desc':'Every component in each hosted repository, streamed through the same storage path an upload takes',
+    'mig.docker.label':'Container images','mig.docker.desc':'Manifests, image indexes and the blobs they reference — re-created so the image is pullable byte-for-byte',
+    'mig.users.label':'Privileges, roles, users','mig.users.desc':'Nexus built-ins skipped; nested roles flattened; local users get a temporary password, external ones no credential',
+    'mig.rules.label':'Routing rules','mig.rules.desc':'ALLOW / BLOCK rules with their regex matchers, stored whole or not at all',
+    'mig.notmig':'<strong>Not migrated:</strong> cleanup policies and task schedules — Nexus OSS exposes neither through its REST API. Proxy caches are skipped too: a proxy re-fetches from its own upstream.',
+    'mig.s1.title':'Test the connection','mig.s1.desc':'Go to <strong>Admin &rarr; Migration &rarr; New Migration</strong>, enter the Nexus URL and admin credentials, then press <strong>Test connection</strong>. It is a pure read — no job is created — and it lists the repositories it can see, or the exact reason the source refused.',
+    'mig.s2.title':'Choose the scope','mig.s2.desc':'Every stage is an independent flag: repositories, artifacts, privileges, roles, users, routing rules. A repositories-only run touches nothing else. All are on by default.',
+    'mig.s3.title':'Start and watch','mig.s3.desc':'The job runs in the background and reports repositories done, assets done and an error count. One artifact that will not come across is counted and named; the run continues.',
+    'mig.order.sep':'Order of Operations',
+    'mig.order.sub':'Repositories are created hosted &rarr; proxy &rarr; group, so a group&rsquo;s members exist before the group naming them. Then artifacts, then privileges &rarr; roles &rarr; users — each references the previous one by name — and finally routing rules.',
+    'mig.resume.sep':'Pause, Resume, Restart',
+    'mig.resume.sub':'Everything is matched by its logical name — repository, privilege, role, username, asset path — and anything already present is skipped rather than overwritten. That is what makes re-running cheap: <strong>Pause</strong> stops the run and keeps its progress, <strong>Resume</strong> starts a fresh pass over what is left, and a restart of Nexspence re-attaches to jobs that were still running. The source credential is persisted for that, sealed with the instance encryption key and never returned by the API.',
+    'mig.note':'<strong>No downtime.</strong> Migration only reads from the source. Requires Nexus admin credentials for the security endpoints; a Nexus on an internal address needs that range in <code>outbound.allowed_internal_cidrs</code>.',
     'mon.title':'Monitoring','mon.sub':'Nexspence exposes a Prometheus metrics endpoint and ships a pre-built Grafana dashboard with 8 panels.',
     'mon.metrics.sep':'Available Metrics','mon.th.metric':'Metric','mon.th.desc':'Description',
     'mon.m.requests':'Total HTTP requests (by method, path, status)',
@@ -2019,16 +2035,22 @@ const TRANSLATIONS={
     'wh.s2.title':'Тест доставки','wh.s2.desc':'Нажмите кнопку ⚡ на карточке вебхука для отправки тестового события.',
     'wh.s3.title':'Проверка подписи','wh.s3.desc':'При наличии секрета каждый запрос содержит заголовок <code>X-Nexspence-Signature</code> (HMAC-SHA256 тела).',
     'wh.retry.note':'<strong>Доставка:</strong> Вебхуки отправляются асинхронно. При недоступности endpoint событие не повторяется.',
-    'mig.title':'Миграция из Nexus','mig.sub':'Перенесите репозитории, пользователей, роли и артефакты из работающего Nexus OSS или Pro без остановки сервиса.',
+    'mig.title':'Миграция из Nexus','mig.sub':'Импорт работающего Nexus Repository 3 через его REST API — репозитории, артефакты, образы контейнеров и модель доступа. Источник продолжает обслуживать трафик; в него ничего не записывается.',
     'mig.what.sep':'Что переносится','mig.th.item':'Элемент','mig.th.detail':'Описание',
-    'mig.repos.label':'Репозитории','mig.repos.desc':'Определения hosted, proxy и group репозиториев',
-    'mig.users.label':'Пользователи и роли','mig.users.desc':'Локальные пользователи, роли и привилегии Nexus',
-    'mig.blobs.label':'Артефакты','mig.blobs.desc':'Все компоненты через REST API Nexus — большие репозитории с паузой/продолжением',
-    'mig.cleanup.label':'Политики очистки','mig.cleanup.desc':'Импортируются и привязываются к соответствующим репозиториям',
-    'mig.s1.title':'Откройте вкладку Migration','mig.s1.desc':'Перейдите в <strong>Admin → System → Migration</strong>. Введите URL источника Nexus, логин и пароль.',
-    'mig.s2.title':'Выберите область','mig.s2.desc':'Выберите что переносить: Repositories, Users, Cleanup Policies, Artifacts. Можно запускать раздельно.',
-    'mig.s3.title':'Запустите и следите','mig.s3.desc':'Нажмите <strong>Start Migration</strong>. Миграцию больших репозиториев можно ставить на паузу и продолжать.',
-    'mig.note':'<strong>Без простоя:</strong> Миграция читает из работающего Nexus через его REST API. Переключите клиентов на Nexspence когда будете готовы.',
+    'mig.repos.label':'Репозитории','mig.repos.desc':'Определения hosted, proxy и group — формат, тип, состав группы, remote URL прокси',
+    'mig.blobs.label':'Артефакты','mig.blobs.desc':'Все компоненты каждого hosted-репозитория, через тот же путь хранения, что и обычная загрузка',
+    'mig.docker.label':'Образы контейнеров','mig.docker.desc':'Манифесты, индексы образов и блобы, на которые они ссылаются — образ воссоздаётся побайтово и остаётся pullable',
+    'mig.users.label':'Привилегии, роли, пользователи','mig.users.desc':'Встроенные объекты Nexus пропускаются; вложенные роли расплющиваются; локальные пользователи получают временный пароль, внешние — никаких учётных данных',
+    'mig.rules.label':'Правила маршрутизации','mig.rules.desc':'Правила ALLOW / BLOCK с их regex-матчерами, целиком или никак',
+    'mig.notmig':'<strong>Не переносится:</strong> политики очистки и расписания задач — Nexus OSS не отдаёт ни то, ни другое через REST API. Кэш прокси тоже пропускается: прокси заново забирает данные со своего upstream.',
+    'mig.s1.title':'Проверьте подключение','mig.s1.desc':'Перейдите в <strong>Admin &rarr; Migration &rarr; New Migration</strong>, введите URL Nexus и учётные данные администратора, затем нажмите <strong>Test connection</strong>. Это чистое чтение — задача не создаётся — и в ответ вы получите список видимых репозиториев либо точную причину отказа источника.',
+    'mig.s2.title':'Выберите объём','mig.s2.desc':'Каждый этап — независимый флаг: репозитории, артефакты, привилегии, роли, пользователи, правила маршрутизации. Запуск только с репозиториями не тронет ничего другого. По умолчанию включено всё.',
+    'mig.s3.title':'Запустите и следите','mig.s3.desc':'Задача выполняется в фоне и показывает обработанные репозитории, артефакты и число ошибок. Один артефакт, который не удалось перенести, будет посчитан и назван, а выполнение продолжится.',
+    'mig.order.sep':'Порядок выполнения',
+    'mig.order.sub':'Репозитории создаются в порядке hosted &rarr; proxy &rarr; group, чтобы участники группы существовали раньше самой группы. Затем артефакты, затем привилегии &rarr; роли &rarr; пользователи — каждый ссылается на предыдущего по имени — и в конце правила маршрутизации.',
+    'mig.resume.sep':'Пауза, продолжение, перезапуск',
+    'mig.resume.sub':'Всё сопоставляется по логическому имени — репозиторий, привилегия, роль, имя пользователя, путь артефакта — и всё уже существующее пропускается, а не перезаписывается. Именно поэтому повторный запуск дёшев: <strong>Pause</strong> останавливает выполнение, сохраняя прогресс, <strong>Resume</strong> запускает новый проход по остатку, а перезапуск Nexspence подхватывает задачи, которые оставались в работе. Ради этого пароль источника сохраняется — зашифрованным ключом инстанса, и API его никогда не возвращает.',
+    'mig.note':'<strong>Без простоя.</strong> Миграция только читает из источника. Нужны учётные данные администратора Nexus для эндпоинтов безопасности; для Nexus во внутренней сети добавьте её диапазон в <code>outbound.allowed_internal_cidrs</code>.',
     'mon.title':'Мониторинг','mon.sub':'Nexspence предоставляет endpoint Prometheus и поставляется с готовым дашбордом Grafana из 8 панелей.',
     'mon.metrics.sep':'Доступные метрики','mon.th.metric':'Метрика','mon.th.desc':'Описание',
     'mon.m.requests':'Всего HTTP-запросов (по методу, пути, статусу)',
@@ -2245,6 +2267,7 @@ let FEATURE_BADGE={
   'replication':'v1.3.0',
   'promotion':'v1.8.1',
   'monitoring':'v1.9.0',
+  'migration':'v1.33.0',
   'security':'v1.18.0',
   'upgrade':'v1.18.0',
 };

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://nexspence.com/</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-08-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://nexspence.com/docs/</loc>
-    <lastmod>2026-05-29</lastmod>
+    <lastmod>2026-08-08</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Closes #171. Closes #172.

## The bug

`internal/api/handlers/migration.go` was CRUD over a job row and nothing else. `CreateJob` wrote `pending`; no code path ever read it back. So a migration sat in **Pending** forever — no worker, no error, no progress. That is #171 exactly, and it is why an invalid source URL was accepted with `201` in #172: nothing ever tried to reach it.

This PR adds the engine behind that UI.

## What is here

**`internal/nexusclient`** — a read-only client for the Nexus OSS 3 REST API. Repository settings (falling back to the basic listing when the admin endpoint is not exposed), paginated components, security users/roles/privileges, routing rules, and the registry surface. It never writes to the instance it is pointed at.

**`internal/service/nexus_migration_service.go`** — the runner. One goroutine per job; each stage gated by its own scope flag:

1. **Repositories** — hosted → proxy → group, so a group's members exist before the group naming them. A member that could not be migrated is left out rather than blocking the group.
2. **Artifacts** — hosted repositories only. A proxy re-fetches from its own upstream, so copying its cache would only duplicate bytes.
3. **Privileges → roles → users** — each references the previous one by name. Nested roles are flattened (no nested-role table here) after a topological sort; a cycle is reported, and the roles in it are still created with their own privileges rather than silently dropped.
4. **Routing rules** — stored whole or not at all; a matcher that will not compile rejects the rule instead of half-applying it.

Everything is matched by logical name and anything already present is **skipped, not overwritten**. That single property is what makes the lifecycle cheap: re-running costs only what was missing, **Pause** keeps its progress, **Resume** starts a fresh pass over the remainder, and `ResumeAll` re-attaches on startup to jobs a crash left `running` — which is why the source credential is persisted, sealed with the instance encryption key the same way replication target passwords are.

**Container images.** These could not be copied the way the component listing describes them, and testing against a real Nexus is what showed it: Nexus stores registry blobs content-addressed, lists them under a placeholder image name (`/v2/-/blobs/<digest>`), and reports **only the manifest** as a component. Copying what the listing reports produces an image nobody can pull. So each manifest is read and used as the index of what to fetch — an index is followed into its children, config and layer blobs come from the image's own path and are stored **before** the manifest, and a tagged manifest gets its content-digest alias, the way a push registers one.

**`POST /api/v1/migration/preview`** — the read-only check behind the UI's *Test connection* button. `422` for a URL that is not absolute `http(s)`, `502` carrying the source's own error when it cannot be reached, `200` with the repository list. Creates nothing, so it is safe to press as often as the form is edited.

**Frontend** — Test connection with a result that clears the moment the connection details change, scope checkboxes, the statuses the API actually returns (`done`/`error`, not `completed`/`failed`), `lastError` on the card, and polling that also covers `pending`.

## Compatibility

Additive. Migration `026` adds `migration_jobs.source_password`, three per-scope flags, and `users.must_reset_password`. `migratePolicies` stays as the default the three security scopes fall back to, so a client written against the older API shape keeps its meaning. `MigrationRepo` and `RoleRepo` gain methods; `domain.User` gains one field.

A migrated **local** account gets a random temporary password and `mustResetPassword`; an **LDAP/OIDC/SAML** account gets no local credential. Migrated users log in normally — blocking them until reset strands every account at once — and the flag clears when a password is set.

## Verification

TDD throughout: every behaviour here has a test that failed first.

- 33 service tests, 15 client tests, 28 handler tests, 15 frontend tests; `2047 passed` overall. The one failure, `TestWebhookHandler_Test_200`, fails identically on a clean checkout — the sandbox blocks its loopback POST.
- Repository-layer changes covered by integration tests against a real PostgreSQL (`868 passed` with `-tags=integration`).

Then end to end against a **real Sonatype Nexus 3.95** container, driven through this API:

| | |
|---|---|
| Repositories | 10/10, groups with their members, proxies with their remote URLs |
| Artifacts | raw + maven, byte-identical to the source |
| Container image | `alpine:3.20` — manifest `sha256:45e0995…` and both blobs served by Nexspence under the same digests Nexus reports |
| Security | built-ins skipped, `developer` correctly carrying its own privilege plus the one inherited from `base-reader` |
| Users | local account with `mustReset=true` and its role attached |
| Re-run | idempotent — 0 errors, nothing duplicated |
| Restart | a job left `running` in the database picked up by `ResumeAll` and finished |
| Credential | 88 chars of ciphertext in `source_password`, absent from every API response |

## Docs

`docs/nexus-migration.md` is new. `docs/api-spec.yaml` was describing endpoints that did not exist (`/cancel`, `/errors`) and a request shape the handler never accepted; it now matches the code. The website's Migration section was describing the same imagined feature — rewritten in both locales.
