### PR TITLE
ci: stop two website deploys from racing each other onto the droplet

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -8,6 +8,16 @@ on:
       - '.github/workflows/deploy-website.yml'
   workflow_dispatch: {}
 
+# The deploy is not atomic: it removes the running container and then starts a
+# new one under the same name. Two pushes landing close together raced through
+# that gap and the second one died with "container name already in use", leaving
+# the site on whichever image won — not on the newer commit. Serialising the
+# workflow closes the gap. The queue is not cancelled: every push should reach
+# the droplet, and the last one to arrive is the one that stays.
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nexspence/nexspence-website


### PR DESCRIPTION
#170 and #184 landed 24 seconds apart. Both triggered a deploy, and the
second one failed:

    docker: Error response from daemon: Conflict. The container name
    "/nexspence-website" is already in use

The deploy removes the running container and then starts a new one under the
same name, which is not atomic. The second run reached `docker run` while the
first was still creating its container, so the name was taken and the run
died with exit 125 — leaving the site serving the older commit's image with
nothing to say it had not been updated.

A concurrency group serialises the workflow, so the second deploy waits for
the first to finish instead of stepping on it. The queue is deliberately not
cancelled: every push to website/ should reach the droplet, and the last one
to arrive is the one that stays.

Merging this also redeploys the site, which is what puts the corrected
Migration docs from #184 in front of readers.
