### PR TITLE
fix(pypi): PEP 691 JSON simple pages break the proxy cache and group merging for modern pip

### DIFF
--- a/internal/formats/pypi/handler.go
+++ b/internal/formats/pypi/handler.go
@@ -51,6 +51,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	// Package simple index: GET /simple/ (path.Clean strips trailing slash → "/simple")
 	case c.Request.Method == http.MethodGet && (p == "/simple" || p == "/simple/"):
 		if repo != nil && repo.Type == domain.TypeProxy {
+			forceHTMLSimplePage(c)
 			coords := base.Coords{Name: "_simple", Version: "index"}
 			// The simple index is mutable metadata — revalidate on a TTL.
 			if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8", repoproxy.MetadataMaxAge(repo)); err != nil {
@@ -64,6 +65,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	case c.Request.Method == http.MethodGet && strings.HasPrefix(p, "/simple/"):
 		pkgName := strings.TrimSuffix(strings.TrimPrefix(p, "/simple/"), "/")
 		if repo != nil && repo.Type == domain.TypeProxy {
+			forceHTMLSimplePage(c)
 			normalized := normalizePackageName(pkgName)
 			coords := base.Coords{Name: normalized, Version: "simple-page"}
 			// A per-package simple page is mutable metadata (new releases appear).
@@ -228,6 +230,18 @@ func (h *Handler) serveFile(c *gin.Context, repoName, filePath string) {
 		return
 	}
 	c.DataFromReader(http.StatusOK, asset.SizeBytes, asset.ContentType, rc, nil)
+}
+
+// forceHTMLSimplePage pins the upstream Accept for proxied simple pages to
+// PEP 503 HTML (#191). Modern pip asks for the PEP 691 JSON page; forwarding
+// that upstream breaks everything downstream that assumes HTML — href
+// rewriting (#98), anchor-based group merging (#99), and the one-representation
+// -per-path cache. pip accepts an HTML answer via content negotiation, so
+// always fetching HTML keeps the cache correct by construction. The request
+// here is the handler's own (groups fan out on a clone), so the mutation never
+// leaks back to the client's request.
+func forceHTMLSimplePage(c *gin.Context) {
+	c.Request.Header.Set("Accept", "text/html")
 }
 
 func normalizePackageName(name string) string {

--- a/internal/formats/pypi/pep691_test.go
+++ b/internal/formats/pypi/pep691_test.go
@@ -1,0 +1,155 @@
+package pypi_test
+
+// PEP 691 regression tests (#191): modern pip asks for the JSON simple page
+// (application/vnd.pypi.simple.v1+json). Forwarding that Accept upstream broke
+// URL rewriting, group merging, and cache consistency, because the whole
+// simple-page pipeline is built around the PEP 503 HTML representation. The
+// proxy must always request text/html upstream regardless of the client's
+// Accept header.
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/formats/pypi"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// pipAccept is what pip ≥ 22.2 sends for simple pages (PEP 691).
+const pipAccept = "application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html;q=0.1, text/html;q=0.01"
+
+// pep691Upstream models pypi.org content negotiation: JSON only when the
+// client explicitly asks for it, HTML otherwise.
+func pep691Upstream(t *testing.T, capturedAccept *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*capturedAccept = r.Header.Get("Accept")
+		if strings.Contains(*capturedAccept, "application/vnd.pypi.simple.v1+json") {
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			fmt.Fprint(w, `{"files":[{"filename":"requests-2.31.0-py3-none-any.whl","url":"https://files.pythonhosted.org/packages/ab/cd/requests-2.31.0-py3-none-any.whl"}],"name":"requests"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!DOCTYPE html><html><body><a href="https://files.pythonhosted.org/packages/ab/cd/requests-2.31.0-py3-none-any.whl#sha256=deadbeef">requests-2.31.0-py3-none-any.whl</a></body></html>`)
+	}))
+}
+
+func proxyRepo(name, remoteURL string) *domain.Repository {
+	return &domain.Repository{
+		ID:          name,
+		Name:        name,
+		Format:      "pypi",
+		Type:        domain.TypeProxy,
+		Online:      true,
+		ProxyConfig: map[string]any{"remote_url": remoteURL},
+	}
+}
+
+// TestPyPI_Proxy_PackageIndex_ForcesHTMLUpstream: a pip client asking for the
+// JSON simple page must not make the proxy fetch JSON from upstream — the
+// upstream request always asks for text/html, and the served page is the
+// rewritten HTML representation.
+func TestPyPI_Proxy_PackageIndex_ForcesHTMLUpstream(t *testing.T) {
+	var capturedAccept string
+	upstream := pep691Upstream(t, &capturedAccept)
+	defer upstream.Close()
+
+	r := setupExtra(proxyRepo("pypi-prx-691", upstream.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-prx-691/simple/requests/", nil)
+	req.Header.Set("Accept", pipAccept)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/html", capturedAccept, "upstream fetch must always ask for the PEP 503 HTML page")
+	body := w.Body.String()
+	assert.NotContains(t, body, `"files"`, "client must get HTML, not the PEP 691 JSON page")
+	assert.Contains(t, body, `href="http://localhost:8080/repository/pypi-prx-691/packages/ab/cd/requests-2.31.0-py3-none-any.whl#sha256=deadbeef"`,
+		"file links must be rewritten to the proxy")
+}
+
+// TestPyPI_Proxy_SimpleIndex_ForcesHTMLUpstream: same guarantee for the root
+// simple index (/simple/).
+func TestPyPI_Proxy_SimpleIndex_ForcesHTMLUpstream(t *testing.T) {
+	var capturedAccept string
+	upstream := pep691Upstream(t, &capturedAccept)
+	defer upstream.Close()
+
+	r := setupExtra(proxyRepo("pypi-prx-691-idx", upstream.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-prx-691-idx/simple/", nil)
+	req.Header.Set("Accept", pipAccept)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "text/html", capturedAccept, "upstream fetch must always ask for the PEP 503 HTML page")
+	assert.NotContains(t, w.Body.String(), `"files"`)
+}
+
+// TestPyPI_Group_PipAccept_MergesProxyMember: end-to-end group reproduction
+// from #191 — pip's Accept header must not empty out the merged group page.
+// The proxy member fetches HTML upstream, so the anchor-based merge sees links.
+func TestPyPI_Group_PipAccept_MergesProxyMember(t *testing.T) {
+	var capturedAccept string
+	upstream := pep691Upstream(t, &capturedAccept)
+	defer upstream.Close()
+
+	member := proxyRepo("pypi-prx-g691", upstream.URL)
+	groupDef := &domain.Repository{
+		ID:     "pypi-group-691",
+		Name:   "pypi-group-691",
+		Format: "pypi",
+		Type:   domain.TypeGroup,
+		Online: true,
+		FormatConfig: map[string]any{
+			"member_names": []interface{}{"pypi-prx-g691"},
+		},
+	}
+
+	repoRepo := testutil.NewRepoRepo(member, groupDef)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	pypiH := pypi.New(d)
+	groupH := group.New(d, map[string]formats.FormatHandler{"pypi": pypiH})
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		pypiH.ServeHTTP(c)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-group-691/simple/requests/", nil)
+	req.Header.Set("Accept", pipAccept)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.Contains(t, body, "requests-2.31.0-py3-none-any.whl",
+		"merged group page must not be empty for a pip client")
+	assert.Contains(t, body, `/repository/pypi-group-691/packages/`,
+		"file links must be re-rooted at the group")
+	// The client's own request must be untouched by the member fan-out.
+	assert.Equal(t, pipAccept, req.Header.Get("Accept"))
+}


### PR DESCRIPTION
## Summary

Fixes #191 with the minimal approach suggested there: for proxied pypi simple pages (`/simple/` and `/simple/<pkg>/`), the upstream fetch no longer forwards the client's `Accept` — it always requests `text/html` (PEP 503).

Modern pip (>= 22.2) asks for `application/vnd.pypi.simple.v1+json` (PEP 691); pypi.org only returns JSON when explicitly asked. Forwarding pip's Accept broke three things at once:

1. **Cache bypass** — `RewriteSimplePage` only rewrites HTML `href` attributes, so JSON `"url"` fields pointed pip straight at `files.pythonhosted.org`.
2. **Empty group pages** — the anchor-regex group merge saw zero anchors in a JSON member page, so pypi groups answered modern pip with `(from versions: none)`.
3. **Representation cache poisoning** — the cache keys by path while the response varied with the forwarded Accept; whoever asked first pinned JSON-vs-HTML for everyone until the metadata TTL expired.

Pinning the upstream representation to HTML makes the single-representation cache correct by construction; pip accepts the HTML answer via content negotiation (which is why hosted repos always worked).

The mutation happens on the handler's own request — group fan-out calls members on a `Clone`, so the client's request is untouched (asserted in the group test).

## Tests (TDD)

New `pep691_test.go`, all written first and observed failing with exactly the three symptoms from the issue:

- `TestPyPI_Proxy_PackageIndex_ForcesHTMLUpstream` — upstream sees `Accept: text/html`; client gets rewritten HTML, not JSON.
- `TestPyPI_Proxy_SimpleIndex_ForcesHTMLUpstream` — same for the root index.
- `TestPyPI_Group_PipAccept_MergesProxyMember` — end-to-end group repro with a PEP 691-negotiating upstream: merged page is non-empty and re-rooted at the group; client's own Accept header is untouched.

`go test ./internal/formats/...` fully green; full suite green except the known sandbox-only webhook network test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rVAoCq1tgwZaGuD4htHiT