### PR TITLE
fix(oci): verify client-claimed digest on blob and manifest push

### DIFF
--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -21,6 +21,8 @@ package oci
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -297,6 +299,16 @@ func (h *Handler) pushManifest(c *gin.Context, repoName, imageName, reference st
 		dockerError(c, http.StatusRequestEntityTooLarge, "MANIFEST_INVALID",
 			"manifest exceeds the 4MiB limit")
 		return
+	}
+
+	// A reference that names a digest is a claim about the bytes; verify it
+	// before anything is written, or a pusher could register arbitrary content
+	// under a digest another consumer already pins (issue #194).
+	if strings.Contains(reference, ":") {
+		if msg := digestMismatch(reference, body); msg != "" {
+			dockerError(c, http.StatusBadRequest, "DIGEST_INVALID", msg)
+			return
+		}
 	}
 
 	res, err := base.StoreArtifact(c.Request.Context(), h.deps,
@@ -774,6 +786,14 @@ func (h *Handler) finalizeUpload(c *gin.Context, repoName, imageName, uuid strin
 		return
 	}
 
+	// The blob is stored and served under the client-claimed digest, so the
+	// claim must match the bytes before anything is written (issue #194). The
+	// session is kept: the client may retry the PUT with the correct digest.
+	if msg := digestMismatch(digest, data); msg != "" {
+		dockerError(c, http.StatusBadRequest, "DIGEST_INVALID", msg)
+		return
+	}
+
 	fp := blobPath(imageName, digest)
 	coords := base.Coords{Name: imageName, Version: digest}
 	if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
@@ -805,6 +825,27 @@ func requireDockerAuth(c *gin.Context) bool {
 	c.Header("WWW-Authenticate", `Basic realm="Nexspence"`)
 	dockerError(c, http.StatusUnauthorized, "UNAUTHORIZED", "authentication required")
 	return false
+}
+
+// digestMismatch verifies a client-claimed digest against the content it
+// claims to describe. It returns "" when the claim holds, otherwise a message
+// for a 400 DIGEST_INVALID response. Only sha256 is accepted: an algorithm
+// the registry cannot compute itself cannot be verified, and storing content
+// under an unverified digest would let any pusher publish arbitrary bytes
+// under a digest a consumer already pins (issue #194).
+func digestMismatch(claimed string, content []byte) string {
+	algo, hexDigest, ok := strings.Cut(claimed, ":")
+	if !ok {
+		return fmt.Sprintf("digest %q must have the form <algorithm>:<hex>", claimed)
+	}
+	if algo != "sha256" {
+		return fmt.Sprintf("unsupported digest algorithm %q: only sha256 can be verified", algo)
+	}
+	sum := sha256.Sum256(content)
+	if actual := hex.EncodeToString(sum[:]); actual != hexDigest {
+		return fmt.Sprintf("digest %s does not match content sha256:%s", claimed, actual)
+	}
+	return ""
 }
 
 func dockerError(c *gin.Context, status int, code, message string) {

--- a/internal/formats/oci/handler_test.go
+++ b/internal/formats/oci/handler_test.go
@@ -264,6 +264,153 @@ func TestDocker_TagsList_AfterPush(t *testing.T) {
 	assert.Contains(t, body, "latest")
 }
 
+// ── Digest verification (issue #194) ──────────────────────────
+
+func TestDocker_BlobPush_DigestMismatch_Rejected(t *testing.T) {
+	repo := testutil.SimpleRepo("regd1", "docker")
+	r := setup(repo)
+
+	content := "actual layer bytes"
+	claimed := digest("something else entirely")
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/repository/regd1/v2/app/blobs/uploads/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	loc := w.Header().Get("Location")
+
+	req2 := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader(content))
+	req2.ContentLength = int64(len(content))
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusAccepted, w2.Code)
+
+	// Finalize claiming a digest that does not match the uploaded bytes.
+	req3 := httptest.NewRequest(http.MethodPut, loc+"?digest="+claimed, nil)
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, req3)
+	assert.Equal(t, http.StatusBadRequest, w3.Code)
+	assert.Contains(t, w3.Body.String(), "DIGEST_INVALID")
+
+	// Nothing must be registered under the claimed digest.
+	req4 := httptest.NewRequest(http.MethodGet,
+		"/repository/regd1/v2/app/blobs/"+claimed, nil)
+	w4 := httptest.NewRecorder()
+	r.ServeHTTP(w4, req4)
+	assert.Equal(t, http.StatusNotFound, w4.Code)
+}
+
+func TestDocker_BlobPush_UnsupportedDigestAlgorithm_Rejected(t *testing.T) {
+	repo := testutil.SimpleRepo("regd2", "docker")
+	r := setup(repo)
+
+	content := "layer bytes"
+	req := httptest.NewRequest(http.MethodPost,
+		"/repository/regd2/v2/app/blobs/uploads/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	loc := w.Header().Get("Location")
+
+	req2 := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader(content))
+	req2.ContentLength = int64(len(content))
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusAccepted, w2.Code)
+
+	// The registry only computes sha256; an unverifiable algorithm must be rejected,
+	// not trusted blindly.
+	sha512Digest := "sha512:" + strings.Repeat("ab", 64)
+	req3 := httptest.NewRequest(http.MethodPut, loc+"?digest="+sha512Digest, nil)
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, req3)
+	assert.Equal(t, http.StatusBadRequest, w3.Code)
+	assert.Contains(t, w3.Body.String(), "DIGEST_INVALID")
+}
+
+func TestDocker_BlobPush_MalformedDigest_Rejected(t *testing.T) {
+	repo := testutil.SimpleRepo("regd3", "docker")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/repository/regd3/v2/app/blobs/uploads/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	loc := w.Header().Get("Location")
+
+	req2 := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader("data"))
+	req2.ContentLength = 4
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusAccepted, w2.Code)
+
+	req3 := httptest.NewRequest(http.MethodPut, loc+"?digest=sha256:nothex", nil)
+	w3 := httptest.NewRecorder()
+	r.ServeHTTP(w3, req3)
+	assert.Equal(t, http.StatusBadRequest, w3.Code)
+	assert.Contains(t, w3.Body.String(), "DIGEST_INVALID")
+}
+
+func TestDocker_ManifestPushByDigest_Mismatch_Rejected(t *testing.T) {
+	repo := testutil.SimpleRepo("regd4", "docker")
+	r := setup(repo)
+
+	manifest := `{"schemaVersion":2}`
+	claimed := digest("a different manifest")
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/regd4/v2/app/manifests/"+claimed,
+		strings.NewReader(manifest))
+	req.ContentLength = int64(len(manifest))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "DIGEST_INVALID")
+
+	// Nothing must resolve under the claimed digest.
+	req2 := httptest.NewRequest(http.MethodGet,
+		"/repository/regd4/v2/app/manifests/"+claimed, nil)
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusNotFound, w2.Code)
+}
+
+func TestDocker_ManifestPushByDigest_Match_Accepted(t *testing.T) {
+	repo := testutil.SimpleRepo("regd5", "docker")
+	r := setup(repo)
+
+	manifest := `{"schemaVersion":2}`
+	dgst := digest(manifest)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/regd5/v2/app/manifests/"+dgst,
+		strings.NewReader(manifest))
+	req.ContentLength = int64(len(manifest))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, dgst, w.Header().Get("Docker-Content-Digest"))
+}
+
+func TestDocker_ManifestPushByDigest_UnsupportedAlgorithm_Rejected(t *testing.T) {
+	repo := testutil.SimpleRepo("regd6", "docker")
+	r := setup(repo)
+
+	manifest := `{"schemaVersion":2}`
+	ref := "sha512:" + strings.Repeat("cd", 64)
+
+	req := httptest.NewRequest(http.MethodPut,
+		"/repository/regd6/v2/app/manifests/"+ref,
+		strings.NewReader(manifest))
+	req.ContentLength = int64(len(manifest))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "DIGEST_INVALID")
+}
+
 // ── Auth gate ─────────────────────────────────────────────────
 
 func TestDocker_BlobUpload_NoAuth_Returns401(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #194.

`finalizeUpload` stored an uploaded blob under the client-supplied `?digest=` and echoed it back as `Docker-Content-Digest` without ever comparing it against the SHA-256 of the bytes actually received; `pushManifest` accepted a manifest PUT to a `sha256:...` reference the same way. Any account with push RBAC could register arbitrary content under a digest another consumer already pins (CI pipelines, Kubernetes digest-pinned images), defeating the supply-chain guarantee digest pulls exist to provide.

## Fix

Both handlers already buffer the full body, so the claim is verified **before anything is written** (no store-then-delete window):

- `digestMismatch` helper parses the claimed digest, accepts only `sha256` (algorithms the registry cannot compute itself, e.g. `sha512`, are rejected rather than trusted blindly), and compares against the computed sum.
- `finalizeUpload`: mismatch → `400 DIGEST_INVALID`, nothing stored; the upload session is kept so the client can retry with the correct digest.
- `pushManifest`: a reference containing `:` is a digest claim (OCI tags cannot contain `:`) and is verified the same way; tag pushes are unaffected.

Legitimate clients (docker, containerd, buildkit, skopeo, ORAS) always send a digest matching their content, so real pushes are unaffected.

## Tests

Six new tests (written first, verified failing against the vulnerable code): blob digest mismatch, unsupported algorithm, malformed digest, manifest-by-digest mismatch, match accepted, manifest unsupported algorithm. Full `./internal/...` suite green (only the known sandbox-network webhook test fails, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qgfw3sy8j35uqFmVcyZSsj