### PR TITLE
fix(storage): stage local blob writes at a unique temp path

### DIFF
--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -57,12 +57,18 @@ func (s *LocalBlobStore) Put(_ context.Context, key string, r io.Reader, _ int64
 	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
 		return err
 	}
-	// Write to a temp file first, then rename (atomic on same filesystem)
-	tmp := dst + ".tmp"
-	f, err := os.Create(tmp) //nolint:gosec // dst is validated by keyPath to stay within the blob store base dir
+	// Write to a temp file first, then rename (atomic on same filesystem).
+	// The temp name must be unique per attempt: a fixed dst+".tmp" gives two
+	// concurrent Puts for the same key two descriptors on the *same* inode, and
+	// the rename only republishes the directory entry — the loser keeps writing
+	// into the blob the winner already made live, corrupting it (issue #196).
+	// os.CreateTemp opens with O_EXCL and a random suffix, so every writer owns
+	// its own file and cleans up only its own file.
+	f, err := os.CreateTemp(filepath.Dir(dst), filepath.Base(dst)+".tmp.*")
 	if err != nil {
 		return err
 	}
+	tmp := f.Name()
 	if _, err := io.Copy(f, r); err != nil {
 		_ = f.Close()
 		_ = os.Remove(tmp)

--- a/internal/storage/local_internal_test.go
+++ b/internal/storage/local_internal_test.go
@@ -44,8 +44,29 @@ func TestLocalBlobStore_Put_SyncsBlobBeforeRename(t *testing.T) {
 
 	require.NotEmpty(t, *calls, "Put must fsync the blob contents before renaming it into place")
 	first := (*calls)[0]
-	assert.Equal(t, dst+".tmp", first.name, "the staged temp file must be the first thing fsynced")
+	assert.True(t, strings.HasPrefix(first.name, dst+".tmp."),
+		"the staged temp file must be the first thing fsynced, got %q", first.name)
 	assert.False(t, first.dstExists, "the fsync must happen before the rename, not after")
+}
+
+// Every Put must stage under its own temp path. Sharing one fixed temp name
+// lets two concurrent writers for the same key write into the same inode, so
+// the loser corrupts the blob the winner already published (issue #196).
+func TestLocalBlobStore_Put_StagesAtUniqueTempPath(t *testing.T) {
+	base := t.TempDir()
+	s, err := NewLocalBlobStore(base)
+	require.NoError(t, err)
+
+	const key = "abcdef1234567890"
+	dst := filepath.Join(base, "ab", "cd", key)
+	calls := recordSyncs(s, dst)
+
+	require.NoError(t, s.Put(context.Background(), key, strings.NewReader("first"), 5))
+	require.NoError(t, s.Put(context.Background(), key, strings.NewReader("second"), 6))
+
+	require.Len(t, *calls, 4, "each Put must fsync the blob and then its parent directory")
+	assert.NotEqual(t, (*calls)[0].name, (*calls)[2].name,
+		"two Puts for the same key must not stage at the same temp path")
 }
 
 func TestLocalBlobStore_Put_SyncsParentDirAfterRename(t *testing.T) {
@@ -74,7 +95,7 @@ func TestLocalBlobStore_Put_SyncFailure_LeavesNoBlob(t *testing.T) {
 	dst := filepath.Join(base, "ab", "cd", key)
 	syncErr := errors.New("fsync failed")
 	s.syncFile = func(f *os.File) error {
-		if f.Name() == dst+".tmp" {
+		if strings.HasPrefix(f.Name(), dst+".tmp.") {
 			return syncErr
 		}
 		return f.Sync()
@@ -84,7 +105,9 @@ func TestLocalBlobStore_Put_SyncFailure_LeavesNoBlob(t *testing.T) {
 
 	require.ErrorIs(t, err, syncErr, "a failed fsync must fail the Put")
 	assert.NoFileExists(t, dst, "no blob may be published when its contents were not flushed to disk")
-	assert.NoFileExists(t, dst+".tmp", "the temp file must be cleaned up")
+	leftovers, globErr := filepath.Glob(dst + ".tmp.*")
+	require.NoError(t, globErr)
+	assert.Empty(t, leftovers, "the temp file must be cleaned up")
 }
 
 func TestLocalBlobStore_Put_DirSyncFailure_IsNotFatal(t *testing.T) {

--- a/internal/storage/local_test.go
+++ b/internal/storage/local_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -46,6 +47,53 @@ func TestLocalBlobStore_PutGet_Roundtrip(t *testing.T) {
 	assert.EqualValues(t, len(data), size)
 	got, _ := io.ReadAll(rc)
 	assert.Equal(t, data, got)
+}
+
+// Two clients racing to store the same blob key (a proxy cache-fill stampede,
+// or two pushes of the same artifact) must never mix their bytes: whichever
+// writer publishes last, the blob on disk must be exactly one writer's payload,
+// and no writer may fail because another one was staging at the same time.
+func TestLocalBlobStore_Put_ConcurrentSameKey_NoCorruption(t *testing.T) {
+	store := newLocal(t)
+	ctx := context.Background()
+	const (
+		key     = "abcdef1234567890"
+		writers = 20
+		// Bigger than io.Copy's 32 KiB buffer so the writes interleave instead of
+		// completing in a single syscall.
+		payloadSize = 256 * 1024
+	)
+
+	payloads := make([][]byte, writers)
+	for i := range payloads {
+		payloads[i] = bytes.Repeat([]byte{byte('a' + i)}, payloadSize)
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, writers)
+	start := make(chan struct{})
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs[i] = store.Put(ctx, key, bytes.NewReader(payloads[i]), payloadSize)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "writer %d must not fail because of a concurrent writer", i)
+	}
+
+	rc, size, err := store.Get(ctx, key)
+	require.NoError(t, err)
+	defer rc.Close()
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.EqualValues(t, payloadSize, size, "the published blob must have exactly one payload's size")
+	assert.Contains(t, payloads, got, "the published blob must be one writer's payload, not a mix of several")
 }
 
 func TestLocalBlobStore_Put_ShortKey(t *testing.T) {


### PR DESCRIPTION
## Problem

`LocalBlobStore.Put` staged every write at the deterministic path `dst+".tmp"` using `os.Create` (no `O_EXCL`, no per-attempt suffix). Two concurrent `Put` calls for the same blob key therefore held two descriptors on the **same inode**, and `os.Rename` only republishes the directory entry — it does not stop the loser from continuing to write into the inode the winner has already made live.

Two real consequences, both reported in #196:

- **Direct push** (`base.StoreArtifact`): the loser's `io.Copy` keeps writing into the now-public blob, corrupting content a client may already be downloading.
- **Proxy cache-fill** (`repoproxy.storeAndServeResponse`): the loser's own `os.Rename` fails with `ENOENT` (its temp file is gone — the winner renamed it), and the caller treats any `putErr` as fatal and calls `physStore.Delete` on the blob key, deleting the *winner's* blob that the winner has already registered as an asset. Result: a DB asset row with no bytes behind it.

## Fix

Stage with `os.CreateTemp(dir, base+".tmp.*")` — `O_EXCL` plus a random suffix — so two writers for the same key never share a file, and each failure path removes only its own temp file. The `ENOENT`-on-rename trigger for the proxy's erroneous `Delete` disappears with it.

Side effect worth noting: blobs are now created `0600` instead of umask-dependent `0644`, which lines up with the `0750` store directories.

## Tests

- `TestLocalBlobStore_Put_ConcurrentSameKey_NoCorruption` — 20 goroutines `Put` distinct 256 KiB payloads at one key; every `Put` must succeed and the published blob must be exactly one writer's payload. Fails 10/10 runs under `-race` before the fix, passes 10/10 after.
- `TestLocalBlobStore_Put_StagesAtUniqueTempPath` — two sequential `Put`s must stage at different temp paths.
- Existing internal fsync tests updated to match on the `dst+".tmp."` prefix, and the cleanup assertion now globs for leftover temp files.

Full suite: 2063 passed; the only failure is the pre-existing `TestWebhookHandler_Test_200`, which dials a loopback `httptest` server and fails in this sandbox for network reasons unrelated to this change. `golangci-lint` clean.

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbm2FRAiTqoVxNwnPSsRf4