### PR TITLE
fix(proxy): stop a failed cache fill from deleting another request's blob

### DIFF
--- a/internal/formats/repoproxy/cachefill_cleanup_test.go
+++ b/internal/formats/repoproxy/cachefill_cleanup_test.go
@@ -1,0 +1,145 @@
+package repoproxy_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+)
+
+// Cleanup after a failed cache fill (#198). The blob key is derived from repo
+// name + path, so every request filling the same artifact writes to the same
+// key: a fill that cleans up by deleting that key destroys whatever else is
+// there — the copy already cached at that path, or the one a concurrent fill
+// just published and registered. Neither belongs to the failing request.
+
+// flakyUpstream serves a body, and can be switched to abort mid-response:
+// it announces a Content-Length it never delivers and drops the connection,
+// which surfaces as an unexpected EOF while the proxy is streaming the body.
+type flakyUpstream struct {
+	mu       sync.Mutex
+	body     string
+	truncate bool
+}
+
+func newFlakyUpstream(body string) (*flakyUpstream, *httptest.Server) {
+	fu := &flakyUpstream{body: body}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fu.mu.Lock()
+		payload, truncate := fu.body, fu.truncate
+		fu.mu.Unlock()
+
+		if !truncate {
+			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(payload))
+			return
+		}
+		// Hand-write a response promising more than we send, then hang up.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_, _ = fmt.Fprintf(buf, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %d\r\n\r\n%s",
+			len(payload)+64, payload)
+		_ = buf.Flush()
+		_ = conn.Close()
+	}))
+	return fu, srv
+}
+
+func (fu *flakyUpstream) set(body string, truncate bool) {
+	fu.mu.Lock()
+	defer fu.mu.Unlock()
+	fu.body, fu.truncate = body, truncate
+}
+
+// A refill that dies mid-stream must leave the previously cached copy alone.
+// The failing request published nothing of its own (Put stages at its own temp
+// path and drops it on error), so deleting the shared key can only destroy
+// someone else's blob — leaving the asset row that points at it with no bytes.
+func TestServeGET_Revalidation_FillFails_KeepsCachedBlob(t *testing.T) {
+	useUnguardedUpstream(t)
+	fu, srv := newFlakyUpstream("InRelease-v1")
+	defer srv.Close()
+
+	const path = "/dists/trixie/InRelease"
+	repo := proxyRepo("failfill", srv.URL)
+	d, assets, blobStore := newRevalDeps(repo)
+
+	require.Equal(t, http.StatusOK, revalGET(d, repo, path, 10*time.Minute).Code)
+	require.Equal(t, "InRelease-v1", blobStoreBody(t, blobStore, "failfill", path))
+
+	// Stale cache + an upstream that now aborts mid-body → the refill fails.
+	makeStale(t, assets, "failfill", path)
+	fu.set("InRelease-v2-trunc", true)
+	revalGET(d, repo, path, 10*time.Minute)
+
+	assert.Empty(t, blobStore.Deleted, "a failed fill must not delete the shared blob key")
+	assert.Equal(t, "InRelease-v1", blobStoreBody(t, blobStore, "failfill", path),
+		"the previously cached copy must survive a failed refill")
+	_, err := assets.GetByPath(nil, "failfill", path) //nolint:staticcheck // mock ignores ctx
+	require.NoError(t, err, "the asset row must not be left pointing at a deleted blob")
+}
+
+// The post-stream quota gate drops an over-quota fill that could not be checked
+// up front (no Content-Length). It must not drop the blob when an asset row
+// already points at that key — those bytes are not this request's to delete.
+func TestServeGET_Revalidation_OverQuotaChunkedRefill_KeepsReferencedBlob(t *testing.T) {
+	useUnguardedUpstream(t)
+	const path = "/pkg/1.0/a.jar"
+
+	var mu sync.Mutex
+	body := "v1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		payload := body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.WriteHeader(http.StatusOK)
+		// Flush between writes so the response is chunked (no Content-Length),
+		// which defers the quota check until after the bytes are streamed.
+		fl := w.(http.Flusher)
+		_, _ = w.Write([]byte(payload[:1]))
+		fl.Flush()
+		_, _ = w.Write([]byte(payload[1:]))
+	}))
+	defer srv.Close()
+
+	repo := proxyRepo("quotarefill", srv.URL)
+	quota := int64(100)
+	repo.QuotaBytes = &quota
+	d, assets, blobStore := quotaDeps(repo)
+
+	require.Equal(t, http.StatusOK, revalGET(d, repo, path, 10*time.Minute).Code)
+	require.Equal(t, "v1", blobStoreBody(t, blobStore, "quotarefill", path))
+
+	// Stale cache + a refill that busts the quota only once fully streamed.
+	makeStale(t, assets, "quotarefill", path)
+	mu.Lock()
+	body = overQuotaBody
+	mu.Unlock()
+	quota = 10
+
+	w := revalGET(d, repo, path, 10*time.Minute)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, overQuotaBody, w.Body.String(), "the client still receives the artifact")
+
+	assert.Empty(t, blobStore.Deleted, "an over-quota fill must not delete a blob an asset row points at")
+	exists, err := blobStore.Exists(nil, base.BlobKey("quotarefill", path)) //nolint:staticcheck // mock ignores ctx
+	require.NoError(t, err)
+	assert.True(t, exists, "the cached asset must keep its bytes")
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -537,7 +537,13 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 	putErr := <-putErrCh
 
 	if copyErr != nil || putErr != nil {
-		_ = physStore.Delete(ctx, blobKey)
+		// No cleanup by blob key here (#198). A failed Put publishes nothing —
+		// it stages under its own temp path and removes it on error (#196) — and
+		// a copy error always fails the Put too, since the pipe is closed with
+		// that error. So the only thing at blobKey is someone else's data: the
+		// copy already cached at this path, or one a concurrent fill just
+		// published and registered. Deleting it leaves an asset row with no
+		// bytes behind it; leaving it costs nothing.
 		return fmt.Errorf("proxy cache write: %w", errors.Join(copyErr, putErr))
 	}
 
@@ -556,7 +562,7 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 	// client already has the bytes, so just drop the over-quota blob unregistered.
 	if resp.ContentLength <= 0 && size > 0 {
 		if qErr := base.CheckQuota(ctx, d, repo, size); errors.Is(qErr, base.ErrQuotaExceeded) {
-			_ = physStore.Delete(ctx, blobKey)
+			dropUnreferencedBlob(ctx, d, repo, repoRelativePath, physStore, blobKey)
 			return nil
 		}
 	}
@@ -573,6 +579,25 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 		d.Downloads.Add(regAsset.ID)
 	}
 	return nil
+}
+
+// dropUnreferencedBlob removes a blob this request wrote but will not register,
+// but only while no asset row points at that path. The blob key is shared by
+// every request caching the same artifact, so an existing row means the bytes
+// belong to a cache entry — either the one that was already there or one a
+// concurrent fill just registered — and deleting them would leave that row
+// pointing at nothing (#198). The check narrows the window to the gap between
+// the lookup and the delete; it cannot close it without store-level ownership.
+func dropUnreferencedBlob(ctx context.Context, d formats.Deps, repo *domain.Repository,
+	repoRelativePath string, physStore storage.BlobStore, blobKey string,
+) {
+	if d.Assets != nil {
+		existing, err := d.Assets.GetByPath(ctx, repo.Name, repoRelativePath)
+		if err == nil && existing != nil {
+			return
+		}
+	}
+	_ = physStore.Delete(ctx, blobKey)
 }
 
 // storeOriginal persists an already-buffered upstream body to the blob store


### PR DESCRIPTION
## Problem

`storeAndServeResponse` cleaned up after a failed cache fill by deleting the **blob key** — but the key is `BlobKey(repo.Name, path)`, shared by every request caching that artifact. Nothing at that key ever belongs to the failing request:

- A failed `Put` publishes nothing (it stages under its own temp path and removes it on error — #196/#197), and a `copyErr` always fails the `Put` with it, since the pipe is closed with that error.
- So the delete could only hit the copy already cached at that path, or one a **concurrent** fill had just published and registered — leaving an asset row pointing at a blob key with no bytes behind it.

This is the residual race from #196, filed as #198.

## Fix

- `repoproxy.go:539` — drop the `Delete` on `copyErr`/`putErr` entirely. There is nothing of this request's to clean up, and leaving the existing blob in place costs nothing.
- `repoproxy.go:557` — the post-stream quota gate genuinely did write the blob it wants to drop (chunked upstream, quota only checkable after streaming), so it keeps deleting — but via `dropUnreferencedBlob`, which skips the delete when an asset row already points at that path. That narrows the window to the gap between lookup and delete; closing it fully needs store-level ownership of a write, which is a bigger change than this bug warrants.

Single-flighting fills per key was the other candidate. It would also cut duplicate upstream fetches, but it only coordinates within one process — with HA (multiple nodes on one blob store) the delete would still cross requests — so scoping the cleanup is both smaller and more robust.

## Tests

Both reproduce deterministically via the revalidation path (stale cache → upstream 200 → fill fails), which hits the same shared-key cleanup as the concurrent case without racing goroutines:

- `TestServeGET_Revalidation_FillFails_KeepsCachedBlob` — upstream announces a `Content-Length` it never delivers and hangs up; the previously cached copy and its asset row must survive.
- `TestServeGET_Revalidation_OverQuotaChunkedRefill_KeepsReferencedBlob` — a chunked over-quota refill must not delete the blob the existing asset row points at.

Existing #189 quota tests (no prior asset row → blob still dropped) continue to pass unchanged. Full backend suite: 2049 passed, only the pre-existing sandbox-network `TestWebhookHandler_Test_200` fails. `golangci-lint` clean.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rbm2FRAiTqoVxNwnPSsRf4