### PR TITLE
feat(metrics): let operators serve /metrics without a scrape token

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Published on the [Terraform Registry](https://registry.terraform.io/providers/ne
 - Audit log — every action logged; NDJSON streaming export; 90-day partition rotation
 - Webhooks — HMAC-SHA256 signed; `artifact.published`, `artifact.deleted`, repo events
 - Content Replication — push to remote instance on cron schedule
-- **Monitoring** — Prometheus `/metrics` endpoint (Bearer-auth); pre-built Grafana dashboard; ring-buffer history API; UI Charts + Repositories tabs
+- **Monitoring** — Prometheus `/metrics` endpoint (Bearer-auth by default, anonymous with `metrics.public`); pre-built Grafana dashboard; ring-buffer history API; UI Charts + Repositories tabs
 
 ---
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -98,6 +98,16 @@ log:
 search:
   min_query_len: 2
 
+# Prometheus scrape endpoint (GET /metrics).
+# It is served on the same listener as the API, so by default it requires a
+# Bearer token (a JWT or an nxs_* token) — an anonymous scrape would publish
+# install size, artifact and download counts and the Go runtime fingerprint.
+# Set public: true when the listener is only reachable from a trusted network
+# (a cluster-internal Service, a localhost bind, or a reverse proxy that blocks
+# /metrics from outside); then Prometheus scrapes it with no token secret.
+metrics:
+  public: false
+
 cleanup:
   default_schedule: "0 */6 * * *"   # cron schedule used for policies without schedule_cron
 

--- a/deploy/helm/nexspence/README.md
+++ b/deploy/helm/nexspence/README.md
@@ -165,6 +165,41 @@ For multi-replica deployments, use S3 storage (see above).
 
 ---
 
+## Monitoring (Prometheus)
+
+The pod serves `GET /metrics` on the same port as the API, so it requires a
+Bearer token by default. Inside a cluster the Service is usually only reachable
+by Prometheus anyway, and then the token is one more secret to rotate:
+
+```bash
+helm upgrade nexspence deploy/helm/nexspence \
+  --set config.metricsPublic=true \
+  --namespace nexspence
+```
+
+A matching `ServiceMonitor` (the chart does not ship one — port name is `http`):
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nexspence
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nexspence
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+```
+
+Leaving `config.metricsPublic=false` keeps the token requirement — add an
+`authorization:` block pointing at a Secret holding an `nxs_*` token. See
+[docs/deployment.md](../../../docs/deployment.md#prometheus).
+
+---
+
 ## Upgrading
 
 ```bash

--- a/deploy/helm/nexspence/templates/configmap.yaml
+++ b/deploy/helm/nexspence/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
   NEXSPENCE_BOOTSTRAP_ADMIN_USERNAME: {{ .Values.config.adminUsername | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_EMAIL: {{ .Values.config.adminEmail | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_FIRST_NAME: {{ .Values.config.adminFirstName | quote }}
+  NEXSPENCE_METRICS_PUBLIC: {{ .Values.config.metricsPublic | quote }}
   {{- if eq .Values.storage.type "local" }}
   NEXSPENCE_STORAGE_LOCAL_BASE_PATH: {{ .Values.storage.local.mountPath | quote }}
   {{- else if eq .Values.storage.type "s3" }}

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -59,6 +59,11 @@ config:
   adminPassword: "admin123"
   adminEmail: "admin@example.com"
   adminFirstName: "Admin"
+  # -- Serve GET /metrics without authentication. It shares the listener with
+  # the API, so the default requires a Bearer token; set this to true when only
+  # the cluster network reaches the Service and a scrape token would just be one
+  # more secret to rotate.
+  metricsPublic: false
 
 # -- Blob storage: "local" or "s3"
 storage:

--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -301,14 +301,30 @@ paths:
         '200': { description: OK, content: { application/json: { schema: { $ref: '#/components/schemas/User' } } } }
         '401': { description: Unauthorized }
 
-  # ── Metrics (Nexspence-native, public) ───────────────────────────
+  # ── Metrics (Nexspence-native) ───────────────────────────────────
+
+  /metrics:
+    get:
+      tags: [System]
+      summary: Prometheus scrape endpoint (text exposition format)
+      description: >
+        Requires a Bearer token (JWT or nxs_*) unless the server sets
+        `metrics.public: true`, which serves it anonymously for deployments
+        whose listener is only reachable from a trusted network.
+      operationId: getPrometheusMetrics
+      responses:
+        '200':
+          description: Prometheus text exposition
+          content:
+            text/plain:
+              schema: { type: string }
+        '401': { description: Unauthorized (metrics.public is false and no token was sent) }
 
   /api/v1/metrics:
     get:
       tags: [System]
-      summary: In-process metrics snapshot (no auth required)
+      summary: In-process metrics snapshot (JSON, for the UI)
       operationId: getMetrics
-      security: []
       responses:
         '200':
           description: Metrics snapshot

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -157,5 +157,59 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `bootstrap.admin_password` | `admin123` | Auto-created admin password — **change this** |
 | `cleanup.default_schedule` | `0 2 * * *` | Default cron for cleanup policies |
 | `audit.retention_days` | `90` | Audit log partition retention |
+| `metrics.public` | `false` | Serve `GET /metrics` without authentication. Default requires a Bearer token; see [Prometheus](#prometheus). |
 | `redis.enabled` | `false` | Enable Redis (required for HA) |
 | `redis.addr` | `localhost:6379` | Redis address |
+
+---
+
+## Prometheus
+
+Nexspence exposes the Prometheus text format at `GET /metrics`, on the same listener as the API.
+
+That shared listener is why the endpoint requires a Bearer token by default: an anonymous scrape publishes install size, artifact and download counts and the Go runtime fingerprint to anyone who can reach the instance.
+
+**Authenticated scrape (default).** Create a user token in the UI (Profile → Tokens) and hand it to Prometheus:
+
+```yaml
+scrape_configs:
+  - job_name: nexspence
+    authorization:
+      type: Bearer
+      credentials: nxs_...
+    static_configs:
+      - targets: ["nexspence:8081"]
+```
+
+With a `ServiceMonitor`, put the token in a Secret instead:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nexspence
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nexspence
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      authorization:
+        type: Bearer
+        credentials:
+          name: nexspence-metrics-token   # Secret with key `token` = nxs_...
+          key: token
+```
+
+**Anonymous scrape.** When the listener is only reachable from a trusted network — a cluster-internal `Service`, a localhost bind, or a reverse proxy that blocks `/metrics` from outside — a scrape token is just one more secret to rotate. Turn it off:
+
+```yaml
+metrics:
+  public: true
+```
+
+or `NEXSPENCE_METRICS_PUBLIC=true`, or `--set config.metricsPublic=true` for the Helm chart. The `authorization:` block then drops out of the scrape config.
+
+The endpoint serves `nexspence_requests_total`, `nexspence_request_duration_seconds`, `nexspence_artifacts_total`, `nexspence_bytes_stored_bytes`, `nexspence_downloads_total`, `nexspence_goroutines` and `nexspence_memory_alloc_bytes`, plus the standard Go and process collectors. `/healthz` and `/readyz` are always unauthenticated and are the right targets for probes.

--- a/internal/api/metrics_route.go
+++ b/internal/api/metrics_route.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/nexspence-oss/nexspence/internal/metrics"
+)
+
+// registerMetricsRoute mounts the Prometheus scrape endpoint.
+//
+// The endpoint requires a Bearer token (JWT or nxs_*) unless metrics.public is
+// set: it shares the public listener with the API, so an anonymous scrape
+// publishes install size, artifact and download counts and the Go runtime
+// fingerprint. Deployments that keep the listener on a trusted network scrape
+// it without a token secret instead.
+func registerMetricsRoute(r *gin.Engine, public bool, authMW gin.HandlerFunc) {
+	handler := gin.WrapH(promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{}))
+	if public {
+		r.GET("/metrics", handler)
+		return
+	}
+	r.GET("/metrics", authMW, handler)
+}

--- a/internal/api/metrics_route_test.go
+++ b/internal/api/metrics_route_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// denyAll stands in for the real AuthMiddleware: an unauthenticated scrape is
+// exactly the request it rejects, so a 401 proves the middleware ran.
+func denyAll() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.AbortWithStatus(http.StatusUnauthorized)
+	}
+}
+
+func scrape(t *testing.T, public bool) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	registerMetricsRoute(r, public, denyAll())
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	return w
+}
+
+func TestMetricsRoute_RequiresAuthByDefault(t *testing.T) {
+	w := scrape(t, false)
+	assert.Equal(t, http.StatusUnauthorized, w.Code,
+		"/metrics must stay behind Bearer auth when metrics.public is false")
+}
+
+// With metrics.public the endpoint is a plain anonymous scrape target, so a
+// Prometheus ServiceMonitor needs no token secret.
+func TestMetricsRoute_PublicSkipsAuth(t *testing.T) {
+	w := scrape(t, true)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "nexspence_goroutines",
+		"the public endpoint must still serve the Prometheus text exposition")
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	uiembed "github.com/nexspence-oss/nexspence"
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
@@ -40,7 +39,6 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/formats/terraform"
 	"github.com/nexspence-oss/nexspence/internal/formats/yum"
 	"github.com/nexspence-oss/nexspence/internal/logger"
-	"github.com/nexspence-oss/nexspence/internal/metrics"
 	"github.com/nexspence-oss/nexspence/internal/redisclient"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/repository/postgres"
@@ -394,8 +392,8 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		r.POST("/api/v1/auth/saml/acs", samlH.ACS)
 	}
 
-	// Prometheus scrape endpoint — requires Bearer auth (JWT or nxs_* token)
-	r.GET("/metrics", authMW, gin.WrapH(promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{})))
+	// Prometheus scrape endpoint — Bearer auth unless metrics.public is set.
+	registerMetricsRoute(r, cfg.Metrics.Public, authMW)
 
 	// ── Authenticated endpoints (all valid users) ────────────
 	authed := r.Group("", authMW)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,6 +31,19 @@ type Config struct {
 	Redis     RedisConfig     `mapstructure:"redis"`
 	Proxy     ProxyConfig     `mapstructure:"proxy"`
 	Outbound  OutboundConfig  `mapstructure:"outbound"`
+	Metrics   MetricsConfig   `mapstructure:"metrics"`
+}
+
+// MetricsConfig governs the Prometheus scrape endpoint at /metrics.
+type MetricsConfig struct {
+	// Public serves /metrics without authentication. It defaults to false
+	// because the endpoint shares the public listener with the API, so an
+	// anonymous scrape hands out install size, artifact and download counts
+	// and the Go runtime fingerprint. Turn it on when the listener is only
+	// reachable from a trusted network — a cluster-internal Service, a
+	// localhost bind, a reverse proxy that blocks /metrics from outside —
+	// and a scrape token would just be one more secret to rotate.
+	Public bool `mapstructure:"public"`
 }
 
 // OutboundConfig governs where the server is allowed to make requests when the
@@ -511,6 +524,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("bootstrap.admin_password", "admin123")
 	v.SetDefault("bootstrap.admin_email", "admin@example.com")
 	v.SetDefault("bootstrap.admin_first_name", "Admin")
+	v.SetDefault("metrics.public", false)
 	v.SetDefault("redis.enabled", false)
 	v.SetDefault("redis.addr", "localhost:6379")
 	v.SetDefault("redis.db", 0)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -268,6 +268,51 @@ func TestLoad_TrustedProxies_EnvOverride(t *testing.T) {
 	assert.Equal(t, []string{"10.0.0.0/8", "192.168.1.1"}, cfg.HTTP.TrustedProxies)
 }
 
+// The Prometheus scrape endpoint stays behind Bearer auth unless an operator
+// opts out: it is served on the same public listener as the rest of the API,
+// so an anonymous /metrics would publish install size and Go runtime details.
+func TestLoad_MetricsPublic_DefaultsFalse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Metrics.Public,
+		"metrics.public must default to false so /metrics keeps requiring a Bearer token")
+}
+
+func TestLoad_MetricsPublic_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n" +
+		"metrics:\n  public: true\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Metrics.Public)
+}
+
+func TestLoad_MetricsPublic_EnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	t.Setenv("NEXSPENCE_METRICS_PUBLIC", "true")
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Metrics.Public)
+}
+
 func TestLoad_AllowInsecureDefaults_EnvOverride(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")


### PR DESCRIPTION
## Why

`/metrics` is served on the same public listener as the API, so it has always required a Bearer token. That is the right default on an exposed instance — an anonymous scrape publishes install size, artifact and download counts, and the Go runtime fingerprint.

It is the wrong default for a cluster where the Service is only reachable by Prometheus: the token is then one more secret to create, mount and rotate in every `ServiceMonitor`, guarding data nobody outside the cluster can reach.

## What

`metrics.public` (env `NEXSPENCE_METRICS_PUBLIC`, `config.metricsPublic` in the Helm chart) drops the auth middleware from that one route.

- Defaults to `false` — existing deployments keep the token requirement, no migration.
- Only `/metrics` is affected; `/api/v1/metrics*` (the JSON snapshot the UI reads) stays authenticated.

Route registration moved into `registerMetricsRoute` so both modes are testable without standing up a database.

## Tests

TDD, red first:

- `internal/config`: default is `false`, read from YAML, overridden by env.
- `internal/api`: `/metrics` without a token → 401 when `public=false`; → 200 with Prometheus text exposition when `public=true`.

`go test ./...` — 2085 pass (the one failure is the pre-existing `TestWebhookHandler_Test_200`, which needs outbound networking). `golangci-lint`: clean. `helm lint` + `helm template` verified the rendered ConfigMap.

## Docs

`docs/deployment.md` gains a Prometheus section (authenticated and anonymous scrape configs, ServiceMonitor examples, the metric list); config reference, `config.yaml.example`, README, chart README and `docs/api-spec.yaml` updated. The spec also gets the `/metrics` path, which it was missing, and its claim that `/api/v1/metrics` needs no auth is corrected — that endpoint is authenticated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHWD1rpYXdEDoK6F76iuFu