### PR TITLE
fix(replication): serialize rules and history as snake_case JSON

### DIFF
--- a/internal/domain/replication_json_test.go
+++ b/internal/domain/replication_json_test.go
@@ -1,0 +1,122 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// The replication handlers serialize these structs straight to the wire, and the
+// Replication tab reads snake_case keys off them, so the JSON shape is part of
+// the API contract.
+
+func TestReplicationRuleMarshalsSnakeCase(t *testing.T) {
+	finished := time.Date(2026, 8, 13, 10, 0, 0, 0, time.UTC)
+	rule := ReplicationRule{
+		ID:                "rule-1",
+		Name:              "nightly",
+		SourceRepo:        "maven-hosted",
+		TargetURL:         "https://remote.example.com",
+		TargetRepo:        "maven-mirror",
+		TargetUsername:    "svc-replication",
+		TargetPasswordEnc: "SECRET",
+		CronExpr:          "0 2 * * *",
+		Enabled:           true,
+		LastRunAt:         &finished,
+		LastRunStatus:     "ok",
+		CreatedAt:         finished,
+	}
+
+	var got map[string]any
+	raw, err := json.Marshal(rule)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := map[string]any{
+		"id":              "rule-1",
+		"name":            "nightly",
+		"source_repo":     "maven-hosted",
+		"target_url":      "https://remote.example.com",
+		"target_repo":     "maven-mirror",
+		"target_username": "svc-replication",
+		"cron_expr":       "0 2 * * *",
+		"enabled":         true,
+		"last_run_status": "ok",
+	}
+	for key, expected := range want {
+		if got[key] != expected {
+			t.Errorf("key %q = %#v, want %#v", key, got[key], expected)
+		}
+	}
+	for _, key := range []string{"last_run_at", "created_at"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("key %q missing from payload", key)
+		}
+	}
+}
+
+func TestReplicationRuleNeverExposesEncryptedPassword(t *testing.T) {
+	raw, err := json.Marshal(ReplicationRule{TargetPasswordEnc: "SECRET"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for key := range got {
+		if key == "target_password_enc" || key == "TargetPasswordEnc" {
+			t.Fatalf("encrypted password serialized under %q: %s", key, raw)
+		}
+	}
+}
+
+func TestReplicationHistoryMarshalsSnakeCase(t *testing.T) {
+	started := time.Date(2026, 8, 13, 10, 0, 0, 0, time.UTC)
+	entry := ReplicationHistory{
+		ID:               "run-1",
+		RuleID:           "rule-1",
+		StartedAt:        started,
+		DurationMs:       1500,
+		PushedCount:      12,
+		SkippedCount:     3,
+		FailedCount:      1,
+		TransferredBytes: 4096,
+		Error:            "one asset failed",
+	}
+
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := map[string]any{
+		"id":                "run-1",
+		"rule_id":           "rule-1",
+		"duration_ms":       float64(1500),
+		"pushed_count":      float64(12),
+		"skipped_count":     float64(3),
+		"failed_count":      float64(1),
+		"transferred_bytes": float64(4096),
+		"error":             "one asset failed",
+	}
+	for key, expected := range want {
+		if got[key] != expected {
+			t.Errorf("key %q = %#v, want %#v", key, got[key], expected)
+		}
+	}
+	for _, key := range []string{"started_at", "finished_at"} {
+		if _, ok := got[key]; !ok {
+			t.Errorf("key %q missing from payload", key)
+		}
+	}
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -629,32 +629,32 @@ type SearchParams struct {
 
 // ReplicationRule defines a push-replication job from a local repo to a remote Nexspence instance.
 type ReplicationRule struct {
-	ID                string
-	Name              string
-	SourceRepo        string
-	TargetURL         string
-	TargetRepo        string
-	TargetUsername    string
-	TargetPasswordEnc string // AES-256-GCM encrypted, base64url; never returned in API responses
-	CronExpr          string
-	Enabled           bool
-	LastRunAt         *time.Time
-	LastRunStatus     string // "ok", "error", "running", ""
-	CreatedAt         time.Time
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	SourceRepo        string     `json:"source_repo"`
+	TargetURL         string     `json:"target_url"`
+	TargetRepo        string     `json:"target_repo"`
+	TargetUsername    string     `json:"target_username"`
+	TargetPasswordEnc string     `json:"-"` // AES-256-GCM encrypted, base64url; never returned in API responses
+	CronExpr          string     `json:"cron_expr"`
+	Enabled           bool       `json:"enabled"`
+	LastRunAt         *time.Time `json:"last_run_at"`
+	LastRunStatus     string     `json:"last_run_status"` // "ok", "error", "running", ""
+	CreatedAt         time.Time  `json:"created_at"`
 }
 
 // ReplicationHistory records the outcome of a single replication run.
 type ReplicationHistory struct {
-	ID               string
-	RuleID           string
-	StartedAt        time.Time
-	FinishedAt       *time.Time
-	DurationMs       int64
-	PushedCount      int
-	SkippedCount     int
-	FailedCount      int
-	TransferredBytes int64
-	Error            string
+	ID               string     `json:"id"`
+	RuleID           string     `json:"rule_id"`
+	StartedAt        time.Time  `json:"started_at"`
+	FinishedAt       *time.Time `json:"finished_at"`
+	DurationMs       int64      `json:"duration_ms"`
+	PushedCount      int        `json:"pushed_count"`
+	SkippedCount     int        `json:"skipped_count"`
+	FailedCount      int        `json:"failed_count"`
+	TransferredBytes int64      `json:"transferred_bytes"`
+	Error            string     `json:"error"`
 }
 
 // ── Promotion ────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #207.

`domain.ReplicationRule` and `domain.ReplicationHistory` are returned straight from the replication handlers with no `json` tags, so `encoding/json` emitted Go field names (`ID`, `SourceRepo`, `TargetURL`, …) while `ReplicationTab` reads `rule.id`, `rule.source_repo`, `h.started_at`. Every field came back `undefined` — blank names, undefined React keys, and action requests to `/api/v1/replication/rules/undefined`.

`TargetPasswordEnc` is documented as never returned in API responses but had no tag either, so the encrypted password shipped in every response. It is now `json:"-"`.

**Tests first.** Three tests in `internal/domain/replication_json_test.go` marshal a populated rule and a history entry and assert the wire keys, plus one that fails if the encrypted password appears under any key. They fail on main (`key "id" = <nil>`, `encrypted password serialized under "TargetPasswordEnc"`) and pass with the tags added.

Field names match the `ruleInput` DTO the handler already uses for input and the `ReplicationRule` / `ReplicationHistory` interfaces in `frontend/src/api/client.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01728qZ7XQsm8YpJKcNDQZ4x