### PR TITLE
fix(oci): bound staged blob uploads instead of buffering them unchecked

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -117,6 +117,15 @@ gc:
   schedule: "0 3 * * 0"      # cron: weekly, Sunday 03:00
   min_age: "24h"             # only collect orphans older than this (grace period)
 
+# Docker / OCI registry settings.
+# The /v2/ blob-upload paths are exempt from http.max_body_mb so large image
+# layers are not truncated, which makes max_upload_bytes the only bound on a
+# staged upload: a chunk that would push a session past it is rejected with
+# 413 before the session is buffered. Raise it if you push layers larger than
+# the default; 0 removes the cap entirely (not recommended on a shared instance).
+docker:
+  max_upload_bytes: 10737418240   # 10 GiB per blob upload session
+
 # Automatic vulnerability scanning (Trivy for docker/oci, OSV.dev for
 # npm/maven/pypi/cargo).
 # Every upload is queued for a background scan; the queue is bounded and drops

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,7 @@ Nexspence follows a clean layered architecture. Each layer depends only on the l
 - **Audit middleware** — goroutine write after POST/PUT/DELETE/PATCH on key paths; login events use `action=LOGIN`, `entityName=username` (set by Login handler via `c.Set("username", ...)` before returning)
 - **Metrics middleware** — atomic counter increments (requests, errors); cumulative counters (`ArtifactsStored`, `BytesStored`, `DownloadsTotal`) seeded from DB on startup
 - **Security headers** — CSP built from config (`cspPolicy`), plus the usual frame/content-type/referrer set
-- **Body limit** — `http.max_body_mb`, skipped for the artifact upload paths that stream
+- **Body limit** — `http.max_body_mb`, skipped for the artifact upload paths that stream; the exempted `/v2/` blob uploads are instead bounded per session by `docker.max_upload_bytes`
 - **Rate limiting** — token bucket; enabled by `auth.rate_limit_enabled` (`auth.rate_limit_rps` / `_burst`)
 - **[Phase 9]** OTel trace middleware — span per request with format/repo labels
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -240,6 +240,9 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		RoutingRules: rrRepo,
 		RBAC:         rbacSvc,
 		Scanner:      scanTrigger,
+		// /v2/ upload paths are exempt from the global body cap, so this is the
+		// only bound on a staged blob upload (issue #208).
+		MaxUploadBytes: cfg.Docker.MaxUploadBytes,
 	}
 	formatRegistry := map[string]formats.FormatHandler{
 		"raw":       raw.New(formatDeps),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -417,6 +417,10 @@ type AuditConfig struct {
 // DockerConfig holds Docker-specific settings such as the subdomain connector.
 type DockerConfig struct {
 	SubdomainConnector SubdomainConnectorConfig `mapstructure:"subdomain_connector"`
+	// MaxUploadBytes caps a single staged blob upload. The /v2/ upload paths
+	// are exempt from http.max_body_mb so large image layers survive intact,
+	// which leaves this as their only bound. 0 disables the cap.
+	MaxUploadBytes int64 `mapstructure:"max_upload_bytes"`
 }
 
 // SubdomainConnectorConfig configures per-repository Docker subdomain routing.
@@ -491,6 +495,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("audit.lookahead_months", 2)
 	v.SetDefault("docker.subdomain_connector.enabled", false)
 	v.SetDefault("docker.subdomain_connector.base_domain", "")
+	v.SetDefault("docker.max_upload_bytes", int64(10<<30)) // 10 GiB
 	v.SetDefault("oidc.enabled", false)
 	v.SetDefault("oidc.display_name", "SSO")
 	v.SetDefault("oidc.public_issuer_url", "")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -326,3 +326,33 @@ func TestLoad_AllowInsecureDefaults_EnvOverride(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, cfg.Auth.AllowInsecureDefaults)
 }
+
+// The /v2/ upload paths are exempt from http.max_body_mb so large image layers
+// are not truncated, so this cap is the only thing bounding a staged upload —
+// it ships on by default rather than as an opt-in hardening step.
+func TestLoad_DockerMaxUploadBytes_Default(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, int64(10<<30), cfg.Docker.MaxUploadBytes)
+}
+
+func TestLoad_DockerMaxUploadBytes_Configurable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n" +
+		"docker:\n  max_upload_bytes: 1048576\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1048576), cfg.Docker.MaxUploadBytes)
+}

--- a/internal/formats/deps.go
+++ b/internal/formats/deps.go
@@ -31,6 +31,11 @@ type Deps struct {
 	// Scanner is optional — nil disables automatic vulnerability scanning of
 	// uploads.
 	Scanner ScanTrigger
+	// MaxUploadBytes caps the total size of a single staged blob upload. The
+	// /v2/ upload paths are exempt from the global request-body cap so large
+	// image layers are not truncated, which leaves this as their only bound.
+	// 0 disables the cap.
+	MaxUploadBytes int64
 }
 
 // ScanTrigger requests a background vulnerability scan of a stored component.

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -776,6 +777,10 @@ func (h *Handler) patchUpload(c *gin.Context, _, _, uuid string) {
 		dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
 		return
 	}
+	if errors.Is(err, errUploadTooLarge) {
+		dockerError(c, http.StatusRequestEntityTooLarge, "BLOB_UPLOAD_INVALID", err.Error())
+		return
+	}
 	if err != nil {
 		dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())
 		return
@@ -801,6 +806,9 @@ func (h *Handler) finalizeUpload(c *gin.Context, repoName, imageName, uuid strin
 	if c.Request.ContentLength > 0 {
 		if _, ok, err := h.uploads.append(ctx, uuid, c.Request.Body); !ok {
 			dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
+			return
+		} else if errors.Is(err, errUploadTooLarge) {
+			dockerError(c, http.StatusRequestEntityTooLarge, "BLOB_UPLOAD_INVALID", err.Error())
 			return
 		} else if err != nil {
 			dockerError(c, http.StatusInternalServerError, "UNKNOWN", err.Error())

--- a/internal/formats/oci/upload_limit_test.go
+++ b/internal/formats/oci/upload_limit_test.go
@@ -1,0 +1,158 @@
+package oci_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// setupWithUploadLimit wires a hosted docker repository whose blob uploads are
+// capped at maxUploadBytes (0 = uncapped).
+func setupWithUploadLimit(maxUploadBytes int64) *gin.Engine {
+	repo := &domain.Repository{
+		ID: "repo-limit", Name: "docker-hosted",
+		Format: domain.FormatDocker, Type: domain.TypeHosted, Online: true,
+	}
+	d := formats.Deps{
+		Repos:          testutil.NewRepoRepo(repo),
+		Blobs:          testutil.NewBlobStoreRepo(),
+		Components:     testutil.NewComponentRepo(),
+		Assets:         testutil.NewAssetRepo(),
+		BlobStore:      testutil.NewBlobStore(),
+		BaseURL:        "http://localhost:8080",
+		MaxUploadBytes: maxUploadBytes,
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+// startUpload initiates a blob upload and returns the upload location.
+func startUpload(t *testing.T, r *gin.Engine) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost,
+		"/repository/docker-hosted/v2/app/blobs/uploads/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code, "initiate upload: %s", w.Body.String())
+	loc := w.Header().Get("Location")
+	require.NotEmpty(t, loc)
+	return loc
+}
+
+func patchChunk(t *testing.T, r *gin.Engine, location string, size int) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPatch, location,
+		bytes.NewReader(bytes.Repeat([]byte("x"), size)))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func dockerErrorCode(t *testing.T, body string) string {
+	t.Helper()
+	var payload struct {
+		Errors []struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &payload), "body: %s", body)
+	require.NotEmpty(t, payload.Errors, "body: %s", body)
+	return payload.Errors[0].Code
+}
+
+func TestPatchUploadAcceptsChunkUnderLimit(t *testing.T) {
+	r := setupWithUploadLimit(1024)
+	loc := startUpload(t, r)
+
+	w := patchChunk(t, r, loc, 512)
+
+	assert.Equal(t, http.StatusAccepted, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "0-511", w.Header().Get("Range"))
+}
+
+func TestPatchUploadRejectsChunkOverLimit(t *testing.T) {
+	r := setupWithUploadLimit(1024)
+	loc := startUpload(t, r)
+
+	w := patchChunk(t, r, loc, 4096)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "BLOB_UPLOAD_INVALID", dockerErrorCode(t, w.Body.String()))
+}
+
+func TestPatchUploadRejectsChunkThatCrossesLimitAndKeepsSessionIntact(t *testing.T) {
+	r := setupWithUploadLimit(1024)
+	loc := startUpload(t, r)
+
+	first := patchChunk(t, r, loc, 800)
+	require.Equal(t, http.StatusAccepted, first.Code, "body: %s", first.Body.String())
+
+	second := patchChunk(t, r, loc, 800)
+	require.Equal(t, http.StatusRequestEntityTooLarge, second.Code, "body: %s", second.Body.String())
+
+	// The rejected chunk must not have been staged: the session still holds
+	// exactly the 800 bytes the accepted chunk wrote, so the remaining budget
+	// is 224 bytes — no more, no less.
+	assert.Equal(t, "0-799", first.Header().Get("Range"))
+
+	third := patchChunk(t, r, loc, 224)
+	require.Equal(t, http.StatusAccepted, third.Code,
+		"rejected chunk consumed budget it never used: %s", third.Body.String())
+	assert.Equal(t, "0-1023", third.Header().Get("Range"))
+
+	fourth := patchChunk(t, r, loc, 1)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, fourth.Code,
+		"session at the cap accepted more bytes: %s", fourth.Body.String())
+}
+
+func TestUploadLimitDisabledAcceptsLargeChunk(t *testing.T) {
+	r := setupWithUploadLimit(0)
+	loc := startUpload(t, r)
+
+	w := patchChunk(t, r, loc, 4096)
+
+	assert.Equal(t, http.StatusAccepted, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "0-4095", w.Header().Get("Range"))
+}
+
+func TestFinalizeUploadRejectsBodyOverLimit(t *testing.T) {
+	r := setupWithUploadLimit(1024)
+	loc := startUpload(t, r)
+
+	body := bytes.Repeat([]byte("y"), 4096)
+	sep := "?"
+	if strings.Contains(loc, "?") {
+		sep = "&"
+	}
+	req := httptest.NewRequest(http.MethodPut,
+		fmt.Sprintf("%s%sdigest=%s", loc, sep, digest(string(body))),
+		bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, "BLOB_UPLOAD_INVALID", dockerErrorCode(t, w.Body.String()))
+}

--- a/internal/formats/oci/uploads.go
+++ b/internal/formats/oci/uploads.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 
@@ -89,19 +90,50 @@ func (s uploadStore) read(ctx context.Context, id string) (data []byte, ok bool,
 	return data, true, err
 }
 
+// errUploadTooLarge reports a session that would grow past deps.MaxUploadBytes.
+// Handlers map it to 413 rather than a generic 500.
+var errUploadTooLarge = errors.New("upload exceeds the configured maximum size")
+
 // append adds a chunk and returns the new total size. ok is false when the
 // session is unknown. The blob store API is whole-object, so the chunk is
 // concatenated onto what is already staged.
+//
+// With a cap configured, the session size is checked with a stat-only size()
+// call and the chunk is read through a LimitReader before anything already
+// staged is loaded — so an over-cap push never re-buffers the session's bytes,
+// which is what made the read-modify-write cycle a memory-exhaustion vector.
 func (s uploadStore) append(ctx context.Context, id string, r io.Reader) (total int64, ok bool, err error) {
+	stored, ok := s.size(ctx, id)
+	if !ok {
+		return 0, false, nil
+	}
+
+	limit := s.deps.MaxUploadBytes
+	if limit > 0 {
+		if stored >= limit {
+			return 0, true, errUploadTooLarge
+		}
+		// One byte past the remaining budget is enough to detect the overflow
+		// without buffering more than the cap allows.
+		r = io.LimitReader(r, limit-stored+1)
+	}
+
+	var chunk bytes.Buffer
+	if _, err := io.Copy(&chunk, r); err != nil {
+		return 0, true, err
+	}
+	if limit > 0 && stored+int64(chunk.Len()) > limit {
+		return 0, true, errUploadTooLarge
+	}
+
 	existing, ok, err := s.read(ctx, id)
 	if err != nil || !ok {
 		return 0, ok, err
 	}
 	var buf bytes.Buffer
+	buf.Grow(len(existing) + chunk.Len())
 	buf.Write(existing)
-	if _, err := io.Copy(&buf, r); err != nil {
-		return 0, true, err
-	}
+	buf.Write(chunk.Bytes())
 	if err := s.deps.BlobStore.Put(ctx, s.key(id), bytes.NewReader(buf.Bytes()), int64(buf.Len())); err != nil {
 		return 0, true, err
 	}


### PR DESCRIPTION
Fixes #208.

`/v2/` upload paths are exempt from `http.max_body_mb` so large image layers are not truncated, and nothing else bounded them. `uploadStore.append` read the whole upload-so-far back into memory and rewrote it on every PATCH chunk, so a multi-GB push materialized in process RAM repeatedly, well before `checkQuota` in `base.StoreArtifact` ever ran. Write access to a single repository was enough to exhaust server memory.

**What changed**

- `append` now stats the session with `size()` first and reads the chunk through an `io.LimitReader` sized to the remaining budget. A chunk that would cross the cap is rejected *before* the already-staged bytes are read back — the read-modify-write cycle is what made this a memory vector, so an over-cap push no longer pays it.
- `patchUpload` / `finalizeUpload` map the new sentinel to `413` + `BLOB_UPLOAD_INVALID` instead of a generic `500`.
- New `docker.max_upload_bytes`, default **10 GiB**, `0` disables. Documented in `config.yaml.example` and the middleware section of `docs/architecture.md`.

**Tests first.** Five HTTP-level tests in `internal/formats/oci/upload_limit_test.go` drive the real registry protocol through the gin router: a chunk under the cap still returns `202` with the right `Range`; a single over-cap chunk returns `413`; a chunk that crosses the cap across two PATCHes is rejected *and* leaves the session at exactly the bytes the accepted chunk wrote (verified by pushing exactly the remaining 224 bytes, then one byte too many); a monolithic `PUT` body over the cap returns `413`; and with the cap disabled behavior is unchanged. Three of them failed on main (`202`/`201` instead of `413`). Two config tests cover the default and the override.

**Not attempted:** true incremental streaming. The `BlobStore` interface only exposes whole-object `Put`/`Get` for every backend, so genuine append-as-you-go would be a much larger change — this bounds the damage rather than removing the buffering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01728qZ7XQsm8YpJKcNDQZ4x