### PR TITLE
docs(site): count 15 formats, document upgrading for every install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   ![Docker](https://img.shields.io/badge/Docker-ready-2496ED?style=flat-square&logo=docker&logoColor=white)
   [![License: AGPL v3 or later](https://img.shields.io/badge/License-AGPL--3.0--or--later-22c55e?style=flat-square)](LICENSE)
   ![Lint](https://img.shields.io/badge/lint-golangci--lint%20v2-22c55e?style=flat-square&logo=go&logoColor=white)
-  ![Tests](https://img.shields.io/badge/tests-2209%20passing-22c55e?style=flat-square)
+  ![Tests](https://img.shields.io/badge/tests-2600+%20passing-22c55e?style=flat-square)
 
   <br>
 

--- a/internal/domain/site_formats_test.go
+++ b/internal/domain/site_formats_test.go
@@ -1,0 +1,105 @@
+package domain_test
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// The docs site states a format count in two languages and lists the formats in
+// a table. All three drifted behind the code when OCI was added, and nothing
+// caught it — the claim is only ever read by humans. This test reads the page
+// and holds it to what the code actually supports.
+
+const sitePath = "../../website/docs/index.html"
+
+func siteHTML(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(sitePath)
+	if err != nil {
+		t.Fatalf("read docs site: %v", err)
+	}
+	return string(b)
+}
+
+func TestSiteFormatCountMatchesCode(t *testing.T) {
+	html := siteHTML(t)
+	want := len(domain.AllFormats)
+
+	for _, tc := range []struct {
+		lang string
+		re   *regexp.Regexp
+	}{
+		{"en", regexp.MustCompile(`(\d+) artifact formats`)},
+		{"ru", regexp.MustCompile(`(\d+) форматов артефактов`)},
+	} {
+		matches := tc.re.FindAllStringSubmatch(html, -1)
+		if len(matches) == 0 {
+			t.Errorf("%s: no format count found on the docs site", tc.lang)
+			continue
+		}
+		for _, m := range matches {
+			got, err := strconv.Atoi(m[1])
+			if err != nil {
+				t.Errorf("%s: unparsable count %q", tc.lang, m[1])
+				continue
+			}
+			if got != want {
+				t.Errorf("%s: docs site claims %d formats, code supports %d", tc.lang, got, want)
+			}
+		}
+	}
+}
+
+func TestSiteFormatTableListsEveryFormat(t *testing.T) {
+	html := siteHTML(t)
+	i := strings.Index(html, "artifact formats")
+	if i < 0 {
+		t.Fatal("formats section not found on the docs site")
+	}
+	rows := regexp.MustCompile(`<tr><td>([^<]+)</td><td>([^<]+)</td>`).FindAllStringSubmatch(html[i:i+4000], -1)
+	if len(rows) != len(domain.AllFormats) {
+		t.Errorf("formats table has %d rows, code supports %d formats", len(rows), len(domain.AllFormats))
+	}
+
+	// Each format needs a row a reader can recognize it by; the table uses
+	// display names, so match on a substring the row is expected to carry.
+	labels := map[domain.RepoFormat]string{
+		domain.FormatMaven2:    "Maven",
+		domain.FormatNPM:       "npm",
+		domain.FormatPyPI:      "PyPI",
+		domain.FormatDocker:    "Docker",
+		domain.FormatOCI:       "OCI",
+		domain.FormatGo:        "Go Modules",
+		domain.FormatNuGet:     "NuGet",
+		domain.FormatHelm:      "Helm",
+		domain.FormatCargo:     "Cargo",
+		domain.FormatApt:       "Apt",
+		domain.FormatYum:       "Yum",
+		domain.FormatConan:     "Conan",
+		domain.FormatRaw:       "Raw",
+		domain.FormatConda:     "Conda",
+		domain.FormatTerraform: "Terraform",
+	}
+	for _, f := range domain.AllFormats {
+		label, ok := labels[f]
+		if !ok {
+			t.Errorf("format %q has no expected table label — add one when adding the format", f)
+			continue
+		}
+		found := false
+		for _, r := range rows {
+			if strings.Contains(r[1], label) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("format %q (%s) is missing from the docs formats table", f, label)
+		}
+	}
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -21,19 +21,44 @@ const (
 	FormatDocker RepoFormat = "docker"
 	// FormatOCI is the same OCI Distribution protocol as FormatDocker, labeled
 	// for charts, ORAS artifacts and signatures rather than container images.
-	FormatOCI   RepoFormat = "oci"
-	FormatPyPI  RepoFormat = "pypi"
-	FormatGo    RepoFormat = "go"
-	FormatNuGet RepoFormat = "nuget"
-	FormatHelm  RepoFormat = "helm"
-	FormatRaw   RepoFormat = "raw"
-	FormatApt   RepoFormat = "apt"
-	FormatYum   RepoFormat = "yum"
+	FormatOCI       RepoFormat = "oci"
+	FormatPyPI      RepoFormat = "pypi"
+	FormatGo        RepoFormat = "go"
+	FormatNuGet     RepoFormat = "nuget"
+	FormatHelm      RepoFormat = "helm"
+	FormatRaw       RepoFormat = "raw"
+	FormatApt       RepoFormat = "apt"
+	FormatYum       RepoFormat = "yum"
+	FormatCargo     RepoFormat = "cargo"
+	FormatConan     RepoFormat = "conan"
+	FormatConda     RepoFormat = "conda"
+	FormatTerraform RepoFormat = "terraform"
 
 	TypeHosted RepoType = "hosted"
 	TypeProxy  RepoType = "proxy"
 	TypeGroup  RepoType = "group"
 )
+
+// AllFormats is every repository format the server serves, in the order the
+// documentation lists them. It is the one place to update when a format is
+// added — the docs site is checked against it.
+var AllFormats = []RepoFormat{
+	FormatMaven2,
+	FormatNPM,
+	FormatPyPI,
+	FormatDocker,
+	FormatOCI,
+	FormatGo,
+	FormatNuGet,
+	FormatHelm,
+	FormatCargo,
+	FormatApt,
+	FormatYum,
+	FormatConan,
+	FormatRaw,
+	FormatConda,
+	FormatTerraform,
+}
 
 // IsOCIRegistry reports whether a repository of this format speaks the OCI
 // Distribution protocol — the /v2/ surface with /manifests/... and /blobs/...

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -391,7 +391,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
       <section id="sec-intro" class="doc-section">
         <div class="doc-section-title">Nexspence Documentation</div>
         <div class="doc-section-sub">Guides, configuration reference, and versioned changelog for Nexspence — the free, open-source universal artifact repository manager and drop-in alternative to commercial artifact repository managers.</div>
-        <p style="color:var(--dim);line-height:1.7;margin:14px 0">Nexspence manages Maven, npm, PyPI, Docker, Go modules, NuGet, Cargo, Helm, Apt, Yum/RPM, Conan, Raw, Conda and Terraform artifacts from a single self-hosted registry. Repositories can be Hosted (your published artifacts), Proxy (cached remote registries) or Group (multiple repositories under one URL).</p>
+        <p style="color:var(--dim);line-height:1.7;margin:14px 0">Nexspence manages Maven, npm, PyPI, Docker, OCI artifacts, Go modules, NuGet, Cargo, Helm, Apt, Yum/RPM, Conan, Raw, Conda and Terraform packages from a single self-hosted registry. Repositories can be Hosted (your published artifacts), Proxy (cached remote registries) or Group (multiple repositories under one URL).</p>
         <p style="color:var(--dim);line-height:1.7;margin:14px 0">This documentation covers Quick Start, Installation, Repositories, per-format guides, Browse &amp; Search, Users, Roles &amp; Privileges (RBAC), Cleanup policies, Webhooks, Migration from Nexus, Monitoring, Build Promotion, Replication, and the full REST API reference.</p>
         <p style="color:var(--dim);line-height:1.7;margin:14px 0">Get started in under two minutes with Docker Compose: download the latest release, set a strong <code>admin_password</code> and <code>jwt_secret</code> in <code>config.yaml</code>, then run <code>docker compose up -d</code> and open the UI at <code>http://localhost:8081</code>.</p>
       </section>
@@ -834,7 +834,99 @@ server {
       </section>
       <section id="sec-upgrade" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="upg.title">Upgrading</div>
-  <div class="doc-section-sub" data-i18n="upg.sub">Notes for moving an existing deployment to a newer Nexspence release.</div>
+  <div class="doc-section-sub" data-i18n="upg.sub">Moving an existing deployment to a newer Nexspence release — one section per install method.</div>
+
+  <div class="inst-sep" data-i18n="upg.before.sep">Before You Upgrade</div>
+  <div class="alert-info" data-i18n="upg.before.info"><strong>Migrations run automatically, and only forward.</strong> Every start applies pending schema migrations before the server accepts traffic. There is no automatic downgrade, so take a database dump first — that dump is what a rollback to an older release depends on.</div>
+  <div class="cb"><div class="cb-bar"><span data-i18n="upg.before.dump.bar">shell — back up PostgreSQL first</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">pg_dump "postgres://nexspence:***@db.example.com:5432/nexspence" \
+  --format=custom --file nexspence-$(date +%Y%m%d).dump</div></div>
+  <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="upg.before.note">Artifact storage is never rewritten by an upgrade: local blob directories and S3 buckets are read and written in the same layout across releases. Skipping versions is supported — migrations from every intermediate release run in order. Read the release notes for each version you skip; anything needing a manual step is called out there.</p>
+
+  <div class="inst-sep" data-i18n="upg.compose.sep">Docker Compose</div>
+  <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="upg.compose.desc">If the compose file pins a tag, edit it to the new version first. With <code>:latest</code> or a <code>NEXSPENCE_VERSION</code> variable, pulling is enough.</p>
+  <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">docker compose pull nexspence
+docker compose up -d nexspence
+docker compose logs -f nexspence     # wait for: migrations OK</div></div>
+  <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="upg.compose.note">Named volumes carry the blob store and the generated JWT secret across the replacement, so no data or session state is lost. PostgreSQL in the same compose file is untouched by the pull.</p>
+
+  <div class="inst-sep" data-i18n="upg.docker.sep">Docker (single container)</div>
+  <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="upg.docker.desc">Recreate the container from the new image with the same volumes, environment and database. Keeping the volume mounts identical is the whole trick — the container is disposable, its volumes are not.</p>
+  <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">docker pull ghcr.io/nexspence/nexspence:v1.35.3
+
+docker stop nexspence &amp;&amp; docker rm nexspence
+
+docker run -d --name nexspence \
+  -p 8081:8081 \
+  -e NEXSPENCE_DATABASE_DSN="postgres://nexspence:***@db:5432/nexspence?sslmode=disable" \
+  -v nexspence_blobs:/app/data/blobs \
+  -v nexspence_secrets:/app/secrets \
+  ghcr.io/nexspence/nexspence:v1.35.3</div></div>
+
+  <div class="inst-sep" data-i18n="upg.helm.sep">Kubernetes (Helm)</div>
+  <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="upg.helm.desc">Each release publishes a chart version matching the app version. <code>--reuse-values</code> keeps your existing overrides; drop it and pass your values file if you prefer an explicit upgrade.</p>
+  <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">helm upgrade nexspence oci://ghcr.io/nexspence/charts/nexspence \
+  --version 1.35.3 \
+  --namespace nexspence --reuse-values
+
+kubectl -n nexspence rollout status deploy/nexspence</div></div>
+  <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="upg.helm.note">With more than one replica, the first new pod to become ready runs the migrations while old pods still serve traffic. Additive migrations tolerate that overlap; when release notes flag a schema change as breaking, scale to one replica for the upgrade. <code>helm rollback nexspence -n nexspence</code> reverts the workload — but see Rolling Back below, because the schema does not revert with it.</p>
+
+  <div class="inst-sep" data-i18n="upg.linux.sep">Linux — .deb / .rpm</div>
+  <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body"># Debian / Ubuntu
+sudo dpkg -i nexspence_1.35.3_linux_amd64.deb
+
+# RHEL / Fedora / SUSE
+sudo dnf upgrade ./nexspence-1.35.3.x86_64.rpm
+
+sudo systemctl restart nexspence
+journalctl -u nexspence -f</div></div>
+  <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="upg.linux.note">Package upgrades replace the binary and leave <code>/etc/nexspence/config.yaml</code>, the <code>nexspence</code> system user and <code>/var/lib/nexspence</code> as they are. New configuration keys always ship with defaults, so an untouched config keeps working.</p>
+
+  <div class="inst-sep" data-i18n="upg.tarball.sep">Linux — tarball</div>
+  <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">curl -fsSLO https://github.com/nexspence/nexspence/releases/download/v1.35.3/nexspence_1.35.3_linux_amd64.tar.gz
+tar xzf nexspence_1.35.3_linux_amd64.tar.gz
+
+sudo systemctl stop nexspence
+sudo install -m 0755 nexspence /usr/bin/nexspence
+sudo systemctl start nexspence</div></div>
+
+  <div class="inst-sep" data-i18n="upg.macos.sep">macOS</div>
+  <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">tar xzf nexspence_1.35.3_darwin_arm64.tar.gz     # or darwin_amd64 on Intel
+
+sudo launchctl unload -w /Library/LaunchDaemons/com.nexspence.server.plist
+sudo install -m 0755 nexspence /usr/local/bin/nexspence
+sudo launchctl load -w /Library/LaunchDaemons/com.nexspence.server.plist
+
+tail -f /usr/local/var/log/nexspence.err.log</div></div>
+
+  <div class="inst-sep" data-i18n="upg.windows.sep">Windows</div>
+  <div class="cb"><div class="cb-bar"><span data-i18n="upg.windows.bar">PowerShell — as Administrator</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">Stop-Service nexspence
+
+Expand-Archive .\nexspence_1.35.3_windows_amd64.zip -DestinationPath $env:TEMP\nexspence-new -Force
+Copy-Item $env:TEMP\nexspence-new\nexspence.exe 'C:\Program Files\Nexspence\nexspence.exe' -Force
+
+Start-Service nexspence
+Get-Content C:\ProgramData\Nexspence\logs\nexspence.log -Tail 40 -Wait</div></div>
+  <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="upg.windows.note">The service registration and <code>C:\ProgramData\Nexspence\config.yaml</code> survive the replacement — only the executable changes. Re-run <code>install-service.ps1</code> only if the service itself is missing.</p>
+
+  <div class="inst-sep" data-i18n="upg.verify.sep">Verifying the Upgrade</div>
+  <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">curl -s -u admin:$ADMIN_PASSWORD http://localhost:8081/api/v1/system/info
+# {"product":"Nexspence","version":"v1.35.3"}
+
+curl -sf http://localhost:8081/service/rest/v1/status/check</div></div>
+  <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="upg.verify.note">The running version also appears under System Admin → Info and at the bottom of the sidebar. The startup log line <code>migrations OK</code> confirms the schema is current; a failure there stops the server before it serves a single request, so a silent half-migrated state is not a state you can reach.</p>
+
+  <div class="inst-sep" data-i18n="upg.rollback.sep">Rolling Back</div>
+  <div class="alert-info" style="background:rgba(245,158,11,.06);border-color:rgba(245,158,11,.2)" data-i18n="upg.rollback.info"><strong style="color:var(--amber)">Schema changes do not roll back with the binary.</strong> Reverting to the previous image or package works only while the newer schema stays readable by the older release — true for additive migrations, not guaranteed otherwise. If the older version fails to start after a rollback, restore the dump you took before upgrading and start the older release against it.</div>
 
   <div class="inst-sep" data-i18n="upg.v1180.sep">Upgrading to v1.18.0 — Blob Ownership Fix</div>
   <div class="alert-info" style="background:rgba(245,158,11,.06);border-color:rgba(245,158,11,.2)" data-i18n="upg.v1180.info"><strong style="color:var(--amber)">One-time step for existing single-node Docker Compose deployments.</strong> The v1.18.0 image now runs as non-root <code>uid 1000</code>, but blob volumes created by older root-running images are owned by <code>root</code>. Fix ownership once before starting the new image, otherwise Nexspence cannot write to its blob store.</div>
@@ -1498,14 +1590,15 @@ export NEXSPENCE_OIDC_CLIENT_SECRET="..."</div></div>
       </section>
       <section id="sec-formats" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="fmt.title">Supported Formats</div>
-  <div class="doc-section-sub" data-i18n="fmt.sub">14 artifact formats — each supports Hosted, Proxy, and Group repository types.</div>
+  <div class="doc-section-sub" data-i18n="fmt.sub">15 artifact formats — each supports Hosted, Proxy, and Group repository types.</div>
   <table class="doc-table">
     <thead><tr><th>Format</th><th>Protocol</th><th>Hosted</th><th>Proxy</th><th>Group</th></tr></thead>
     <tbody>
       <tr><td>Maven 2/3</td><td>Maven HTTP</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>npm</td><td>npm registry v1</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>PyPI</td><td>Simple index + twine</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
-      <tr><td>Docker / OCI</td><td>OCI Distribution v2</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
+      <tr><td>Docker</td><td>OCI Distribution v2</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
+<tr><td>OCI artifacts</td><td>OCI Distribution v2</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Go Modules</td><td>GOPROXY v2</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>NuGet</td><td>v2 OData + v3 flat</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Helm</td><td>chart index.yaml</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
@@ -1788,7 +1881,30 @@ const TRANSLATIONS={
     'sec.selfservice.sep':'Self-Service Password Change',
     'sec.selfservice.desc':'Any non-admin user can rotate their own password without an administrator. Changing the password bumps the JWT cutoff, so existing sessions are invalidated.',
     'upg.title':'Upgrading',
-    'upg.sub':'Notes for moving an existing deployment to a newer Nexspence release.',
+    'upg.sub':'Moving an existing deployment to a newer Nexspence release — one section per install method.',
+'upg.before.sep':'Before You Upgrade',
+'upg.before.info':'<strong>Migrations run automatically, and only forward.</strong> Every start applies pending schema migrations before the server accepts traffic. There is no automatic downgrade, so take a database dump first — that dump is what a rollback to an older release depends on.',
+'upg.before.dump.bar':'shell — back up PostgreSQL first',
+'upg.before.note':'Artifact storage is never rewritten by an upgrade: local blob directories and S3 buckets are read and written in the same layout across releases. Skipping versions is supported — migrations from every intermediate release run in order. Read the release notes for each version you skip; anything needing a manual step is called out there.',
+'upg.compose.sep':'Docker Compose',
+'upg.compose.desc':'If the compose file pins a tag, edit it to the new version first. With <code>:latest</code> or a <code>NEXSPENCE_VERSION</code> variable, pulling is enough.',
+'upg.compose.note':'Named volumes carry the blob store and the generated JWT secret across the replacement, so no data or session state is lost. PostgreSQL in the same compose file is untouched by the pull.',
+'upg.docker.sep':'Docker (single container)',
+'upg.docker.desc':'Recreate the container from the new image with the same volumes, environment and database. Keeping the volume mounts identical is the whole trick — the container is disposable, its volumes are not.',
+'upg.helm.sep':'Kubernetes (Helm)',
+'upg.helm.desc':'Each release publishes a chart version matching the app version. <code>--reuse-values</code> keeps your existing overrides; drop it and pass your values file if you prefer an explicit upgrade.',
+'upg.helm.note':'With more than one replica, the first new pod to become ready runs the migrations while old pods still serve traffic. Additive migrations tolerate that overlap; when release notes flag a schema change as breaking, scale to one replica for the upgrade. <code>helm rollback nexspence -n nexspence</code> reverts the workload — but see Rolling Back below, because the schema does not revert with it.',
+'upg.linux.sep':'Linux — .deb / .rpm',
+'upg.linux.note':'Package upgrades replace the binary and leave <code>/etc/nexspence/config.yaml</code>, the <code>nexspence</code> system user and <code>/var/lib/nexspence</code> as they are. New configuration keys always ship with defaults, so an untouched config keeps working.',
+'upg.tarball.sep':'Linux — tarball',
+'upg.macos.sep':'macOS',
+'upg.windows.sep':'Windows',
+'upg.windows.bar':'PowerShell — as Administrator',
+'upg.windows.note':'The service registration and <code>C:\ProgramData\Nexspence\config.yaml</code> survive the replacement — only the executable changes. Re-run <code>install-service.ps1</code> only if the service itself is missing.',
+'upg.verify.sep':'Verifying the Upgrade',
+'upg.verify.note':'The running version also appears under System Admin → Info and at the bottom of the sidebar. The startup log line <code>migrations OK</code> confirms the schema is current; a failure there stops the server before it serves a single request, so a silent half-migrated state is not a state you can reach.',
+'upg.rollback.sep':'Rolling Back',
+'upg.rollback.info':'<strong style="color:var(--amber)">Schema changes do not roll back with the binary.</strong> Reverting to the previous image or package works only while the newer schema stays readable by the older release — true for additive migrations, not guaranteed otherwise. If the older version fails to start after a rollback, restore the dump you took before upgrading and start the older release against it.',
     'upg.v1180.sep':'Upgrading to v1.18.0 — Blob Ownership Fix',
     'upg.v1180.info':'<strong style="color:var(--amber)">One-time step for existing single-node Docker Compose deployments.</strong> The v1.18.0 image now runs as non-root <code>uid 1000</code>, but blob volumes created by older root-running images are owned by <code>root</code>. Fix ownership once before starting the new image, otherwise Nexspence cannot write to its blob store.',
     'upg.v1180.note':'Fresh installs and S3 blob stores are unaffected. After the <code>chown</code>, start the stack normally with <code>docker compose up -d</code>.',
@@ -1886,7 +2002,7 @@ const TRANSLATIONS={
     'sb.native-install':'Native Install',
     'crumb.native-install':'native install',
     'fmt.title':'Supported Formats',
-    'fmt.sub':'14 artifact formats — each supports Hosted, Proxy, and Group repository types.',
+    'fmt.sub':'15 artifact formats — each supports Hosted, Proxy, and Group repository types.',
     'api.title':'API Reference','api.sub':'Nexspence exposes two API surfaces.',
     'api.auth.title':'Authentication',
     'api.auth.desc':'JWT Bearer token (from <code>POST /api/v1/auth/login</code>), API tokens (<code>nxs_*</code> prefix via Bearer or Basic password), or HTTP Basic with username + password.',
@@ -2107,7 +2223,30 @@ const TRANSLATIONS={
     'sec.selfservice.sep':'Самостоятельная смена пароля',
     'sec.selfservice.desc':'Любой пользователь без прав администратора может сменить свой пароль без участия администратора. Смена пароля обновляет отметку JWT, поэтому существующие сессии становятся недействительными.',
     'upg.title':'Обновление',
-    'upg.sub':'Заметки по переходу существующего развёртывания на новую версию Nexspence.',
+    'upg.sub':'Перевод существующего развёртывания на новую версию Nexspence — по разделу на каждый способ установки.',
+'upg.before.sep':'Перед обновлением',
+'upg.before.info':'<strong>Миграции выполняются автоматически и только вперёд.</strong> При каждом старте применяются накопившиеся миграции схемы, и только после этого сервер начинает принимать запросы. Автоматического отката нет, поэтому сначала снимите дамп базы — именно он понадобится, если придётся вернуться на прежнюю версию.',
+'upg.before.dump.bar':'shell — сначала бэкап PostgreSQL',
+'upg.before.note':'Хранилище артефактов при обновлении не переписывается: локальные каталоги блобов и S3-бакеты во всех версиях читаются и пишутся в одном и том же формате. Перепрыгивать через версии можно — миграции всех промежуточных релизов выполнятся по порядку. Прочитайте release notes каждой пропущенной версии: всё, что требует ручного шага, отмечено там.',
+'upg.compose.sep':'Docker Compose',
+'upg.compose.desc':'Если в compose-файле тег зафиксирован, сначала поменяйте его на новую версию. Если используется <code>:latest</code> или переменная <code>NEXSPENCE_VERSION</code>, достаточно pull.',
+'upg.compose.note':'Именованные тома переносят blob-хранилище и сгенерированный JWT-секрет в новый контейнер, поэтому ни данные, ни сессии не теряются. PostgreSQL из того же compose-файла pull не затрагивает.',
+'upg.docker.sep':'Docker (одиночный контейнер)',
+'upg.docker.desc':'Пересоздайте контейнер из нового образа с теми же томами, переменными окружения и базой. Весь фокус в том, чтобы монтирование томов осталось прежним: контейнер одноразовый, тома — нет.',
+'upg.helm.sep':'Kubernetes (Helm)',
+'upg.helm.desc':'Каждый релиз публикует версию чарта, совпадающую с версией приложения. <code>--reuse-values</code> сохраняет ваши текущие переопределения; уберите флаг и передайте свой values-файл, если предпочитаете явное обновление.',
+'upg.helm.note':'Если реплик больше одной, миграции выполнит первый новый под, дошедший до ready, пока старые поды ещё обслуживают трафик. Аддитивные миграции такое пересечение переживают; если в release notes изменение схемы помечено как несовместимое — на время обновления оставьте одну реплику. <code>helm rollback nexspence -n nexspence</code> вернёт рабочую нагрузку, но схема вместе с ней не откатится — см. раздел «Откат».',
+'upg.linux.sep':'Linux — .deb / .rpm',
+'upg.linux.note':'Обновление пакета заменяет бинарник и не трогает <code>/etc/nexspence/config.yaml</code>, системного пользователя <code>nexspence</code> и <code>/var/lib/nexspence</code>. Новые ключи конфигурации всегда приходят со значениями по умолчанию, поэтому нетронутый конфиг продолжает работать.',
+'upg.tarball.sep':'Linux — tar-архив',
+'upg.macos.sep':'macOS',
+'upg.windows.sep':'Windows',
+'upg.windows.bar':'PowerShell — от имени администратора',
+'upg.windows.note':'Регистрация службы и <code>C:\ProgramData\Nexspence\config.yaml</code> замену переживают — меняется только исполняемый файл. Повторно запускать <code>install-service.ps1</code> нужно, только если сама служба отсутствует.',
+'upg.verify.sep':'Проверка обновления',
+'upg.verify.note':'Работающую версию также видно в System Admin → Info и внизу боковой панели. Строка в логе старта <code>migrations OK</code> подтверждает, что схема актуальна; при ошибке миграции сервер останавливается до того, как обслужит хоть один запрос, так что состояния «наполовину мигрировано» просто не бывает.',
+'upg.rollback.sep':'Откат',
+'upg.rollback.info':'<strong style="color:var(--amber)">Изменения схемы не откатываются вместе с бинарником.</strong> Возврат на прежний образ или пакет сработает, только пока новая схема остаётся читаемой для старой версии — это верно для аддитивных миграций и не гарантировано в остальных случаях. Если после отката старая версия не стартует, восстановите снятый перед обновлением дамп и запускайте старую версию на нём.',
     'upg.v1180.sep':'Обновление до v1.18.0 — исправление владельца blob-хранилища',
     'upg.v1180.info':'<strong style="color:var(--amber)">Однократный шаг для существующих одноузловых развёртываний на Docker Compose.</strong> Образ v1.18.0 теперь работает без root, под <code>uid 1000</code>, но тома blob-хранилища, созданные старыми образами под root, принадлежат пользователю <code>root</code>. Однократно исправьте владельца перед запуском нового образа, иначе Nexspence не сможет писать в blob-хранилище.',
     'upg.v1180.note':'Новые установки и S3-хранилища это не затрагивает. После <code>chown</code> запустите стек как обычно: <code>docker compose up -d</code>.',
@@ -2212,7 +2351,7 @@ const TRANSLATIONS={
     'sb.native-install':'Нативная установка',
     'crumb.native-install':'нативная установка',
     'fmt.title':'Поддерживаемые форматы',
-    'fmt.sub':'14 форматов артефактов — каждый поддерживает типы Hosted, Proxy и Group.',
+    'fmt.sub':'15 форматов артефактов — каждый поддерживает типы Hosted, Proxy и Group.',
     'api.title':'Справочник API',
     'api.sub':'Nexspence предоставляет два API-интерфейса.',
     'api.auth.title':'Аутентификация',


### PR DESCRIPTION
Two corrections and one missing page.

**Format count.** The docs site said *14 artifact formats* in both languages and merged Docker and OCI into one table row. They are two formats a repository can be created as, with their own labels, proxy defaults and UI treatment — the README, the landing page and the org profile all already say 15. Table split, counts fixed, and the prose list of what Nexspence manages now includes OCI artifacts.

**Upgrading.** The page contained exactly one note — the v1.18.0 blob ownership fix — for every deployment shape there is. It now covers:

- **Before you upgrade** — migrations run automatically and only forward, so the pre-upgrade `pg_dump` is what a rollback depends on; artifact storage is never rewritten; skipping versions is supported
- **Docker Compose** — pull, up, watch for `migrations OK`
- **Docker** — recreate with identical volumes and env
- **Kubernetes (Helm)** — `helm upgrade` against the chart version matching the release, rollout status, and what multi-replica overlap means for migrations
- **Linux** — `.deb`/`.rpm` upgrade and the tarball path, both with the systemd restart
- **macOS** — launchd unload/install/load
- **Windows** — Stop-Service, replace the exe, Start-Service
- **Verifying** — `/api/v1/system/info` returns the running version
- **Rolling back** — honest about what does not revert: the schema

Both languages, 23 new i18n keys each.

**Tests.** `internal/domain/site_formats_test.go` reads the published page and holds the stated count (EN and RU) and the table rows against `domain.AllFormats` — a new canonical list, which also adds the four format constants (`cargo`, `conan`, `conda`, `terraform`) that until now existed only as strings in the handler registry. Both tests fail against the previous version of the page and pass against this one; verified by swapping the old file back in.

Also: the README test badge said 2209 passing; the suite is at 2100 Go tests plus 522 frontend, so it now reads 2600+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01728qZ7XQsm8YpJKcNDQZ4x