### PR TITLE
feat(storage): stream chunked blob uploads instead of rewriting the session

### DIFF
--- a/internal/formats/oci/upload_append_test.go
+++ b/internal/formats/oci/upload_append_test.go
@@ -1,0 +1,364 @@
+package oci_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/storage"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// ── Instrumented blob stores ────────────────────────────────────────────────
+
+// appendCountingStore is an in-memory blob store that records how often each
+// operation is called, so a test can assert what a chunked push actually costs
+// rather than only what it produces.
+type appendCountingStore struct {
+	mu    sync.Mutex
+	blobs map[string][]byte
+	times map[string]time.Time
+
+	gets, puts, appends, truncates, finalizes, aborts int
+}
+
+func newAppendCountingStore() *appendCountingStore {
+	return &appendCountingStore{blobs: map[string][]byte{}, times: map[string]time.Time{}}
+}
+
+func (c *appendCountingStore) counts() (gets, puts, appends int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.gets, c.puts, c.appends
+}
+
+func (c *appendCountingStore) Put(_ context.Context, key string, r io.Reader, _ int64) error {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.puts++
+	c.blobs[key] = data
+	c.times[key] = time.Now()
+	return nil
+}
+
+func (c *appendCountingStore) Get(_ context.Context, key string) (io.ReadCloser, int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gets++
+	data, ok := c.blobs[key]
+	if !ok {
+		return nil, 0, fmt.Errorf("blob not found: %s", key)
+	}
+	return io.NopCloser(bytes.NewReader(data)), int64(len(data)), nil
+}
+
+func (c *appendCountingStore) Delete(_ context.Context, key string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.blobs, key)
+	delete(c.times, key)
+	return nil
+}
+
+func (c *appendCountingStore) Exists(_ context.Context, key string) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.blobs[key]
+	return ok, nil
+}
+
+func (c *appendCountingStore) Size(_ context.Context, key string) (int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	data, ok := c.blobs[key]
+	if !ok {
+		return 0, fmt.Errorf("blob not found: %s", key)
+	}
+	return int64(len(data)), nil
+}
+
+func (c *appendCountingStore) UsedBytes(_ context.Context) (int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var total int64
+	for _, d := range c.blobs {
+		total += int64(len(d))
+	}
+	return total, nil
+}
+
+func (c *appendCountingStore) ListKeys(_ context.Context) ([]string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	keys := make([]string, 0, len(c.blobs))
+	for k := range c.blobs {
+		keys = append(keys, k)
+	}
+	return keys, nil
+}
+
+func (c *appendCountingStore) ListEntries(_ context.Context) ([]storage.BlobEntry, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entries := make([]storage.BlobEntry, 0, len(c.blobs))
+	for k, d := range c.blobs {
+		entries = append(entries, storage.BlobEntry{Key: k, Size: int64(len(d)), ModTime: c.times[k]})
+	}
+	return entries, nil
+}
+
+// AppendBlob grows the blob without reading it back through Get — the whole
+// point of the extension, and what the call counters here prove.
+func (c *appendCountingStore) AppendBlob(_ context.Context, key string, r io.Reader) (int64, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return 0, err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.appends++
+	c.blobs[key] = append(c.blobs[key], data...)
+	c.times[key] = time.Now()
+	return int64(len(c.blobs[key])), nil
+}
+
+func (c *appendCountingStore) TruncateBlob(_ context.Context, key string, size int64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.truncates++
+	data, ok := c.blobs[key]
+	if !ok {
+		return fmt.Errorf("blob not found: %s", key)
+	}
+	if size > int64(len(data)) {
+		return fmt.Errorf("truncate %s: %d beyond staged %d", key, size, len(data))
+	}
+	c.blobs[key] = data[:size]
+	return nil
+}
+
+func (c *appendCountingStore) AppendedSize(_ context.Context, key string) (int64, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	data, ok := c.blobs[key]
+	if !ok {
+		return 0, false, nil
+	}
+	return int64(len(data)), true, nil
+}
+
+func (c *appendCountingStore) FinalizeAppend(_ context.Context, _ string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.finalizes++
+	return nil
+}
+
+func (c *appendCountingStore) AbortAppend(_ context.Context, _ string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.aborts++
+	return nil
+}
+
+// plainStore exposes the same in-memory store *without* the append extension,
+// so the fallback path stays covered. The wrapping is explicit rather than an
+// embedded field: embedding would promote AppendBlob and the type assertion in
+// uploadStore would take the streaming branch anyway.
+type plainStore struct{ inner *appendCountingStore }
+
+func (p *plainStore) Put(ctx context.Context, key string, r io.Reader, size int64) error {
+	return p.inner.Put(ctx, key, r, size)
+}
+func (p *plainStore) Get(ctx context.Context, key string) (io.ReadCloser, int64, error) {
+	return p.inner.Get(ctx, key)
+}
+func (p *plainStore) Delete(ctx context.Context, key string) error { return p.inner.Delete(ctx, key) }
+func (p *plainStore) Exists(ctx context.Context, key string) (bool, error) {
+	return p.inner.Exists(ctx, key)
+}
+func (p *plainStore) Size(ctx context.Context, key string) (int64, error) {
+	return p.inner.Size(ctx, key)
+}
+func (p *plainStore) UsedBytes(ctx context.Context) (int64, error) { return p.inner.UsedBytes(ctx) }
+func (p *plainStore) ListKeys(ctx context.Context) ([]string, error) {
+	return p.inner.ListKeys(ctx)
+}
+func (p *plainStore) ListEntries(ctx context.Context) ([]storage.BlobEntry, error) {
+	return p.inner.ListEntries(ctx)
+}
+
+// ── Harness ─────────────────────────────────────────────────────────────────
+
+func setupWithStore(store storage.BlobStore, maxUploadBytes int64) *gin.Engine {
+	repo := &domain.Repository{
+		ID: "repo-append", Name: "docker-hosted",
+		Format: domain.FormatDocker, Type: domain.TypeHosted, Online: true,
+	}
+	d := formats.Deps{
+		Repos:          testutil.NewRepoRepo(repo),
+		Blobs:          testutil.NewBlobStoreRepo(),
+		Components:     testutil.NewComponentRepo(),
+		Assets:         testutil.NewAssetRepo(),
+		BlobStore:      store,
+		BaseURL:        "http://localhost:8080",
+		MaxUploadBytes: maxUploadBytes,
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+// pushChunkedBlob runs a full chunked push — POST, one PATCH per chunk, PUT — and
+// returns the finalizing response.
+func pushChunkedBlob(t *testing.T, r *gin.Engine, chunks []string) *httptest.ResponseRecorder {
+	t.Helper()
+	loc := startUpload(t, r)
+	for i, chunk := range chunks {
+		req := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader(chunk))
+		req.Header.Set("Content-Type", "application/octet-stream")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusAccepted, w.Code, "chunk %d: %s", i, w.Body.String())
+	}
+	sep := "?"
+	if strings.Contains(loc, "?") {
+		sep = "&"
+	}
+	req := httptest.NewRequest(http.MethodPut,
+		fmt.Sprintf("%s%sdigest=%s", loc, sep, digest(strings.Join(chunks, ""))), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+// A chunked push on an appendable store must never read the staged blob back:
+// that read-modify-write is what made an N-chunk push move O(N²) bytes (#214).
+func TestPatchUploadStreamsChunksWithoutReadingSessionBack(t *testing.T) {
+	store := newAppendCountingStore()
+	r := setupWithStore(store, 0)
+	loc := startUpload(t, r)
+
+	for i := 0; i < 5; i++ {
+		w := patchChunk(t, r, loc, 128)
+		require.Equal(t, http.StatusAccepted, w.Code, "chunk %d: %s", i, w.Body.String())
+		assert.Equal(t, fmt.Sprintf("0-%d", 128*(i+1)-1), w.Header().Get("Range"))
+	}
+
+	gets, _, appends := store.counts()
+	assert.Equal(t, 5, appends, "each chunk must be a single streaming append")
+	assert.Zero(t, gets, "no chunk may read the staged session back")
+}
+
+// The bytes still have to arrive intact, chunk boundaries and all: the push is
+// verified end to end through the digest the registry checks before storing.
+func TestChunkedPushOnAppendableStoreStoresExactBytes(t *testing.T) {
+	store := newAppendCountingStore()
+	r := setupWithStore(store, 0)
+	chunks := []string{"alpha", "-beta-", "gamma", "", "-delta"}
+
+	w := pushChunkedBlob(t, r, chunks)
+
+	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, digest(strings.Join(chunks, "")), w.Header().Get("Docker-Content-Digest"))
+}
+
+// A store without the extension keeps today's behavior, unchanged.
+func TestChunkedPushFallsBackForNonAppendableStore(t *testing.T) {
+	inner := newAppendCountingStore()
+	r := setupWithStore(&plainStore{inner: inner}, 0)
+	chunks := []string{"one", "-two", "-three"}
+
+	w := pushChunkedBlob(t, r, chunks)
+
+	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+	assert.Equal(t, digest(strings.Join(chunks, "")), w.Header().Get("Docker-Content-Digest"))
+	gets, _, appends := inner.counts()
+	assert.Zero(t, appends, "a plain store must never take the streaming branch")
+	assert.Positive(t, gets, "the fallback stages a chunk by rewriting the session")
+}
+
+// The cap contract of #211 must survive the switch to streaming appends: a
+// chunk that crosses the cap is rejected and costs the session nothing, even
+// though a streaming append can only discover the overflow after writing it.
+func TestStreamingAppendRejectsChunkOverLimitAndRollsBack(t *testing.T) {
+	store := newAppendCountingStore()
+	r := setupWithStore(store, 1024)
+	loc := startUpload(t, r)
+
+	first := patchChunk(t, r, loc, 800)
+	require.Equal(t, http.StatusAccepted, first.Code, "body: %s", first.Body.String())
+	assert.Equal(t, "0-799", first.Header().Get("Range"))
+
+	second := patchChunk(t, r, loc, 800)
+	require.Equal(t, http.StatusRequestEntityTooLarge, second.Code, "body: %s", second.Body.String())
+	assert.Equal(t, "BLOB_UPLOAD_INVALID", dockerErrorCode(t, second.Body.String()))
+
+	store.mu.Lock()
+	truncates := store.truncates
+	store.mu.Unlock()
+	assert.Equal(t, 1, truncates, "the over-cap chunk must be rolled back, not left staged")
+
+	third := patchChunk(t, r, loc, 224)
+	require.Equal(t, http.StatusAccepted, third.Code,
+		"rejected chunk consumed budget it never used: %s", third.Body.String())
+	assert.Equal(t, "0-1023", third.Header().Get("Range"))
+
+	fourth := patchChunk(t, r, loc, 1)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, fourth.Code,
+		"session at the cap accepted more bytes: %s", fourth.Body.String())
+}
+
+// A finished session must release whatever the backend still holds for it —
+// abandoned multipart parts are invisible to the blob-key GC sweep.
+func TestFinalizedUploadAbortsAndDeletesSession(t *testing.T) {
+	store := newAppendCountingStore()
+	r := setupWithStore(store, 0)
+
+	w := pushChunkedBlob(t, r, []string{"payload"})
+	require.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+
+	store.mu.Lock()
+	finalizes, aborts := store.finalizes, store.aborts
+	store.mu.Unlock()
+	assert.Positive(t, finalizes, "the staged bytes must be published before they are read")
+	assert.Positive(t, aborts, "a removed session must release its backend resources")
+
+	for _, k := range mustListKeys(t, store) {
+		assert.False(t, strings.HasPrefix(k, "_uploads/"), "upload session %q outlived its push", k)
+	}
+}
+
+func mustListKeys(t *testing.T, store *appendCountingStore) []string {
+	t.Helper()
+	keys, err := store.ListKeys(context.Background())
+	require.NoError(t, err)
+	return keys
+}

--- a/internal/formats/oci/uploads.go
+++ b/internal/formats/oci/uploads.go
@@ -10,6 +10,7 @@ import (
 	"io"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/storage"
 )
 
 // uploadKeyPrefix namespaces in-progress blob uploads inside the blob store.
@@ -48,6 +49,14 @@ func validUploadID(id string) bool {
 
 func (s uploadStore) key(id string) string { return uploadKeyPrefix + id }
 
+// appendable returns the blob store's incremental-append extension when it has
+// one. Without it a chunk can only be staged by rewriting the whole session, so
+// every method below keeps a fallback branch that does exactly that (#214).
+func (s uploadStore) appendable() (storage.AppendableBlobStore, bool) {
+	as, ok := s.deps.BlobStore.(storage.AppendableBlobStore)
+	return as, ok
+}
+
 // create starts an empty session and returns its id.
 func (s uploadStore) create(ctx context.Context) (string, error) {
 	id, err := newUploadID()
@@ -65,6 +74,15 @@ func (s uploadStore) size(ctx context.Context, id string) (n int64, ok bool) {
 	if !validUploadID(id) {
 		return 0, false
 	}
+	if as, isAppendable := s.appendable(); isAppendable {
+		// Bytes handed to AppendBlob may not be visible at the key yet, so the
+		// store — not a stat of the key — is what knows how far the session got.
+		n, ok, err := as.AppendedSize(ctx, s.key(id))
+		if err != nil {
+			return 0, false
+		}
+		return n, ok
+	}
 	exists, err := s.deps.BlobStore.Exists(ctx, s.key(id))
 	if err != nil || !exists {
 		return 0, false
@@ -81,6 +99,15 @@ func (s uploadStore) read(ctx context.Context, id string) (data []byte, ok bool,
 	if _, ok = s.size(ctx, id); !ok {
 		return nil, false, nil
 	}
+	if as, isAppendable := s.appendable(); isAppendable {
+		// Publish the appended bytes at the key before reading them back: on a
+		// backend that stages them out of band (S3 multipart) a Get would
+		// otherwise return whatever the key held before the session started.
+		// Idempotent, so a client re-sending the finalizing PUT is fine.
+		if err := as.FinalizeAppend(ctx, s.key(id)); err != nil {
+			return nil, true, err
+		}
+	}
 	rc, _, err := s.deps.BlobStore.Get(ctx, s.key(id))
 	if err != nil {
 		return nil, true, err
@@ -95,8 +122,12 @@ func (s uploadStore) read(ctx context.Context, id string) (data []byte, ok bool,
 var errUploadTooLarge = errors.New("upload exceeds the configured maximum size")
 
 // append adds a chunk and returns the new total size. ok is false when the
-// session is unknown. The blob store API is whole-object, so the chunk is
-// concatenated onto what is already staged.
+// session is unknown.
+//
+// On a store with the append extension the chunk streams straight onto the
+// staged blob, so a push costs O(bytes pushed) in total. Otherwise the blob
+// store API is whole-object and the chunk is concatenated onto what is already
+// staged, which makes an N-chunk push move O(N²) bytes (#214).
 //
 // With a cap configured, the session size is checked with a stat-only size()
 // call and the chunk is read through a LimitReader before anything already
@@ -116,6 +147,10 @@ func (s uploadStore) append(ctx context.Context, id string, r io.Reader) (total 
 		// One byte past the remaining budget is enough to detect the overflow
 		// without buffering more than the cap allows.
 		r = io.LimitReader(r, limit-stored+1)
+	}
+
+	if as, isAppendable := s.appendable(); isAppendable {
+		return s.appendStreaming(ctx, as, id, r, stored, limit)
 	}
 
 	var chunk bytes.Buffer
@@ -140,10 +175,40 @@ func (s uploadStore) append(ctx context.Context, id string, r io.Reader) (total 
 	return int64(buf.Len()), true, nil
 }
 
+// appendStreaming stages the chunk through the append extension: nothing
+// already staged is read, and nothing but the chunk itself is written.
+//
+// A streaming append cannot know a chunk's length before committing it —
+// measuring it up front means buffering it, the very thing being avoided — so a
+// chunk that crosses the cap is written and then rolled back to where the
+// session was. The session is left holding exactly the bytes it held before, so
+// the rejected chunk consumes none of the remaining budget.
+func (s uploadStore) appendStreaming(ctx context.Context, as storage.AppendableBlobStore,
+	id string, r io.Reader, stored, limit int64,
+) (total int64, ok bool, err error) {
+	total, err = as.AppendBlob(ctx, s.key(id), r)
+	if err != nil {
+		return 0, true, err
+	}
+	if limit > 0 && total > limit {
+		if terr := as.TruncateBlob(ctx, s.key(id), stored); terr != nil {
+			return 0, true, fmt.Errorf("%w (rolling the session back to %d bytes failed: %w)",
+				errUploadTooLarge, stored, terr)
+		}
+		return 0, true, errUploadTooLarge
+	}
+	return total, true, nil
+}
+
 // remove drops a finished (or abandoned) session.
 func (s uploadStore) remove(ctx context.Context, id string) {
 	if !validUploadID(id) {
 		return
+	}
+	if as, isAppendable := s.appendable(); isAppendable {
+		// Deleting the key alone leaves whatever an unfinished append holds
+		// behind the scenes (S3 multipart parts), which no GC sweep can see.
+		_ = as.AbortAppend(ctx, s.key(id))
 	}
 	_ = s.deps.BlobStore.Delete(ctx, s.key(id))
 }

--- a/internal/storage/local.go
+++ b/internal/storage/local.go
@@ -93,6 +93,75 @@ func (s *LocalBlobStore) Put(_ context.Context, key string, r io.Reader, _ int64
 	return nil
 }
 
+// AppendBlob appends r to the blob for key and returns its new total size,
+// creating the blob when it does not exist yet.
+//
+// It opens the blob's own path with O_APPEND rather than staging a temp file:
+// the point of the whole extension is to never read back — nor rewrite — what is
+// already stored, which a copy-then-rename would do on every call.
+//
+// Deliberately not fsynced. The caller is upload staging, never a finished
+// artifact — that still goes through Put, which does fsync — and syncing every
+// chunk costs far more than the guarantee is worth here: a crash loses at most
+// the tail of an upload that was never complete anyway, and the client resumes
+// from the size the next progress GET reports.
+func (s *LocalBlobStore) AppendBlob(_ context.Context, key string, r io.Reader) (int64, error) {
+	dst, err := s.keyPath(key)
+	if err != nil {
+		return 0, err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o750); err != nil {
+		return 0, err
+	}
+	f, err := os.OpenFile(dst, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // dst is validated by keyPath to stay within the blob store base dir
+	if err != nil {
+		return 0, err
+	}
+	if _, err := io.Copy(f, r); err != nil {
+		_ = f.Close()
+		return 0, classifyWriteErr(err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return 0, err
+	}
+	if err := f.Close(); err != nil {
+		return 0, err
+	}
+	return info.Size(), nil
+}
+
+// TruncateBlob shrinks the blob for key to size.
+func (s *LocalBlobStore) TruncateBlob(_ context.Context, key string, size int64) error {
+	p, err := s.keyPath(key)
+	if err != nil {
+		return err
+	}
+	return os.Truncate(p, size)
+}
+
+// AppendedSize reports the bytes staged for key. An appended file is the live
+// blob from the first byte on, so this is just Exists plus Size.
+func (s *LocalBlobStore) AppendedSize(ctx context.Context, key string) (int64, bool, error) {
+	exists, err := s.Exists(ctx, key)
+	if err != nil || !exists {
+		return 0, false, err
+	}
+	n, err := s.Size(ctx, key)
+	if err != nil {
+		return 0, false, err
+	}
+	return n, true, nil
+}
+
+// FinalizeAppend is a no-op: appended bytes are already readable at key.
+func (s *LocalBlobStore) FinalizeAppend(_ context.Context, _ string) error { return nil }
+
+// AbortAppend is a no-op: a local append holds no backend resource beyond the
+// file itself, which the caller deletes with Delete.
+func (s *LocalBlobStore) AbortAppend(_ context.Context, _ string) error { return nil }
+
 // classifyWriteErr tags a full-disk failure with ErrNoSpace so handlers can
 // answer 507 Insufficient Storage; any other error is returned unchanged.
 func classifyWriteErr(err error) error {

--- a/internal/storage/local_append_test.go
+++ b/internal/storage/local_append_test.go
@@ -1,0 +1,202 @@
+package storage_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/storage"
+)
+
+// appendable pins the compile-time contract: the local store is the fallback
+// backend, so a chunked upload only streams if it satisfies the extension.
+func appendable(t *testing.T, s *storage.LocalBlobStore) storage.AppendableBlobStore {
+	t.Helper()
+	as, ok := interface{}(s).(storage.AppendableBlobStore)
+	require.True(t, ok, "LocalBlobStore must implement AppendableBlobStore")
+	return as
+}
+
+func TestLocalBlobStore_AppendBlob_CreatesAndRoundtrips(t *testing.T) {
+	store := newLocal(t)
+	as := appendable(t, store)
+	ctx := context.Background()
+	key := "abcdef1234567890"
+	data := []byte("first chunk")
+
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader(data))
+	require.NoError(t, err)
+	assert.EqualValues(t, len(data), total)
+
+	rc, size, err := store.Get(ctx, key)
+	require.NoError(t, err)
+	defer rc.Close()
+	assert.EqualValues(t, len(data), size)
+	got, _ := io.ReadAll(rc)
+	assert.Equal(t, data, got)
+}
+
+func TestLocalBlobStore_AppendBlob_AccumulatesAcrossCalls(t *testing.T) {
+	store := newLocal(t)
+	as := appendable(t, store)
+	ctx := context.Background()
+	key := "1122334455667788"
+
+	chunks := []string{"alpha", "-beta", "-gamma"}
+	var want string
+	for _, c := range chunks {
+		want += c
+		total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte(c)))
+		require.NoError(t, err)
+		assert.EqualValues(t, len(want), total, "size after appending %q", c)
+	}
+
+	rc, _, err := store.Get(ctx, key)
+	require.NoError(t, err)
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	assert.Equal(t, want, string(got))
+}
+
+// Appending onto a blob written by Put must extend it, not replace it: a
+// session starts with Put of an empty object and grows from there.
+func TestLocalBlobStore_AppendBlob_ExtendsPutBlob(t *testing.T) {
+	store := newLocal(t)
+	as := appendable(t, store)
+	ctx := context.Background()
+	key := "99aabbccddeeff00"
+
+	require.NoError(t, store.Put(ctx, key, bytes.NewReader([]byte("head-")), 5))
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("tail")))
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, total)
+
+	rc, _, err := store.Get(ctx, key)
+	require.NoError(t, err)
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	assert.Equal(t, "head-tail", string(got))
+}
+
+func TestLocalBlobStore_TruncateBlob_RollsBackAndResumes(t *testing.T) {
+	store := newLocal(t)
+	as := appendable(t, store)
+	ctx := context.Background()
+	key := "deadbeefcafe0011"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("keep-drop")))
+	require.NoError(t, err)
+	require.NoError(t, as.TruncateBlob(ctx, key, 4))
+
+	size, err := store.Size(ctx, key)
+	require.NoError(t, err)
+	assert.EqualValues(t, 4, size)
+
+	// A truncated blob must still be appendable — the rejected chunk costs the
+	// session nothing, so the next one continues from the rolled-back offset.
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("-more")))
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, total)
+
+	rc, _, err := store.Get(ctx, key)
+	require.NoError(t, err)
+	defer rc.Close()
+	got, _ := io.ReadAll(rc)
+	assert.Equal(t, "keep-more", string(got))
+}
+
+func TestLocalBlobStore_TruncateBlob_MissingKey(t *testing.T) {
+	as := appendable(t, newLocal(t))
+	require.Error(t, as.TruncateBlob(context.Background(), "0000111122223333", 0))
+}
+
+func TestLocalBlobStore_AppendedSize(t *testing.T) {
+	store := newLocal(t)
+	as := appendable(t, store)
+	ctx := context.Background()
+	key := "5566778899aabbcc"
+
+	_, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	assert.False(t, ok, "unknown key must not report a staged size")
+
+	_, err = as.AppendBlob(ctx, key, bytes.NewReader([]byte("1234567")))
+	require.NoError(t, err)
+
+	size, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.EqualValues(t, 7, size)
+}
+
+func TestLocalBlobStore_AppendedSize_InvalidKey(t *testing.T) {
+	as := appendable(t, newLocal(t))
+	_, _, err := as.AppendedSize(context.Background(), "../../escape")
+	require.Error(t, err)
+}
+
+// Finalize and abort exist for backends that stage out of band; on local disk
+// the bytes are live from the first append, so both are no-ops that must leave
+// the blob exactly as it is.
+func TestLocalBlobStore_FinalizeAndAbortAppend_AreNoOps(t *testing.T) {
+	store := newLocal(t)
+	as := appendable(t, store)
+	ctx := context.Background()
+	key := "aabb00112233ccdd"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("payload")))
+	require.NoError(t, err)
+
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	require.NoError(t, as.AbortAppend(ctx, key))
+	require.NoError(t, as.FinalizeAppend(ctx, "no-such-session"))
+
+	size, err := store.Size(ctx, key)
+	require.NoError(t, err)
+	assert.EqualValues(t, 7, size)
+}
+
+func TestLocalBlobStore_AppendBlob_InvalidKey(t *testing.T) {
+	as := appendable(t, newLocal(t))
+	_, err := as.AppendBlob(context.Background(), "../../escape", bytes.NewReader([]byte("x")))
+	require.Error(t, err)
+}
+
+func TestLocalBlobStore_AppendBlob_ReaderError(t *testing.T) {
+	as := appendable(t, newLocal(t))
+	_, err := as.AppendBlob(context.Background(), "eeff001122334455",
+		failingReader{err: io.ErrUnexpectedEOF})
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+// The point of the extension is that a chunk costs O(chunk), not O(blob): a
+// read-modify-write of 2000 chunks would move ~128 GiB through the process and
+// the disk instead of 128 MiB. The bound is deliberately generous — it catches
+// a return to quadratic behavior (or a per-call fsync, which measured ~60x
+// slower here), not a few percent of disk performance.
+func TestLocalBlobStore_AppendBlob_ManyChunksStayLinear(t *testing.T) {
+	if testing.Short() {
+		t.Skip("writes 128 MiB")
+	}
+	as := appendable(t, newLocal(t))
+	ctx := context.Background()
+	key := "77778888999900aa"
+	chunk := bytes.Repeat([]byte("x"), 64*1024)
+
+	start := time.Now()
+	var total int64
+	for i := 0; i < 2000; i++ {
+		var err error
+		total, err = as.AppendBlob(ctx, key, bytes.NewReader(chunk))
+		require.NoError(t, err)
+	}
+	elapsed := time.Since(start)
+
+	assert.EqualValues(t, 2000*len(chunk), total)
+	assert.Less(t, elapsed, 5*time.Second, "2000 appends took %s — appends are not streaming", elapsed)
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -60,6 +60,46 @@ type PresignableStore interface {
 	ConfigureLifecycle(ctx context.Context, expirationDays int32) error
 }
 
+// AppendableBlobStore is an optional extension of BlobStore for backends that
+// can grow a blob in place, without reading back what is already stored.
+// Check with a type assertion: as, ok := store.(storage.AppendableBlobStore)
+//
+// It exists for chunked uploads (the OCI blob PATCH sequence): with Put/Get
+// alone, every chunk has to re-read and rewrite the whole staged blob, so an
+// N-chunk push moves O(N²) bytes. Callers must keep a fallback path for stores
+// that do not implement it.
+//
+// Every method is keyed exactly like Put/Get — no in-process handle, channel or
+// goroutine — so a staged upload survives being continued by another instance,
+// or by a fresh process after a restart.
+type AppendableBlobStore interface {
+	// AppendBlob appends everything r yields to the blob at key, creating it if
+	// absent, and returns the blob's new total size. Cost is O(len(chunk)), not
+	// O(current size).
+	AppendBlob(ctx context.Context, key string, r io.Reader) (total int64, err error)
+
+	// TruncateBlob shrinks the blob at key back to size. A streaming append
+	// cannot measure an incoming chunk before committing it — that is the
+	// buffering being avoided — so a caller enforcing a size cap appends first
+	// and rolls back here.
+	TruncateBlob(ctx context.Context, key string, size int64) error
+
+	// AppendedSize returns the bytes staged so far, including any an in-progress
+	// append has not published at key yet; ok is false when nothing is staged.
+	// Plain Size cannot answer this for backends where append progress is
+	// invisible until FinalizeAppend runs (S3 multipart).
+	AppendedSize(ctx context.Context, key string) (size int64, ok bool, err error)
+
+	// FinalizeAppend publishes everything appended so far as the blob at key, so
+	// Get/Size see it. Idempotent, and a no-op when no append is in progress.
+	FinalizeAppend(ctx context.Context, key string) error
+
+	// AbortAppend discards an unfinished append and releases whatever the
+	// backend holds for it (S3 multipart parts, which nothing else reclaims).
+	// Idempotent, and a no-op when no append is in progress.
+	AbortAppend(ctx context.Context, key string) error
+}
+
 // Meta holds blob content metadata returned alongside the data stream.
 type Meta struct {
 	Key         string


### PR DESCRIPTION
Below the #211 cap, every PATCH chunk of an OCI blob push still read the whole staged upload back — `Get` + `io.ReadAll` — and rewrote the concatenation through `Put`. #211 bounded how much memory that could cost; it did not remove the read-modify-write. An N-chunk push kept moving O(N²) bytes through the process and the blob store: a 2 GiB layer sent as 4 MiB chunks re-read and rewrote the session ~500 times, writing many times the blob's actual size to disk.

**The extension.** `AppendableBlobStore` is an optional extension of `BlobStore`, in the shape of the existing `PresignableStore` — a type assertion, and stores that do not implement it keep today's behavior untouched:

- `AppendBlob` grows the blob and returns its new size, at O(len(chunk))
- `TruncateBlob` rolls a chunk back
- `AppendedSize` / `FinalizeAppend` / `AbortAppend` cover backends where an in-progress append is not visible at the key until it is finalized (not local disk — see the S3 follow-up in #216, where all three earn their keep)

Every method is keyed exactly like `Put`/`Get`, with no in-process handle, channel or goroutine, so the cross-instance/restart constraint of `uploadKeyPrefix` (#104) still holds: any instance, or a fresh process after a crash, can keep appending to the same key.

**Local disk.** `AppendBlob` opens the blob's own path with `O_APPEND|O_CREATE` and returns the new size from `Stat` — no read of existing content anywhere. `TruncateBlob` is `os.Truncate`; `AppendedSize` is `Exists` + `Size`; finalize and abort are no-ops.

No per-call `fsync`, deliberately. The caller here is upload *staging*, never the finished artifact — that still goes through `Put`, which does fsync — and syncing every chunk measured far slower on many small chunks for a guarantee staging does not need: a crash loses at most the tail of an upload that was never complete, and the client resumes from the size the next progress `GET` reports.

**The cap still holds.** A streaming append cannot know a chunk's length before committing it — measuring it up front means buffering it, the very thing being avoided — so a chunk that crosses `MaxUploadBytes` is written and then rolled back to exactly where the session was. The contract `TestPatchUploadRejectsChunkThatCrossesLimitAndKeepsSessionIntact` pins is unchanged: the rejected chunk consumes none of the remaining budget.

## Tests

- `internal/storage/local_append_test.go` — append round-trip, implicit creation, accumulation across calls, extending a `Put` blob, truncate-and-resume, `AppendedSize` on a missing key, finalize/abort as no-ops, invalid keys, reader errors, and a regression bound: 2000 × 64 KiB appends (128 MiB) finish well inside 5s, where a read-modify-write would move ~128 GiB
- `internal/formats/oci/upload_append_test.go` — an instrumented store proves 5 PATCH chunks produce 5 `AppendBlob` calls and **zero** `Get` calls; a full chunked push verified end to end through the digest the registry checks; the same push against a non-appendable store confirms the fallback still concatenates; the cap-crossing contract re-run on the streaming path, asserting the rollback; and a finished session shown to release its backend resources and leave no `_uploads/` key behind
- All 5 pre-existing tests in `upload_limit_test.go` pass unmodified, on the fallback path they already covered

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` and `go test ./...` are green.

Closes #214