### PR TITLE
feat(storage): implement streaming appends for S3 via real multipart upload

### DIFF
--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -127,6 +127,11 @@ func (s *S3BlobStore) Get(ctx context.Context, key string) (io.ReadCloser, int64
 
 // Delete removes the object for key; a missing object is not an error.
 func (s *S3BlobStore) Delete(ctx context.Context, key string) error {
+	// An unfinished append holds multipart parts that no listing shows and no
+	// object delete reclaims, so dropping the key without aborting first would
+	// leak them permanently — including when GC collects an abandoned upload
+	// session. Best effort: a failed abort must not block the delete.
+	_ = s.AbortAppend(ctx, key)
 	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(s.objectKey(key)),
@@ -182,7 +187,7 @@ func (s *S3BlobStore) ListKeys(ctx context.Context) ([]string, error) {
 			return keys, fmt.Errorf("s3 list keys: %w", err)
 		}
 		for _, obj := range page.Contents {
-			if obj.Key == nil {
+			if obj.Key == nil || isAppendMetaObject(*obj.Key) {
 				continue
 			}
 			// Object key = "ab/cd/abcdef..." → blob key = "abcdef..."
@@ -209,7 +214,7 @@ func (s *S3BlobStore) ListEntries(ctx context.Context) ([]BlobEntry, error) {
 			return entries, fmt.Errorf("s3 list entries: %w", err)
 		}
 		for _, obj := range page.Contents {
-			if obj.Key == nil {
+			if obj.Key == nil || isAppendMetaObject(*obj.Key) {
 				continue
 			}
 			parts := strings.SplitN(*obj.Key, "/", 3)
@@ -245,6 +250,9 @@ func (s *S3BlobStore) UsedBytes(ctx context.Context) (int64, error) {
 			return total, fmt.Errorf("s3 list: %w", err)
 		}
 		for _, obj := range page.Contents {
+			if obj.Key != nil && isAppendMetaObject(*obj.Key) {
+				continue // bookkeeping, not stored blob content
+			}
 			if obj.Size != nil {
 				total += *obj.Size
 			}

--- a/internal/storage/s3_append.go
+++ b/internal/storage/s3_append.go
@@ -1,0 +1,395 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// S3 implements AppendableBlobStore with a real multipart upload: each flush is
+// an UploadPart, so a chunked push costs O(bytes pushed) instead of the
+// O(N²) a read-modify-write over Put/Get costs (#214, #216).
+//
+// The awkward part is that S3 parts have a 5 MiB minimum (waived only for the
+// last one) while a Docker client may PATCH chunks of any size. So AppendBlob
+// keeps a sub-5 MiB tail in the session state and only uploads a part once that
+// tail is big enough.
+//
+// Session state lives in a small JSON side-object next to the blob rather than
+// in memory: the upload id, the completed parts, and the pending tail. That
+// keeps the cross-instance/restart guarantee the local backend gives for free —
+// any instance can continue a push another one started — and it stays
+// proportional to the part count plus one sub-5 MiB buffer, never to the blob.
+const (
+	// s3MinPartSize is S3's minimum size for every part but the last.
+	s3MinPartSize = 5 * 1024 * 1024
+	// s3AppendReadChunk bounds how much of an incoming chunk is held at once, so
+	// a client sending one enormous PATCH still costs ~5 MiB of memory, not its
+	// whole chunk.
+	s3AppendReadChunk = 256 * 1024
+	// s3AppendMetaSuffix names the session side-object. Keys carrying it are
+	// hidden from the listings, so GC never mistakes bookkeeping for a blob.
+	s3AppendMetaSuffix = ".append-meta"
+)
+
+// s3AppendPart records one uploaded part; CompleteMultipartUpload needs the
+// number and ETag of every one of them.
+type s3AppendPart struct {
+	Number int32  `json:"number"`
+	ETag   string `json:"etag"`
+	Size   int64  `json:"size"`
+}
+
+// s3AppendState is the durable state of one in-progress append.
+type s3AppendState struct {
+	UploadID string         `json:"upload_id"`
+	Parts    []s3AppendPart `json:"parts"`
+	Uploaded int64          `json:"uploaded"` // bytes in completed parts
+	Pending  []byte         `json:"pending"`  // tail too small to be a part yet
+}
+
+// staged is how many bytes the caller has handed over so far, uploaded or not.
+func (st *s3AppendState) staged() int64 { return st.Uploaded + int64(len(st.Pending)) }
+
+func (s *S3BlobStore) appendMetaKey(key string) string {
+	return s.objectKey(key) + s3AppendMetaSuffix
+}
+
+// AppendBlob appends r to the blob at key and returns the total staged so far.
+// The bytes are not visible at key until FinalizeAppend runs — S3 shows nothing
+// of a multipart upload until it is completed — which is why AppendedSize
+// exists rather than callers reading Size.
+func (s *S3BlobStore) AppendBlob(ctx context.Context, key string, r io.Reader) (int64, error) {
+	st, err := s.loadAppendState(ctx, key)
+	if errors.Is(err, errNoAppendSession) {
+		st, err = s.startAppend(ctx, key)
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	buf := bytes.NewBuffer(st.Pending)
+	window := make([]byte, s3AppendReadChunk)
+	for {
+		n, rerr := r.Read(window)
+		if n > 0 {
+			buf.Write(window[:n])
+			// One read can add at most s3AppendReadChunk, so at most one part
+			// becomes due per iteration and the buffer never exceeds
+			// 5 MiB + one window.
+			if buf.Len() >= s3MinPartSize {
+				if err := s.flushPart(ctx, key, st, buf); err != nil {
+					return 0, err
+				}
+			}
+		}
+		if rerr == io.EOF {
+			break
+		}
+		if rerr != nil {
+			return 0, fmt.Errorf("s3 append %s: %w", key, rerr)
+		}
+	}
+
+	st.Pending = buf.Bytes()
+	if err := s.saveAppendState(ctx, key, st); err != nil {
+		return 0, err
+	}
+	return st.staged(), nil
+}
+
+// startAppend opens a multipart upload for key and seeds it with whatever the
+// key already holds, so appending extends the blob exactly as it does on local
+// disk. Without the seed, completing the upload would silently replace bytes a
+// previous session had already published there.
+func (s *S3BlobStore) startAppend(ctx context.Context, key string) (*s3AppendState, error) {
+	out, err := s.client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(s.objectKey(key)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("s3 create multipart upload %s: %w", key, err)
+	}
+	st := &s3AppendState{UploadID: aws.ToString(out.UploadId)}
+
+	exists, err := s.Exists(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return st, nil
+	}
+	size, err := s.Size(ctx, key)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case size == 0:
+		// The empty object an upload session starts from: nothing to carry over.
+	case size >= s3MinPartSize:
+		// Big enough to be a part on its own, so it is copied server-side — the
+		// bytes never travel through this process.
+		if err := s.seedFromCopy(ctx, key, st, size); err != nil {
+			return nil, err
+		}
+	default:
+		// Too small to be a non-final part, so it becomes the pending tail.
+		rc, _, err := s.Get(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = rc.Close() }()
+		if st.Pending, err = io.ReadAll(rc); err != nil {
+			return nil, fmt.Errorf("s3 append seed %s: %w", key, err)
+		}
+	}
+	return st, nil
+}
+
+// seedFromCopy carries an existing object into the new upload as its first part
+// via UploadPartCopy (server-side, no bytes through this process).
+func (s *S3BlobStore) seedFromCopy(ctx context.Context, key string, st *s3AppendState, size int64) error {
+	// Blob keys are machine-generated (hex digests, upload ids, the upload
+	// prefix), so the copy source needs no percent-encoding.
+	out, err := s.client.UploadPartCopy(ctx, &s3.UploadPartCopyInput{
+		Bucket:     aws.String(s.bucket),
+		Key:        aws.String(s.objectKey(key)),
+		UploadId:   aws.String(st.UploadID),
+		PartNumber: aws.Int32(1),
+		CopySource: aws.String(s.bucket + "/" + s.objectKey(key)),
+	})
+	if err != nil {
+		return fmt.Errorf("s3 append seed copy %s: %w", key, err)
+	}
+	etag := ""
+	if out.CopyPartResult != nil {
+		etag = aws.ToString(out.CopyPartResult.ETag)
+	}
+	st.Parts = append(st.Parts, s3AppendPart{Number: 1, ETag: etag, Size: size})
+	st.Uploaded = size
+	return nil
+}
+
+// flushPart uploads everything buffered as the next part and empties buf.
+// Called with at least s3MinPartSize buffered, except from FinalizeAppend where
+// the part is the last one and S3 waives the minimum.
+func (s *S3BlobStore) flushPart(ctx context.Context, key string, st *s3AppendState, buf *bytes.Buffer) error {
+	// buf.Reset keeps the backing array, which the request body would still be
+	// aliasing, so the part gets its own copy.
+	data := make([]byte, buf.Len())
+	copy(data, buf.Bytes())
+	buf.Reset()
+
+	number := int32(len(st.Parts)) + 1 //nolint:gosec // part count is bounded by S3's 10k limit
+	out, err := s.client.UploadPart(ctx, &s3.UploadPartInput{
+		Bucket:        aws.String(s.bucket),
+		Key:           aws.String(s.objectKey(key)),
+		UploadId:      aws.String(st.UploadID),
+		PartNumber:    aws.Int32(number),
+		Body:          bytes.NewReader(data),
+		ContentLength: aws.Int64(int64(len(data))),
+	})
+	if err != nil {
+		return fmt.Errorf("s3 upload part %d of %s: %w", number, key, err)
+	}
+	st.Parts = append(st.Parts, s3AppendPart{
+		Number: number, ETag: aws.ToString(out.ETag), Size: int64(len(data)),
+	})
+	st.Uploaded += int64(len(data))
+	return nil
+}
+
+// TruncateBlob discards staged bytes past size.
+//
+// Known limitation: only the pending tail can be discarded. Bytes already
+// uploaded as a part are immutable, and rolling back past one would mean
+// aborting the whole multipart upload — throwing away every part, not just the
+// last. That is only reachable when the byte crossing a caller's size cap also
+// crosses a 5 MiB part boundary in the same append, so this fails loudly rather
+// than quietly dropping data the caller expected to keep.
+func (s *S3BlobStore) TruncateBlob(ctx context.Context, key string, size int64) error {
+	st, err := s.loadAppendState(ctx, key)
+	if errors.Is(err, errNoAppendSession) {
+		return fmt.Errorf("s3 truncate %s: %w", key, err)
+	}
+	if err != nil {
+		return err
+	}
+	if size > st.staged() {
+		return fmt.Errorf("s3 truncate %s: %d is past the %d bytes staged", key, size, st.staged())
+	}
+	if size < st.Uploaded {
+		return fmt.Errorf("s3 truncate %s: %d bytes are already committed as multipart parts "+
+			"and cannot be rolled back without discarding the whole upload", key, st.Uploaded)
+	}
+	st.Pending = st.Pending[:size-st.Uploaded]
+	return s.saveAppendState(ctx, key, st)
+}
+
+// AppendedSize reports the bytes staged for key. An in-progress multipart
+// upload is invisible at the key itself — HeadObject would keep answering with
+// the empty object the session started from — so the session state answers
+// whenever there is one.
+func (s *S3BlobStore) AppendedSize(ctx context.Context, key string) (int64, bool, error) {
+	st, err := s.loadAppendState(ctx, key)
+	if err == nil {
+		return st.staged(), true, nil
+	}
+	if !errors.Is(err, errNoAppendSession) {
+		return 0, false, err
+	}
+	exists, err := s.Exists(ctx, key)
+	if err != nil || !exists {
+		return 0, false, err
+	}
+	size, err := s.Size(ctx, key)
+	if err != nil {
+		return 0, false, err
+	}
+	return size, true, nil
+}
+
+// FinalizeAppend publishes the appended bytes at key. The pending tail goes up
+// as the final part, where S3 waives the 5 MiB minimum.
+func (s *S3BlobStore) FinalizeAppend(ctx context.Context, key string) error {
+	st, err := s.loadAppendState(ctx, key)
+	if errors.Is(err, errNoAppendSession) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if len(st.Pending) > 0 {
+		buf := bytes.NewBuffer(st.Pending)
+		if err := s.flushPart(ctx, key, st, buf); err != nil {
+			return err
+		}
+		st.Pending = nil
+	}
+	if len(st.Parts) == 0 {
+		// Nothing was ever appended. CompleteMultipartUpload rejects an empty
+		// part list, so the session is dropped and the empty object written
+		// directly — the result a zero-byte blob must have either way.
+		if err := s.abortMultipart(ctx, key, st.UploadID); err != nil {
+			return err
+		}
+		if err := s.Put(ctx, key, bytes.NewReader(nil), 0); err != nil {
+			return err
+		}
+		return s.deleteAppendState(ctx, key)
+	}
+
+	parts := make([]types.CompletedPart, 0, len(st.Parts))
+	for _, p := range st.Parts {
+		parts = append(parts, types.CompletedPart{
+			PartNumber: aws.Int32(p.Number),
+			ETag:       aws.String(p.ETag),
+		})
+	}
+	if _, err := s.client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+		Bucket:          aws.String(s.bucket),
+		Key:             aws.String(s.objectKey(key)),
+		UploadId:        aws.String(st.UploadID),
+		MultipartUpload: &types.CompletedMultipartUpload{Parts: parts},
+	}); err != nil {
+		return fmt.Errorf("s3 complete multipart upload %s: %w", key, err)
+	}
+	return s.deleteAppendState(ctx, key)
+}
+
+// AbortAppend drops an unfinished append. This is not merely tidiness: parts of
+// an abandoned multipart upload stay billable in the bucket indefinitely, and
+// nothing else reclaims them — they are invisible to ListObjects, so the blob
+// GC sweep cannot see them either.
+func (s *S3BlobStore) AbortAppend(ctx context.Context, key string) error {
+	st, err := s.loadAppendState(ctx, key)
+	if errors.Is(err, errNoAppendSession) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if err := s.abortMultipart(ctx, key, st.UploadID); err != nil {
+		return err
+	}
+	return s.deleteAppendState(ctx, key)
+}
+
+func (s *S3BlobStore) abortMultipart(ctx context.Context, key, uploadID string) error {
+	_, err := s.client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+		Bucket:   aws.String(s.bucket),
+		Key:      aws.String(s.objectKey(key)),
+		UploadId: aws.String(uploadID),
+	})
+	if err != nil && !isNotFound(err) {
+		return fmt.Errorf("s3 abort multipart upload %s: %w", key, err)
+	}
+	return nil
+}
+
+// errNoAppendSession reports that a key has no append in progress. Every entry
+// point treats that as a normal state — an idle key, a finished session, a
+// second finalize — not a failure.
+var errNoAppendSession = errors.New("no append session")
+
+// loadAppendState returns the session for key, or errNoAppendSession.
+func (s *S3BlobStore) loadAppendState(ctx context.Context, key string) (*s3AppendState, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(s.appendMetaKey(key)),
+	})
+	if err != nil {
+		if isNotFound(err) {
+			return nil, errNoAppendSession
+		}
+		return nil, fmt.Errorf("s3 read append state %s: %w", key, err)
+	}
+	defer func() { _ = out.Body.Close() }()
+	var st s3AppendState
+	if err := json.NewDecoder(out.Body).Decode(&st); err != nil {
+		return nil, fmt.Errorf("s3 decode append state %s: %w", key, err)
+	}
+	return &st, nil
+}
+
+func (s *S3BlobStore) saveAppendState(ctx context.Context, key string, st *s3AppendState) error {
+	body, err := json.Marshal(st)
+	if err != nil {
+		return fmt.Errorf("s3 encode append state %s: %w", key, err)
+	}
+	if _, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(s.bucket),
+		Key:           aws.String(s.appendMetaKey(key)),
+		Body:          bytes.NewReader(body),
+		ContentLength: aws.Int64(int64(len(body))),
+	}); err != nil {
+		return fmt.Errorf("s3 write append state %s: %w", key, err)
+	}
+	return nil
+}
+
+func (s *S3BlobStore) deleteAppendState(ctx context.Context, key string) error {
+	if _, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(s.appendMetaKey(key)),
+	}); err != nil && !isNotFound(err) {
+		return fmt.Errorf("s3 delete append state %s: %w", key, err)
+	}
+	return nil
+}
+
+// isAppendMetaObject reports whether an object key is append bookkeeping rather
+// than a blob. Listings hide those: counted as blobs they would inflate usage
+// and, worse, offer GC an "orphan" whose deletion would strand the multipart
+// parts it is the only record of.
+func isAppendMetaObject(objectKey string) bool {
+	return strings.HasSuffix(objectKey, s3AppendMetaSuffix)
+}

--- a/internal/storage/s3_append_integration_test.go
+++ b/internal/storage/s3_append_integration_test.go
@@ -1,0 +1,300 @@
+//go:build integration
+
+package storage_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/storage"
+)
+
+// s3Appendable pins the compile-time contract and gives the tests the
+// extension's view of the store.
+func s3Appendable(t *testing.T, bs *storage.S3BlobStore) storage.AppendableBlobStore {
+	t.Helper()
+	as, ok := interface{}(bs).(storage.AppendableBlobStore)
+	require.True(t, ok, "S3BlobStore must implement AppendableBlobStore")
+	return as
+}
+
+func s3Content(t *testing.T, bs *storage.S3BlobStore, key string) []byte {
+	t.Helper()
+	rc, _, err := bs.Get(context.Background(), key)
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	return data
+}
+
+func TestS3BlobStore_AppendBlob_SmallChunkRoundtrip(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap01aaaa11112222"
+
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("hello append")))
+	require.NoError(t, err)
+	assert.EqualValues(t, 12, total)
+
+	// Below the part minimum nothing has been uploaded yet, so the object still
+	// has to answer for the staged bytes through AppendedSize.
+	size, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.EqualValues(t, 12, size)
+
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	assert.Equal(t, "hello append", string(s3Content(t, bs, key)))
+}
+
+func TestS3BlobStore_AppendBlob_AccumulatesAcrossCalls(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap02bbbb11112222"
+
+	var want string
+	for _, chunk := range []string{"alpha", "-beta", "-gamma"} {
+		want += chunk
+		total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte(chunk)))
+		require.NoError(t, err)
+		assert.EqualValues(t, len(want), total)
+	}
+
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	assert.Equal(t, want, string(s3Content(t, bs, key)))
+}
+
+// The part minimum is where an S3 append differs from a local one: bytes cross
+// from the pending tail into a real uploaded part mid-session, and the blob must
+// still reassemble byte for byte in the order it was appended.
+func TestS3BlobStore_AppendBlob_CrossesPartBoundary(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap03cccc11112222"
+
+	const mib = 1024 * 1024
+	first := bytes.Repeat([]byte("A"), 3*mib)
+	second := bytes.Repeat([]byte("B"), 3*mib) // pushes the session past 5 MiB
+	third := bytes.Repeat([]byte("C"), mib)
+
+	for _, seg := range [][]byte{first, second, third} {
+		_, err := as.AppendBlob(ctx, key, bytes.NewReader(seg))
+		require.NoError(t, err)
+	}
+	staged, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.EqualValues(t, 7*mib, staged)
+
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+
+	got := s3Content(t, bs, key)
+	require.Len(t, got, 7*mib)
+	assert.True(t, bytes.Equal(first, got[:3*mib]), "first segment corrupted")
+	assert.True(t, bytes.Equal(second, got[3*mib:6*mib]), "second segment corrupted")
+	assert.True(t, bytes.Equal(third, got[6*mib:]), "third segment corrupted")
+}
+
+func TestS3BlobStore_TruncateBlob_ShrinksPendingTail(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap04dddd11112222"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("keep-drop")))
+	require.NoError(t, err)
+	require.NoError(t, as.TruncateBlob(ctx, key, 4))
+
+	staged, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.EqualValues(t, 4, staged)
+
+	// The session must stay usable: a rejected chunk costs it nothing.
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("-more")))
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, total)
+
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	assert.Equal(t, "keep-more", string(s3Content(t, bs, key)))
+}
+
+// Rolling back past an uploaded part would mean discarding the whole multipart
+// upload, so it fails loudly instead of quietly dropping committed data.
+func TestS3BlobStore_TruncateBlob_PastCompletedPart_Errors(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap05eeee11112222"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader(bytes.Repeat([]byte("x"), 6*1024*1024)))
+	require.NoError(t, err)
+
+	err = as.TruncateBlob(ctx, key, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already committed")
+
+	require.NoError(t, as.AbortAppend(ctx, key))
+}
+
+func TestS3BlobStore_TruncateBlob_PastStaged_Errors(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap06ffff11112222"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("short")))
+	require.NoError(t, err)
+	require.Error(t, as.TruncateBlob(ctx, key, 99))
+	require.NoError(t, as.AbortAppend(ctx, key))
+}
+
+func TestS3BlobStore_FinalizeAppend_NoSessionAndIdempotent(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap07000011112222"
+
+	// No session at all: finalizing must be a no-op, not an error.
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("once")))
+	require.NoError(t, err)
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	// A client re-sending the finalizing PUT must not corrupt the blob.
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	assert.Equal(t, "once", string(s3Content(t, bs, key)))
+}
+
+// An abandoned session must really release its multipart upload: parts that
+// outlive it stay billable and no listing — so no GC sweep — can see them.
+func TestS3BlobStore_AbortAppend_ReleasesSession(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap08111122223333"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("abandoned")))
+	require.NoError(t, err)
+	require.NoError(t, as.AbortAppend(ctx, key))
+	require.NoError(t, as.AbortAppend(ctx, key), "abort must be idempotent")
+
+	_, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	assert.False(t, ok, "an aborted session must leave nothing staged")
+
+	// A later append starts a brand new session rather than resuming the
+	// aborted one.
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("fresh")))
+	require.NoError(t, err)
+	assert.EqualValues(t, 5, total)
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	assert.Equal(t, "fresh", string(s3Content(t, bs, key)))
+}
+
+// Appending must extend what the key already holds, exactly as it does on local
+// disk — a completed multipart upload replaces the object wholesale, so the
+// existing bytes have to be carried into the new upload.
+func TestS3BlobStore_AppendBlob_ExtendsExistingObject(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap09222233334444"
+
+	require.NoError(t, bs.Put(ctx, key, bytes.NewReader([]byte("head-")), 5))
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("tail")))
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, total)
+
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	assert.Equal(t, "head-tail", string(s3Content(t, bs, key)))
+}
+
+// The same carry-over for an object too big to become a pending tail: it is
+// copied server-side into the upload as its first part.
+func TestS3BlobStore_AppendBlob_ExtendsLargeExistingObject(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap10333344445555"
+
+	head := bytes.Repeat([]byte("H"), 6*1024*1024)
+	require.NoError(t, bs.Put(ctx, key, bytes.NewReader(head), int64(len(head))))
+
+	total, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("tail")))
+	require.NoError(t, err)
+	assert.EqualValues(t, len(head)+4, total)
+
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+	got := s3Content(t, bs, key)
+	require.Len(t, got, len(head)+4)
+	assert.True(t, bytes.Equal(head, got[:len(head)]), "carried-over bytes corrupted")
+	assert.Equal(t, "tail", string(got[len(head):]))
+}
+
+// A session that never received a byte still has to finalize into a real
+// zero-byte object: S3 rejects completing an upload with no parts.
+func TestS3BlobStore_FinalizeAppend_EmptySession(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap11444455556666"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader(nil))
+	require.NoError(t, err)
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+
+	size, err := bs.Size(ctx, key)
+	require.NoError(t, err)
+	assert.Zero(t, size)
+}
+
+// Session bookkeeping is not blob content: listing it would inflate usage and
+// hand GC an "orphan" whose deletion strands the parts it is the only record of.
+func TestS3BlobStore_AppendState_HiddenFromListings(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap12555566667777"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("staged")))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = as.AbortAppend(ctx, key) })
+
+	keys, err := bs.ListKeys(ctx)
+	require.NoError(t, err)
+	for _, k := range keys {
+		assert.NotContains(t, k, ".append-meta", "append bookkeeping must not list as a blob")
+	}
+	entries, err := bs.ListEntries(ctx)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Key, ".append-meta", "append bookkeeping must not list as a blob")
+	}
+}
+
+// Deleting a key mid-session is how GC collects an abandoned upload, and it has
+// to take the multipart upload with it.
+func TestS3BlobStore_Delete_AbortsInFlightAppend(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap13666677778888"
+
+	_, err := as.AppendBlob(ctx, key, bytes.NewReader([]byte("in flight")))
+	require.NoError(t, err)
+	require.NoError(t, bs.Delete(ctx, key))
+
+	_, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	assert.False(t, ok, "delete must leave no append session behind")
+}


### PR DESCRIPTION
Follow-up to #214 (#219), which added `AppendableBlobStore` and implemented it for `LocalBlobStore`. `S3BlobStore` needed a materially different implementation — real multipart upload work, not a different `Put` call — which is why it was flagged separately.

**The complication.** S3 parts have a 5 MiB minimum, waived only for the last one, while a Docker client may PATCH chunks of any size. `AppendBlob` keeps a sub-5 MiB tail and only calls `UploadPart` once it is large enough, persisting `{upload id, completed parts (number + ETag), pending tail}` as a small JSON side-object at `<object key>.append-meta`. That state is proportional to the part count plus one buffer, never to the blob, so a push survives moving between instances or a process restart exactly as it does on local disk (#104). Memory stays bounded at ~5 MiB regardless of how large a single PATCH is: the incoming reader is consumed through a fixed window.

`FinalizeAppend` flushes the remaining tail as the *final* part and calls `CompleteMultipartUpload`. Why `AppendedSize` exists rather than teaching `Size` to see progress: `create()`'s initial `Put` already wrote a real empty object at the key, and multipart progress is invisible there via `HeadObject`/`GetObject` until the upload completes — `Size(key)` would report a stuck `0` for the whole session.

**Leaks.** `AbortAppend` calls `AbortMultipartUpload`, which matters more than it sounds: an abandoned session's already-uploaded parts stay billable in S3 indefinitely outside a lifecycle rule, and being invisible to `ListObjects` they are invisible to the blob GC sweep too. `Delete` therefore aborts any live session for the key first — that is the path GC takes when it collects an abandoned upload, and without it the collection would strand the parts.

Session bookkeeping is hidden from `ListKeys` / `ListEntries` / `UsedBytes`. Counted as a blob it would inflate reported usage and, worse, hand GC an "orphan" whose deletion strands the very parts it is the only record of.

**Extending, not replacing.** Starting an append seeds the upload from whatever the key already holds — server-side `UploadPartCopy` above the part minimum, a read into the pending tail below it — so `AppendBlob` extends the blob exactly as it does on local disk. Without the seed, completing the upload would silently replace bytes a previous session had published there (reachable when a client keeps pushing after a digest-mismatched PUT, which #194 deliberately keeps the session alive for).

**Known limitation, documented rather than solved.** Once bytes are flushed as a completed part they are immutable, so `TruncateBlob` can only discard what is still pending. Rolling back past a completed part would mean aborting the *whole* upload, losing every part rather than the last one — so it fails loudly instead of quietly discarding legitimately uploaded data. Only reachable when the exact byte crossing a caller's size cap also crosses a 5 MiB part boundary in the same `AppendBlob` call.

## Tests

`internal/storage/s3_append_integration_test.go`, against a real MinIO container (`dockertest`, the pattern the pre-existing `s3_integration_test.go` already uses):

- single sub-5 MiB chunk round-trip, and accumulation across calls
- **crossing a real 5 MiB part boundary across three `AppendBlob` calls, with byte-for-byte verification of all three segments after reassembly**
- `TruncateBlob` shrinking the pending tail and the session staying usable afterwards; truncating past a completed part, and past what is staged, both erroring
- `FinalizeAppend` as a no-op with no session, and idempotent on a second call — a client re-sending the finalizing PUT must not corrupt the blob
- `AbortAppend` actually releasing the upload: a fresh `AppendBlob` afterwards starts a new session rather than resuming the aborted one
- appending onto an existing object, both below the part minimum (read into the tail) and above it (server-side copy), verified byte for byte
- a session that never received a byte finalizing into a real zero-byte object
- bookkeeping absent from both listings, and `Delete` aborting an in-flight append

13 new tests plus the 13 pre-existing S3 integration tests green (26/26). `go build ./...`, `go vet ./...`, `golangci-lint run ./...`, `go test ./...` and `go test -tags integration ./internal/storage/...` all green.

Closes #216