### PR TITLE
fix(distlock): release the lock only while this holder still owns it

### DIFF
--- a/internal/distlock/redis.go
+++ b/internal/distlock/redis.go
@@ -12,6 +12,9 @@ import (
 type RedisBackend interface {
 	SetNX(ctx context.Context, key, value string, ttl time.Duration) (bool, error)
 	Del(ctx context.Context, key string) error
+	// DelIfMatch deletes key only while it still holds value, reporting whether
+	// it did. It must be atomic on the Redis side.
+	DelIfMatch(ctx context.Context, key, value string) (bool, error)
 }
 
 // RedisLocker implements Locker using Redis SetNX for mutual exclusion across nodes.
@@ -34,16 +37,21 @@ func (l *RedisLocker) Acquire(ctx context.Context, key string, ttl time.Duration
 	if !ok {
 		return nil, ErrLockHeld
 	}
-	return &redisLock{rdb: l.rdb, key: key}, nil
+	return &redisLock{rdb: l.rdb, key: key, token: token}, nil
 }
 
 type redisLock struct {
-	rdb RedisBackend
-	key string
+	rdb   RedisBackend
+	key   string
+	token string
 }
 
+// Release drops the lock only if this holder still owns it. A holder whose TTL
+// expired mid-run must not delete the key another node has legitimately taken
+// since — deleting it unconditionally would let a third node in while that
+// second run is still going.
 func (l *redisLock) Release(ctx context.Context) error {
-	if err := l.rdb.Del(ctx, l.key); err != nil {
+	if _, err := l.rdb.DelIfMatch(ctx, l.key, l.token); err != nil {
 		return fmt.Errorf("distlock release %q: %w", l.key, err)
 	}
 	return nil

--- a/internal/distlock/redis_test.go
+++ b/internal/distlock/redis_test.go
@@ -10,9 +10,10 @@ import (
 )
 
 type stubRedis struct {
-	keys   map[string]string
-	setNXf func(key string) (bool, error)
-	delf   func(key string) error
+	keys      map[string]string
+	setNXf    func(key string) (bool, error)
+	delf      func(key string) error
+	delMatchf func(key, value string) (bool, error)
 }
 
 func newStubRedis() *stubRedis {
@@ -36,6 +37,19 @@ func (s *stubRedis) Del(_ context.Context, key string) error {
 	}
 	delete(s.keys, key)
 	return nil
+}
+
+// DelIfMatch models the Redis-side compare-and-delete: the key is removed only
+// while it still holds the exact value the caller wrote.
+func (s *stubRedis) DelIfMatch(_ context.Context, key, value string) (bool, error) {
+	if s.delMatchf != nil {
+		return s.delMatchf(key, value)
+	}
+	if cur, exists := s.keys[key]; !exists || cur != value {
+		return false, nil
+	}
+	delete(s.keys, key)
+	return true, nil
 }
 
 func TestRedisLocker_AcquireRelease(t *testing.T) {
@@ -68,9 +82,38 @@ func TestRedisLocker_AlreadyLocked(t *testing.T) {
 	}
 }
 
+// A holder whose TTL expired must not delete the lock a second node has since
+// taken: Release is a compare-and-delete against the token Acquire wrote.
+func TestRedisLocker_ReleaseAfterExpiryKeepsNewHoldersLock(t *testing.T) {
+	const key = "nexspence:lock:expired"
+	stub := newStubRedis()
+	l := distlock.NewRedisLocker(stub)
+
+	stale, err := l.Acquire(context.Background(), key, time.Minute)
+	if err != nil {
+		t.Fatalf("first Acquire: %v", err)
+	}
+
+	// The TTL runs out while the first holder is still working; a second node
+	// legitimately takes the lock for its own run.
+	delete(stub.keys, key)
+	if _, err := l.Acquire(context.Background(), key, time.Minute); err != nil {
+		t.Fatalf("second Acquire: %v", err)
+	}
+	newToken := stub.keys[key]
+
+	if err := stale.Release(context.Background()); err != nil {
+		t.Fatalf("stale Release: %v", err)
+	}
+
+	if got := stub.keys[key]; got != newToken {
+		t.Fatalf("stale Release clobbered the new holder's lock: key = %q, want %q", got, newToken)
+	}
+}
+
 func TestRedisLocker_ReleaseError(t *testing.T) {
 	stub := newStubRedis()
-	stub.delf = func(key string) error { return errors.New("redis down") }
+	stub.delMatchf = func(string, string) (bool, error) { return false, errors.New("redis down") }
 	l := distlock.NewRedisLocker(stub)
 
 	lock, err := l.Acquire(context.Background(), "nexspence:lock:x", time.Minute)

--- a/internal/redisclient/client.go
+++ b/internal/redisclient/client.go
@@ -52,6 +52,27 @@ func (c *Client) Del(ctx context.Context, key string) error {
 	return c.rdb.Del(ctx, key).Err()
 }
 
+// delIfMatchScript is the classic Redlock compare-and-delete: a lock holder may
+// only drop the key while it still carries that holder's own token.
+var delIfMatchScript = redis.NewScript(`
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+	return redis.call("DEL", KEYS[1])
+else
+	return 0
+end
+`)
+
+// DelIfMatch atomically deletes key only if it currently holds value.
+// Returns true if the key was deleted, false if it was missing or held a
+// different value.
+func (c *Client) DelIfMatch(ctx context.Context, key, value string) (bool, error) {
+	n, err := delIfMatchScript.Run(ctx, c.rdb, []string{key}, value).Int64()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}
+
 // Ping checks connectivity to Redis.
 func (c *Client) Ping(ctx context.Context) error {
 	return c.rdb.Ping(ctx).Err()


### PR DESCRIPTION
## Problem

`RedisLocker.Acquire` generated a per-acquisition UUID token and stored it as the Redis value, but `redisLock.Release` never read it back — it called `Del` unconditionally. The token was written once and never referenced again.

If an operation outlives its own TTL (a slow cleanup pass, a blob-store migration near its 2h budget), Redis expires the key, a second node legitimately acquires it, and then the *original* holder's deferred `Release` deletes the lock that now belongs to the second node's in-flight run — letting a third node in on top of it.

## Fix

- `redisLock` now carries the acquisition token, and `Release` is a compare-and-delete via a new `DelIfMatch(ctx, key, value)` on the Redis backend.
- `redisclient.Client.DelIfMatch` implements it with the classic Redlock Lua script (`GET`-compare then `DEL`) through go-redis's `redis.NewScript`, so the compare and the delete are atomic on the Redis side.
- A missing key or a foreign token is a no-op, not an error — releasing a lock you already lost stays safe for every `defer lock.Release(ctx)` caller.

## Tests

- New `TestRedisLocker_ReleaseAfterExpiryKeepsNewHoldersLock` reproduces the race exactly: first holder acquires, TTL expires, a second node acquires, then the stale holder releases — asserting the second holder's key survives. Confirmed it fails against the old unconditional `Del` and passes with the fix.
- Also verified the real Lua script against a live Redis 7 container (not just the Go-level stub): matching token deletes, mismatched token leaves the key untouched, missing key returns false with no error.
- `go build`, `go vet`, `go test ./...`, `golangci-lint` green.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnt5RyqWXYVfrphjEWQhri