### PR TITLE
fix(cleanup): run every scheduled policy under the distributed lock

### DIFF
--- a/docs/ha-setup.md
+++ b/docs/ha-setup.md
@@ -74,7 +74,7 @@ readinessProbe:
 | Feature | Redis key | TTL |
 |---|---|---|
 | Docker anon-check cache | `nexspence:docker:anon_allowed` | 30s |
-| Cleanup lock | `nexspence:lock:cleanup:run` | 30 min |
+| Cleanup lock (per policy) | `nexspence:lock:cleanup:policy:<policy id>` | 30 min |
 | Blob migration lock | `nexspence:lock:blobmig:<repo>` | 2 hours |
 
 ## Docker Blob Uploads

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -153,7 +153,7 @@ func (s *CleanupService) addEntryLocked(p domain.CleanupPolicy) {
 	}
 
 	job := func() {
-		if _, err := s.runPolicy(context.Background(), p); err != nil {
+		if _, err := s.runPolicyLocked(context.Background(), p); err != nil {
 			s.log.Error("cleanup cron error", "policy", p.Name, "err", err)
 		}
 	}
@@ -167,23 +167,41 @@ func (s *CleanupService) addEntryLocked(p domain.CleanupPolicy) {
 	s.entryIDs[p.ID] = id
 }
 
-const cleanupLockKey = "nexspence:lock:cleanup:run"
+const cleanupPolicyLockPrefix = "nexspence:lock:cleanup:policy:"
 const cleanupLockTTL = 30 * time.Minute
+
+// errAcquireLock marks a failure to reach the lock backend, as opposed to a
+// policy that simply failed to run. Without the lock there is no exclusion, so
+// callers stop instead of running unprotected.
+var errAcquireLock = errors.New("cleanup: acquire lock")
+
+// runPolicyLocked runs p while holding its own distributed lock. Every path that
+// runs a policy — the cron schedule, a manual single-policy run, RunAll — goes
+// through here, so nodes in an HA deployment never run the same policy at once.
+// The lock is per policy, so unrelated policies still run in parallel.
+func (s *CleanupService) runPolicyLocked(ctx context.Context, p domain.CleanupPolicy) (*domain.CleanupRunResult, error) {
+	if s.locker == nil {
+		return s.runPolicy(ctx, p)
+	}
+
+	lock, err := s.locker.Acquire(ctx, cleanupPolicyLockPrefix+p.ID, cleanupLockTTL)
+	if errors.Is(err, distlock.ErrLockHeld) {
+		const reason = "another node is already running this policy"
+		s.log.Info("cleanup skipped: "+reason, "policy", p.Name)
+		return &domain.CleanupRunResult{
+			PolicyID: p.ID, DryRun: p.DryRun, Skipped: true, SkippedReason: reason,
+		}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w for policy %q: %w", errAcquireLock, p.Name, err)
+	}
+	defer func() { _ = lock.Release(ctx) }()
+
+	return s.runPolicy(ctx, p)
+}
 
 // RunAll executes all enabled cleanup policies once and returns a summary.
 func (s *CleanupService) RunAll(ctx context.Context) error {
-	if s.locker != nil {
-		lock, err := s.locker.Acquire(ctx, cleanupLockKey, cleanupLockTTL)
-		if errors.Is(err, distlock.ErrLockHeld) {
-			s.log.Info("cleanup skipped: another node is running cleanup")
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("cleanup: acquire lock: %w", err)
-		}
-		defer func() { _ = lock.Release(ctx) }()
-	}
-
 	policies, err := s.policies.List(ctx)
 	if err != nil {
 		return fmt.Errorf("cleanup: list policies: %w", err)
@@ -192,7 +210,10 @@ func (s *CleanupService) RunAll(ctx context.Context) error {
 		if !p.Enabled {
 			continue
 		}
-		if _, err := s.runPolicy(ctx, p); err != nil {
+		if _, err := s.runPolicyLocked(ctx, p); err != nil {
+			if errors.Is(err, errAcquireLock) {
+				return err
+			}
 			s.log.Error("cleanup policy failed", "policy", p.Name, "err", err)
 		}
 	}
@@ -217,7 +238,7 @@ func (s *CleanupService) RunPolicyResult(ctx context.Context, id string) (*domai
 	if p == nil {
 		return nil, fmt.Errorf("cleanup policy %q not found", id)
 	}
-	return s.runPolicy(ctx, *p)
+	return s.runPolicyLocked(ctx, *p)
 }
 
 func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) (*domain.CleanupRunResult, error) {

--- a/internal/service/cleanup_service_extra_test.go
+++ b/internal/service/cleanup_service_extra_test.go
@@ -200,8 +200,14 @@ func TestExtraCleanup_RunAll_LockerHeld_Skips(t *testing.T) {
 }
 
 func TestExtraCleanup_RunAll_LockerAcquireError_ReturnsError(t *testing.T) {
+	// A policy has to exist for RunAll to reach the lock at all: the lock is
+	// taken per policy, not once per batch.
+	p := &domain.CleanupPolicy{
+		ID: "p-lockerr", Name: "lockerr", Enabled: true, Format: "*",
+		Criteria: map[string]any{"artifactAgeDays": float64(1)},
+	}
 	svc := service.NewCleanupService(
-		testutil.NewCleanupPolicyRepo(),
+		testutil.NewCleanupPolicyRepo(p),
 		testutil.NewRepoRepo(),
 		testutil.NewAssetRepo(),
 		testutil.NewBlobStoreRepo(),

--- a/internal/service/cleanup_service_test.go
+++ b/internal/service/cleanup_service_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
+	"github.com/nexspence-oss/nexspence/internal/distlock"
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
@@ -577,4 +579,145 @@ func TestRunPolicy_LastAssetOnBlob_FreesBytesAndUsage(t *testing.T) {
 	got, err := blobRepo.Get(ctx, "default")
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), got.UsedBytes)
+}
+
+// ── Distributed locking on the scheduled path ────────────────
+
+// The cron schedule is the path cleanup actually runs on in production. It must
+// take the same distributed lock the admin "run all now" path does, or every
+// node in an HA deployment runs every policy concurrently.
+func TestCronSchedule_TakesTheDistributedLock(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 100, Path: "/foo.jar"}}
+
+	blobs := testutil.NewBlobStore()
+	require.NoError(t, blobs.Put(ctx, "bk1", testutil.MakeReader("data1"), 5))
+
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "p-cron", Name: "cron-policy", Enabled: true, Format: "*",
+		ScheduleCron: "@every 50ms",
+		Criteria:     map[string]any{"artifactAgeDays": float64(1)},
+	})
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "r", ID: "r1", Format: domain.FormatRaw, CleanupPolicyIDs: []string{"p-cron"},
+	})
+
+	lk := &lockRecorder{err: distlock.ErrLockHeld} // another node owns the lock
+	svc := service.NewCleanupService(policies, repos, assets, testutil.NewBlobStoreRepo(), blobs, nopLog())
+	svc.WithLocker(lk)
+
+	go svc.StartCronScheduler(ctx, "@every 50ms")
+
+	require.Eventually(t, func() bool { return len(lk.acquired()) > 0 }, 2*time.Second, 10*time.Millisecond,
+		"the scheduled run never went through the distributed lock")
+	cancel()
+
+	assert.Equal(t, "nexspence:lock:cleanup:policy:p-cron", lk.acquired()[0])
+	assert.Empty(t, blobs.Deleted, "nothing is deleted while another node holds the lock")
+	assert.Empty(t, policies.RunRecords, "and no run is recorded that never happened")
+}
+
+// The manual single-policy run takes the same lock.
+func TestRunPolicyResult_LockHeldByAnotherNode_SkipsWithReason(t *testing.T) {
+	ctx := context.Background()
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", BlobKey: "bk1", SizeBytes: 100, Path: "/foo.jar"}}
+
+	blobs := testutil.NewBlobStore()
+	require.NoError(t, blobs.Put(ctx, "bk1", testutil.MakeReader("data1"), 5))
+
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "p-manual", Name: "manual-policy", Enabled: true, Format: "*",
+		Criteria: map[string]any{"artifactAgeDays": float64(1)},
+	})
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "r", ID: "r1", Format: domain.FormatRaw, CleanupPolicyIDs: []string{"p-manual"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, testutil.NewBlobStoreRepo(), blobs, nopLog())
+	svc.WithLocker(testutil.NewHeldLocker())
+
+	res, err := svc.RunPolicyResult(ctx, "p-manual")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.Skipped, "the caller is told the run was skipped, not that it succeeded")
+	assert.NotEmpty(t, res.SkippedReason)
+	assert.Empty(t, blobs.Deleted)
+}
+
+// Policies lock independently, so one policy running on another node does not
+// serialize unrelated policies here.
+func TestCleanupLock_IsScopedPerPolicy(t *testing.T) {
+	ctx := context.Background()
+	assets := testutil.NewAssetRepo()
+	blobs := testutil.NewBlobStore()
+
+	policies := testutil.NewCleanupPolicyRepo(
+		&domain.CleanupPolicy{
+			ID: "p-one", Name: "one", Enabled: true, Format: "*",
+			Criteria: map[string]any{"artifactAgeDays": float64(1)},
+		},
+		&domain.CleanupPolicy{
+			ID: "p-two", Name: "two", Enabled: true, Format: "*",
+			Criteria: map[string]any{"artifactAgeDays": float64(1)},
+		},
+	)
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "r", ID: "r1", Format: domain.FormatRaw, CleanupPolicyIDs: []string{"p-one", "p-two"},
+	})
+
+	lk := &lockRecorder{}
+	svc := service.NewCleanupService(policies, repos, assets, testutil.NewBlobStoreRepo(), blobs, nopLog())
+	svc.WithLocker(lk)
+
+	require.NoError(t, svc.RunAll(ctx))
+
+	assert.Equal(t, []string{
+		"nexspence:lock:cleanup:policy:p-one",
+		"nexspence:lock:cleanup:policy:p-two",
+	}, lk.acquired())
+	assert.Equal(t, 2, lk.releases(), "each policy releases its own lock when it finishes")
+}
+
+// lockRecorder is a Locker that records the keys it was asked for. With err set
+// it fails every acquisition, standing in for a lock held elsewhere.
+type lockRecorder struct {
+	mu       sync.Mutex
+	err      error
+	keys     []string
+	released int
+}
+
+func (lk *lockRecorder) Acquire(_ context.Context, key string, _ time.Duration) (distlock.Lock, error) {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	lk.keys = append(lk.keys, key)
+	if lk.err != nil {
+		return nil, lk.err
+	}
+	return &recordedLock{owner: lk}, nil
+}
+
+func (lk *lockRecorder) acquired() []string {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	return append([]string(nil), lk.keys...)
+}
+
+func (lk *lockRecorder) releases() int {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	return lk.released
+}
+
+type recordedLock struct{ owner *lockRecorder }
+
+func (l *recordedLock) Release(context.Context) error {
+	l.owner.mu.Lock()
+	defer l.owner.mu.Unlock()
+	l.owner.released++
+	return nil
 }


### PR DESCRIPTION
## Problem

`RunAll` acquired `s.locker` before running policies — but `RunAll` is only reachable from the admin "run all policies now" endpoint. The cron job registered per policy (`addEntryLocked`), which is how cleanup actually runs in production, called `s.runPolicy` directly with no lock at all. So did the manual single-policy run (`RunPolicyResult`).

In an HA deployment sharing one Redis-backed lock, every node ran every scheduled policy concurrently: two nodes race the same blob's count-then-delete-then-decrement sequence and double-decrement the reported blob-store usage for one physical delete.

## Fix

- New `runPolicyLocked` is the single entry point for running a policy; the cron job, `RunPolicyResult` and `RunAll`'s loop all go through it.
- The lock is scoped per policy — `nexspence:lock:cleanup:policy:<id>`, same 30-minute TTL — replacing `RunAll`'s whole-batch lock, so unrelated policies on different nodes no longer serialize against each other.
- A policy already running on another node comes back as a `Skipped` result with a reason, so the manual-run endpoint reports "skipped" instead of a success that deleted nothing.
- If the lock backend itself is unreachable there is no exclusion to rely on, so `RunAll` aborts the batch with the error instead of running unprotected (unchanged from the old whole-batch behavior).
- `docs/ha-setup.md`'s Redis-key table updated to the per-policy key.

## Tests

- `TestCronSchedule_TakesTheDistributedLock` starts the real cron scheduler on a 50ms schedule with a locker that reports the lock held elsewhere, and asserts the scheduled run acquires the per-policy key and deletes nothing / records no run. Confirmed it fails against the old code (the cron path never touches the locker) and passes with the fix.
- `TestRunPolicyResult_LockHeldByAnotherNode_SkipsWithReason` covers the manual path.
- `TestCleanupLock_IsScopedPerPolicy` asserts two policies take two distinct per-policy locks and release each.
- Existing locker-branch tests updated to the per-policy semantics.
- `go build`, `go vet`, `go test ./...`, `golangci-lint` green; `internal/service` coverage 81.6%.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnt5RyqWXYVfrphjEWQhri