### PR TITLE
chore(ci): build and scan with Go 1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
       - name: Install golangci-lint (pinned, via Go proxy)
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
       - name: Enforce per-package ≥80% floor
         run: |
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
       - name: Run postgres integration tests with coverage
         run: |

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest


### PR DESCRIPTION
## Problem

The blocking `govulncheck` job fails on every PR right now — not because of any change in them. Six standard-library advisories fixed in **go1.26.6** are reachable from our code while CI still pins **go1.26.5**:

- `GO-2026-5972` — `encoding/asn1` recursion depth, reached via `auth.loadOrGenerateKeyPair` → `x509.ParsePKCS8PrivateKey`
- `GO-2026-5026` — `golang.org/x/net/idna` punycode handling, reached via `net/http` (replication `TestConnection`, SAML IDP metadata fetch, S3 presign)
- plus four more in the same scan

## Fix

Bump the `setup-go` pin from `1.26.5` to `1.26.6` in `ci.yml` (all three jobs) and `govulncheck.yml`. `go.mod` keeps its `go 1.26.5` language line — the patched toolchain satisfies it — and the Docker build already tracks `golang:1.26-alpine`, so it picks the patch up on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnt5RyqWXYVfrphjEWQhri