### PR TITLE
fix(blobmig): close the lock lifecycle gaps in Start and ResumeAll

### DIFF
--- a/internal/distlock/lock.go
+++ b/internal/distlock/lock.go
@@ -12,6 +12,11 @@ var ErrLockHeld = errors.New("distlock: lock already held")
 // Locker acquires distributed locks identified by key.
 type Locker interface {
 	Acquire(ctx context.Context, key string, ttl time.Duration) (Lock, error)
+	// ForceRelease drops key whoever holds it. It exists for cleaning up after a
+	// holder that can no longer release its own lock — a node that crashed
+	// mid-run — where waiting out the TTL would block the work for hours. Every
+	// other caller releases through the Lock it acquired.
+	ForceRelease(ctx context.Context, key string) error
 }
 
 // Lock represents an acquired distributed lock that can be released.

--- a/internal/distlock/noop.go
+++ b/internal/distlock/noop.go
@@ -14,6 +14,9 @@ func (NoopLocker) Acquire(_ context.Context, _ string, _ time.Duration) (Lock, e
 	return noopLock{}, nil
 }
 
+// ForceRelease is a no-op: without coordination there is nothing to clear.
+func (NoopLocker) ForceRelease(_ context.Context, _ string) error { return nil }
+
 type noopLock struct{}
 
 func (noopLock) Release(_ context.Context) error { return nil }

--- a/internal/distlock/noop_test.go
+++ b/internal/distlock/noop_test.go
@@ -32,3 +32,10 @@ func TestNoopLocker_MultipleAcquireSameKey(t *testing.T) {
 	_ = lock1.Release(context.Background())
 	_ = lock2.Release(context.Background())
 }
+
+func TestNoopLocker_ForceRelease(t *testing.T) {
+	var l distlock.Locker = distlock.NoopLocker{}
+	if err := l.ForceRelease(context.Background(), "any-key"); err != nil {
+		t.Fatalf("ForceRelease: unexpected error: %v", err)
+	}
+}

--- a/internal/distlock/redis.go
+++ b/internal/distlock/redis.go
@@ -40,6 +40,15 @@ func (l *RedisLocker) Acquire(ctx context.Context, key string, ttl time.Duration
 	return &redisLock{rdb: l.rdb, key: key, token: token}, nil
 }
 
+// ForceRelease deletes the lock key regardless of who holds it, for cleaning up
+// after a holder that can no longer release it itself.
+func (l *RedisLocker) ForceRelease(ctx context.Context, key string) error {
+	if err := l.rdb.Del(ctx, key); err != nil {
+		return fmt.Errorf("distlock force release %q: %w", key, err)
+	}
+	return nil
+}
+
 type redisLock struct {
 	rdb   RedisBackend
 	key   string

--- a/internal/distlock/redis_test.go
+++ b/internal/distlock/redis_test.go
@@ -124,3 +124,34 @@ func TestRedisLocker_ReleaseError(t *testing.T) {
 		t.Fatal("want error from Release, got nil")
 	}
 }
+
+// ForceRelease exists for cleaning up after a holder that can no longer release
+// its own lock, so it drops the key whoever wrote it.
+func TestRedisLocker_ForceReleaseDropsAnotherHoldersKey(t *testing.T) {
+	const key = "nexspence:lock:crashed"
+	stub := newStubRedis()
+	stub.keys[key] = "token-from-a-dead-node"
+	l := distlock.NewRedisLocker(stub)
+
+	if err := l.ForceRelease(context.Background(), key); err != nil {
+		t.Fatalf("ForceRelease: %v", err)
+	}
+	if _, exists := stub.keys[key]; exists {
+		t.Fatal("key still held after ForceRelease")
+	}
+
+	// The lock is free for the next node to take.
+	if _, err := l.Acquire(context.Background(), key, time.Minute); err != nil {
+		t.Fatalf("Acquire after ForceRelease: %v", err)
+	}
+}
+
+func TestRedisLocker_ForceReleaseError(t *testing.T) {
+	stub := newStubRedis()
+	stub.delf = func(string) error { return errors.New("redis down") }
+	l := distlock.NewRedisLocker(stub)
+
+	if err := l.ForceRelease(context.Background(), "nexspence:lock:x"); err == nil {
+		t.Fatal("want error from ForceRelease, got nil")
+	}
+}

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -90,25 +90,14 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 		sourceStoreID = *repo.BlobStoreID
 	}
 
-	m := &domain.BlobStoreMigration{
-		RepositoryName: repoName,
-		SourceStoreID:  sourceStoreID,
-		TargetStoreID:  targetStoreID,
-		Status:         "pending",
-	}
-	if err := s.migrations.Create(ctx, m); err != nil {
-		return nil, fmt.Errorf("create migration record: %w", err)
-	}
-
-	migCtx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored in s.cancels and invoked via Cancel() or runMigration's defer on every exit path (no leak)
-	s.mu.Lock()
-	s.cancels[m.ID] = cancel
-	s.mu.Unlock()
-
+	// Take the lock before anything is recorded. runMigration is the only path
+	// that clears the migration row and the cancel func, and it never runs if
+	// the lock is lost — so a row created first would stay "pending" forever and
+	// wedge every later Start for this repo as "already running".
 	var migLock distlock.Lock
 	if s.locker != nil {
 		var lockErr error
-		migLock, lockErr = s.locker.Acquire(ctx, "nexspence:lock:blobmig:"+repoName, 2*time.Hour)
+		migLock, lockErr = s.locker.Acquire(ctx, blobMigLockKey(repoName), blobMigLockTTL)
 		if errors.Is(lockErr, distlock.ErrLockHeld) {
 			return nil, fmt.Errorf("blob store migration for %q is already running on another node", repoName)
 		}
@@ -117,9 +106,33 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 		}
 	}
 
+	m := &domain.BlobStoreMigration{
+		RepositoryName: repoName,
+		SourceStoreID:  sourceStoreID,
+		TargetStoreID:  targetStoreID,
+		Status:         "pending",
+	}
+	if err := s.migrations.Create(ctx, m); err != nil {
+		// Nothing will run, so hand the lock back now rather than leave the repo
+		// blocked for the rest of its TTL.
+		if migLock != nil {
+			_ = migLock.Release(ctx)
+		}
+		return nil, fmt.Errorf("create migration record: %w", err)
+	}
+
+	migCtx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored in s.cancels and invoked via Cancel() or runMigration's defer on every exit path (no leak)
+	s.mu.Lock()
+	s.cancels[m.ID] = cancel
+	s.mu.Unlock()
+
 	go s.runMigration(migCtx, m, migLock) //nolint:gosec // detached context is intentional: background migration must outlive the request
 	return m, nil
 }
+
+const blobMigLockTTL = 2 * time.Hour
+
+func blobMigLockKey(repoName string) string { return "nexspence:lock:blobmig:" + repoName }
 
 // Cancel signals the running migration goroutine to stop.
 func (s *BlobStoreMigrationService) Cancel(_ context.Context, migrationID string) error {
@@ -147,6 +160,12 @@ func (s *BlobStoreMigrationService) ResumeAll(ctx context.Context) error {
 	interrupted := "interrupted by server restart"
 	for _, m := range active {
 		_ = s.migrations.FinishMigration(ctx, m.ID, "cancelled", &interrupted) //nolint:misspell // API/DB status value consumed by frontend (status === 'cancelled')
+		// The process that took this lock died without releasing it, and only
+		// runMigration's deferred Release ever would. Clearing it here is what
+		// makes the migration restartable now instead of two hours from now.
+		if s.locker != nil {
+			_ = s.locker.ForceRelease(ctx, blobMigLockKey(m.RepositoryName))
+		}
 	}
 	return nil
 }

--- a/internal/service/blob_store_migration_service_extra_test.go
+++ b/internal/service/blob_store_migration_service_extra_test.go
@@ -2,12 +2,17 @@ package service_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/nexspence-oss/nexspence/internal/distlock"
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
@@ -99,4 +104,142 @@ func TestBlobStoreMigration_Start_TargetStoreNotFound(t *testing.T) {
 	require.NoError(t, repoRepo.Create(ctx, repoRec))
 	_, err := svc.Start(ctx, "repo-a", "nonexistent-store")
 	require.Error(t, err)
+}
+
+// ── Lock lifecycle ───────────────────────────────────────────
+
+// migLocker records the keys it was asked for and can fail every acquisition,
+// standing in for a lock held by another node.
+type migLocker struct {
+	mu       sync.Mutex
+	err      error
+	acquired []string
+	forced   []string
+	released int
+}
+
+func (lk *migLocker) Acquire(_ context.Context, key string, _ time.Duration) (distlock.Lock, error) {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	lk.acquired = append(lk.acquired, key)
+	if lk.err != nil {
+		return nil, lk.err
+	}
+	return &migLock{owner: lk}, nil
+}
+
+func (lk *migLocker) ForceRelease(_ context.Context, key string) error {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	lk.forced = append(lk.forced, key)
+	return nil
+}
+
+func (lk *migLocker) forcedKeys() []string {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	return append([]string(nil), lk.forced...)
+}
+
+func (lk *migLocker) releases() int {
+	lk.mu.Lock()
+	defer lk.mu.Unlock()
+	return lk.released
+}
+
+type migLock struct{ owner *migLocker }
+
+func (l *migLock) Release(context.Context) error {
+	l.owner.mu.Lock()
+	defer l.owner.mu.Unlock()
+	l.owner.released++
+	return nil
+}
+
+func seedMigrationRepo(t *testing.T, repoRepo *testutil.RepoRepo, blobStoreRepo *testutil.BlobStoreRepo, name string) string {
+	t.Helper()
+	ctx := context.Background()
+	src := &domain.BlobStore{ID: "bs-src-" + name, Name: "source-" + name}
+	dst := &domain.BlobStore{ID: "bs-dst-" + name, Name: "dest-" + name}
+	require.NoError(t, blobStoreRepo.Create(ctx, src))
+	require.NoError(t, blobStoreRepo.Create(ctx, dst))
+
+	repoRec := &domain.Repository{Name: name, Format: "raw", Type: "hosted"}
+	repoRec.BlobStoreID = &src.ID
+	require.NoError(t, repoRepo.Create(ctx, repoRec))
+	return dst.ID
+}
+
+// Losing the lock race must leave nothing behind: the migration row is only
+// created once this node actually owns the lock, or the repo is wedged as
+// "already active" for every later Start until the process restarts.
+func TestBlobStoreMigration_Start_LockHeld_LeavesNoMigrationRow(t *testing.T) {
+	svc, migRepo, repoRepo, blobStoreRepo := newMigSvc(t)
+	ctx := context.Background()
+	dstID := seedMigrationRepo(t, repoRepo, blobStoreRepo, "locked-repo")
+	svc.WithLocker(&migLocker{err: distlock.ErrLockHeld})
+
+	_, err := svc.Start(ctx, "locked-repo", dstID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "another node")
+
+	_, err = migRepo.GetActiveByRepo(ctx, "locked-repo")
+	assert.ErrorIs(t, err, repository.ErrNotFound, "no migration row may be left behind by a lost lock race")
+
+	// And the repo is not wedged: once the lock frees up, Start works again.
+	svc.WithLocker(&migLocker{})
+	m, err := svc.Start(ctx, "locked-repo", dstID)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+}
+
+// Same for a lock backend that is simply down.
+func TestBlobStoreMigration_Start_LockError_LeavesNoMigrationRow(t *testing.T) {
+	svc, migRepo, repoRepo, blobStoreRepo := newMigSvc(t)
+	ctx := context.Background()
+	dstID := seedMigrationRepo(t, repoRepo, blobStoreRepo, "errored-repo")
+	svc.WithLocker(&migLocker{err: errors.New("redis down")})
+
+	_, err := svc.Start(ctx, "errored-repo", dstID)
+	require.Error(t, err)
+
+	_, err = migRepo.GetActiveByRepo(ctx, "errored-repo")
+	assert.ErrorIs(t, err, repository.ErrNotFound, "no migration row may be left behind when the lock backend fails")
+}
+
+// A migration row that cannot be created must not leave its lock held for the
+// full 2h TTL either.
+func TestBlobStoreMigration_Start_CreateFails_ReleasesLock(t *testing.T) {
+	svc, migRepo, repoRepo, blobStoreRepo := newMigSvc(t)
+	ctx := context.Background()
+	dstID := seedMigrationRepo(t, repoRepo, blobStoreRepo, "create-fails")
+	migRepo.CreateErr = errors.New("db down")
+
+	lk := &migLocker{}
+	svc.WithLocker(lk)
+
+	_, err := svc.Start(ctx, "create-fails", dstID)
+	require.Error(t, err)
+	assert.Equal(t, 1, lk.releases(), "the lock taken for a migration that never started is given back")
+}
+
+// ResumeAll tells the operator an interrupted migration was canceled, so the
+// lock the crashed process left behind has to go with it — otherwise Start
+// keeps failing with "already running on another node" for up to 2 hours.
+func TestBlobStoreMigration_ResumeAll_ReleasesStaleLocks(t *testing.T) {
+	svc, migRepo, _, _ := newMigSvc(t)
+	ctx := context.Background()
+
+	require.NoError(t, migRepo.Create(ctx, &domain.BlobStoreMigration{RepositoryName: "repo1", Status: "running"}))
+	require.NoError(t, migRepo.Create(ctx, &domain.BlobStoreMigration{RepositoryName: "repo2", Status: "pending"}))
+
+	lk := &migLocker{}
+	svc.WithLocker(lk)
+
+	require.NoError(t, svc.ResumeAll(ctx))
+
+	assert.ElementsMatch(t,
+		[]string{"nexspence:lock:blobmig:repo1", "nexspence:lock:blobmig:repo2"},
+		lk.forcedKeys(),
+		"every migration ResumeAll gives up gives its lock back")
 }

--- a/internal/service/cleanup_service_extra_test.go
+++ b/internal/service/cleanup_service_extra_test.go
@@ -37,6 +37,8 @@ func (lk *extraCleanupLocker) Acquire(_ context.Context, _ string, _ time.Durati
 	return lk.lock, nil
 }
 
+func (lk *extraCleanupLocker) ForceRelease(_ context.Context, _ string) error { return nil }
+
 // ── NewCleanupService constructor (line 56) ───────────────────
 
 func TestExtraCleanup_NewCleanupService_NotNil(t *testing.T) {

--- a/internal/service/cleanup_service_test.go
+++ b/internal/service/cleanup_service_test.go
@@ -701,6 +701,8 @@ func (lk *lockRecorder) Acquire(_ context.Context, key string, _ time.Duration) 
 	return &recordedLock{owner: lk}, nil
 }
 
+func (lk *lockRecorder) ForceRelease(_ context.Context, _ string) error { return nil }
+
 func (lk *lockRecorder) acquired() []string {
 	lk.mu.Lock()
 	defer lk.mu.Unlock()

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -1243,6 +1243,8 @@ func (HeldLocker) Acquire(_ context.Context, _ string, _ time.Duration) (distloc
 	return nil, distlock.ErrLockHeld
 }
 
+func (HeldLocker) ForceRelease(_ context.Context, _ string) error { return nil }
+
 // ── Helpers ───────────────────────────────────────────────────
 
 // SimpleRepo returns a hosted repository ready for use in tests.
@@ -2053,6 +2055,10 @@ func (r *PrivilegeRepo) PrivilegeRoleMap(_ context.Context) (map[string][]string
 type BlobStoreMigrationRepo struct {
 	mu         sync.Mutex
 	migrations map[string]*domain.BlobStoreMigration
+
+	// CreateErr, when set, makes Create fail — for exercising what a caller
+	// leaves behind when the migration row cannot be written.
+	CreateErr error
 }
 
 func NewBlobStoreMigrationRepo(ms ...*domain.BlobStoreMigration) *BlobStoreMigrationRepo {
@@ -2066,6 +2072,9 @@ func NewBlobStoreMigrationRepo(ms ...*domain.BlobStoreMigration) *BlobStoreMigra
 func (r *BlobStoreMigrationRepo) Create(_ context.Context, m *domain.BlobStoreMigration) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.CreateErr != nil {
+		return r.CreateErr
+	}
 	if m.ID == "" {
 		m.ID = fmt.Sprintf("mig-%d", len(r.migrations)+1)
 	}


### PR DESCRIPTION
## Problem

Three related gaps in `BlobStoreMigrationService`, all around the distributed lock:

1. **`Start` recorded before it locked.** The migration row was created and `s.cancels[m.ID]` registered *before* `Acquire`. If the lock was held (or the backend errored), `Start` returned immediately and `runMigration` — the only path that clears either — never ran.
2. **The row wedges the repo.** `GetActiveByRepo` treats `pending`/`running` as active, so every later `Start` for that repo was rejected as "a migration is already running" until the process restarted.
3. **The cancel func leaks.** The `s.cancels` entry and its `context.CancelFunc` survived for the life of the process on every lost lock race.
4. **`ResumeAll` left the lock behind.** It marked interrupted migrations as canceled in the DB but never touched the Redis lock (2h TTL) the crashed process took — so `Start` still failed with "already running on another node" for up to two hours, defeating the purpose of `ResumeAll` in exactly the HA deployment it was written for.

## Fix

- `Start` acquires the lock first, then creates the row and registers the cancel func — which fixes (2) and (3) at once, since neither happens until this node owns the migration.
- If `Create` then fails, the just-acquired lock is released immediately rather than left to expire (a new edge case introduced by the reordering).
- `ResumeAll` clears the stale lock for every migration it gives up on, through a new `Locker.ForceRelease(ctx, key)` — it drops the key whoever holds it, for cleaning up after a holder that can no longer release its own lock. Every ordinary caller still releases through the `Lock` it acquired. Implemented on `RedisLocker` (`DEL`) and `NoopLocker` (no-op).
- The lock key/TTL are now a `blobMigLockKey(repo)` helper and a `blobMigLockTTL` constant instead of being spelled out inline.

## Tests

Each reproduces a bug and was confirmed to fail against the current code:

- `Start` with the lock held leaves no active migration row, and a later `Start` succeeds once the lock frees (the repo is not wedged).
- Same for a generic lock-backend error.
- `Create` failing releases the lock that was just taken.
- `ResumeAll` force-releases the right key for every interrupted migration.
- `ForceRelease` covered for both lockers, including the Redis error path.

`go build`, `go vet`, `go test ./...`, `golangci-lint` green; `internal/service` 81.9%, `internal/distlock` 94.1%.

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnt5RyqWXYVfrphjEWQhri