### PR TITLE
fix(apt): build a group's Release from the union of its members

### DIFF
--- a/internal/formats/apt/groupindex.go
+++ b/internal/formats/apt/groupindex.go
@@ -3,13 +3,22 @@ package apt
 // Group index merging (#99 phase 2): the Packages index answers 200-empty
 // for members without matching debs, shadowing later members under
 // first-non-404 fan-out, and a single member's index hides the others'
-// packages. Stanzas are unioned, deduped by Filename. Release/InRelease
-// are generated boilerplate (no member URLs) and stay on plain fan-out.
+// packages. Stanzas are unioned, deduped by Filename.
+//
+// Release/InRelease (#221) are rebuilt rather than relayed: a member's own
+// document describes that member's indexes, while the group serves the union,
+// so its Architectures line and checksums would describe something the client
+// never downloads — a hash-sum mismatch, or an architecture apt never looks
+// for. Release.gpg keeps plain fan-out: a detached signature can only be made
+// with a key, and the merger has no way to answer "not applicable" (404)
+// distinct from "merge failed", which degrades to a member's raw body.
 
 import (
-	"bytes"
-	"compress/gzip"
+	"context"
+	"path"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
 )
@@ -18,14 +27,46 @@ import (
 // fans out on the PLAIN document — members serve plain text, the merger
 // gzips the merged result.
 func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
-	if !strings.HasPrefix(p, "/dists/") || !strings.Contains(p, "/Packages") {
+	if !strings.HasPrefix(p, "/dists/") {
 		return "", false
 	}
-	return strings.TrimSuffix(p, ".gz"), true
+	if strings.Contains(p, "/Packages") {
+		return strings.TrimSuffix(p, ".gz"), true
+	}
+	// The members' own Release documents are the source: they are what names
+	// the architectures and components the group has to cover.
+	switch path.Base(p) {
+	case "Release", "InRelease":
+		return p, true
+	}
+	return "", false
 }
 
 // MergeGroupIndex implements formats.GroupIndexMerger.
-func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+func (h *Handler) MergeGroupIndex(groupName, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	return h.MergeGroupIndexWithFetch(groupName, p, parts, nil)
+}
+
+// MergeGroupIndexWithFetch implements formats.GroupIndexDependentMerger.
+func (h *Handler) MergeGroupIndexWithFetch(groupName, p string, parts []formats.GroupIndexPart,
+	fetch formats.GroupIndexFetcher,
+) ([]byte, string, error) {
+	if base := path.Base(p); base == "Release" || base == "InRelease" {
+		return h.mergeRelease(groupName, p, base == "InRelease", parts, fetch)
+	}
+	return mergePackages(p, parts), packagesContentType(p), nil
+}
+
+func packagesContentType(p string) string {
+	if strings.HasSuffix(p, ".gz") {
+		return "application/x-gzip"
+	}
+	return "text/plain; charset=utf-8"
+}
+
+// mergePackages unions the members' stanzas, deduped by Filename (first member
+// wins), and gzips the result for the .gz flavor.
+func mergePackages(p string, parts []formats.GroupIndexPart) []byte {
 	var stanzas []string
 	seen := map[string]bool{}
 	for _, part := range parts {
@@ -53,13 +94,112 @@ func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) (
 	plain := []byte(sb.String())
 
 	if strings.HasSuffix(p, ".gz") {
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		_, _ = gw.Write(plain)
-		_ = gw.Close()
-		return buf.Bytes(), "application/x-gzip", nil
+		return gzipBytes(plain)
 	}
-	return plain, "text/plain; charset=utf-8", nil
+	return plain
+}
+
+// mergeRelease builds the group's own Release: every architecture and component
+// its members declare, with checksums taken over the merged Packages indexes the
+// group itself serves at those paths.
+func (h *Handler) mergeRelease(groupName, p string, inline bool, parts []formats.GroupIndexPart,
+	fetch formats.GroupIndexFetcher,
+) ([]byte, string, error) {
+	const contentType = "text/plain; charset=utf-8"
+
+	dist := releaseDist(p)
+	archs := unionReleaseField(parts, "Architectures", func(v string) bool { return v != "all" })
+	components := unionReleaseField(parts, "Components", func(string) bool { return true })
+	if len(components) == 0 {
+		components = []string{"main"}
+	}
+
+	var files []releaseIndexFile
+	if fetch != nil {
+		for _, component := range components {
+			for _, arch := range archs {
+				for _, suffix := range []string{"", ".gz"} {
+					rel := component + "/binary-" + arch + "/Packages" + suffix
+					body, err := fetch("/dists/" + dist + "/" + rel)
+					if err != nil {
+						// A path no member serves is a path the group does not
+						// serve either, so it belongs in no checksum section.
+						continue
+					}
+					files = append(files, releaseIndexFile{relPath: rel, body: body})
+				}
+			}
+		}
+	}
+
+	body := renderRelease(dist, archs, components, releaseDateOf(parts), files)
+	if !inline {
+		return body, contentType, nil
+	}
+
+	// Signed with the GROUP's own key, never a member's: a member's key vouches
+	// for that member's index, not for a union it never served. An unsigned
+	// group keeps serving the plain document, which is what [trusted=yes]
+	// sources expect.
+	repo, _ := h.deps.Repos.Get(context.Background(), groupName) // unreadable group == unsigned group
+	if repo == nil || !signingConfigured(repo) {
+		return body, contentType, nil
+	}
+	signed, err := clearSign(repo, body)
+	if err != nil {
+		return nil, "", err
+	}
+	return signed, contentType, nil
+}
+
+// unionReleaseField collects the values of a space-separated Release header
+// across members, keeping those keep reports, sorted so the document is stable.
+func unionReleaseField(parts []formats.GroupIndexPart, field string, keep func(string) bool) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, part := range parts {
+		for _, v := range strings.Fields(releaseHeader(string(part.Body), field)) {
+			if !keep(v) || seen[v] {
+				continue
+			}
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// releaseDateOf is the newest Date the members declare. The document has to be
+// byte-identical across requests — apt fetches Release and its signature
+// separately and verifies one against the other — so it tracks the members'
+// content rather than the wall clock, exactly as a single repository's does.
+func releaseDateOf(parts []formats.GroupIndexPart) string {
+	var newest time.Time
+	for _, part := range parts {
+		d, err := time.Parse(releaseDateLayout, releaseHeader(string(part.Body), "Date"))
+		if err == nil && d.After(newest) {
+			newest = d
+		}
+	}
+	if newest.IsZero() {
+		return time.Now().UTC().Format(releaseDateLayout)
+	}
+	return newest.UTC().Format(releaseDateLayout)
+}
+
+// releaseHeader reads a single-line "Field: value" header out of a Release
+// document, skipping the indented checksum lines.
+func releaseHeader(doc, field string) string {
+	for _, line := range strings.Split(doc, "\n") {
+		if strings.HasPrefix(line, " ") {
+			continue
+		}
+		if v, found := strings.CutPrefix(line, field+":"); found {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
 }
 
 // stanzaFilename extracts the Filename: field used as the dedup key.

--- a/internal/formats/apt/groupindex_test.go
+++ b/internal/formats/apt/groupindex_test.go
@@ -3,14 +3,24 @@ package apt_test
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/md5" //nolint:gosec // apt protocol checksum
+	"crypto/sha256"
+	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/clearsign"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
 	"github.com/nexspence-oss/nexspence/internal/formats/apt"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
 const (
@@ -32,8 +42,17 @@ func TestApt_GroupIndexSourcePath(t *testing.T) {
 
 	_, ok = h.GroupIndexSourcePath("/pool/main/c/curl/curl_8.0.0_amd64.deb")
 	assert.False(t, ok, ".deb downloads keep first-non-404")
-	_, ok = h.GroupIndexSourcePath("/dists/focal/Release")
-	assert.False(t, ok, "Release is boilerplate — not merged")
+	// Release/InRelease are rebuilt from the union: a member's own document
+	// describes that member's indexes, not the group's (#221).
+	src, ok = h.GroupIndexSourcePath("/dists/focal/Release")
+	require.True(t, ok)
+	assert.Equal(t, "/dists/focal/Release", src)
+	src, ok = h.GroupIndexSourcePath("/dists/focal/InRelease")
+	require.True(t, ok)
+	assert.Equal(t, "/dists/focal/InRelease", src)
+
+	_, ok = h.GroupIndexSourcePath("/dists/focal/Release.gpg")
+	assert.False(t, ok, "a detached signature needs a key, so it stays on plain fan-out")
 }
 
 func TestApt_MergeGroupIndex_UnionsStanzas(t *testing.T) {
@@ -76,4 +95,111 @@ func TestApt_MergeGroupIndex_EmptyMemberContributesNothing(t *testing.T) {
 	body, _, err := h.MergeGroupIndex("g", "/dists/focal/main/binary-amd64/Packages", parts)
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "Package: nginx")
+}
+
+// ── Release merged from the union (#221) ─────────────────────
+
+const (
+	releaseAmd64 = "Origin: Nexspence\nSuite: focal\nCodename: focal\n" +
+		"Date: Mon, 04 Aug 2026 10:00:00 UTC\nArchitectures: amd64 all\nComponents: main\n" +
+		"SHA256:\n 1111 10 main/binary-amd64/Packages\n"
+	releaseArm64 = "Origin: Nexspence\nSuite: focal\nCodename: focal\n" +
+		"Date: Wed, 05 Aug 2026 11:00:00 UTC\nArchitectures: arm64 all\nComponents: main contrib\n" +
+		"SHA256:\n 2222 20 main/binary-arm64/Packages\n"
+)
+
+func releaseParts() []formats.GroupIndexPart {
+	return []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(releaseAmd64)},
+		{Member: "m2", Body: []byte(releaseArm64)},
+	}
+}
+
+// The group's Release covers every architecture and component its members
+// declare, and its checksums are taken over the bodies the GROUP serves.
+func TestApt_MergeRelease_UnionsArchitecturesAndChecksumsFetchedBodies(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	fetched := map[string][]byte{}
+	fetch := func(p string) ([]byte, error) {
+		if !strings.Contains(p, "binary-amd64") && !strings.Contains(p, "binary-arm64") {
+			return nil, errors.New("no such index")
+		}
+		body := []byte("merged-index-for " + p)
+		fetched[p] = body
+		return body, nil
+	}
+
+	body, ct, err := h.MergeGroupIndexWithFetch("g", "/dists/focal/Release", releaseParts(), fetch)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "text/plain")
+	out := string(body)
+
+	assert.Contains(t, out, "Architectures: amd64 arm64 all")
+	assert.Contains(t, out, "Components: contrib main")
+	assert.Contains(t, out, "Suite: focal")
+	// The newest member Date wins, so the document tracks content, not the clock.
+	assert.Contains(t, out, "Date: Wed, 05 Aug 2026 11:00:00 UTC")
+
+	// Every fetched body is vouched for with its own hash and length.
+	require.NotEmpty(t, fetched)
+	for p, b := range fetched {
+		rel := strings.TrimPrefix(p, "/dists/focal/")
+		assert.Contains(t, out, fmt.Sprintf(" %x %d %s\n", sha256.Sum256(b), len(b), rel))
+		assert.Contains(t, out, fmt.Sprintf(" %x %d %s\n", md5.Sum(b), len(b), rel)) //nolint:gosec // apt protocol checksum
+	}
+	// A member's own checksum lines never survive into the group's document.
+	assert.NotContains(t, out, "1111")
+	assert.NotContains(t, out, "2222")
+}
+
+// Without a fetcher there are no index bodies to vouch for, so the document is
+// headers only — never a checksum the group cannot stand behind.
+func TestApt_MergeRelease_WithoutFetcher_HasNoChecksums(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	body, _, err := h.MergeGroupIndex("g", "/dists/focal/Release", releaseParts())
+	require.NoError(t, err)
+	out := string(body)
+	assert.Contains(t, out, "Architectures: amd64 arm64 all")
+	assert.NotContains(t, out, "binary-amd64/Packages")
+}
+
+// An unsigned group serves InRelease plain — the same document as Release.
+func TestApt_MergeInRelease_UnsignedGroupServesPlain(t *testing.T) {
+	h := apt.New(formats.Deps{Repos: testutil.NewRepoRepo(testutil.SimpleRepo("g", "apt"))})
+
+	release, _, err := h.MergeGroupIndex("g", "/dists/focal/Release", releaseParts())
+	require.NoError(t, err)
+	inRelease, _, err := h.MergeGroupIndex("g", "/dists/focal/InRelease", releaseParts())
+	require.NoError(t, err)
+	assert.Equal(t, string(release), string(inRelease))
+}
+
+// A group with its own key signs the union inline. A member's key is never
+// used: it cannot vouch for content that member did not serve.
+func TestApt_MergeInRelease_SignedWithTheGroupsOwnKey(t *testing.T) {
+	groupRepo, ring := signedRepo(t, "g")
+	member, _ := signedRepo(t, "m1") // a member key must not be reached for
+	h := apt.New(formats.Deps{Repos: testutil.NewRepoRepo(groupRepo, member)})
+
+	body, _, err := h.MergeGroupIndex("g", "/dists/focal/InRelease", releaseParts())
+	require.NoError(t, err)
+	require.True(t, bytes.HasPrefix(body, []byte("-----BEGIN PGP SIGNED MESSAGE-----")),
+		"a signed group clearsigns InRelease, got: %.60s", body)
+
+	block, _ := clearsign.Decode(body)
+	require.NotNil(t, block)
+	_, err = openpgp.CheckDetachedSignature(ring, bytes.NewReader(block.Bytes), block.ArmoredSignature.Body, nil)
+	require.NoError(t, err, "signed with the group's own key")
+}
+
+// Members that declare no parsable Date leave the group with nothing to pin the
+// document to, so it falls back to now rather than to a zero timestamp.
+func TestApt_MergeRelease_NoMemberDate_FallsBackToNow(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{{Member: "m1", Body: []byte("Architectures: amd64\n")}}
+
+	body, _, err := h.MergeGroupIndex("g", "/dists/focal/Release", parts)
+	require.NoError(t, err)
+	assert.NotContains(t, string(body), "Date: Mon, 01 Jan 0001")
+	assert.Contains(t, string(body), "Date: "+time.Now().UTC().Format("Mon, 02 Jan 2006"))
 }

--- a/internal/formats/apt/handler.go
+++ b/internal/formats/apt/handler.go
@@ -301,39 +301,62 @@ func (h *Handler) servePublicKey(c *gin.Context, repo *domain.Repository) {
 // Date would break verification. The date therefore tracks the content — the
 // newest package in the repository (#103).
 func (h *Handler) buildRelease(ctx context.Context, repoName, p string) ([]byte, error) {
-	// Parse distribution from path: /dists/:dist/Release
-	parts := strings.Split(strings.TrimPrefix(p, "/dists/"), "/")
-	dist := "stable"
-	if len(parts) > 0 && parts[0] != "" {
-		dist = parts[0]
-	}
-
+	dist := releaseDist(p)
 	archs := h.repoArchitectures(ctx, repoName)
-	archList := strings.Join(append(append([]string{}, archs...), "all"), " ")
 
 	// apt verifies the Packages indexes against these checksum sections —
 	// without them a default (verifying) client rejects the repo (#103).
-	type indexFile struct {
-		relPath string
-		body    []byte
-	}
-	var files []indexFile
+	var files []releaseIndexFile
 	for _, arch := range archs {
 		plain, err := h.buildPackagesIndex(ctx, repoName, arch)
 		if err != nil {
 			continue
 		}
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		_, _ = gw.Write(plain)
-		_ = gw.Close()
 		files = append(files,
-			indexFile{relPath: "main/binary-" + arch + "/Packages", body: plain},
-			indexFile{relPath: "main/binary-" + arch + "/Packages.gz", body: buf.Bytes()},
+			releaseIndexFile{relPath: "main/binary-" + arch + "/Packages", body: plain},
+			releaseIndexFile{relPath: "main/binary-" + arch + "/Packages.gz", body: gzipBytes(plain)},
 		)
 	}
 
-	date := h.releaseDate(ctx, repoName).UTC().Format("Mon, 02 Jan 2006 15:04:05 UTC")
+	date := h.releaseDate(ctx, repoName).UTC().Format(releaseDateLayout)
+	return renderRelease(dist, archs, []string{"main"}, date, files), nil
+}
+
+// releaseDateLayout is the Date format apt reads, and the one a group parses
+// back out of its members' documents.
+const releaseDateLayout = "Mon, 02 Jan 2006 15:04:05 UTC"
+
+// releaseIndexFile is one index document a Release vouches for: the path
+// relative to the distribution, and the exact bytes served at it.
+type releaseIndexFile struct {
+	relPath string
+	body    []byte
+}
+
+// releaseDist parses the distribution out of /dists/:dist/Release.
+func releaseDist(p string) string {
+	parts := strings.Split(strings.TrimPrefix(p, "/dists/"), "/")
+	if len(parts) > 0 && parts[0] != "" {
+		return parts[0]
+	}
+	return "stable"
+}
+
+func gzipBytes(plain []byte) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, _ = gw.Write(plain)
+	_ = gw.Close()
+	return buf.Bytes()
+}
+
+// renderRelease writes the Release document. One repository and a group produce
+// it through this same code, differing only in where archs, components and the
+// index bodies come from — a group's are the union across its members, so the
+// checksums always describe the indexes that repository actually serves.
+func renderRelease(dist string, archs, components []string, date string, files []releaseIndexFile) []byte {
+	archList := strings.Join(append(append([]string{}, archs...), "all"), " ")
+
 	var sb strings.Builder
 	fmt.Fprintf(&sb, `Origin: Nexspence
 Label: Nexspence
@@ -341,9 +364,9 @@ Suite: %s
 Codename: %s
 Date: %s
 Architectures: %s
-Components: main
+Components: %s
 Description: Nexspence APT Repository
-`, dist, dist, date, archList)
+`, dist, dist, date, archList, strings.Join(components, " "))
 	sb.WriteString("MD5Sum:\n")
 	for _, f := range files {
 		fmt.Fprintf(&sb, " %x %d %s\n", md5.Sum(f.body), len(f.body), f.relPath) //nolint:gosec // apt protocol checksum
@@ -352,7 +375,7 @@ Description: Nexspence APT Repository
 	for _, f := range files {
 		fmt.Fprintf(&sb, " %x %d %s\n", sha256.Sum256(f.body), len(f.body), f.relPath)
 	}
-	return []byte(sb.String()), nil
+	return []byte(sb.String())
 }
 
 // releaseDate is the timestamp stamped into Release. It follows the newest

--- a/internal/formats/group/handler.go
+++ b/internal/formats/group/handler.go
@@ -180,7 +180,6 @@ func (h *Handler) callMemberWithQuery(ctx context.Context, c *gin.Context, membe
 func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, members []string,
 	rule *domain.RoutingRule, merger formats.GroupIndexMerger, source, requestPath string,
 ) {
-	ctx := c.Request.Context()
 	strict, isStrict := merger.(formats.GroupIndexStrictMerger)
 	pager, isPager := merger.(formats.GroupIndexPaginator)
 
@@ -191,6 +190,63 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 	if isPager {
 		memberQuery = pager.GroupIndexMemberQuery(source, memberQuery)
 	}
+
+	parts, contributing, failure := h.collectIndexParts(c, repoDef, members, rule, strict, source, memberQuery)
+	if failure != nil {
+		// Relayed verbatim: the member's handler already phrased the failure in
+		// its own protocol's error shape, and re-wrapping it would cost the
+		// client the reason.
+		h.relayMemberFailure(c, failure.member, failure.rec)
+		return
+	}
+
+	if len(parts) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": fmt.Sprintf("index not found in any member of group %q", repoDef.Name),
+		})
+		return
+	}
+
+	c.Writer.Header().Set("X-Nexspence-Source", strings.Join(contributing, ","))
+	body, contentType, err := h.mergeIndexParts(c, repoDef, members, rule, merger, strict, requestPath, parts)
+	if err == nil && isPager {
+		// Paged after the merge, so the page and the cursor that walks it are
+		// both cut out of the order the client is being served.
+		body, err = pager.PageGroupIndex(c, requestPath, body)
+	}
+	if err != nil {
+		if isStrict {
+			// A member's document that could not be merged is a member whose
+			// contribution is missing from the result, which is the same fact a
+			// fatal member failure reports.
+			c.JSON(http.StatusBadGateway, gin.H{
+				"error": fmt.Sprintf("members of group %q could not be merged into one index, so the answer "+
+					"would be incomplete: %v", repoDef.Name, err),
+			})
+			return
+		}
+		// Degrade to the first member's document rather than failing the group.
+		c.Data(http.StatusOK, "application/octet-stream", parts[0].Body)
+		return
+	}
+	c.Data(http.StatusOK, contentType, body)
+}
+
+// memberFailure is a member answer the merger calls fatal — the member could not
+// be consulted, so the group must not present a result merged around it.
+type memberFailure struct {
+	member string
+	rec    *httptest.ResponseRecorder
+}
+
+// collectIndexParts fans source out to every eligible member and returns their
+// 2xx bodies in member order (member order = priority). A member that failed is
+// skipped so one down upstream cannot take the group with it, unless the merger
+// calls that failure fatal — then it comes back for the caller to relay.
+func (h *Handler) collectIndexParts(c *gin.Context, repoDef *domain.Repository, members []string,
+	rule *domain.RoutingRule, strict formats.GroupIndexStrictMerger, source, memberQuery string,
+) ([]formats.GroupIndexPart, []string, *memberFailure) {
+	ctx := c.Request.Context()
 
 	var parts []formats.GroupIndexPart
 	var contributing []string
@@ -213,49 +269,63 @@ func (h *Handler) serveMergedIndex(c *gin.Context, repoDef *domain.Repository, m
 			code = http.StatusOK
 		}
 		if code < 200 || code > 299 {
-			if isStrict && strict.GroupIndexMemberFailureIsFatal(source, code) {
-				// Relayed verbatim: the member's handler already phrased the
-				// failure in its own protocol's error shape, and re-wrapping it
-				// would cost the client the reason.
-				h.relayMemberFailure(c, memberName, rec)
-				return
+			if strict != nil && strict.GroupIndexMemberFailureIsFatal(source, code) {
+				return nil, nil, &memberFailure{member: memberName, rec: rec}
 			}
 			continue
 		}
 		parts = append(parts, formats.GroupIndexPart{Member: memberName, Body: rec.Body.Bytes()})
 		contributing = append(contributing, memberName)
 	}
+	return parts, contributing, nil
+}
 
-	if len(parts) == 0 {
-		c.JSON(http.StatusNotFound, gin.H{
-			"error": fmt.Sprintf("index not found in any member of group %q", repoDef.Name),
-		})
-		return
+// mergeIndexParts merges the collected member bodies. A format whose document
+// describes other index documents (apt Release, yum repomd.xml) is additionally
+// handed a fetcher for the group's own merged bodies at those paths, so the
+// checksums it writes describe what the group actually serves.
+func (h *Handler) mergeIndexParts(c *gin.Context, repoDef *domain.Repository, members []string,
+	rule *domain.RoutingRule, merger formats.GroupIndexMerger, strict formats.GroupIndexStrictMerger,
+	requestPath string, parts []formats.GroupIndexPart,
+) ([]byte, string, error) {
+	dependent, ok := merger.(formats.GroupIndexDependentMerger)
+	if !ok {
+		return merger.MergeGroupIndex(repoDef.Name, requestPath, parts)
 	}
+	return dependent.MergeGroupIndexWithFetch(repoDef.Name, requestPath, parts,
+		h.subIndexFetcher(c, repoDef, members, rule, merger, strict))
+}
 
-	c.Writer.Header().Set("X-Nexspence-Source", strings.Join(contributing, ","))
-	body, contentType, err := merger.MergeGroupIndex(repoDef.Name, requestPath, parts)
-	if err == nil && isPager {
-		// Paged after the merge, so the page and the cursor that walks it are
-		// both cut out of the order the client is being served.
-		body, err = pager.PageGroupIndex(c, requestPath, body)
-	}
-	if err != nil {
-		if isStrict {
-			// A member's document that could not be merged is a member whose
-			// contribution is missing from the result, which is the same fact a
-			// fatal member failure reports.
-			c.JSON(http.StatusBadGateway, gin.H{
-				"error": fmt.Sprintf("members of group %q could not be merged into one index, so the answer "+
-					"would be incomplete: %v", repoDef.Name, err),
-			})
-			return
+// subIndexFetcher returns the group's own merged body at another index path.
+// Member responses are collected once per source path and reused, so a document
+// covering both the plain and the gzipped flavor of an index costs one fan-out.
+func (h *Handler) subIndexFetcher(c *gin.Context, repoDef *domain.Repository, members []string,
+	rule *domain.RoutingRule, merger formats.GroupIndexMerger, strict formats.GroupIndexStrictMerger,
+) formats.GroupIndexFetcher {
+	cache := map[string][]formats.GroupIndexPart{}
+	return func(p string) ([]byte, error) {
+		source, ok := merger.GroupIndexSourcePath(p)
+		if !ok {
+			source = p
 		}
-		// Degrade to the first member's document rather than failing the group.
-		c.Data(http.StatusOK, "application/octet-stream", parts[0].Body)
-		return
+		parts, cached := cache[source]
+		if !cached {
+			var failure *memberFailure
+			parts, _, failure = h.collectIndexParts(c, repoDef, members, rule, strict, source, "")
+			if failure != nil {
+				return nil, fmt.Errorf("member %q could not serve %q", failure.member, source)
+			}
+			cache[source] = parts
+		}
+		if len(parts) == 0 {
+			return nil, fmt.Errorf("index %q not found in any member of group %q", p, repoDef.Name)
+		}
+		// Merged without a fetcher of its own: a sub-index describes artifacts,
+		// not other indexes, and letting one reach back through the group layer
+		// would be a cycle waiting to happen.
+		body, _, err := merger.MergeGroupIndex(repoDef.Name, p, parts)
+		return body, err
 	}
-	c.Data(http.StatusOK, contentType, body)
 }
 
 // relayMemberFailure passes a member's failed response through unchanged, so the

--- a/internal/formats/group/merge_apt_test.go
+++ b/internal/formats/group/merge_apt_test.go
@@ -1,0 +1,189 @@
+package group_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/md5" //nolint:gosec // apt protocol checksum
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/apt"
+	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// buildAptGroupEngine wires real apt handlers for members and a group over them.
+func buildAptGroupEngine(t *testing.T, groupName string, memberNames ...string) *gin.Engine {
+	t.Helper()
+
+	repos := make([]*domain.Repository, 0, len(memberNames)+1)
+	ms := make([]interface{}, len(memberNames))
+	for i, name := range memberNames {
+		repos = append(repos, testutil.SimpleRepo(name, "apt"))
+		ms[i] = name
+	}
+	repos = append(repos, &domain.Repository{
+		ID: "repo-" + groupName, Name: groupName, Format: "apt",
+		Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": ms},
+	})
+
+	repoRepo := testutil.NewRepoRepo(repos...)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	aptH := apt.New(d)
+	groupH := group.New(d, map[string]formats.FormatHandler{"apt": aptH})
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		aptH.ServeHTTP(c)
+	})
+	return r
+}
+
+func putDeb(t *testing.T, r *gin.Engine, repoName, filename string) {
+	t.Helper()
+	body := "deb-payload-" + filename
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+"/pool/main/x/"+filename, strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Contains(t, []int{http.StatusCreated, http.StatusOK}, w.Code, "upload %s: %s", filename, w.Body.String())
+}
+
+// releaseField returns the value of a single-line "Field: value" header.
+func releaseField(t *testing.T, release, field string) string {
+	t.Helper()
+	for _, line := range strings.Split(release, "\n") {
+		if v, found := strings.CutPrefix(line, field+":"); found {
+			return strings.TrimSpace(v)
+		}
+	}
+	t.Fatalf("field %q not found in Release:\n%s", field, release)
+	return ""
+}
+
+// releaseChecksums parses one checksum section into "relative path" → "hash size".
+func releaseChecksums(release, section string) map[string]string {
+	out := map[string]string{}
+	inSection := false
+	for _, line := range strings.Split(release, "\n") {
+		if strings.HasSuffix(strings.TrimSpace(line), ":") && !strings.HasPrefix(line, " ") {
+			inSection = strings.TrimSpace(line) == section+":"
+			continue
+		}
+		if !inSection || !strings.HasPrefix(line, " ") {
+			continue
+		}
+		f := strings.Fields(line)
+		if len(f) == 3 {
+			out[f[2]] = f[0] + " " + f[1]
+		}
+	}
+	return out
+}
+
+// A group's Release must describe the group: every architecture its members
+// contribute, and checksums over the very bytes the group's own Packages
+// endpoints serve. Relaying one member's Release makes apt reject the repo with
+// a hash-sum mismatch, or silently miss the other members' architectures.
+func TestGroupMerge_AptReleaseDescribesTheMergedIndexes(t *testing.T) {
+	r := buildAptGroupEngine(t, "ag", "ad1", "ad2")
+	putDeb(t, r, "ad1", "curl_8.0.0_amd64.deb")
+	putDeb(t, r, "ad2", "vim_9.0_arm64.deb")
+
+	w := get(r, "/repository/ag/dists/stable/Release")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	release := w.Body.String()
+
+	archs := strings.Fields(releaseField(t, release, "Architectures"))
+	assert.Contains(t, archs, "amd64", "the group carries both members' architectures")
+	assert.Contains(t, archs, "arm64")
+
+	sha := releaseChecksums(release, "SHA256")
+	md := releaseChecksums(release, "MD5Sum")
+	require.NotEmpty(t, sha, "Release declares SHA256 checksums")
+
+	for _, arch := range []string{"amd64", "arm64"} {
+		for _, suffix := range []string{"", ".gz"} {
+			rel := "main/binary-" + arch + "/Packages" + suffix
+			served := get(r, "/repository/ag/dists/stable/"+rel)
+			require.Equal(t, http.StatusOK, served.Code, rel)
+			b := served.Body.Bytes()
+
+			assert.Equal(t, fmt.Sprintf("%x %d", sha256.Sum256(b), len(b)), sha[rel],
+				"SHA256 in Release must match the %s the group actually serves", rel)
+			assert.Equal(t, fmt.Sprintf("%x %d", md5.Sum(b), len(b)), md[rel], //nolint:gosec // apt protocol checksum
+				"MD5Sum in Release must match the %s the group actually serves", rel)
+		}
+	}
+
+	// Both members' packages are reachable through the indexes Release covers.
+	amd := get(r, "/repository/ag/dists/stable/main/binary-amd64/Packages").Body.String()
+	arm := get(r, "/repository/ag/dists/stable/main/binary-arm64/Packages").Body.String()
+	assert.Contains(t, amd, "curl")
+	assert.Contains(t, arm, "vim")
+}
+
+// InRelease is the same document; unsigned groups serve it plain, which is what
+// [trusted=yes] sources expect.
+func TestGroupMerge_AptInReleaseMatchesRelease(t *testing.T) {
+	r := buildAptGroupEngine(t, "ag2", "ae1", "ae2")
+	putDeb(t, r, "ae1", "curl_8.0.0_amd64.deb")
+	putDeb(t, r, "ae2", "vim_9.0_arm64.deb")
+
+	rel := get(r, "/repository/ag2/dists/stable/Release")
+	inrel := get(r, "/repository/ag2/dists/stable/InRelease")
+	require.Equal(t, http.StatusOK, inrel.Code)
+	assert.Equal(t, rel.Body.String(), inrel.Body.String())
+}
+
+// A one-member group is that member: its Release must be the member's own.
+func TestGroupMerge_AptSingleMemberReleaseMatchesMember(t *testing.T) {
+	r := buildAptGroupEngine(t, "ag3", "af1")
+	putDeb(t, r, "af1", "curl_8.0.0_amd64.deb")
+
+	direct := get(r, "/repository/af1/dists/stable/Release")
+	viaGroup := get(r, "/repository/ag3/dists/stable/Release")
+	require.Equal(t, http.StatusOK, viaGroup.Code)
+	assert.Equal(t, direct.Body.String(), viaGroup.Body.String())
+}
+
+// The gzip flavor the checksums cover has to be the same document, not a
+// separately merged one.
+func TestGroupMerge_AptPackagesGzUnzipsToPlain(t *testing.T) {
+	r := buildAptGroupEngine(t, "ag4", "ah1", "ah2")
+	putDeb(t, r, "ah1", "curl_8.0.0_amd64.deb")
+	putDeb(t, r, "ah2", "wget_1.21_amd64.deb")
+
+	plain := get(r, "/repository/ag4/dists/stable/main/binary-amd64/Packages").Body.Bytes()
+	gz := get(r, "/repository/ag4/dists/stable/main/binary-amd64/Packages.gz").Body.Bytes()
+
+	zr, err := gzip.NewReader(bytes.NewReader(gz))
+	require.NoError(t, err)
+	unzipped, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	assert.Equal(t, string(plain), string(unzipped))
+}

--- a/internal/formats/group_merge.go
+++ b/internal/formats/group_merge.go
@@ -25,6 +25,32 @@ type GroupIndexMerger interface {
 	MergeGroupIndex(groupName, path string, parts []GroupIndexPart) (body []byte, contentType string, err error)
 }
 
+// GroupIndexFetcher returns the body the GROUP itself serves at path — the
+// merged document, not any single member's copy.
+type GroupIndexFetcher func(path string) ([]byte, error)
+
+// GroupIndexDependentMerger is optionally implemented alongside GroupIndexMerger
+// by formats whose index document describes OTHER index documents: apt's Release
+// carries a checksum of every Packages file, yum's repomd.xml one of primary.xml
+// and its siblings.
+//
+// Merging those from the members' own copies cannot work. Each member's document
+// describes that member's own indexes, while the group serves the union — so the
+// checksums never match the bytes the client then downloads, and apt/dnf reject
+// the repository outright. Such a merger is handed a fetcher instead, and builds
+// its document from what the group itself serves.
+//
+// The fetched path must not itself be dependent: the fetcher merges it without
+// one, so a format that pointed a document at itself would get an empty result
+// rather than a recursion through the group layer.
+type GroupIndexDependentMerger interface {
+	GroupIndexMerger
+	// MergeGroupIndexWithFetch merges like MergeGroupIndex, additionally able to
+	// ask for the group's own merged body at another index path.
+	MergeGroupIndexWithFetch(groupName, path string, parts []GroupIndexPart,
+		fetch GroupIndexFetcher) (body []byte, contentType string, err error)
+}
+
 // GroupIndexStrictMerger is optionally implemented alongside GroupIndexMerger by
 // formats whose merged index must never be served incomplete.
 //

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -626,11 +626,18 @@ func (a *AssetRepo) Snapshot() []domain.Asset {
 	return out
 }
 
-func (a *AssetRepo) List(_ context.Context, _ string, _, _ int) (*domain.Page[domain.Asset], error) {
+// List returns the repository's assets. An empty repoName lists everything,
+// so tests that never set Asset.Repository keep working; naming a repository
+// filters to it, which is what a group of several members needs to behave like
+// several members.
+func (a *AssetRepo) List(_ context.Context, repoName string, _, _ int) (*domain.Page[domain.Asset], error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	items := make([]domain.Asset, 0, len(a.byID))
 	for _, v := range a.byID {
+		if repoName != "" && v.Repository != "" && v.Repository != repoName {
+			continue
+		}
 		items = append(items, *v)
 	}
 	return &domain.Page[domain.Asset]{Items: items}, nil


### PR DESCRIPTION
## Problem

`apt-get update` against an apt `group` whose members contribute different package sets fails with a hash-sum mismatch — or silently hides packages.

The group's `Packages`/`Packages.gz` endpoints correctly serve the union of all members, but `Release`/`InRelease` were relayed verbatim from a single arbitrarily-picked member. That document describes *that member's* indexes: its `Architectures:` line names only that member's architecture, and its `MD5Sum:`/`SHA256:` sections were computed over that member's own single-member `Packages`. apt verifies every downloaded index against `Release` independently of GPG, and uses `Architectures:` to decide which `binary-<arch>/Packages` to fetch at all — so the other members' packages are either invisible or the sync fails outright.

## Fix

`Release`/`InRelease` are now rebuilt for the group instead of relayed:

- `GroupIndexSourcePath` claims `/dists/:dist/Release` and `/dists/:dist/InRelease`.
- Architectures and components are the union of what the members' own `Release` documents declare.
- Every checksum is taken over the merged index **the group itself serves** at that path.

That last part needed a small addition to the group plumbing. A merger only ever sees the member bodies for the path being requested, so a document that describes *other* documents cannot check them. `formats.GroupIndexDependentMerger` lets such a merger ask the group layer for its own merged body at another path; the group collects member responses once per source path and reuses them. Deriving the indexes from local assets instead would have been wrong for **proxy** members, whose `Packages` comes from upstream and is not in our database at all.

Also here:
- `buildRelease`'s rendering moved into a shared `renderRelease`, so one repository and a group produce the document through the same code, differing only in where the architectures, components and index bodies come from.
- `InRelease` is clearsigned only when the **group's own** repository has a signing key — a member's key cannot vouch for a union that member never served.
- `testutil.AssetRepo.List` now honors its `repoName` argument (it previously returned every asset for every repository), so a group of several members behaves like several members in tests. An empty name still lists everything, so tests that never set `Asset.Repository` are unaffected.

### Known limitation — `Release.gpg`

The detached signature keeps the old plain fan-out. Claiming the path would mean mapping it onto the `Release` source, and a group with no key would then have to answer "not applicable" — which a merger cannot express today (an error degrades to serving a member's raw body rather than a 404). The common unsigned case already 404s correctly, since every member's fan-out for `/Release.gpg` returns 404. Happy to take a follow-up for it.

## Tests

End-to-end through real apt handlers and the real group handler:

- Two members contributing disjoint architectures: the group's `Release` lists both, and every `SHA256`/`MD5Sum` line matches an independently computed hash of the exact `Packages`/`Packages.gz` bytes the group serves at that path.
- `InRelease` matches `Release` for an unsigned group; a signed group's `InRelease` verifies against the **group's** key.
- A one-member group's `Release` is byte-identical to that member's own.
- `Packages.gz` unzips to exactly the merged plain document.
- Unit tests for the union of architectures/components, the newest-member `Date`, the no-fetcher case, and that a member's own checksum lines never survive into the group's document.

`go build`, `go vet`, `go test ./...`, `golangci-lint` green; `internal/formats/apt` 85.9%, `internal/formats/group` 89.6%.

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnt5RyqWXYVfrphjEWQhri