### PR TITLE
fix(yum): build a group's repomd over the repodata it actually serves

### DIFF
--- a/internal/formats/group/merge_yum_test.go
+++ b/internal/formats/group/merge_yum_test.go
@@ -1,0 +1,159 @@
+package group_test
+
+import (
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/formats/yum"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// repomdDoc is enough of repomd.xml to check what it advertises.
+type repomdDoc struct {
+	Data []struct {
+		Type     string `xml:"type,attr"`
+		Location struct {
+			Href string `xml:"href,attr"`
+		} `xml:"location"`
+		Checksum struct {
+			Value string `xml:",chardata"`
+		} `xml:"checksum"`
+		OpenChecksum struct {
+			Value string `xml:",chardata"`
+		} `xml:"open-checksum"`
+		Size     int64 `xml:"size"`
+		OpenSize int64 `xml:"open-size"`
+	} `xml:"data"`
+}
+
+func buildYumGroupEngine(t *testing.T, groupName string, memberNames ...string) *gin.Engine {
+	t.Helper()
+
+	repos := make([]*domain.Repository, 0, len(memberNames)+1)
+	ms := make([]interface{}, len(memberNames))
+	for i, name := range memberNames {
+		repos = append(repos, testutil.SimpleRepo(name, "yum"))
+		ms[i] = name
+	}
+	repos = append(repos, &domain.Repository{
+		ID: "repo-" + groupName, Name: groupName, Format: "yum",
+		Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": ms},
+	})
+
+	repoRepo := testutil.NewRepoRepo(repos...)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	yumH := yum.New(d)
+	groupH := group.New(d, map[string]formats.FormatHandler{"yum": yumH})
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		yumH.ServeHTTP(c)
+	})
+	return r
+}
+
+func putRpmTo(t *testing.T, r *gin.Engine, repoName, filename string) {
+	t.Helper()
+	body := "rpm-payload-" + filename
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+"/Packages/"+filename, strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "upload %s: %s", filename, w.Body.String())
+}
+
+// dnf verifies every repodata document against repomd.xml before using it, so a
+// group's repomd has to describe the merged documents the group serves — not a
+// single member's copy of them.
+func TestGroupMerge_YumRepomdDescribesTheMergedRepodata(t *testing.T) {
+	r := buildYumGroupEngine(t, "yg", "y1", "y2")
+	putRpmTo(t, r, "y1", "curl-8.0.0-1.x86_64.rpm")
+	putRpmTo(t, r, "y2", "vim-9.0-1.x86_64.rpm")
+
+	w := get(r, "/repository/yg/repodata/repomd.xml")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var repomd repomdDoc
+	require.NoError(t, xml.Unmarshal(w.Body.Bytes(), &repomd))
+	require.Len(t, repomd.Data, 3, "primary, filelists and other are all advertised")
+
+	for _, d := range repomd.Data {
+		gz := get(r, "/repository/yg/"+d.Location.Href)
+		require.Equal(t, http.StatusOK, gz.Code, d.Location.Href)
+		gzBody := gz.Body.Bytes()
+
+		assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(gzBody)), d.Checksum.Value,
+			"%s checksum must match the %s the group serves", d.Type, d.Location.Href)
+		assert.Equal(t, int64(len(gzBody)), d.Size, "%s size", d.Type)
+
+		plainPath := strings.TrimSuffix(d.Location.Href, ".gz")
+		plain := get(r, "/repository/yg/"+plainPath)
+		require.Equal(t, http.StatusOK, plain.Code, plainPath)
+		plainBody := plain.Body.Bytes()
+
+		assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(plainBody)), d.OpenChecksum.Value,
+			"%s open-checksum must match the %s the group serves", d.Type, plainPath)
+		assert.Equal(t, int64(len(plainBody)), d.OpenSize, "%s open-size", d.Type)
+
+		// The gzip flavor is the same document, not a separately merged one.
+		zr, err := gzip.NewReader(strings.NewReader(string(gzBody)))
+		require.NoError(t, err)
+		unzipped, err := io.ReadAll(zr)
+		require.NoError(t, err)
+		assert.Equal(t, string(plainBody), string(unzipped))
+	}
+}
+
+// filelists/other are aggregated indexes like primary: a group that serves one
+// member's copy hides every other member's packages from `dnf provides` and
+// changelog queries.
+func TestGroupMerge_YumFilelistsAndOtherCoverEveryMember(t *testing.T) {
+	r := buildYumGroupEngine(t, "yg2", "y3", "y4")
+	putRpmTo(t, r, "y3", "curl-8.0.0-1.x86_64.rpm")
+	putRpmTo(t, r, "y4", "vim-9.0-1.x86_64.rpm")
+
+	for _, doc := range []string{"primary", "filelists", "other"} {
+		body := get(r, "/repository/yg2/repodata/"+doc+".xml").Body.String()
+		assert.Contains(t, body, "curl", "%s.xml lists the first member's package", doc)
+		assert.Contains(t, body, "vim", "%s.xml lists the second member's package", doc)
+		assert.Contains(t, body, `packages="2"`, "%s.xml counts both", doc)
+	}
+}
+
+// The same package in two members is one package in the group.
+func TestGroupMerge_YumDedupsPackagesAcrossMembers(t *testing.T) {
+	r := buildYumGroupEngine(t, "yg3", "y5", "y6")
+	putRpmTo(t, r, "y5", "curl-8.0.0-1.x86_64.rpm")
+	putRpmTo(t, r, "y6", "curl-8.0.0-1.x86_64.rpm")
+
+	primary := get(r, "/repository/yg3/repodata/primary.xml").Body.String()
+	assert.Equal(t, 1, strings.Count(primary, "<name>curl</name>"))
+	assert.Contains(t, primary, `packages="1"`)
+}

--- a/internal/formats/yum/groupindex.go
+++ b/internal/formats/yum/groupindex.go
@@ -1,81 +1,194 @@
 package yum
 
 // Group index merging (#99 phase 2): repodata is merged across group members
-// — a single member's primary.xml hid the others' rpms from dnf, and
-// repomd.xml embedded a member-scoped href that steered clients off the
-// group.
+// — a single member's primary.xml hid the others' rpms from dnf.
+//
+// #222 extends that to the rest of the repodata set. filelists.xml and
+// other.xml are aggregated indexes just like primary, so a group serving one
+// member's copy hides every other member's packages from `dnf provides` and
+// changelog queries. And repomd.xml cannot be relayed at all: it carries the
+// checksum of each of those documents, computed by that member over its own
+// single-member copy, while the group serves the union — a mismatch dnf treats
+// as a hard sync failure. The group builds its own repomd over the merged
+// documents it serves, which it asks the group layer for (see
+// formats.GroupIndexDependentMerger) so proxy members, whose metadata comes
+// from upstream, are covered the same way.
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/xml"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
 )
 
+// repodataDocTypes are the documents repomd.xml vouches for, in the order dnf
+// reads them.
+var repodataDocTypes = []string{"primary", "filelists", "other"}
+
 // GroupIndexSourcePath implements formats.GroupIndexMerger. The .gz flavor
-// of primary fans out on the PLAIN document — the merger gzips the result.
+// of each document fans out on the PLAIN one — the merger gzips the result.
 func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
-	switch p {
-	case "/repodata/repomd.xml":
+	if p == "/repodata/repomd.xml" {
 		return p, true
-	case "/repodata/primary.xml", "/repodata/primary.xml.gz":
-		return "/repodata/primary.xml", true
+	}
+	for _, typ := range repodataDocTypes {
+		plain := "/repodata/" + typ + ".xml"
+		if p == plain || p == plain+".gz" {
+			return plain, true
+		}
 	}
 	return "", false
 }
 
 // MergeGroupIndex implements formats.GroupIndexMerger.
 func (h *Handler) MergeGroupIndex(groupName, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	return h.MergeGroupIndexWithFetch(groupName, p, parts, nil)
+}
+
+// MergeGroupIndexWithFetch implements formats.GroupIndexDependentMerger.
+func (h *Handler) MergeGroupIndexWithFetch(_, p string, parts []formats.GroupIndexPart,
+	fetch formats.GroupIndexFetcher,
+) ([]byte, string, error) {
 	if p == "/repodata/repomd.xml" {
-		// repomd shapes are identical across members; take the first and
-		// re-root its member-scoped hrefs at the group.
-		body := strings.ReplaceAll(string(parts[0].Body),
-			"/repository/"+parts[0].Member+"/", "/repository/"+groupName+"/")
-		return []byte(body), "application/xml; charset=utf-8", nil
+		return mergeRepomd(fetch)
 	}
 
-	// primary.xml: union <package> entries across members, dedup by location
-	// href (first member wins), recount the packages attribute.
-	merged := primaryXML{XMLNS: "http://linux.duke.edu/metadata/common"}
-	seen := map[string]bool{}
-	parsed := false
-	for _, part := range parts {
-		var doc primaryXML
-		if err := xml.Unmarshal(part.Body, &doc); err != nil {
-			continue // malformed member copy — merge the rest
-		}
-		parsed = true
-		for _, pkg := range doc.Packages {
-			key := pkg.Location.Href
-			if key != "" && seen[key] {
-				continue
-			}
-			if key != "" {
-				seen[key] = true
-			}
-			merged.Packages = append(merged.Packages, pkg)
-		}
-	}
-	if !parsed {
-		return nil, "", fmt.Errorf("yum group merge: no parsable primary.xml among %d members", len(parts))
-	}
-	merged.Count = len(merged.Packages)
-
-	out, err := xml.Marshal(merged)
+	doc, err := mergeRepodataDoc(p, parts)
 	if err != nil {
 		return nil, "", err
 	}
-	doc := append([]byte(xml.Header), out...)
-
 	if strings.HasSuffix(p, ".gz") {
-		var buf bytes.Buffer
-		gw := gzip.NewWriter(&buf)
-		_, _ = gw.Write(doc)
-		_ = gw.Close()
-		return buf.Bytes(), "application/x-gzip", nil
+		return gzipBytes(doc), "application/x-gzip", nil
 	}
 	return doc, "application/xml; charset=utf-8", nil
+}
+
+// mergeRepomd builds the group's own repomd.xml over the merged documents the
+// group serves, so every checksum describes bytes a client can actually
+// download from it.
+func mergeRepomd(fetch formats.GroupIndexFetcher) ([]byte, string, error) {
+	if fetch == nil {
+		return nil, "", fmt.Errorf("yum group merge: repomd.xml describes the group's own repodata, which was not available")
+	}
+
+	now := time.Now().Unix()
+	var entries []repomdEntry
+	for _, typ := range repodataDocTypes {
+		plain, err := fetch("/repodata/" + typ + ".xml")
+		if err != nil {
+			continue // a document no member serves is one the group cannot vouch for
+		}
+		gz, err := fetch("/repodata/" + typ + ".xml.gz")
+		if err != nil {
+			continue
+		}
+		entries = append(entries, repomdEntryFor(typ, gz, plain, now))
+	}
+	if len(entries) == 0 {
+		return nil, "", fmt.Errorf("yum group merge: no repodata document could be merged")
+	}
+	return renderRepomd(now, entries), "application/xml; charset=utf-8", nil
+}
+
+// mergeRepodataDoc unions one document type across members. Packages are
+// deduped by identity — the location href for primary, the pkgid for the file
+// and changelog lists — with the first member winning, the same priority the
+// rest of the group fan-out uses.
+func mergeRepodataDoc(p string, parts []formats.GroupIndexPart) ([]byte, error) {
+	switch {
+	case strings.HasPrefix(p, "/repodata/primary.xml"):
+		merged := primaryXML{XMLNS: "http://linux.duke.edu/metadata/common"}
+		parsed := false
+		seen := map[string]bool{}
+		for _, part := range parts {
+			var doc primaryXML
+			if err := xml.Unmarshal(part.Body, &doc); err != nil {
+				continue // malformed member copy — merge the rest
+			}
+			parsed = true
+			for _, pkg := range doc.Packages {
+				if firstWins(seen, pkg.Location.Href) {
+					merged.Packages = append(merged.Packages, pkg)
+				}
+			}
+		}
+		if !parsed {
+			return nil, fmt.Errorf("yum group merge: no parsable primary.xml among %d members", len(parts))
+		}
+		merged.Count = len(merged.Packages)
+		return marshalXML(merged), nil
+
+	case strings.HasPrefix(p, "/repodata/filelists.xml"):
+		merged := filelistsXML{XMLNS: "http://linux.duke.edu/metadata/filelists"}
+		entries, err := mergeFileListEntries(p, parts, func(part []byte) ([]fileListEntry, error) {
+			var doc filelistsXML
+			err := xml.Unmarshal(part, &doc)
+			return doc.Packages, err
+		})
+		if err != nil {
+			return nil, err
+		}
+		merged.Packages = entries
+		merged.Count = len(entries)
+		return marshalXML(merged), nil
+
+	case strings.HasPrefix(p, "/repodata/other.xml"):
+		merged := otherXML{XMLNS: "http://linux.duke.edu/metadata/other"}
+		entries, err := mergeFileListEntries(p, parts, func(part []byte) ([]fileListEntry, error) {
+			var doc otherXML
+			err := xml.Unmarshal(part, &doc)
+			return doc.Packages, err
+		})
+		if err != nil {
+			return nil, err
+		}
+		merged.Packages = entries
+		merged.Count = len(entries)
+		return marshalXML(merged), nil
+	}
+	return nil, fmt.Errorf("yum group merge: %q is not a mergeable repodata document", p)
+}
+
+func mergeFileListEntries(p string, parts []formats.GroupIndexPart,
+	unmarshal func([]byte) ([]fileListEntry, error),
+) ([]fileListEntry, error) {
+	var out []fileListEntry
+	seen := map[string]bool{}
+	parsed := false
+	for _, part := range parts {
+		packages, err := unmarshal(part.Body)
+		if err != nil {
+			continue // malformed member copy — merge the rest
+		}
+		parsed = true
+		for _, entry := range packages {
+			key := entry.PkgID
+			if key == "" {
+				key = entry.Name + "-" + entry.Version.Ver + "-" + entry.Version.Rel + "." + entry.Arch
+			}
+			if firstWins(seen, key) {
+				out = append(out, entry)
+			}
+		}
+	}
+	if !parsed {
+		return nil, fmt.Errorf("yum group merge: no parsable %s among %d members", strings.TrimPrefix(p, "/repodata/"), len(parts))
+	}
+	return out, nil
+}
+
+// firstWins reports whether key is new, recording it when it is. An entry
+// without an identity is always kept: dropping every one of them would lose
+// real packages to a metadata gap.
+func firstWins(seen map[string]bool, key string) bool {
+	if key == "" {
+		return true
+	}
+	if seen[key] {
+		return false
+	}
+	seen[key] = true
+	return true
 }

--- a/internal/formats/yum/groupindex_test.go
+++ b/internal/formats/yum/groupindex_test.go
@@ -3,7 +3,12 @@ package yum_test
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/xml"
+	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -60,14 +65,147 @@ func TestYum_MergeGroupIndex_PrimaryGzip(t *testing.T) {
 	assert.Contains(t, string(plain), "<name>curl</name>")
 }
 
-func TestYum_MergeGroupIndex_RepomdRewritesMemberHref(t *testing.T) {
+// repomd.xml is built over the documents the group serves, not relayed: a
+// member's copy carries checksums of that member's own single-member metadata,
+// which dnf rejects against the union it downloads (#222).
+func TestYum_MergeGroupIndex_RepomdChecksumsTheFetchedDocuments(t *testing.T) {
 	h := yum.New(formats.Deps{})
-	repomd := []byte(`<repomd><data type="primary"><location href="/repository/m1/repodata/primary.xml.gz"/></data></repomd>`)
-	body, _, err := h.MergeGroupIndex("yum-group", "/repodata/repomd.xml", []formats.GroupIndexPart{
-		{Member: "m1", Body: repomd},
+	served := map[string][]byte{
+		"/repodata/primary.xml":      []byte("merged-primary"),
+		"/repodata/primary.xml.gz":   []byte("merged-primary-gz"),
+		"/repodata/filelists.xml":    []byte("merged-filelists"),
+		"/repodata/filelists.xml.gz": []byte("merged-filelists-gz"),
+		"/repodata/other.xml":        []byte("merged-other"),
+		"/repodata/other.xml.gz":     []byte("merged-other-gz"),
+	}
+	fetch := func(p string) ([]byte, error) {
+		body, ok := served[p]
+		if !ok {
+			return nil, errors.New("no such document")
+		}
+		return body, nil
+	}
+
+	memberRepomd := []byte(`<repomd><data type="primary"><checksum type="sha256">deadbeef</checksum>` +
+		`<location href="repodata/primary.xml.gz"/></data></repomd>`)
+	body, ct, err := h.MergeGroupIndexWithFetch("yum-group", "/repodata/repomd.xml",
+		[]formats.GroupIndexPart{{Member: "m1", Body: memberRepomd}}, fetch)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "xml")
+
+	var doc struct {
+		Data []struct {
+			Type     string `xml:"type,attr"`
+			Location struct {
+				Href string `xml:"href,attr"`
+			} `xml:"location"`
+			Checksum struct {
+				Value string `xml:",chardata"`
+			} `xml:"checksum"`
+			OpenChecksum struct {
+				Value string `xml:",chardata"`
+			} `xml:"open-checksum"`
+			Size     int64 `xml:"size"`
+			OpenSize int64 `xml:"open-size"`
+		} `xml:"data"`
+	}
+	require.NoError(t, xml.Unmarshal(body, &doc))
+	require.Len(t, doc.Data, 3, "primary, filelists and other")
+
+	for _, d := range doc.Data {
+		gz := served["/repodata/"+d.Type+".xml.gz"]
+		plain := served["/repodata/"+d.Type+".xml"]
+		assert.Equal(t, "repodata/"+d.Type+".xml.gz", d.Location.Href)
+		assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(gz)), d.Checksum.Value)
+		assert.Equal(t, fmt.Sprintf("%x", sha256.Sum256(plain)), d.OpenChecksum.Value)
+		assert.Equal(t, int64(len(gz)), d.Size)
+		assert.Equal(t, int64(len(plain)), d.OpenSize)
+	}
+	assert.NotContains(t, string(body), "deadbeef", "a member's own checksum never survives into the group's repomd")
+}
+
+// A document no member could serve is one the group cannot vouch for, so it is
+// left out rather than advertised with a checksum of nothing.
+func TestYum_MergeGroupIndex_RepomdSkipsUnavailableDocuments(t *testing.T) {
+	h := yum.New(formats.Deps{})
+	fetch := func(p string) ([]byte, error) {
+		if strings.HasPrefix(p, "/repodata/primary.xml") {
+			return []byte("merged-primary" + p), nil
+		}
+		return nil, errors.New("no such document")
+	}
+
+	body, _, err := h.MergeGroupIndexWithFetch("g", "/repodata/repomd.xml",
+		[]formats.GroupIndexPart{{Member: "m1", Body: []byte("<repomd/>")}}, fetch)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `type="primary"`)
+	assert.NotContains(t, string(body), `type="filelists"`)
+}
+
+// Without the group's own documents there is nothing to checksum, and a repomd
+// that guesses is worse than none — the group falls back to a member's copy.
+func TestYum_MergeGroupIndex_RepomdWithoutFetcherFails(t *testing.T) {
+	h := yum.New(formats.Deps{})
+	_, _, err := h.MergeGroupIndex("g", "/repodata/repomd.xml",
+		[]formats.GroupIndexPart{{Member: "m1", Body: []byte("<repomd/>")}})
+	require.Error(t, err)
+}
+
+func TestYum_MergeGroupIndex_FilelistsAndOtherUnion(t *testing.T) {
+	h := yum.New(formats.Deps{})
+	m1 := `<?xml version="1.0" encoding="UTF-8"?><filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="1">` +
+		`<package pkgid="aaa" name="curl" arch="x86_64"><version epoch="0" ver="8.0.0" rel="1"></version></package></filelists>`
+	m2 := `<?xml version="1.0" encoding="UTF-8"?><filelists xmlns="http://linux.duke.edu/metadata/filelists" packages="2">` +
+		`<package pkgid="aaa" name="curl" arch="x86_64"><version epoch="0" ver="8.0.0" rel="1"></version></package>` +
+		`<package pkgid="bbb" name="vim" arch="x86_64"><version epoch="0" ver="9.0" rel="2"></version></package></filelists>`
+
+	body, ct, err := h.MergeGroupIndex("g", "/repodata/filelists.xml", []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(m1)},
+		{Member: "m2", Body: []byte(m2)},
 	})
 	require.NoError(t, err)
+	assert.Contains(t, ct, "xml")
 	out := string(body)
-	assert.Contains(t, out, "/repository/yum-group/repodata/primary.xml.gz")
-	assert.NotContains(t, out, "/repository/m1/")
+	assert.Contains(t, out, `name="curl"`)
+	assert.Contains(t, out, `name="vim"`)
+	assert.Equal(t, 1, strings.Count(out, `name="curl"`), "dedup by pkgid")
+	assert.Contains(t, out, `packages="2"`, "package count recomputed")
+
+	other := `<?xml version="1.0" encoding="UTF-8"?><otherdata xmlns="http://linux.duke.edu/metadata/other" packages="1">` +
+		`<package pkgid="ccc" name="wget" arch="x86_64"><version epoch="0" ver="1.21" rel="1"></version></package></otherdata>`
+	body, _, err = h.MergeGroupIndex("g", "/repodata/other.xml", []formats.GroupIndexPart{{Member: "m1", Body: []byte(other)}})
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `name="wget"`)
+	assert.Contains(t, string(body), "otherdata")
+}
+
+// A member that answered with something unparsable is merged around, but a
+// document nobody could parse is an error rather than a silently empty index.
+func TestYum_MergeGroupIndex_UnparsableMembers(t *testing.T) {
+	h := yum.New(formats.Deps{})
+
+	body, _, err := h.MergeGroupIndex("g", "/repodata/filelists.xml", []formats.GroupIndexPart{
+		{Member: "broken", Body: []byte("not xml at all")},
+		{Member: "m1", Body: []byte(`<filelists packages="1"><package pkgid="aaa" name="curl" arch="x86_64"></package></filelists>`)},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `name="curl"`)
+
+	_, _, err = h.MergeGroupIndex("g", "/repodata/filelists.xml", []formats.GroupIndexPart{
+		{Member: "broken", Body: []byte("not xml at all")},
+	})
+	require.Error(t, err)
+}
+
+func TestYum_GroupIndexSourcePath_FilelistsAndOther(t *testing.T) {
+	h := yum.New(formats.Deps{})
+	for _, typ := range []string{"filelists", "other"} {
+		src, ok := h.GroupIndexSourcePath("/repodata/" + typ + ".xml")
+		require.True(t, ok, typ)
+		assert.Equal(t, "/repodata/"+typ+".xml", src)
+
+		src, ok = h.GroupIndexSourcePath("/repodata/" + typ + ".xml.gz")
+		require.True(t, ok, typ+".gz")
+		assert.Equal(t, "/repodata/"+typ+".xml", src, ".gz fans out on the plain doc")
+	}
 }

--- a/internal/formats/yum/repodata.go
+++ b/internal/formats/yum/repodata.go
@@ -121,38 +121,46 @@ func (h *Handler) buildRepodata(ctx context.Context, repoName string) (*repodata
 	other.Count = len(other.Packages)
 
 	docs := &repodataDocs{}
-	marshal := func(v any) []byte {
-		out, _ := xml.Marshal(v)
-		return append([]byte(xml.Header), out...)
-	}
-	docs.Primary = marshal(primary)
+	docs.Primary = marshalXML(primary)
 	docs.PrimaryGz = gzipBytes(docs.Primary)
-	docs.Filelists = marshal(filelists)
+	docs.Filelists = marshalXML(filelists)
 	docs.FilelistsGz = gzipBytes(docs.Filelists)
-	docs.Other = marshal(other)
+	docs.Other = marshalXML(other)
 	docs.OtherGz = gzipBytes(docs.Other)
 
 	now := time.Now().Unix()
-	entry := func(typ string, gz, plain []byte) repomdEntry {
-		return repomdEntry{
-			Type:         typ,
-			Location:     repomdLoc{Href: "repodata/" + typ + ".xml.gz"},
-			Checksum:     repomdCksum{Type: "sha256", Value: fmt.Sprintf("%x", sha256.Sum256(gz))},
-			OpenChecksum: &repomdCksum{Type: "sha256", Value: fmt.Sprintf("%x", sha256.Sum256(plain))},
-			Size:         int64(len(gz)),
-			OpenSize:     int64(len(plain)),
-			Timestamp:    now,
-		}
-	}
-	repomd := repomdXML{
-		XMLNS:    "http://linux.duke.edu/metadata/repo",
-		Revision: now,
-		Data: []repomdEntry{
-			entry("primary", docs.PrimaryGz, docs.Primary),
-			entry("filelists", docs.FilelistsGz, docs.Filelists),
-			entry("other", docs.OtherGz, docs.Other),
-		},
-	}
-	docs.Repomd = marshal(repomd)
+	docs.Repomd = renderRepomd(now, []repomdEntry{
+		repomdEntryFor("primary", docs.PrimaryGz, docs.Primary, now),
+		repomdEntryFor("filelists", docs.FilelistsGz, docs.Filelists, now),
+		repomdEntryFor("other", docs.OtherGz, docs.Other, now),
+	})
 	return docs, nil
+}
+
+func marshalXML(v any) []byte {
+	out, _ := xml.Marshal(v)
+	return append([]byte(xml.Header), out...)
+}
+
+// repomdEntryFor describes one metadata document: dnf checks the compressed
+// bytes it downloads against Checksum and the decompressed ones against
+// OpenChecksum, so both must be taken over the documents actually served.
+func repomdEntryFor(typ string, gz, plain []byte, now int64) repomdEntry {
+	return repomdEntry{
+		Type:         typ,
+		Location:     repomdLoc{Href: "repodata/" + typ + ".xml.gz"},
+		Checksum:     repomdCksum{Type: "sha256", Value: fmt.Sprintf("%x", sha256.Sum256(gz))},
+		OpenChecksum: &repomdCksum{Type: "sha256", Value: fmt.Sprintf("%x", sha256.Sum256(plain))},
+		Size:         int64(len(gz)),
+		OpenSize:     int64(len(plain)),
+		Timestamp:    now,
+	}
+}
+
+func renderRepomd(revision int64, entries []repomdEntry) []byte {
+	return marshalXML(repomdXML{
+		XMLNS:    "http://linux.duke.edu/metadata/repo",
+		Revision: revision,
+		Data:     entries,
+	})
 }


### PR DESCRIPTION
## Problem

The same class of bug as #221, on the dnf side.

- **`repomd.xml` was relayed from one member**, with only its href prefix rewritten — zero checksums touched. Its `<checksum>`/`<open-checksum>` for `primary` were computed by that member over its *own* single-member `primary.xml.gz`, while the group serves the union. `dnf`/`librepo` verifies every repodata file against `repomd.xml` unconditionally, so a group with more than one contributing member is a hard sync failure.
- **`filelists.xml`/`other.xml` were never merged.** They were not recognized as mergeable paths at all, so a group exposed whichever member answered first — silently hiding every other member's packages from `dnf provides` and changelog queries.

## Fix

- `GroupIndexSourcePath` now claims `filelists.xml[.gz]` and `other.xml[.gz]` alongside `primary.xml[.gz]` and `repomd.xml`.
- `filelists`/`other` are unioned across members and deduped by `pkgid` (first member wins — the same priority rule `primary`'s merge already used), with the `packages` count recomputed.
- `repomd.xml` is rebuilt for the group over the merged documents **the group itself serves**, obtained through the `formats.GroupIndexDependentMerger` fetcher added in #221. Both the compressed and the decompressed checksum, and both sizes, are taken over exactly the bytes a client downloads from the group. Going through the group layer rather than rebuilding from local assets is what makes this correct for **proxy** members, whose repodata comes from upstream.
- `buildRepodata`'s repomd rendering was extracted (`repomdEntryFor`/`renderRepomd`/`marshalXML`) so one repository and a group produce the document the same way.
- A document no member can serve is left out of `repomd` rather than advertised with a checksum of nothing.

## Tests

End-to-end through real yum handlers and the real group handler:

- Two members each contributing an rpm: for every entry in the group's `repomd.xml`, the declared checksum/size and open-checksum/open-size match an independently computed hash of the exact `.gz` and plain bytes the group serves at that href, and the `.gz` unzips to the plain document.
- `primary`, `filelists` and `other` all list both members' packages and count both.
- The same rpm in two members appears once in the group.
- Unit tests: repomd checksums the fetched documents (and a member's own checksum never survives into it), unavailable documents are skipped, no fetcher is an error rather than a guess, filelists/other union and dedup by pkgid, an unparsable member is merged around while an all-unparsable set is an error.

`go build`, `go vet`, `go test ./...`, `golangci-lint` green; `internal/formats/yum` 88.5%, `internal/formats/group` 89.6%.

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnt5RyqWXYVfrphjEWQhri