### PR TITLE
fix(group): refuse request paths that carry a traversal segment

### DIFF
--- a/internal/formats/apt/groupindex.go
+++ b/internal/formats/apt/groupindex.go
@@ -16,6 +16,7 @@ package apt
 import (
 	"context"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -108,8 +109,8 @@ func (h *Handler) mergeRelease(groupName, p string, inline bool, parts []formats
 	const contentType = "text/plain; charset=utf-8"
 
 	dist := releaseDist(p)
-	archs := unionReleaseField(parts, "Architectures", func(v string) bool { return v != "all" })
-	components := unionReleaseField(parts, "Components", func(string) bool { return true })
+	archs := unionReleaseField(parts, "Architectures", maxReleaseArchs, func(v string) bool { return v != "all" })
+	components := unionReleaseField(parts, "Components", maxReleaseComponents, func(string) bool { return true })
 	if len(components) == 0 {
 		components = []string{"main"}
 	}
@@ -152,14 +153,31 @@ func (h *Handler) mergeRelease(groupName, p string, inline bool, parts []formats
 	return signed, contentType, nil
 }
 
+// releaseName is what an architecture or component may be called. A member's
+// Release is untrusted input — for a proxy member it is whatever the upstream
+// chose to serve — and these values are spliced into the paths the group then
+// asks itself for, so anything that is not a plain name is dropped instead of
+// becoming a path.
+var releaseName = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]*$`)
+
+// The index matrix a group will vouch for is bounded: one member declaring
+// thousands of architectures would otherwise turn a single Release request into
+// that many fan-outs across every member. Real distributions are far below
+// these limits (Debian ships ~10 architectures and 3 components).
+const (
+	maxReleaseArchs      = 64
+	maxReleaseComponents = 32
+)
+
 // unionReleaseField collects the values of a space-separated Release header
-// across members, keeping those keep reports, sorted so the document is stable.
-func unionReleaseField(parts []formats.GroupIndexPart, field string, keep func(string) bool) []string {
+// across members, keeping the well-formed ones that keep reports, sorted so the
+// document is stable and capped at limit.
+func unionReleaseField(parts []formats.GroupIndexPart, field string, limit int, keep func(string) bool) []string {
 	seen := map[string]bool{}
 	var out []string
 	for _, part := range parts {
 		for _, v := range strings.Fields(releaseHeader(string(part.Body), field)) {
-			if !keep(v) || seen[v] {
+			if !releaseName.MatchString(v) || !keep(v) || seen[v] {
 				continue
 			}
 			seen[v] = true
@@ -167,6 +185,9 @@ func unionReleaseField(parts []formats.GroupIndexPart, field string, keep func(s
 		}
 	}
 	sort.Strings(out)
+	if len(out) > limit {
+		out = out[:limit]
+	}
 	return out
 }
 

--- a/internal/formats/apt/groupindex_test.go
+++ b/internal/formats/apt/groupindex_test.go
@@ -203,3 +203,54 @@ func TestApt_MergeRelease_NoMemberDate_FallsBackToNow(t *testing.T) {
 	assert.NotContains(t, string(body), "Date: Mon, 01 Jan 0001")
 	assert.Contains(t, string(body), "Date: "+time.Now().UTC().Format("Mon, 02 Jan 2006"))
 }
+
+// A member's Release is untrusted input — for a proxy member it is whatever the
+// upstream serves. Its architecture and component names end up in the paths the
+// group asks itself for, so anything that is not a plain name is dropped rather
+// than turned into a path.
+func TestApt_MergeRelease_RejectsHostileFieldValues(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	var asked []string
+	fetch := func(p string) ([]byte, error) {
+		asked = append(asked, p)
+		return []byte("x"), nil
+	}
+
+	body := "Date: Mon, 04 Aug 2026 10:00:00 UTC\n" +
+		"Architectures: amd64 ../../../pool ..\n" +
+		"Components: main ..%2f.. ../etc\n"
+	out, _, err := h.MergeGroupIndexWithFetch("g", "/dists/stable/Release",
+		[]formats.GroupIndexPart{{Member: "m1", Body: []byte(body)}}, fetch)
+	require.NoError(t, err)
+
+	for _, p := range asked {
+		assert.NotContains(t, p, "..", "the group must not ask itself for a traversal path: %s", p)
+	}
+	assert.Contains(t, string(out), "Architectures: amd64 all", "the sound values still survive")
+	assert.Contains(t, string(out), "Components: main")
+	assert.NotContains(t, string(out), "..")
+}
+
+// One member declaring a huge matrix must not turn a single Release request into
+// an unbounded fan-out across every member.
+func TestApt_MergeRelease_CapsTheIndexMatrix(t *testing.T) {
+	h := apt.New(formats.Deps{})
+	archs := make([]string, 500)
+	for i := range archs {
+		archs[i] = fmt.Sprintf("arch%d", i)
+	}
+	components := make([]string, 200)
+	for i := range components {
+		components[i] = fmt.Sprintf("comp%d", i)
+	}
+	body := "Date: Mon, 04 Aug 2026 10:00:00 UTC\nArchitectures: " + strings.Join(archs, " ") +
+		"\nComponents: " + strings.Join(components, " ") + "\n"
+
+	calls := 0
+	fetch := func(string) ([]byte, error) { calls++; return []byte("x"), nil }
+	_, _, err := h.MergeGroupIndexWithFetch("g", "/dists/stable/Release",
+		[]formats.GroupIndexPart{{Member: "m1", Body: []byte(body)}}, fetch)
+	require.NoError(t, err)
+
+	assert.LessOrEqual(t, calls, 2*64*32, "the fan-out is bounded regardless of what a member declares")
+}

--- a/internal/formats/group/handler.go
+++ b/internal/formats/group/handler.go
@@ -39,6 +39,18 @@ func New(deps formats.Deps, formatRegistry map[string]formats.FormatHandler) *Ha
 func (h *Handler) Name() string { return "group" }
 
 func (h *Handler) ServeHTTP(c *gin.Context) {
+	// A routing rule — the only path-level policy a group has, since RBAC grants
+	// a repository rather than a path inside it — is matched against the path as
+	// requested, while the member that finally serves it normalizes the path
+	// first. A path that names the same artifact a second way would therefore be
+	// checked as one string and served as another. Refused rather than quietly
+	// rewritten, so no legitimate path changes meaning on the way through: an
+	// artifact path never contains a ".." segment.
+	if hasTraversalSegment(c.Param("path")) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": `path must not contain a ".." segment`})
+		return
+	}
+
 	switch c.Request.Method {
 	case http.MethodGet, http.MethodHead:
 		h.serveGet(c)
@@ -49,6 +61,17 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			"error": "group repository is read-only — publish to a member hosted repository",
 		})
 	}
+}
+
+// hasTraversalSegment reports whether p has a ".." path segment. A name that
+// merely contains dots ("we..ird.txt") is an ordinary artifact name and passes.
+func hasTraversalSegment(p string) bool {
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *Handler) serveGet(c *gin.Context) {
@@ -304,6 +327,12 @@ func (h *Handler) subIndexFetcher(c *gin.Context, repoDef *domain.Repository, me
 ) formats.GroupIndexFetcher {
 	cache := map[string][]formats.GroupIndexPart{}
 	return func(p string) ([]byte, error) {
+		// The path a merger asks for is built from its members' documents, which
+		// for a proxy member is whatever the upstream serves. It gets the same
+		// answer a client would: a traversal segment is not a path here either.
+		if hasTraversalSegment(p) {
+			return nil, fmt.Errorf("index path %q must not contain a \"..\" segment", p)
+		}
 		source, ok := merger.GroupIndexSourcePath(p)
 		if !ok {
 			source = p

--- a/internal/formats/group/merge_test.go
+++ b/internal/formats/group/merge_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 
@@ -22,14 +23,24 @@ import (
 type mergeFmt struct {
 	deps     formats.Deps
 	failWith error // when non-nil, MergeGroupIndex fails
+	// fetchPath, when set, makes this a dependent merger that asks the group
+	// layer for that path and serves whatever comes back.
+	fetchPath string
 }
 
 func (m *mergeFmt) Name() string { return "mergefmt" }
 
 func (m *mergeFmt) ServeHTTP(c *gin.Context) {
 	repoName := c.Param("repoName")
-	p := c.Param("path")
+	// Real format handlers normalize before they look anything up — that gap
+	// between the path the group checked and the path a member resolves is what
+	// the traversal guard exists for, so the fake models it.
+	p := path.Clean("/" + strings.TrimPrefix(c.Param("path"), "/"))
 	repo, _ := m.deps.Repos.Get(c.Request.Context(), repoName)
+	if p == "/secret" {
+		c.String(http.StatusOK, "SECRET")
+		return
+	}
 	if p == "/index" && repo != nil {
 		body, _ := repo.FormatConfig["body"].(string)
 		if body == "FAIL" {
@@ -63,6 +74,23 @@ func (m *mergeFmt) MergeGroupIndex(groupName, path string, parts []formats.Group
 		return []byte("sha1(" + sb.String() + ")"), "text/plain", nil
 	}
 	return []byte(sb.String()), "text/merged", nil
+}
+
+// MergeGroupIndexWithFetch implements formats.GroupIndexDependentMerger for the
+// tests that need one. Only used when fetchPath is set.
+func (m *mergeFmt) MergeGroupIndexWithFetch(groupName, path string, parts []formats.GroupIndexPart,
+	fetch formats.GroupIndexFetcher,
+) ([]byte, string, error) {
+	if m.fetchPath == "" {
+		return m.MergeGroupIndex(groupName, path, parts)
+	}
+	body, err := fetch(m.fetchPath)
+	if err != nil {
+		// Surfaced as the document body so a test can read why the fetch was
+		// refused; a real merger would decide what a missing sub-index means.
+		return []byte("fetch refused: " + err.Error()), "text/plain", nil //nolint:nilerr // the refusal IS this fake's result
+	}
+	return append([]byte("fetched:"), body...), "text/plain", nil
 }
 
 func mergeMember(name, body string) *domain.Repository {
@@ -190,4 +218,32 @@ func TestGroupMerge_NonIndexPathKeepsFirstNon404(t *testing.T) {
 
 	w := get(r, "/repository/g7/some/artifact.bin")
 	assert.Equal(t, http.StatusNotFound, w.Code) // members 404 everything but /index
+}
+
+// A merger builds sub-index paths out of its members' documents — untrusted
+// content for a proxy member — so the group refuses a traversal path there too,
+// instead of trusting the merger to have validated it.
+func TestGroupMerge_SubIndexFetchRefusesTraversal(t *testing.T) {
+	repoRepo := testutil.NewRepoRepo(mergeGroup("gt", "m1"), mergeMember("m1", "aaa"))
+	d := formats.Deps{
+		Repos: repoRepo, Blobs: testutil.NewBlobStoreRepo(), Components: testutil.NewComponentRepo(),
+		Assets: testutil.NewAssetRepo(), BlobStore: testutil.NewBlobStore(), BaseURL: "http://localhost:8080",
+	}
+	mh := &mergeFmt{deps: d, fetchPath: "/index/../secret"}
+	groupH := group.New(d, map[string]formats.FormatHandler{"mergefmt": mh})
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		mh.ServeHTTP(c)
+	})
+
+	w := get(r, "/repository/gt/index")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `must not contain a ".." segment`)
+	assert.NotContains(t, w.Body.String(), "SECRET", "the traversal path must not resolve to the member's artifact")
 }

--- a/internal/formats/group/traversal_test.go
+++ b/internal/formats/group/traversal_test.go
@@ -1,0 +1,75 @@
+package group_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A routing rule is the only path-level policy a group has — RBAC grants a
+// repository, not a path inside it. The rule is matched against the request
+// path, so a path that reaches the artifact by another spelling must not reach
+// it at all: otherwise the string that was checked is not the string that is
+// served.
+func TestGroupHandler_RoutingRule_TraversalDoesNotBypassBlock(t *testing.T) {
+	rule := makeBlockRule("rule-traversal", `^/private/`)
+
+	member := testutil.SimpleRepo("secrets", "raw")
+	ruleID := "rule-traversal"
+	grp := &domain.Repository{
+		ID: "repo-grp-t", Name: "tgroup", Format: "raw",
+		Type: domain.TypeGroup, Online: true,
+		RoutingRuleID: &ruleID,
+		FormatConfig:  map[string]any{"member_names": []any{"secrets"}},
+	}
+
+	r := buildEngineWithRule(rule, member, grp)
+	require.Equal(t, http.StatusCreated, put(r, "secrets", "/private/secret.txt", "TOPSECRET"))
+
+	// The blocked path itself, for the baseline the rule already delivered.
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/repository/tgroup/private/secret.txt", nil))
+	require.Equal(t, http.StatusNotFound, rec.Code, "baseline: the rule blocks its own path")
+
+	for _, url := range []string{
+		"/repository/tgroup/public/../private/secret.txt",
+		"/repository/tgroup/%2e%2e/private/secret.txt",
+		"/repository/tgroup/a/b/../../private/secret.txt",
+	} {
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, url, nil))
+		assert.NotEqual(t, http.StatusOK, rec.Code, "%s must not reach the blocked artifact", url)
+		assert.NotContains(t, rec.Body.String(), "TOPSECRET", "%s leaked the blocked content", url)
+	}
+}
+
+// A traversal segment is refused outright rather than quietly rewritten, so no
+// legitimate path changes meaning.
+func TestGroupHandler_TraversalSegmentRejected(t *testing.T) {
+	member := testutil.SimpleRepo("plain", "raw")
+	grp := &domain.Repository{
+		ID: "repo-grp-p", Name: "pgroup", Format: "raw",
+		Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": []any{"plain"}},
+	}
+
+	r := buildEngineWithRule(nil, member, grp)
+	require.Equal(t, http.StatusCreated, put(r, "plain", "/ok/file.txt", "data"))
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/repository/pgroup/x/../ok/file.txt", nil))
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	// A path that merely contains ".." inside a name is not a traversal.
+	require.Equal(t, http.StatusCreated, put(r, "plain", "/ok/we..ird.txt", "fine"))
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, httptest.NewRequest(http.MethodGet, "/repository/pgroup/ok/we..ird.txt", nil))
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.Equal(t, "fine", rec2.Body.String())
+}


### PR DESCRIPTION
## Problem

A routing rule is the only path-level policy a `group` repository has — RBAC grants access to a *repository*, not to paths inside it. The rule is matched against the request path exactly as it arrives, but the member that finally serves the artifact normalizes the path first. Because the string that is checked is not the string that is served, a request naming the same artifact with a `..` segment reached content the rule denies.

Reproduced on `raw` and `maven2`; the mechanism does not depend on the format, and it predates this release line (routing rules landed in v1.13.0 — verified by running the same reproduction against the v1.36.0 tag).

Handled privately as `GHSA-xq6f-xp6w-c555`; the advisory publishes once a release carrying this fix is out.

## Fix

- The group handler refuses any request path containing a `..` segment (400) before anything else happens — refused rather than quietly normalized, so no legitimate path changes meaning on the way through. An artifact path never contains a `..` segment, while a name that merely contains dots (`we..ird.txt`) still passes.
- The same guard covers the sub-index paths a merger asks the group for (`subIndexFetcher`), since those are built from member documents — for a proxy member, whatever the upstream chose to serve.
- **apt** (second commit): the architectures and components a group covers are parsed out of members' `Release` documents and spliced into those paths. They now have to look like names (`^[A-Za-z0-9][A-Za-z0-9._+-]*$`), and the matrix is capped at 64×32. Without the cap, one member declaring a large matrix turned a single `Release` request into a fan-out proportional to what it claimed — measured at **50 000 sub-index fetches** for 500 architectures × 50 components. Real distributions are orders of magnitude below the cap (Debian: ~10 architectures, 3 components).

## Tests

Each was confirmed to fail against the current code and pass with the fix:

- A `BLOCK ^/private/` rule blocks its own path *and* every alternate spelling (`public/../private/...`, `%2e%2e/private/...`, `a/b/../../private/...`), asserting the blocked content never appears in the body.
- A `..` segment is rejected with 400, while `ok/we..ird.txt` is still served.
- A merger asking the group for a traversal sub-index path is refused; the fake member in that test now normalizes its own path, the way every real format handler does, so the test would catch the gap rather than pass by accident.
- apt: hostile `Architectures:`/`Components:` values never become fetched paths, sound values still survive, and the fan-out stays bounded regardless of what a member declares.

`go build`, `go vet`, `go test ./...`, `golangci-lint` green; `internal/formats/group` 90.1%, `internal/formats/apt` 86.0%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lnt5RyqWXYVfrphjEWQhri