### PR TITLE
feat(bootstrap): let an operator turn the admin bootstrap off (#243)

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -379,6 +379,27 @@ func s3ConfigEqual(cur, desired map[string]any) bool {
 // bootstrap correction) this no longer matches and the password is left alone.
 const seedPlaceholderAdminHash = "$2a$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdBPj/VcSAg/ROS"
 
+// seedAdminUsername is the account migration 001 pre-creates.
+const seedAdminUsername = "admin"
+
+// warnIfAdminUnusable says so when bootstrap is off but the seeded admin still
+// carries the placeholder hash: no password matches it, so on a fresh database
+// that combination means nobody can log in. Turning bootstrap off is only safe
+// once a real account exists, and an operator who got the order wrong needs to
+// hear about it at startup rather than at the login form.
+func warnIfAdminUnusable(ctx context.Context, userRepo repository.UserRepo, b config.BootstrapConfig, log logger.Logger) {
+	name := b.AdminUsername
+	if name == "" {
+		name = seedAdminUsername
+	}
+	admin, err := userRepo.Get(ctx, name)
+	if err != nil || admin == nil || admin.PasswordHash != seedPlaceholderAdminHash {
+		return
+	}
+	log.Warn("bootstrap is disabled but the admin account still has the unusable seed password — no password will log in; enable bootstrap once to set one, or create an account another way",
+		"username", name)
+}
+
 // bootstrapAdmin ensures the admin user exists with the configured password.
 func bootstrapAdmin(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config, log logger.Logger) error {
 	authSvc := auth.NewService(cfg.Auth.JWTSecret, cfg.Auth.JWTExpiryHours, cfg.Auth.BcryptCost)
@@ -391,6 +412,9 @@ func bootstrapAdmin(ctx context.Context, pool *pgxpool.Pool, cfg *config.Config,
 // password and the nx-admin role) and, on subsequent boots, applies the
 // configured password only if the stored hash is still the seed placeholder.
 // An admin whose password has genuinely been changed is never touched.
+//
+// bootstrap.enabled=false skips the whole thing, which is how an operator stops
+// keeping admin credentials in the config file (#243).
 func ensureBootstrapAdmin(
 	ctx context.Context,
 	userRepo repository.UserRepo,
@@ -399,7 +423,9 @@ func ensureBootstrapAdmin(
 	b config.BootstrapConfig,
 	log logger.Logger,
 ) error {
-	if b.AdminUsername == "" || b.AdminPassword == "" {
+	if !b.Enabled || b.AdminUsername == "" || b.AdminPassword == "" {
+		warnIfAdminUnusable(ctx, userRepo, b, log)
+		log.Info("bootstrap: disabled — the admin account is left as it is")
 		return nil
 	}
 

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -13,6 +13,7 @@ import (
 
 func testBootstrapCfg() config.BootstrapConfig {
 	return config.BootstrapConfig{
+		Enabled:        true,
 		AdminUsername:  "admin",
 		AdminPassword:  "admin123",
 		AdminEmail:     "admin@example.com",
@@ -198,5 +199,52 @@ func TestEnsureBootstrapAdmin_Missing_Created(t *testing.T) {
 	}
 	if err := authSvc.CheckPassword(got.PasswordHash, "admin123"); err != nil {
 		t.Fatalf("created admin password does not verify: %v", err)
+	}
+}
+
+// bootstrap.enabled=false is how an operator drops the admin credentials from
+// the config file for good (#243): the account is left entirely alone, even
+// though the shipped admin/admin123 defaults are still what config resolves to.
+func TestEnsureBootstrapAdmin_Disabled_NoAdminCreated(t *testing.T) {
+	authSvc := testAuthSvc()
+	users := testutil.NewUserRepo()
+	roles := testutil.NewRoleRepo(&domain.Role{ID: "r-admin", Name: "nx-admin"})
+	log := logger.New("error", "json")
+
+	b := testBootstrapCfg()
+	b.Enabled = false
+
+	if err := ensureBootstrapAdmin(context.Background(), users, roles, authSvc, b, log); err != nil {
+		t.Fatalf("ensureBootstrapAdmin: %v", err)
+	}
+
+	if got, err := users.Get(context.Background(), "admin"); err == nil && got != nil {
+		t.Fatal("admin user created even though bootstrap is disabled")
+	}
+}
+
+// Disabled bootstrap must not touch an existing admin either — not the seed
+// placeholder it would otherwise correct, and not a rotated password.
+func TestEnsureBootstrapAdmin_Disabled_ExistingAdminUntouched(t *testing.T) {
+	authSvc := testAuthSvc()
+	users := testutil.NewUserRepo(&domain.User{
+		ID:           "u-admin",
+		Username:     "admin",
+		PasswordHash: seedPlaceholderAdminHash,
+		Status:       domain.UserStatusActive,
+		Source:       domain.UserSourceLocal,
+	})
+	log := logger.New("error", "json")
+
+	b := testBootstrapCfg()
+	b.Enabled = false
+
+	if err := ensureBootstrapAdmin(context.Background(), users, testutil.NewRoleRepo(), authSvc, b, log); err != nil {
+		t.Fatalf("ensureBootstrapAdmin: %v", err)
+	}
+
+	got, _ := users.Get(context.Background(), "admin")
+	if got.PasswordHash != seedPlaceholderAdminHash {
+		t.Fatal("disabled bootstrap modified the admin password")
 	}
 }

--- a/cmd/server/startup_security.go
+++ b/cmd/server/startup_security.go
@@ -42,7 +42,11 @@ func checkStartupSecurity(cfg *config.Config, log logger.Logger) error {
 	// Fail closed on shipped insecure defaults unless explicitly allowed
 	// (local dev / quick-start sets auth.allow_insecure_defaults=true).
 	insecureJWT := config.IsDevDefaultJWTSecret(cfg.Auth.JWTSecret)
-	insecureAdmin := cfg.Bootstrap.AdminPassword == "admin123"
+	// Only while bootstrap will actually apply it: with bootstrap.enabled=false
+	// the shipped default is an inert leftover in the config, not a live
+	// credential, and refusing to boot over it would punish the operator who
+	// followed the advice to stop managing the admin password from a file.
+	insecureAdmin := cfg.Bootstrap.Enabled && cfg.Bootstrap.AdminPassword == "admin123"
 	// Only meaningful while OIDC is on: the key seals the state cookie of a
 	// login flow that is not running otherwise.
 	insecureOIDCKey := cfg.OIDC.Enabled && config.IsDevDefaultOIDCCookieKey(cfg.OIDC.CookieKey)

--- a/cmd/server/startup_security_test.go
+++ b/cmd/server/startup_security_test.go
@@ -115,3 +115,25 @@ func TestCheckStartupSecurity_ShippedDefaults_AllowedWhenOptedIn(t *testing.T) {
 
 	require.NoError(t, checkStartupSecurity(cfg, zap.NewNop().Sugar()))
 }
+
+// The shipped admin123 default is only a risk while bootstrap will actually
+// apply it. With bootstrap.enabled=false the value is inert, so it must not
+// keep the server from starting (#243).
+func TestCheckStartupSecurity_DisabledBootstrap_DefaultPasswordIgnored(t *testing.T) {
+	cfg := secureCfg()
+	cfg.Bootstrap.Enabled = false
+	cfg.Bootstrap.AdminPassword = "admin123"
+
+	require.NoError(t, checkStartupSecurity(cfg, zap.NewNop().Sugar()))
+}
+
+// With bootstrap on, admin123 still fails closed.
+func TestCheckStartupSecurity_EnabledBootstrap_DefaultPasswordRefused(t *testing.T) {
+	cfg := secureCfg()
+	cfg.Bootstrap.Enabled = true
+	cfg.Bootstrap.AdminPassword = "admin123"
+
+	err := checkStartupSecurity(cfg, zap.NewNop().Sugar())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "admin123=true")
+}

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -82,10 +82,18 @@ auth:
   rate_limit_rps: 50          # sustained requests/sec
   rate_limit_burst: 100       # burst capacity
 
-# Bootstrap: create / update the admin user on every server start.
-# Safe to run repeatedly — only acts if user is missing or password changed.
+# Bootstrap: create the admin user on server start.
+# Safe to run repeatedly — it creates the account when it is missing and
+# otherwise leaves it alone; a password you have already changed is never
+# overwritten from here (rotate it in the UI or over the API).
 # Override via env: NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD=secret
+#
+# Once real accounts exist you can set enabled: false and delete the four
+# admin_* lines — the credentials then no longer live in this file at all.
+# Do that only after the admin password has been set, otherwise the seeded
+# account has no usable password and nobody can log in.
 bootstrap:
+  enabled: true
   admin_username: "admin"
   admin_password: "admin123"   # change this!
   admin_email:    "admin@example.com"

--- a/deploy/helm/nexspence/templates/configmap.yaml
+++ b/deploy/helm/nexspence/templates/configmap.yaml
@@ -12,6 +12,7 @@ data:
   NEXSPENCE_LOG_FORMAT: {{ .Values.config.logFormat | quote }}
   NEXSPENCE_AUTH_JWT_EXPIRY_HOURS: {{ .Values.config.jwtExpiryHours | quote }}
   NEXSPENCE_AUTH_ALLOW_INSECURE_DEFAULTS: {{ .Values.config.allowInsecureDefaults | quote }}
+  NEXSPENCE_BOOTSTRAP_ENABLED: {{ .Values.config.bootstrapEnabled | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_USERNAME: {{ .Values.config.adminUsername | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_EMAIL: {{ .Values.config.adminEmail | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_FIRST_NAME: {{ .Values.config.adminFirstName | quote }}

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -54,7 +54,11 @@ config:
   # longer a shipped default (it is auto-generated when jwtSecret is empty).
   allowInsecureDefaults: true
   jwtExpiryHours: 8
-  # -- Bootstrap admin credentials
+  # -- Create/repair the bootstrap admin on every start. Set to false once real
+  # accounts exist, so the admin credentials below can be dropped from values
+  # and the Secret; an existing admin is then never touched.
+  bootstrapEnabled: true
+  # -- Bootstrap admin credentials (ignored when bootstrapEnabled is false)
   adminUsername: "admin"
   adminPassword: "admin123"
   adminEmail: "admin@example.com"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -154,12 +154,37 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `outbound.allowed_internal_cidrs` | `[]` | Internal ranges the SSRF guard may reach for proxy, webhook and replication targets. Empty refuses every loopback/private/link-local/CGNAT address. |
 | `auth.rate_limit_enabled` | `true` | Token-bucket throttle per user (per client address when anonymous). Turning it off leaves `/api/v1/login` unmetered. |
 | `auth.rate_limit_rps` / `auth.rate_limit_burst` | `50` / `100` | Sustained rate and burst for the above |
+| `bootstrap.enabled` | `true` | Create the admin account on start. Set to `false` once real accounts exist to stop keeping admin credentials in the config — see [Removing the bootstrap admin credentials](#removing-the-bootstrap-admin-credentials). |
 | `bootstrap.admin_password` | `admin123` | Auto-created admin password — **change this** |
 | `cleanup.default_schedule` | `0 2 * * *` | Default cron for cleanup policies |
 | `audit.retention_days` | `90` | Audit log partition retention |
 | `metrics.public` | `false` | Serve `GET /metrics` without authentication. Default requires a Bearer token; see [Prometheus](#prometheus). |
 | `redis.enabled` | `false` | Enable Redis (required for HA) |
 | `redis.addr` | `localhost:6379` | Redis address |
+
+---
+
+## Removing the bootstrap admin credentials
+
+On every start Nexspence creates the `bootstrap.admin_username` account if it is missing. That is what gives a fresh install someone to log in as — but it also means the admin username and password sit in the config file for the life of the deployment, long after real accounts exist.
+
+To take them out, turn the bootstrap off:
+
+```yaml
+bootstrap:
+  enabled: false
+```
+
+The four `admin_*` keys can then be deleted. Existing accounts — including the admin — are left exactly as they are; bootstrap never overwrites a password that has been set.
+
+Two things to know:
+
+- **Do this only after the admin password has been set** (first login, or any rotation in the UI / over the API). A freshly migrated database seeds the admin row with a placeholder hash that no password matches, so disabling bootstrap before that leaves nobody able to log in. The server logs a warning at startup when it detects exactly this.
+- **Deleting the `bootstrap` block on its own is not enough.** The shipped defaults (`admin` / `admin123`) apply to any key you omit, and the startup security check then refuses to boot on the default password. `enabled: false` is what makes omitting the rest safe.
+
+Under Kubernetes the same switch is `config.bootstrapEnabled: false` in the Helm values, which also lets you drop `adminPassword` from the chart's Secret. Setting it through the environment works too: `NEXSPENCE_BOOTSTRAP_ENABLED=false`.
+
+If you would rather keep the bootstrap on but stop storing the password in the file, leave `enabled: true` and pass it as `NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD` instead.
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,12 @@ type ProxyConfig struct {
 
 // BootstrapConfig holds the admin account that is created/synced on every startup.
 type BootstrapConfig struct {
+	// Enabled runs the startup admin bootstrap. It defaults to true so a fresh
+	// install has an account to log in as. Turn it off once real accounts exist
+	// and the admin credentials no longer belong in the config file: the whole
+	// bootstrap block can then be deleted without the shipped admin/admin123
+	// defaults quietly coming back (#243).
+	Enabled        bool   `mapstructure:"enabled"`
 	AdminUsername  string `mapstructure:"admin_username"`
 	AdminPassword  string `mapstructure:"admin_password"`
 	AdminEmail     string `mapstructure:"admin_email"`
@@ -525,6 +531,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("ldap.group_attribute", "cn")
 	v.SetDefault("ldap.auto_create_users", true)
 	v.SetDefault("ldap.timeout_sec", 10)
+	v.SetDefault("bootstrap.enabled", true)
 	v.SetDefault("bootstrap.admin_username", "admin")
 	v.SetDefault("bootstrap.admin_password", "admin123")
 	v.SetDefault("bootstrap.admin_email", "admin@example.com")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -356,3 +356,53 @@ func TestLoad_DockerMaxUploadBytes_Configurable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(1048576), cfg.Docker.MaxUploadBytes)
 }
+
+// The bootstrap admin exists so a fresh install has someone to log in as, so
+// it is on by default. Operators who have already created their own accounts
+// turn it off — see TestLoad_BootstrapCanBeDisabled.
+func TestLoad_Bootstrap_DefaultsEnabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Bootstrap.Enabled, "bootstrap.enabled must default to true")
+	assert.Equal(t, "admin", cfg.Bootstrap.AdminUsername)
+}
+
+// bootstrap.enabled=false is the supported way to drop the admin credentials
+// from the config file: the block can then be omitted entirely without the
+// shipped admin123 default coming back (#243).
+func TestLoad_BootstrapCanBeDisabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n" +
+		"bootstrap:\n  enabled: false\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Bootstrap.Enabled)
+}
+
+// The Kubernetes path sets configuration through the environment, so the
+// disable switch has to work there too.
+func TestLoad_BootstrapDisabledViaEnv(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	t.Setenv("NEXSPENCE_BOOTSTRAP_ENABLED", "false")
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Bootstrap.Enabled)
+}

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -624,6 +624,7 @@ helm install nexspence deploy/helm/nexspence \
       <tr><td><code>auth.jwt_secret</code></td><td>—</td><td><strong style="color:var(--red)">Required.</strong> JWT signing key — min 32 chars</td></tr>
       <tr><td><code>auth.encryption_key</code></td><td>—</td><td>Optional base64 32-byte key for replication credentials — decouples them from <code>jwt_secret</code>; existing rows re-encrypt automatically at startup. Generate: <code>openssl rand -base64 32</code></td></tr>
       <tr><td><code>bootstrap.admin_password</code></td><td><code>admin123</code></td><td><strong style="color:var(--red)">Change before production.</strong> Auto-created admin password</td></tr>
+      <tr><td><code>bootstrap.enabled</code></td><td><code>true</code></td><td>Create the admin account on start. Set to <code>false</code> once real accounts exist — the <code>admin_*</code> keys can then be removed from the config entirely</td></tr>
       <tr><td><code>http.addr</code></td><td><code>:8081</code></td><td>Listen address</td></tr>
       <tr><td><code>http.base_url</code></td><td><code>http://localhost:8081</code></td><td>Public URL used in download links</td></tr>
       <tr><td><code>auth.jwt_expiry_hours</code></td><td><code>24</code></td><td>JWT token lifetime</td></tr>


### PR DESCRIPTION
Closes #243.

## Problem

The bootstrap admin credentials had no way out of the config file. Deleting the `bootstrap` block does not remove them — every omitted key falls back to the shipped `admin` / `admin123` defaults, and `checkStartupSecurity` then refuses to boot on the default password. The only thing that worked was setting `admin_password: ""`, which was undocumented and silently reverted to `admin123` if written as `admin_password:` with no value.

## Change

`bootstrap.enabled` (default `true`) skips the bootstrap step entirely, so the four `admin_*` keys can be deleted once real accounts exist.

- `ensureBootstrapAdmin` returns early when disabled; existing accounts are untouched either way (it has never overwritten a password that was actually set).
- The `admin123` startup refusal now applies only while bootstrap is on — with it off the value is an inert leftover in the config, not a live credential.
- Disabling it too early is the one way to lock yourself out: a freshly migrated database seeds the admin row with a placeholder hash that no password matches. Startup warns when it sees exactly that combination.

## Docs

- `config.yaml.example` — documents the switch, and corrects the old comment claiming bootstrap acts "if the password changed" (it only ever corrected the seed placeholder).
- `docs/deployment.md` — new "Removing the bootstrap admin credentials" section, plus the config-table row.
- Helm: `config.bootstrapEnabled`, so `adminPassword` can be dropped from the chart Secret.
- The in-app config reference table.

## Verification

- `go test ./...` — passes (the one failure, `TestWebhookHandler_Test_200`, is the pre-existing sandbox network restriction, unrelated).
- `golangci-lint run ./cmd/... ./internal/config/...` — 0 issues.
- Tests cover: default is enabled, disabled via config file, disabled via `NEXSPENCE_BOOTSTRAP_ENABLED`, no admin created when off, existing admin untouched when off, and both directions of the `admin123` startup check.
- Helm rendering was not verified locally (helm is not installed here); the change mirrors the adjacent `NEXSPENCE_*` entries in the same ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvWGdiC6pX2SPmtvoN8mry