### PR TITLE
docs(conan): say what the Conan repository actually speaks (#244)

### DIFF
--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -647,7 +647,7 @@ sudo rpm -ivh mypackage-1.0-1.x86_64.rpm` },
     name: 'Conan C/C++',
     icon: '🔧',
     iconUrl: 'https://cdn.simpleicons.org/conan/6699CB',
-    description: 'Conan v1 package manager repository for C and C++ libraries. Supports upload/download protocol.',
+    description: 'Conan package manager repository for C and C++ libraries. Conan 1.x is supported end to end. The v2 revisions protocol Conan 2.x speaks is implemented for recipes, packages and files, but the credential endpoints it needs to log in and upload are not, so Conan 2 clients cannot publish yet.',
     sections: (base) => [
       {
         title: 'Repository URL',
@@ -655,11 +655,14 @@ sudo rpm -ivh mypackage-1.0-1.x86_64.rpm` },
       },
       {
         title: 'Add Remote and Authenticate',
+        text: 'Conan 1.x:',
         codes: [{ lang: 'bash', content: `conan remote add nexspence ${base}/repository/conan-hosted/
 conan user admin -p admin123 -r nexspence` }],
+        note: 'Conan 2.x replaced "conan user" with "conan remote login", which goes through the /v2/users/* credential endpoints. Those are not implemented yet, so on a Conan 2 client both "conan remote login" and "conan upload" fail with a 405.',
       },
       {
         title: 'Publish a Package',
+        text: 'Conan 1.x:',
         codes: [
           { label: 'Using conan upload:', lang: 'bash', content: `conan upload mylib/1.0@user/stable -r nexspence --all` },
           { label: 'Get upload URLs with curl:', lang: 'bash', content: `curl -u admin:admin123 \\
@@ -668,6 +671,7 @@ conan user admin -p admin123 -r nexspence` }],
       },
       {
         title: 'Install a Package',
+        text: 'Conan 1.x:',
         codes: [
           { label: 'Using conan install:', lang: 'bash', content: `conan install mylib/1.0@user/stable -r nexspence` },
           { label: 'Get download URLs with curl:', lang: 'bash', content: `curl -u admin:admin123 \\

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -1637,7 +1637,7 @@ export NEXSPENCE_OIDC_CLIENT_SECRET="..."</div></div>
       <tr><td>Cargo</td><td>Sparse index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Apt</td><td>Debian Packages index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Yum / RPM</td><td>repomd.xml</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
-      <tr><td>Conan</td><td>Conan v1</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
+      <tr><td>Conan</td><td>Conan v1 (v2 revisions: partial)</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Raw</td><td>HTTP PUT/GET</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Conda</td><td>conda index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Terraform</td><td>Registry protocol v1</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>


### PR DESCRIPTION
Partially addresses #244 — the documentation half. The missing `/v2/users/*` endpoints are still open.

The in-app docs described the format as a "Conan v1 package manager repository" and showed only Conan 1 syntax (`conan user`, `conan upload --all`), both of which were removed in Conan 2. That is doubly misleading: it understates the server — the v2 revisions protocol *is* implemented for recipes, packages and files — while leaving a Conan 2 user to find out by trial that the client dies on the credential handshake.

Changes:
- Format description now states what is implemented and what is not.
- Each example is labelled with the client version it is for.
- A note on the "Add Remote and Authenticate" section explains that `conan remote login` and `conan upload` return 405 on Conan 2 until the `/v2/users/*` endpoints exist.
- The site's protocol table says `Conan v1 (v2 revisions: partial)` instead of `Conan v1`.

The wording is deliberately limited to what is verified: the v2 endpoints reported working in #244, and the two that return 405. It claims nothing about anonymous Conan 2 installs, which nobody has tested end to end.

Verification: `npx tsc --noEmit` clean, `vitest src/pages/DocsPage.test.tsx` 11/11, `go test ./internal/domain -run TestSite` passes (the site format table is checked against `domain.AllFormats`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvWGdiC6pX2SPmtvoN8mry