### PR TITLE
feat(conan): serve the credential handshake Conan 2 clients require (#244)

### DIFF
--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -647,7 +647,7 @@ sudo rpm -ivh mypackage-1.0-1.x86_64.rpm` },
     name: 'Conan C/C++',
     icon: '🔧',
     iconUrl: 'https://cdn.simpleicons.org/conan/6699CB',
-    description: 'Conan package manager repository for C and C++ libraries. Conan 1.x is supported end to end. The v2 revisions protocol Conan 2.x speaks is implemented for recipes, packages and files, but the credential endpoints it needs to log in and upload are not, so Conan 2 clients cannot publish yet.',
+    description: 'Conan package manager repository for C and C++ libraries. Conan 2.x is supported over the v2 revisions protocol — login, upload and install — and Conan 1.x over the v1 API.',
     sections: (base) => [
       {
         title: 'Repository URL',
@@ -655,28 +655,32 @@ sudo rpm -ivh mypackage-1.0-1.x86_64.rpm` },
       },
       {
         title: 'Add Remote and Authenticate',
-        text: 'Conan 1.x:',
-        codes: [{ lang: 'bash', content: `conan remote add nexspence ${base}/repository/conan-hosted/
-conan user admin -p admin123 -r nexspence` }],
-        note: 'Conan 2.x replaced "conan user" with "conan remote login", which goes through the /v2/users/* credential endpoints. Those are not implemented yet, so on a Conan 2 client both "conan remote login" and "conan upload" fail with a 405.',
+        codes: [
+          { label: 'Conan 2.x:', lang: 'bash', content: `conan remote add nexspence ${base}/repository/conan-hosted/
+conan remote login nexspence admin -p admin123` },
+          { label: 'Conan 1.x:', lang: 'bash', content: `conan remote add nexspence ${base}/repository/conan-hosted/
+conan user admin -p admin123 -r nexspence` },
+        ],
       },
       {
         title: 'Publish a Package',
-        text: 'Conan 1.x:',
         codes: [
-          { label: 'Using conan upload:', lang: 'bash', content: `conan upload mylib/1.0@user/stable -r nexspence --all` },
-          { label: 'Get upload URLs with curl:', lang: 'bash', content: `curl -u admin:admin123 \\
+          { label: 'Conan 2.x:', lang: 'bash', content: `conan create .
+conan upload "mylib/1.0" -r=nexspence --confirm` },
+          { label: 'Conan 1.x:', lang: 'bash', content: `conan upload mylib/1.0@user/stable -r nexspence --all` },
+          { label: 'Get upload URLs with curl (v1 API):', lang: 'bash', content: `curl -u admin:admin123 \\
   "${base}/repository/conan-hosted/v1/conans/mylib/1.0/user/stable/upload_urls"` },
         ],
       },
       {
         title: 'Install a Package',
-        text: 'Conan 1.x:',
         codes: [
-          { label: 'Using conan install:', lang: 'bash', content: `conan install mylib/1.0@user/stable -r nexspence` },
-          { label: 'Get download URLs with curl:', lang: 'bash', content: `curl -u admin:admin123 \\
+          { label: 'Conan 2.x:', lang: 'bash', content: `conan install --requires="mylib/1.0" -r=nexspence` },
+          { label: 'Conan 1.x:', lang: 'bash', content: `conan install mylib/1.0@user/stable -r nexspence` },
+          { label: 'Get download URLs with curl (v1 API):', lang: 'bash', content: `curl -u admin:admin123 \\
   "${base}/repository/conan-hosted/v1/conans/mylib/1.0/user/stable/download_urls"` },
         ],
+        note: 'Searching and deleting over the remote (conan search / conan list / conan remove) are not implemented yet — resolve and download work, so upload and install round trips are unaffected.',
       },
     ],
   },

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -240,6 +240,9 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		RoutingRules: rrRepo,
 		RBAC:         rbacSvc,
 		Scanner:      scanTrigger,
+		// Conan's login handshake hands the client a token it then sends as
+		// Bearer, so it has to be the same JWT OptionalAuth validates.
+		Tokens: authSvc,
 		// /v2/ upload paths are exempt from the global body cap, so this is the
 		// only bound on a staged blob upload (issue #208).
 		MaxUploadBytes: cfg.Docker.MaxUploadBytes,

--- a/internal/formats/conan/handler.go
+++ b/internal/formats/conan/handler.go
@@ -14,7 +14,9 @@
 //	GET  /files/:name/:version/:user/:channel/:revision/package/:pkgid/:prevision/:file → download package file
 //
 // The Conan v2 revisions API (Conan 2.x clients) is served under
-// /v2/conans/... — see v2.go for the route list.
+// /v2/conans/... — see v2.go for the route list — and the credential
+// handshake those clients perform before uploading under /v2/users/... — see
+// users.go.
 package conan
 
 import (
@@ -57,6 +59,12 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			servePing(c)
 			return
 		}
+		// So is the credential handshake — it authenticates against this
+		// server, not against the upstream.
+		if isUsersPath(p) {
+			h.serveUsers(c, p)
+			return
+		}
 		// Conan revision files are content-addressed (immutable); the "/latest"
 		// endpoints resolve to a moving recipe/package revision, so revalidate those.
 		var maxAge time.Duration
@@ -94,6 +102,10 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	// Recipe manifest: GET /v1/conans/:name/:ver/:user/:channel
 	case c.Request.Method == http.MethodGet && strings.HasPrefix(p, "/v1/conans/"):
 		h.handleManifest(c, repoName, p)
+
+	// Conan v2 credential handshake (Conan 2.x clients): /v2/users/... (#244)
+	case isUsersPath(p):
+		h.serveUsers(c, p)
 
 	// Conan v2 revisions API (Conan 2.x clients): /v2/conans/... (#95)
 	case strings.HasPrefix(p, "/v2/conans/"):

--- a/internal/formats/conan/users.go
+++ b/internal/formats/conan/users.go
@@ -1,0 +1,91 @@
+package conan
+
+// Conan credential handshake (Conan 2.x clients):
+//
+//	GET /v2/users/authenticate        → bearer token for the Basic-authenticated caller
+//	GET /v2/users/check_credentials   → username the caller is authenticated as
+//
+// The client calls check_credentials immediately before every upload and
+// refuses to write without a 200, so without these two routes a Conan 2 client
+// cannot publish at all even though the rest of the v2 revisions API works
+// (#244).
+//
+// Both responses are plain text carrying a bare value — the client reads the
+// body directly as the token / username. JSON here breaks it, quoted strings
+// included. The reference contract is conan_server's
+// conans/server/rest/controller/v2/.
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// usersPath reports whether p is one of the credential routes, and which.
+const (
+	pathAuthenticate     = "/v2/users/authenticate"
+	pathCheckCredentials = "/v2/users/check_credentials" //nolint:gosec // G101: a request path the Conan client calls, not a credential
+)
+
+// isUsersPath reports whether p is a Conan credential route. These are served
+// locally for every repository type, proxies included: they authenticate the
+// caller against Nexspence, and an upstream that has never heard of this user
+// cannot answer them.
+func isUsersPath(p string) bool {
+	return p == pathAuthenticate || p == pathCheckCredentials
+}
+
+// serveUsers handles the credential routes. The request has already passed
+// through OptionalAuth, so an authenticated caller arrives with a username set
+// in the gin context and everyone else arrives anonymous.
+func (h *Handler) serveUsers(c *gin.Context, p string) {
+	if c.Request.Method != http.MethodGet {
+		c.Status(http.StatusMethodNotAllowed)
+		return
+	}
+
+	username, userID, roles, ok := caller(c)
+	if !ok {
+		// Not "forbidden": the client is asking to log in, and a challenge is
+		// what makes it prompt for credentials instead of giving up. A
+		// repository with allow_anonymous lets the anonymous request reach us,
+		// so the check has to happen here — answering 200 would log the client
+		// in as nobody and attribute its uploads to nobody.
+		c.Header("WWW-Authenticate", `Basic realm="Nexspence"`)
+		c.Status(http.StatusUnauthorized)
+		return
+	}
+
+	if p == pathCheckCredentials {
+		c.String(http.StatusOK, username)
+		return
+	}
+
+	if h.deps.Tokens == nil {
+		c.String(http.StatusServiceUnavailable, "token issuer not configured")
+		return
+	}
+	token, err := h.deps.Tokens.GenerateToken(userID, username, roles)
+	if err != nil {
+		// Deliberately not 401: the credentials were fine, we failed to sign.
+		// Reporting it as an auth failure would send the user off to check a
+		// password that is not the problem.
+		c.String(http.StatusServiceUnavailable, "could not issue token")
+		return
+	}
+	c.String(http.StatusOK, token)
+}
+
+// caller reads the authenticated identity OptionalAuth left on the context.
+func caller(c *gin.Context) (username, userID string, roles []string, ok bool) {
+	u, _ := c.Get("username")
+	username, _ = u.(string)
+	if username == "" {
+		return "", "", nil, false
+	}
+	id, _ := c.Get("userID")
+	userID, _ = id.(string)
+	r, _ := c.Get("roles")
+	roles, _ = r.([]string)
+	return username, userID, roles, true
+}

--- a/internal/formats/conan/users_test.go
+++ b/internal/formats/conan/users_test.go
@@ -1,0 +1,176 @@
+package conan_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/conan"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// stubIssuer stands in for *auth.Service. It records what it was asked to sign
+// so the tests can prove the token is minted for the authenticated caller and
+// not for whoever the request claims to be.
+type stubIssuer struct {
+	userID   string
+	username string
+	roles    []string
+	err      error
+}
+
+func (s *stubIssuer) GenerateToken(userID, username string, roles []string) (string, error) {
+	s.userID, s.username, s.roles = userID, username, roles
+	if s.err != nil {
+		return "", s.err
+	}
+	return "jwt-for-" + username, nil
+}
+
+// setupUsers builds a Conan router whose requests arrive already authenticated
+// as user (empty user = anonymous), mirroring what handlers.OptionalAuth sets
+// on the real route.
+func setupUsers(repo *domain.Repository, user string, issuer formats.TokenIssuer) *gin.Engine {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+		Tokens:     issuer,
+	}
+	h := conan.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		if user != "" {
+			c.Set("username", user)
+			c.Set("userID", "u-"+user)
+			c.Set("roles", []string{"nx-deployer"})
+		}
+		h.ServeHTTP(c)
+	})
+	return r
+}
+
+// The Conan 2 client reads this response body as the bearer token itself, so it
+// has to be the bare token as text — not JSON, not a quoted string (#244).
+func TestConan_V2_Authenticate_ReturnsBareToken(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-auth", "conan")
+	issuer := &stubIssuer{}
+	r := setupUsers(repo, "alice", issuer)
+
+	w := v2Get(r, "/repository/cv2-auth/v2/users/authenticate")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "jwt-for-alice", w.Body.String())
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/plain")
+	assert.Equal(t, "u-alice", issuer.userID, "token must be minted for the authenticated caller")
+	assert.Equal(t, []string{"nx-deployer"}, issuer.roles, "token must carry the caller's roles")
+}
+
+// Without credentials this must not hand out a token for the anonymous user:
+// on a repository with allow_anonymous the request reaches the handler, and
+// answering 200 would let anyone log in as nobody and upload as nobody.
+func TestConan_V2_Authenticate_Anonymous_401(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-auth-anon", "conan")
+	repo.AllowAnonymous = true
+	r := setupUsers(repo, "", &stubIssuer{})
+
+	w := v2Get(r, "/repository/cv2-auth-anon/v2/users/authenticate")
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Header().Get("WWW-Authenticate"), "Basic")
+}
+
+// check_credentials answers with the username as bare text — the client prints
+// it and uses it as the account the remote is logged in as.
+func TestConan_V2_CheckCredentials_ReturnsUsername(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-check", "conan")
+	r := setupUsers(repo, "bob", &stubIssuer{})
+
+	w := v2Get(r, "/repository/cv2-check/v2/users/check_credentials")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "bob", w.Body.String())
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/plain")
+}
+
+func TestConan_V2_CheckCredentials_Anonymous_401(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-check-anon", "conan")
+	repo.AllowAnonymous = true
+	r := setupUsers(repo, "", &stubIssuer{})
+
+	w := v2Get(r, "/repository/cv2-check-anon/v2/users/check_credentials")
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// A signing failure must not look like a wrong password: the client would tell
+// the user to check their credentials, which would be a dead end.
+func TestConan_V2_Authenticate_IssuerError_503(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-auth-err", "conan")
+	r := setupUsers(repo, "carol", &stubIssuer{err: assert.AnError})
+
+	w := v2Get(r, "/repository/cv2-auth-err/v2/users/authenticate")
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// Nothing wires a token issuer on a route that cannot mint one; say so rather
+// than answering 200 with an empty body, which the client would store as a
+// token and then fail on every later request.
+func TestConan_V2_Authenticate_NoIssuer_503(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-auth-noissuer", "conan")
+	r := setupUsers(repo, "dave", nil)
+
+	w := v2Get(r, "/repository/cv2-auth-noissuer/v2/users/authenticate")
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+// check_credentials needs no issuer — it only reports who the caller is.
+func TestConan_V2_CheckCredentials_NoIssuer_StillWorks(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-check-noissuer", "conan")
+	r := setupUsers(repo, "erin", nil)
+
+	w := v2Get(r, "/repository/cv2-check-noissuer/v2/users/check_credentials")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "erin", w.Body.String())
+}
+
+// The routes are GET-only; anything else stays a 405 rather than falling into
+// the authenticate branch.
+func TestConan_V2_Users_NonGET_405(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-users-method", "conan")
+	r := setupUsers(repo, "alice", &stubIssuer{})
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete} {
+		req := httptest.NewRequest(method, "/repository/cv2-users-method/v2/users/authenticate", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code, method)
+	}
+}
+
+// A proxy repository answers the credential handshake itself. Forwarding it
+// upstream would ask a remote that does not know this user, and the whole
+// point of the endpoint is to authenticate against Nexspence.
+func TestConan_V2_Users_ProxyRepo_ServedLocally(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-users-proxy", "conan")
+	repo.Type = domain.TypeProxy
+	repo.ProxyConfig = map[string]any{"remote_url": "http://127.0.0.1:19998"}
+	r := setupUsers(repo, "frank", &stubIssuer{})
+
+	w := v2Get(r, "/repository/cv2-users-proxy/v2/users/check_credentials")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "frank", w.Body.String())
+}

--- a/internal/formats/deps.go
+++ b/internal/formats/deps.go
@@ -31,11 +31,30 @@ type Deps struct {
 	// Scanner is optional — nil disables automatic vulnerability scanning of
 	// uploads.
 	Scanner ScanTrigger
+	// Tokens mints a bearer token for a caller the request has already
+	// authenticated. It is optional — nil makes the handshakes that need one
+	// answer 503 rather than hand out a token nothing can validate.
+	Tokens TokenIssuer
 	// MaxUploadBytes caps the total size of a single staged blob upload. The
 	// /v2/ upload paths are exempt from the global request-body cap so large
 	// image layers are not truncated, which leaves this as their only bound.
 	// 0 disables the cap.
 	MaxUploadBytes int64
+}
+
+// TokenIssuer mints a bearer token for an already-authenticated caller.
+//
+// Some package managers log in over a protocol endpoint of their own before
+// they will upload — Conan's GET /v2/users/authenticate hands the client a
+// token it then sends as Bearer on every later request. The handler cannot
+// mint that itself, and importing internal/auth here would drag the whole
+// authentication service into the format layer, so it asks for the one method
+// it needs. *auth.Service satisfies this.
+type TokenIssuer interface {
+	// GenerateToken signs a token for the given user. The caller is expected to
+	// have been authenticated already: this issues credentials, it does not
+	// check them.
+	GenerateToken(userID, username string, roles []string) (string, error)
 }
 
 // ScanTrigger requests a background vulnerability scan of a stored component.

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -1638,7 +1638,7 @@ export NEXSPENCE_OIDC_CLIENT_SECRET="..."</div></div>
       <tr><td>Cargo</td><td>Sparse index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Apt</td><td>Debian Packages index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Yum / RPM</td><td>repomd.xml</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
-      <tr><td>Conan</td><td>Conan v1 (v2 revisions: partial)</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
+      <tr><td>Conan</td><td>Conan v1 + v2 revisions</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Raw</td><td>HTTP PUT/GET</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Conda</td><td>conda index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Terraform</td><td>Registry protocol v1</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>


### PR DESCRIPTION
Closes #244. Reported, diagnosed and isolated by @strasvet, whose report contained the exact contract and the proof that these two routes were the only gap.

## What was broken

`GET /v2/users/authenticate` and `GET /v2/users/check_credentials` were not registered at all — `internal/formats/conan/handler.go` routed `/ping`, `/v1/*` and `/v2/conans/*` and nothing else. A Conan 2 client calls `check_credentials` immediately before it writes, so every upload failed with `Server exception 405`, and `conan remote login` failed earlier on `authenticate`.

## Implementation

Both handlers are thin, because the request has already been through `OptionalAuth` when it reaches the format layer:

- **`authenticate`** — signs a token for the caller that middleware authenticated, and returns it as a bare string.
- **`check_credentials`** — returns that caller's username as a bare string.
- Bodies are `text/plain`, not JSON: the client reads the body itself as the token / username.
- Anonymous → `401` + `WWW-Authenticate: Basic`. This is load-bearing on a repository with `allowAnonymous`, where the anonymous request does reach the handler — a `200` there would log the client in as nobody and attribute its uploads to nobody.
- A signing failure is `503`, not `401`: the credentials were fine, and reporting an auth failure would send the user to check a password that is not the problem.
- Proxy repositories answer both locally, next to `/ping`. Forwarding upstream would ask a remote that has never heard of this user.

The returned token must be one the server accepts as `Bearer` on the uploads that follow, so it is the same JWT `OptionalAuth` validates. Rather than import `internal/auth` into the format layer, `formats.Deps` gains a `TokenIssuer` — the one method of `*auth.Service` this needs — following the existing `RBACChecker` / `ScanTrigger` pattern.

## Verification

Unit tests (`internal/formats/conan`, coverage 90.7%) cover the bare-token body, the content type, minting for the authenticated caller with their roles, anonymous 401 on both routes, non-GET 405, issuer error and missing issuer, and local handling on a proxy repo.

**Live end-to-end against a real Conan 2.24 client** (server built from this branch, Postgres, hosted `conan` repo, client in a container):

```
conan remote login nx admin -p ***          → OK
conan export .                              → somepkg/1.0#a2f48c4f…
conan upload "somepkg/1.0" -r=nx --confirm  → Uploaded
conan remove "*" -c                         → local cache empty
conan download "somepkg/1.0" -r=nx          → recipe back from the server
```

Server log confirms `/v2/users/authenticate` → 200 and `/v2/users/check_credentials` → 200 on that run. Also checked by hand against the running server:

| Request | Result |
|---|---|
| `authenticate` with wrong password | 401 |
| `authenticate` with no credentials | 401 |
| `authenticate` with valid Basic | 200, bare JWT |
| `check_credentials` with that Bearer | 200, `admin` |
| `PUT /v2/conans/.../files/conanfile.py` with that Bearer | 201 |
| `check_credentials` anonymous, on an `allowAnonymous` repo | 401 |

`go test ./...` passes apart from the pre-existing `TestWebhookHandler_Test_200` sandbox network restriction. `golangci-lint` clean.

## Docs

The in-app format docs now lead with Conan 2 syntax (`conan remote login`, `conan upload --confirm`, `conan install --requires`) and keep the 1.x commands alongside, and note that remote search/remove are still missing (#247). The site's protocol table reads `Conan v1 + v2 revisions`.

## Not in scope

`/v2/conans/search` and the `DELETE` routes — tracked separately in #247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvWGdiC6pX2SPmtvoN8mry