### PR TITLE
feat(conan): implement the v2 search and delete routes (#247)

### DIFF
--- a/internal/formats/conan/handler.go
+++ b/internal/formats/conan/handler.go
@@ -65,6 +65,19 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			h.serveUsers(c, p)
 			return
 		}
+		// Search too (#247): the generic proxy GET below would drop the query
+		// string on the upstream fetch and cache the first answer forever, so
+		// forwarding it can only mislead. A proxy can serve what it has
+		// cached, and that is what its search reports.
+		if c.Request.Method == http.MethodGet && p == "/v2/conans/search" {
+			h.v2SearchRecipes(c, repoName)
+			return
+		}
+		if c.Request.Method == http.MethodGet &&
+			strings.HasPrefix(p, "/v2/conans/") && strings.HasSuffix(p, "/search") {
+			h.v2SearchPackages(c, repoName, p)
+			return
+		}
 		// Conan revision files are content-addressed (immutable); the "/latest"
 		// endpoints resolve to a moving recipe/package revision, so revalidate those.
 		var maxAge time.Duration

--- a/internal/formats/conan/v2.go
+++ b/internal/formats/conan/v2.go
@@ -7,6 +7,9 @@ package conan
 //	GET  /v2/conans/:name/:ver/:user/:channel/revisions/:rrev/files       → list recipe files
 //	GET  /v2/conans/:name/:ver/:user/:channel/latest                      → latest recipe revision
 //	GET  /v2/conans/:name/:ver/:user/:channel/revisions                   → list recipe revisions
+//	GET  /v2/conans/search?q=<pattern>                                    → recipe search (v2_search.go, #247)
+//	GET  /v2/conans/:name/:ver/:user/:channel[/revisions/:rrev]/search    → package search (v2_search.go, #247)
+//	DELETE /v2/conans/:name/:ver/:user/:channel[/revisions/:rrev]         → delete recipe / revision (v2_delete.go, #247)
 //
 // ...and the same shapes under /revisions/:rrev/packages/:pkgid/... for
 // package binaries. Files are stored verbatim under their full
@@ -44,6 +47,18 @@ func (h *Handler) serveV2(c *gin.Context, repoName, p string) {
 	case m == http.MethodGet && strings.HasSuffix(p, "/revisions"):
 		h.v2ListRevisions(c, repoName, p)
 
+	// Repository-wide recipe search: /v2/conans/search?q=<pattern> (#247)
+	case m == http.MethodGet && p == "/v2/conans/search":
+		h.v2SearchRecipes(c, repoName)
+
+	// Binary package search, ref- or revision-level: .../search (#247)
+	case m == http.MethodGet && strings.HasSuffix(p, "/search"):
+		h.v2SearchPackages(c, repoName, p)
+
+	// Recipe deletion, whole reference or one revision (#247)
+	case m == http.MethodDelete:
+		h.v2Delete(c, repoName, p)
+
 	default:
 		c.Status(http.StatusMethodNotAllowed)
 	}
@@ -52,17 +67,20 @@ func (h *Handler) serveV2(c *gin.Context, repoName, p string) {
 // pathsUnder returns stored asset paths (relative to prefix) and their
 // timestamps for every asset under the given path prefix. The second return
 // is false when listing failed and an error response was already written.
+//
+// The listing is exhaustive: ListByRepoAndPath is an unbounded prefix query,
+// unlike the paged Assets.List, whose first page is all a handler would see.
+// That distinction is live for DELETE (#247) — deleting from a truncated
+// listing would remove part of a revision and still answer 200.
 func (h *Handler) pathsUnder(c *gin.Context, repoName, prefix string) (map[string]time.Time, bool) {
-	page, err := h.deps.Assets.List(c.Request.Context(), repoName, 1000, 0)
+	assets, err := h.deps.Assets.ListByRepoAndPath(c.Request.Context(), repoName, prefix)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return nil, false
 	}
 	out := map[string]time.Time{}
-	for _, a := range page.Items {
-		if strings.HasPrefix(a.Path, prefix) {
-			out[strings.TrimPrefix(a.Path, prefix)] = a.LastModified
-		}
+	for _, a := range assets {
+		out[strings.TrimPrefix(a.Path, prefix)] = a.LastModified
 	}
 	return out, true
 }

--- a/internal/formats/conan/v2_delete.go
+++ b/internal/formats/conan/v2_delete.go
@@ -24,7 +24,10 @@ import (
 //
 // Package-granular deletion (…/packages/:pkgID, …/packages/:pkgID/revisions/:prev)
 // is not part of #247 and keeps answering 405 rather than being half-guessed
-// here.
+// here. Content a Conan 1 client stored under /files/… is likewise out of
+// scope, the same way it is for search: these routes only ever see the
+// /v2/conans/… tree, so a retention job built on them expires v2 revisions
+// and leaves v1 files where they are.
 //
 // Write access is the caller's problem to have: RBACMiddleware maps the DELETE
 // method to the "delete" action before the format handler runs, and proxy
@@ -49,12 +52,20 @@ func (h *Handler) v2Delete(c *gin.Context, repoName, p string) {
 		return
 	}
 
+	// Attempt every asset and report the first failure at the end, instead of
+	// stopping on it: DeleteArtifact is idempotent, so a client retry after a
+	// mid-list error then converges on "gone" instead of chasing a
+	// half-deleted revision that revisions/latest still advertise.
 	ctx := c.Request.Context()
+	var firstErr error
 	for f := range rel {
-		if err := base.DeleteArtifact(ctx, h.deps, repoName, prefix+f); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
+		if err := base.DeleteArtifact(ctx, h.deps, repoName, prefix+f); err != nil && firstErr == nil {
+			firstErr = err
 		}
+	}
+	if firstErr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": firstErr.Error()})
+		return
 	}
 	// Components whose last asset just went away must not keep showing up in
 	// browse and search.

--- a/internal/formats/conan/v2_delete.go
+++ b/internal/formats/conan/v2_delete.go
@@ -1,0 +1,66 @@
+package conan
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+)
+
+// v2Delete answers the Conan v2 deletion routes (#247):
+//
+//	DELETE /v2/conans/:n/:v/:u/:c                    → remove the recipe, all revisions
+//	DELETE /v2/conans/:n/:v/:u/:c/revisions/:rrev    → remove one recipe revision
+//
+// The client expects 200 on success and raises RecipeNotFoundException on 404,
+// so a second delete of the same thing is a 404, not a silent 200. Everything
+// stored under the deleted prefix goes — recipe files and package binaries
+// alike — through base.DeleteArtifact, so blob refcounts, store usage and the
+// artifact.deleted webhook behave exactly as they do for any other format.
+// These routes are also what lets a retention job expire Conan revisions the
+// way it does for other formats.
+//
+// Package-granular deletion (…/packages/:pkgID, …/packages/:pkgID/revisions/:prev)
+// is not part of #247 and keeps answering 405 rather than being half-guessed
+// here.
+//
+// Write access is the caller's problem to have: RBACMiddleware maps the DELETE
+// method to the "delete" action before the format handler runs, and proxy
+// repositories never reach this code — RejectMutation refuses the method
+// first.
+func (h *Handler) v2Delete(c *gin.Context, repoName, p string) {
+	segs := strings.Split(strings.TrimPrefix(p, "/v2/conans/"), "/")
+	refLevel := len(segs) == 4
+	revisionLevel := len(segs) == 6 && segs[4] == "revisions" && segs[5] != ""
+	if (!refLevel && !revisionLevel) || segs[0] == "" {
+		c.Status(http.StatusMethodNotAllowed)
+		return
+	}
+
+	prefix := p + "/"
+	rel, ok := h.pathsUnder(c, repoName, prefix)
+	if !ok {
+		return
+	}
+	if len(rel) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	for f := range rel {
+		if err := base.DeleteArtifact(ctx, h.deps, repoName, prefix+f); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+	}
+	// Components whose last asset just went away must not keep showing up in
+	// browse and search.
+	if err := h.deps.Components.DeleteOrphans(ctx, repoName); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusOK)
+}

--- a/internal/formats/conan/v2_delete_test.go
+++ b/internal/formats/conan/v2_delete_test.go
@@ -1,0 +1,81 @@
+package conan_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func v2Delete(r http.Handler, url string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodDelete, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestConan_V2Delete_OneRevisionLeavesTheOther(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-del-rev", "conan")
+	r := setup(repo)
+	ref := "/repository/cv2-del-rev/v2/conans/boost/1.83.0/_/_"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, ref+"/revisions/r1/files/conanfile.py", "one"))
+	require.Equal(t, http.StatusCreated, v2Put(r, ref+"/revisions/r1/packages/pkgA/revisions/p1/files/conan_package.tgz", "bin"))
+	require.Equal(t, http.StatusCreated, v2Put(r, ref+"/revisions/r2/files/conanfile.py", "two"))
+
+	assert.Equal(t, http.StatusOK, v2Delete(r, ref+"/revisions/r1").Code)
+
+	// r1 is gone, binaries included; r2 survives.
+	assert.Equal(t, http.StatusNotFound, v2Get(r, ref+"/revisions/r1/files").Code)
+	assert.Equal(t, http.StatusNotFound, v2Get(r, ref+"/revisions/r1/packages/pkgA/revisions/p1/files/conan_package.tgz").Code)
+	w := v2Get(r, ref+"/revisions")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "r2")
+	assert.NotContains(t, w.Body.String(), "r1")
+
+	// The client raises RecipeNotFound on 404 — a second delete is exactly
+	// that, not a silent 200.
+	assert.Equal(t, http.StatusNotFound, v2Delete(r, ref+"/revisions/r1").Code)
+}
+
+func TestConan_V2Delete_WholeReference(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-del-ref", "conan")
+	r := setup(repo)
+	ref := "/repository/cv2-del-ref/v2/conans/zlib/1.3/team/stable"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, ref+"/revisions/r1/files/conanfile.py", "one"))
+	require.Equal(t, http.StatusCreated, v2Put(r, ref+"/revisions/r2/files/conanfile.py", "two"))
+
+	assert.Equal(t, http.StatusOK, v2Delete(r, ref).Code)
+	assert.Equal(t, http.StatusNotFound, v2Get(r, ref+"/revisions").Code)
+	assert.Equal(t, http.StatusNotFound, v2Delete(r, ref).Code)
+
+	// The deleted reference no longer surfaces in search.
+	assert.Empty(t, searchResults(t, r, "/repository/cv2-del-ref/v2/conans/search"))
+}
+
+func TestConan_V2Delete_PackageGranularStays405(t *testing.T) {
+	// Package-level deletion is out of #247's scope — refuse rather than
+	// half-guess, exactly as before.
+	repo := testutil.SimpleRepo("cv2-del-405", "conan")
+	r := setup(repo)
+	ref := "/repository/cv2-del-405/v2/conans/boost/1.83.0/_/_"
+	require.Equal(t, http.StatusCreated, v2Put(r, ref+"/revisions/r1/packages/pkgA/revisions/p1/files/conaninfo.txt", "x"))
+
+	assert.Equal(t, http.StatusMethodNotAllowed, v2Delete(r, ref+"/revisions/r1/packages/pkgA").Code)
+	assert.Equal(t, http.StatusMethodNotAllowed, v2Delete(r, ref+"/revisions/r1/packages/pkgA/revisions/p1").Code)
+}
+
+func TestConan_V2Delete_ProxyRepoRefuses(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-del-proxy", "conan")
+	repo.Type = domain.TypeProxy
+	r := setup(repo)
+
+	w := v2Delete(r, "/repository/cv2-del-proxy/v2/conans/boost/1.83.0/_/_")
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}

--- a/internal/formats/conan/v2_search.go
+++ b/internal/formats/conan/v2_search.go
@@ -135,13 +135,18 @@ func fnmatchRegexp(pattern string, ignorecase bool) (*regexp.Regexp, error) {
 				b.WriteString(regexp.QuoteMeta("["))
 				continue
 			}
-			cls := pattern[i+1 : j]
-			if strings.HasPrefix(cls, "!") {
-				cls = "^" + cls[1:]
-			}
 			// A backslash is literal inside an fnmatch class; unescaped it
 			// would swallow the closing "]" in the regexp and fail to compile.
-			cls = strings.ReplaceAll(cls, `\`, `\\`)
+			cls := strings.ReplaceAll(pattern[i+1:j], `\`, `\\`)
+			switch {
+			case strings.HasPrefix(cls, "!"):
+				// fnmatch negation is "!", not "^"...
+				cls = "^" + cls[1:]
+			case strings.HasPrefix(cls, "^"):
+				// ...and a leading "^" is a literal caret, like in Python's
+				// fnmatch — escape it so the regexp does not negate.
+				cls = `\^` + cls[1:]
+			}
 			b.WriteString("[" + cls + "]")
 			i = j
 		default:

--- a/internal/formats/conan/v2_search.go
+++ b/internal/formats/conan/v2_search.go
@@ -1,0 +1,251 @@
+package conan
+
+import (
+	"io"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+)
+
+// Conan v2 search (#247):
+//
+//	GET /v2/conans/search?q=<pattern>&ignorecase=<bool>   → {"results": [refs]}
+//	GET /v2/conans/:n/:v/:u/:c/search?list_only=<bool>    → {pkgID: info} for the latest recipe revision
+//	GET /v2/conans/:n/:v/:u/:c/revisions/:rrev/search?list_only=<bool> → {pkgID: info}
+//
+// Contract per conan_server (conans/server/rest/controller/v2/) and the Conan 2
+// client (conan/internal/rest/rest_client_v2.py): recipe search returns bare
+// reference strings, package search returns a JSON object keyed by package ID
+// whose values carry the RAW conaninfo.txt text under "content" — the client
+// parses it itself ("Avoid serializing conaninfo in server side"), and with
+// list_only=True only the keys matter.
+
+// patternMaxBytes bounds the search pattern: references are short, so a long
+// pattern is never legitimate, and compiling one is the only place this
+// handler spends CPU on unauthenticated input.
+const patternMaxBytes = 256
+
+// v2SearchRecipes answers the repository-wide recipe search. References are
+// rendered the way the client prints them — "name/version" when user and
+// channel are the "_" placeholders, "name/version@user/channel" otherwise —
+// and the fnmatch-style pattern is matched against that rendering, folding
+// case unless ignorecase=False (both defaults mirror conan_server).
+//
+// Only the v2 storage tree is indexed. Assets a Conan 1 client stored under
+// /files/... deliberately do not surface: every other v2 route (latest,
+// revisions, download, delete) answers 404 for them, and advertising a
+// reference the follow-up calls cannot resolve makes version-range
+// resolution pick it and abort the whole install.
+func (h *Handler) v2SearchRecipes(c *gin.Context, repoName string) {
+	q := c.Query("q")
+	if len(q) > patternMaxBytes {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "search pattern too long"})
+		return
+	}
+	rx, err := fnmatchRegexp(q, !strings.EqualFold(c.Query("ignorecase"), "false"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "bad search pattern: " + err.Error()})
+		return
+	}
+	// Exhaustive prefix listing — the paged Assets.List would cap the result
+	// at its first page and silently drop recipes from search.
+	assets, err := h.deps.Assets.ListByRepoAndPath(c.Request.Context(), repoName, "/v2/conans/")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	seen := map[string]struct{}{}
+	for _, a := range assets {
+		if ref, ok := refFromAssetPath(a.Path); ok {
+			seen[ref] = struct{}{}
+		}
+	}
+	results := make([]string, 0, len(seen))
+	for ref := range seen {
+		if rx.MatchString(ref) {
+			results = append(results, ref)
+		}
+	}
+	sort.Strings(results)
+	c.JSON(http.StatusOK, gin.H{"results": results})
+}
+
+// refFromAssetPath recovers the recipe reference from an asset stored by the
+// v2 revisions API (verbatim under /v2/conans/{n}/{v}/{u}/{c}/revisions/...).
+func refFromAssetPath(p string) (string, bool) {
+	if !strings.HasPrefix(p, "/v2/conans/") {
+		return "", false
+	}
+	segs := strings.Split(strings.TrimPrefix(p, "/v2/conans/"), "/")
+	if len(segs) < 5 || segs[4] != "revisions" {
+		return "", false
+	}
+	name, version, user, channel := segs[0], segs[1], segs[2], segs[3]
+	if name == "" || version == "" {
+		return "", false
+	}
+	if user == "_" && channel == "_" {
+		return name + "/" + version, true
+	}
+	return name + "/" + version + "@" + user + "/" + channel, true
+}
+
+// matchAll is the compiled form of an absent or "*" pattern: the empty,
+// unanchored regexp matches every reference.
+var matchAll = regexp.MustCompile("")
+
+// fnmatchRegexp translates an fnmatch-style pattern (*, ?, [seq], [!seq]) to
+// an anchored regexp. Unlike path.Match, `*` crosses "/" — the pattern
+// "boost*" has to match "boost/1.83.0", which is how both fnmatch and
+// conan_server behave.
+func fnmatchRegexp(pattern string, ignorecase bool) (*regexp.Regexp, error) {
+	if pattern == "" || pattern == "*" {
+		return matchAll, nil
+	}
+	var b strings.Builder
+	if ignorecase {
+		b.WriteString("(?i)")
+	}
+	b.WriteString("^")
+	for i := 0; i < len(pattern); i++ {
+		switch ch := pattern[i]; ch {
+		case '*':
+			b.WriteString(".*")
+		case '?':
+			b.WriteString(".")
+		case '[':
+			j := i + 1
+			if j < len(pattern) && (pattern[j] == '!' || pattern[j] == '^') {
+				j++
+			}
+			if j < len(pattern) && pattern[j] == ']' { // first ']' is literal
+				j++
+			}
+			for j < len(pattern) && pattern[j] != ']' {
+				j++
+			}
+			if j >= len(pattern) {
+				// Unterminated class: treat "[" as a literal, like fnmatch.
+				b.WriteString(regexp.QuoteMeta("["))
+				continue
+			}
+			cls := pattern[i+1 : j]
+			if strings.HasPrefix(cls, "!") {
+				cls = "^" + cls[1:]
+			}
+			// A backslash is literal inside an fnmatch class; unescaped it
+			// would swallow the closing "]" in the regexp and fail to compile.
+			cls = strings.ReplaceAll(cls, `\`, `\\`)
+			b.WriteString("[" + cls + "]")
+			i = j
+		default:
+			b.WriteString(regexp.QuoteMeta(string(ch)))
+		}
+	}
+	b.WriteString("$")
+	return regexp.Compile(b.String())
+}
+
+// v2SearchPackages answers the binary package search for one recipe, at the
+// reference level (resolve the latest recipe revision first, like
+// conan_server) or for an explicit revision. 404 when the recipe (revision)
+// does not exist; an existing revision with no packages is an empty object,
+// which the download flow treats as "recipe-only" rather than an error.
+func (h *Handler) v2SearchPackages(c *gin.Context, repoName, p string) {
+	refBase := strings.TrimSuffix(p, "/search")
+
+	if !strings.Contains(refBase, "/revisions/") {
+		rel, ok := h.pathsUnder(c, repoName, refBase+"/revisions/")
+		if !ok {
+			return
+		}
+		var bestRev string
+		var bestTime time.Time
+		for rev, ts := range revisionTimes(rel) {
+			if bestRev == "" || ts.After(bestTime) {
+				bestRev, bestTime = rev, ts
+			}
+		}
+		if bestRev == "" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "recipe not found"})
+			return
+		}
+		refBase += "/revisions/" + bestRev
+	}
+
+	rel, ok := h.pathsUnder(c, repoName, refBase+"/")
+	if !ok {
+		return
+	}
+	if len(rel) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "recipe revision not found"})
+		return
+	}
+
+	// Files live under packages/<pkgID>/revisions/<prev>/files/...; report
+	// each package once, reading conaninfo.txt from its newest revision.
+	type pkgRev struct {
+		prev string
+		ts   time.Time
+	}
+	latest := map[string]pkgRev{}
+	for f, ts := range rel {
+		rest, found := strings.CutPrefix(f, "packages/")
+		if !found {
+			continue
+		}
+		pkgID, tail, ok2 := strings.Cut(rest, "/")
+		if !ok2 || pkgID == "" {
+			continue
+		}
+		revPart, ok3 := strings.CutPrefix(tail, "revisions/")
+		if !ok3 {
+			continue
+		}
+		prev, _, ok4 := strings.Cut(revPart, "/")
+		if !ok4 || prev == "" {
+			continue
+		}
+		if cur, seenIt := latest[pkgID]; !seenIt || ts.After(cur.ts) {
+			latest[pkgID] = pkgRev{prev: prev, ts: ts}
+		}
+	}
+
+	listOnly := strings.EqualFold(c.Query("list_only"), "true")
+	out := gin.H{}
+	for pkgID, pr := range latest {
+		if listOnly {
+			out[pkgID] = gin.H{}
+			continue
+		}
+		out[pkgID] = h.packageInfo(c, repoName,
+			refBase+"/packages/"+pkgID+"/revisions/"+pr.prev+"/files/conaninfo.txt")
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// conanInfoMaxBytes bounds the conaninfo.txt read: the file is a few hundred
+// bytes of settings/options, so anything beyond this is not a conaninfo.
+const conanInfoMaxBytes = 64 << 10
+
+// packageInfo returns the value the package search reports for one binary:
+// the raw conaninfo.txt text under "content" when the file is readable, an
+// empty object otherwise — the client falls back to the value as-is.
+func (h *Handler) packageInfo(c *gin.Context, repoName, infoPath string) gin.H {
+	rc, _, err := base.FetchArtifact(c.Request.Context(), h.deps, repoName, infoPath)
+	if err != nil {
+		return gin.H{}
+	}
+	defer func() { _ = rc.Close() }()
+	content, err := io.ReadAll(io.LimitReader(rc, conanInfoMaxBytes))
+	if err != nil {
+		return gin.H{}
+	}
+	return gin.H{"content": string(content)}
+}

--- a/internal/formats/conan/v2_search_test.go
+++ b/internal/formats/conan/v2_search_test.go
@@ -155,6 +155,11 @@ func TestConan_V2Search_ClassWithBackslashIsLiteral(t *testing.T) {
 
 	assert.Equal(t, []string{"boost/1.83.0"},
 		searchResults(t, r, "/repository/cv2-search-cls/v2/conans/search?q="+url.QueryEscape(`[ab\]oost*`)))
+
+	// A leading "^" is a literal caret in fnmatch (negation is "!"), so
+	// "[^b]" matches "b" — it must not negate.
+	assert.Equal(t, []string{"boost/1.83.0"},
+		searchResults(t, r, "/repository/cv2-search-cls/v2/conans/search?q="+url.QueryEscape(`[^b]oost*`)))
 }
 
 func TestConan_V2Search_ProxyRepoServesFromLocalCache(t *testing.T) {

--- a/internal/formats/conan/v2_search_test.go
+++ b/internal/formats/conan/v2_search_test.go
@@ -1,0 +1,171 @@
+package conan_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func searchResults(t *testing.T, r http.Handler, url string) []string {
+	t.Helper()
+	w := v2Get(r, url)
+	require.Equal(t, http.StatusOK, w.Code)
+	var body struct {
+		Results []string `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return body.Results
+}
+
+func TestConan_V2Search_PatternsAndRefShapes(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-search", "conan")
+	r := setup(repo)
+
+	// One ref with the "_" placeholders, one with a real user/channel, and a
+	// v1-file-API upload. The v1 one must NOT surface: every other v2 route
+	// 404s for it, and a search hit the follow-up calls cannot resolve makes
+	// version-range resolution pick it and abort the install.
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, "/repository/cv2-search/v2/conans/boost/1.83.0/_/_/revisions/r1/files/conanfile.py", "a"))
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, "/repository/cv2-search/v2/conans/zlib/1.3/team/stable/revisions/r1/files/conanfile.py", "b"))
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, "/repository/cv2-search/files/openssl/3.2/_/_/0/export/conanfile.py", "c"))
+
+	all := searchResults(t, r, "/repository/cv2-search/v2/conans/search")
+	assert.ElementsMatch(t, []string{"boost/1.83.0", "zlib/1.3@team/stable"}, all)
+
+	// `*` crosses "/" — fnmatch semantics, not path.Match.
+	assert.Equal(t, []string{"boost/1.83.0"},
+		searchResults(t, r, "/repository/cv2-search/v2/conans/search?q=boost*"))
+
+	// Case folds by default; ignorecase=False turns folding off.
+	assert.Equal(t, []string{"boost/1.83.0"},
+		searchResults(t, r, "/repository/cv2-search/v2/conans/search?q=BOOST*"))
+	assert.Empty(t,
+		searchResults(t, r, "/repository/cv2-search/v2/conans/search?q=BOOST*&ignorecase=False"))
+
+	// A pattern over user/channel matches the "@user/channel" rendering.
+	assert.Equal(t, []string{"zlib/1.3@team/stable"},
+		searchResults(t, r, "/repository/cv2-search/v2/conans/search?q=*@team/*"))
+
+	// No match and an empty repository are both an empty list, not null.
+	assert.Empty(t, searchResults(t, r, "/repository/cv2-search/v2/conans/search?q=nothing*"))
+	empty := setup(testutil.SimpleRepo("cv2-search-empty", "conan"))
+	w := v2Get(empty, "/repository/cv2-search-empty/v2/conans/search")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"results":[]`)
+}
+
+func TestConan_V2Search_Packages_RevisionLevel(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-psearch", "conan")
+	r := setup(repo)
+	base := "/repository/cv2-psearch/v2/conans/boost/1.83.0/_/_/revisions/r1"
+	info := "[settings]\nos=Linux\narch=x86_64\n"
+
+	require.Equal(t, http.StatusCreated, v2Put(r, base+"/files/conanfile.py", "recipe"))
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, base+"/packages/pkgA/revisions/p1/files/conaninfo.txt", info))
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, base+"/packages/pkgA/revisions/p1/files/conan_package.tgz", "bin"))
+
+	// list_only → keys only, empty values.
+	w := v2Get(r, base+"/search?list_only=True")
+	require.Equal(t, http.StatusOK, w.Code)
+	var listOnly map[string]map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &listOnly))
+	require.Contains(t, listOnly, "pkgA")
+	assert.Empty(t, listOnly["pkgA"])
+
+	// Full search → the raw conaninfo.txt under "content"; the client parses
+	// it itself.
+	w2 := v2Get(r, base+"/search?list_only=False")
+	require.Equal(t, http.StatusOK, w2.Code)
+	var full map[string]map[string]string
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &full))
+	assert.Equal(t, info, full["pkgA"]["content"])
+}
+
+func TestConan_V2Search_Packages_RefLevelResolvesLatestRevision(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-psearch-ref", "conan")
+	r := setup(repo)
+	ref := "/repository/cv2-psearch-ref/v2/conans/boost/1.83.0/_/_"
+
+	// Older revision carries pkgOld, newer carries pkgNew — the ref-level
+	// search must answer for the newest revision only.
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, ref+"/revisions/r1/packages/pkgOld/revisions/p1/files/conaninfo.txt", "[settings]\n"))
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, ref+"/revisions/r2/packages/pkgNew/revisions/p1/files/conaninfo.txt", "[settings]\n"))
+
+	w := v2Get(r, ref+"/search?list_only=True")
+	require.Equal(t, http.StatusOK, w.Code)
+	var got map[string]map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Contains(t, got, "pkgNew")
+	assert.NotContains(t, got, "pkgOld")
+}
+
+func TestConan_V2Search_Packages_RecipeOnlyIsEmptyObjectAndUnknownIs404(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-psearch-empty", "conan")
+	r := setup(repo)
+	base := "/repository/cv2-psearch-empty/v2/conans/nxtest/1.0/_/_/revisions/r1"
+	require.Equal(t, http.StatusCreated, v2Put(r, base+"/files/conanfile.py", "recipe"))
+
+	// A recipe-only revision answers an empty object — the download flow
+	// treats that as "no binaries", not as an error.
+	w := v2Get(r, base+"/search?list_only=False")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "{}", w.Body.String())
+
+	w2 := v2Get(r, "/repository/cv2-psearch-empty/v2/conans/nope/1.0/_/_/search")
+	assert.Equal(t, http.StatusNotFound, w2.Code)
+	w3 := v2Get(r, base[:len(base)-2]+"rX/search")
+	assert.Equal(t, http.StatusNotFound, w3.Code)
+}
+
+func TestConan_V2Search_BadPattern400(t *testing.T) {
+	repo := testutil.SimpleRepo("cv2-search-bad", "conan")
+	r := setup(repo)
+	w := v2Get(r, "/repository/cv2-search-bad/v2/conans/search?q=%5Bz-a%5D")
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// The pattern length is capped — compiling it is the only CPU an
+	// unauthenticated caller can make this handler spend.
+	long := strings.Repeat("*a", 200)
+	w2 := v2Get(r, "/repository/cv2-search-bad/v2/conans/search?q="+long)
+	assert.Equal(t, http.StatusBadRequest, w2.Code)
+}
+
+func TestConan_V2Search_ClassWithBackslashIsLiteral(t *testing.T) {
+	// fnmatch treats a backslash inside [] as a literal; unescaped it would
+	// swallow the closing "]" in the regexp and turn into a compile error.
+	repo := testutil.SimpleRepo("cv2-search-cls", "conan")
+	r := setup(repo)
+	require.Equal(t, http.StatusCreated,
+		v2Put(r, "/repository/cv2-search-cls/v2/conans/boost/1.83.0/_/_/revisions/r1/files/conanfile.py", "a"))
+
+	assert.Equal(t, []string{"boost/1.83.0"},
+		searchResults(t, r, "/repository/cv2-search-cls/v2/conans/search?q="+url.QueryEscape(`[ab\]oost*`)))
+}
+
+func TestConan_V2Search_ProxyRepoServesFromLocalCache(t *testing.T) {
+	// The generic proxy GET would drop ?q= on the upstream fetch and cache
+	// the first answer forever — search on a proxy answers from the local
+	// cache instead of forwarding.
+	repo := testutil.SimpleRepo("cv2-search-proxy", "conan")
+	repo.Type = domain.TypeProxy
+	r := setup(repo)
+
+	w := v2Get(r, "/repository/cv2-search-proxy/v2/conans/search?q=*")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"results":[]`)
+}


### PR DESCRIPTION
Closes #247.

## What this adds

The remaining Conan v2 routes from the #244 report, at the scope #247 set:

- **`GET /v2/conans/search?q=<pattern>&ignorecase=<bool>`** → `{"results": [refs]}`.
  fnmatch-style pattern (`*` crosses `/` — `boost*` matches `boost/1.83.0`,
  which `path.Match` would not), case folded unless `ignorecase=False`.
  References render the way the client prints them: `name/version`, or
  `name/version@user/channel` when user/channel are real.
- **`GET /v2/conans/{ref}[/revisions/{rrev}]/search?list_only=<bool>`** →
  JSON object keyed by package ID. With `list_only=True` only the keys carry
  meaning; otherwise each value holds the RAW `conaninfo.txt` text under
  `"content"` — the client parses it itself (`load_binary_info` in
  `remote_manager.py`, "Avoid serializing conaninfo in server side"). The
  ref-level form resolves the latest recipe revision first. A recipe-only
  revision answers `{}`, which the download flow treats as "no binaries",
  not an error.
- **`DELETE /v2/conans/{ref}`** and **`DELETE /v2/conans/{ref}/revisions/{rrev}`**
  → remove the recipe (one revision or all of them), package binaries
  included, through `base.DeleteArtifact`, so blob refcounts, store usage and
  the `artifact.deleted` webhook behave like every other format; orphaned
  components are cleaned after. 200 on success, 404 when nothing was there —
  the client raises `RecipeNotFoundException` on 404, so a repeated delete
  reports honestly. These routes are also what retention needs for Conan.

The contract was taken from the Conan 2.31.2 sources directly
(`conan/internal/rest/rest_client_v2.py`, `remote_manager.py`,
`client_routes.py`, `rest_routes.py`) — response shapes, parameter literals
(`list_only=True`, `ignorecase=False`) and status expectations all match what
the client actually sends and parses, and the captured request log of a live
`conan list` / `download` / `remove` session against v1.37.0.

## Decisions worth review

- **Exhaustive listings.** `pathsUnder` now uses `Assets.ListByRepoAndPath`
  (unbounded prefix query) instead of the first page of `Assets.List`. For
  the read routes the old cap was a latent mis-listing; for the new DELETE it
  would have been silent partial deletion answered with 200 in any repository
  over 1000 assets — a few hundred packages with binaries is enough. Search
  uses the same exhaustive prefix listing.
- **v1-stored content stays out of v2 search.** Assets under `/files/...`
  (Conan 1 uploads) are not advertised: every other v2 route 404s for them,
  and a search hit that `latest`/`download` cannot resolve makes the client's
  version-range resolver pick it and abort the install it would otherwise
  complete.
- **Proxy repositories answer search from the local cache.** The generic
  proxy GET would drop the query string on the upstream fetch and cache the
  first upstream answer forever under the path key. A proxy can serve what it
  has cached, so that is what its search reports.
- **Package-granular DELETE** (`…/packages/{pid}`, `…/packages/{pid}/revisions/{prev}`)
  is not in #247's table and keeps answering 405 rather than being
  half-guessed here.
- The search pattern length is capped (256 bytes → 400): compiling it is the
  only CPU an unauthenticated caller can make this handler spend.

Access control is untouched: RBACMiddleware already maps DELETE to the
"delete" action before the format handler runs, and `RejectMutation` keeps
refusing DELETE on proxies.

## Tests

`v2_search_test.go` / `v2_delete_test.go`, same harness as the existing v2
tests: pattern shapes and case folding, `@user/channel` rendering, empty-list
answers, revision- and ref-level package search (latest-revision resolution),
raw-conaninfo `content` passthrough, `list_only`, recipe-only `{}` vs 404,
revision delete leaving siblings intact, whole-ref delete, repeated delete →
404, package-granular 405, proxy behavior for search (local) and delete
(refused), bad/oversized patterns → 400, backslash-in-class literals.

`go test ./internal/...`: conan package green, coverage 88.4% (≥80% floor);
the only failures on my machine are the known local-network-restriction cases
(`TestBlobStoreMigrationHandler_*`, `TestWebhookHandler_Test_200`), which
reproduce on a clean `main`. `golangci-lint run` (v2.12.2): 0 issues.

Reported and verified with a live Conan 2.31.2 client against our v1.37.0
deployment — `conan remote login` / `upload` / `install` work there today, and
this PR is what `conan list -r` / `download` / `remove` were still missing.
