### PR TITLE
fix(assets): match an asset path prefix literally, not as a LIKE pattern

### DIFF
--- a/internal/repository/postgres/asset_repo.go
+++ b/internal/repository/postgres/asset_repo.go
@@ -265,10 +265,8 @@ WITH retained_comps AS (
 		i++
 	}
 	if pathPrefix != "" {
-		escaped := strings.ReplaceAll(strings.ReplaceAll(pathPrefix, `\`, `\\`), "%", `\%`)
-		escaped = strings.ReplaceAll(escaped, "_", `\_`)
 		where += fmt.Sprintf(` AND a.path LIKE $%d ESCAPE '\'`, i)
-		args = append(args, escaped+"%")
+		args = append(args, likePrefix(pathPrefix))
 		i++
 	}
 	if nameGlob != "" {
@@ -464,6 +462,19 @@ func globToLike(glob string) string {
 	return b.String()
 }
 
+// likePrefix turns a literal path prefix into a LIKE pattern that matches it
+// and nothing else. The metacharacters are not exotic here: "_" is the Conan
+// placeholder for an absent user/channel and a common character in package
+// names, and "%" reaches a prefix through a percent-encoded request segment.
+// Left unescaped, either one widens a prefix query into a wildcard scan over
+// the whole repository. Pair with `ESCAPE '\'` in the query.
+func likePrefix(prefix string) string {
+	escaped := strings.ReplaceAll(prefix, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, "%", `\%`)
+	escaped = strings.ReplaceAll(escaped, "_", `\_`)
+	return escaped + "%"
+}
+
 func nullStr(s string) any {
 	if s == "" {
 		return nil
@@ -636,9 +647,9 @@ func (r *assetRepo) ListByRepoAndPath(ctx context.Context, repoName, pathPrefix 
 			assetSelectCols, assetFromJoin)
 		args = []any{repoName}
 	} else {
-		q = fmt.Sprintf(`SELECT %s %s WHERE rep.name = $1 AND a.path LIKE $2 ORDER BY a.path`,
+		q = fmt.Sprintf(`SELECT %s %s WHERE rep.name = $1 AND a.path LIKE $2 ESCAPE '\' ORDER BY a.path`,
 			assetSelectCols, assetFromJoin)
-		args = []any{repoName, pathPrefix + "%"}
+		args = []any{repoName, likePrefix(pathPrefix)}
 	}
 	rows, err := r.db.Query(ctx, q, args...)
 	if err != nil {

--- a/internal/repository/postgres/asset_repo_queries_integration_test.go
+++ b/internal/repository/postgres/asset_repo_queries_integration_test.go
@@ -1411,3 +1411,51 @@ func TestAssetRepoQueries_ListOCIImageNames_EmptyInputs(t *testing.T) {
 		t.Errorf("no repositories means no images, got %v", noRepos)
 	}
 }
+
+func TestAssetRepoQueries_ListByRepoAndPath_PrefixIsLiteral(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "lbrap_literal")
+	repo := NewAssetRepo(pool)
+
+	// "_" is the Conan placeholder for an absent user/channel, and package
+	// names routinely carry one; "%" can reach a path prefix through a
+	// percent-encoded request segment. Both are LIKE metacharacters.
+	paths := []string{
+		"/v2/conans/my_lib/1.0/_/_/revisions/r1/files/conanfile.py",
+		"/v2/conans/myXlib/1.0/a/b/revisions/r1/files/conanfile.py",
+	}
+	for _, path := range paths {
+		a := makeAsset(p, path)
+		a.BlobKey = "bk" + path
+		if err := repo.Create(ctx, a); err != nil {
+			t.Fatalf("Create %q: %v", path, err)
+		}
+	}
+
+	got, err := repo.ListByRepoAndPath(ctx, p.RepoName, "/v2/conans/my_lib/1.0/_/_/")
+	if err != nil {
+		t.Fatalf("ListByRepoAndPath: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("underscore prefix matched %d assets, want 1: %v", len(got), pathsOf(got))
+	}
+
+	got, err = repo.ListByRepoAndPath(ctx, p.RepoName, "/v2/conans/%/%/%/%/")
+	if err != nil {
+		t.Fatalf("ListByRepoAndPath: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("percent prefix matched %d assets, want 0: %v", len(got), pathsOf(got))
+	}
+}
+
+func pathsOf(assets []domain.Asset) []string {
+	out := make([]string, 0, len(assets))
+	for _, a := range assets {
+		out = append(out, a.Path)
+	}
+	return out
+}


### PR DESCRIPTION
`ListByRepoAndPath` built its query as `a.path LIKE $prefix || '%'` with no `ESCAPE` clause, so any LIKE metacharacter inside the prefix widened it into a wildcard scan. The characters are not exotic here: `_` is the Conan placeholder for an absent user/channel and a common character in package and image names, and `%` reaches a prefix through a percent-encoded request segment.

## What it looked like

Against a repository holding `my_lib/1.0`, `myXlib/1.0@a/b` and `secretlib/9.9@team/stable`, on a local server built from `main`:

```
GET /v2/conans/my_lib/1.0/_/_/revisions/r1/files
{"files":{"/v2/conans/myXlib/1.0/a/b/revisions/r1/files/conanfile.py":{},
          "conanfile.py":{},"conanmanifest.txt":{}}}

GET /v2/conans/%25/%25/%25/%25/files
{"files":{"/v2/conans/myXlib/...":{}, "/v2/conans/my_lib/...":{},
          "/v2/conans/secretlib/9.9/team/stable/revisions/r7/files/conanfile.py":{}}}
```

The first is an ordinary client request — every Conan reference without a user/channel is stored under the `_/_` placeholders — and a client reading that listing asks for a file name that does not exist. The second enumerates every path in the repository, past the path selectors RBAC checked against the literal request path. The same prefix is passed straight from an image name in the Docker browse handlers.

After the fix both answer with what was asked for: the real file names, and `404`.

## The fix

The cleanup query two hundred lines up already escaped its prefix inline. This lifts that into `likePrefix` and uses it on both sides, with `ESCAPE '\'` on the query.

## Tests

`TestAssetRepoQueries_ListByRepoAndPath_PrefixIsLiteral` — an integration test against real Postgres, red on `main` (matches 2 and 2, wants 1 and 0), green with the fix. It has to be an integration test: `testutil.AssetRepo` matches prefixes with `strings.HasPrefix`, which is the semantics the SQL was supposed to have, so no unit test can see this divergence.

`go test -tags integration ./internal/repository/postgres/`: 429 passed. `go test ./internal/...`: 2158 passed, the one failure being the known sandbox network case (`TestWebhookHandler_Test_200`), which reproduces on a clean `main`. `golangci-lint run`: 0 issues.

Found while reviewing #249, which makes the Conan v2 routes read and delete through this query — that PR wants this in first.