### PR TITLE
docs(contributing): drop the sign-off requirement nothing enforced

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,25 +15,8 @@ none of it. The practical consequence, stated plainly rather than buried: becaus
 copyright stays spread across everyone who has contributed, the project cannot
 be relicensed later without asking each of you. That is deliberate.
 
-### Sign-off (DCO)
-
-Every commit must carry a `Signed-off-by` line certifying the
-[Developer Certificate of Origin](https://developercertificate.org/) — the same
-mechanism the Linux kernel, Docker and GitLab use. It is a statement that you
-wrote the change, or have the right to submit it.
-
-```bash
-git commit -s -m "fix(scan): ..."
-```
-
-That appends:
-
-```
-Signed-off-by: Your Name <your.email@example.com>
-```
-
-Forgot it? `git commit --amend -s` for the last commit, or
-`git rebase --signoff main` for a branch.
+There is no sign-off requirement either: opening the pull request is the
+statement, and nothing checks for a `Signed-off-by` line.
 
 ## Making a change
 

--- a/README.md
+++ b/README.md
@@ -387,8 +387,8 @@ inside your company, however you like, needs nothing from you — the obligation
 only starts if you offer a modified Nexspence to others over a network, and then
 it is to publish those modifications.
 
-Contributions are accepted under the same licence, with a DCO sign-off and no
-CLA — see [CONTRIBUTING.md](CONTRIBUTING.md).
+Contributions are accepted under the same licence, with no CLA and no sign-off
+to remember — see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Community & contact
 


### PR DESCRIPTION
`CONTRIBUTING.md` told every contributor that every commit must carry a `Signed-off-by` line certifying the DCO. Nothing checks for one — there is no DCO bot on the repository, and of the last fifty commits on `main` the only seven that carry the line are dependabot's, which adds it on its own. No human commit has ever had it, mine included.

A rule that is stated and never enforced is worse than no rule: it is a trap for the one contributor who reads the page carefully, and it describes a project that does not exist. Came up while reviewing #249, whose commit does not carry a sign-off either — and asking for one there would have meant enforcing a rule I have never followed myself.

The licensing paragraph immediately above already gets the agreement it needs ("by submitting a pull request you agree that your work is licensed under AGPL-3.0-or-later and that you have the right to license it that way"), so this drops the sign-off section and says plainly that there is nothing to remember. The README line that advertised the DCO is updated to match.

If the requirement is wanted for real, the change is the opposite one: add a DCO check to CI and start signing off. That is a separate decision.