### PR TITLE
feat(browse): show size and push date in the listing, keep columns aligned (#257, #258)

### DIFF
--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -79,6 +79,47 @@ describe('BrowsePage — repo selector & empty states', () => {
     expect(await screen.findByText(/Promote 1 component/)).toBeInTheDocument()
   })
 
+  it('shows per-component size and push date from the embedded assets (#257)', async () => {
+    server.use(
+      http.get('/service/rest/v1/components', () =>
+        HttpResponse.json({
+          items: [
+            {
+              id: 'c1', name: 'pkg-a', group: '', version: '1.0', format: 'maven2',
+              // Size must be the sum over all assets, the push date the newest
+              // lastModified — not the first asset's values. The unparseable
+              // timestamp comes first: were it carried as "best", every later
+              // NaN comparison would keep it and no date would render.
+              assets: [
+                { id: 'a0', path: 'p/pkg-a.md5', fileSize: 0, contentType: 't', lastModified: 'not-a-date' },
+                { id: 'a1', path: 'p/pkg-a.jar', fileSize: 2048, contentType: 't', lastModified: '2026-08-01T10:00:00Z' },
+                { id: 'a2', path: 'p/pkg-a.pom', fileSize: 1024, contentType: 't', lastModified: '2026-08-17T12:30:00Z' },
+              ],
+            },
+            { id: 'c2', name: 'pkg-b', group: '', version: '2.0', format: 'maven2', assets: [] },
+          ],
+          continuationToken: null,
+        }),
+      ),
+    )
+    renderBrowse('?repo=maven-hosted')
+    expect(await screen.findByText('3.0 KB')).toBeInTheDocument()
+    // Compared whitespace-normalized on both sides: Intl output may separate
+    // time from AM/PM with U+202F, which the testing-library normalizer
+    // collapses in the DOM text but not in the expected string.
+    const norm = (s: string) => s.replace(/\s+/g, ' ')
+    const pushed = norm(new Date('2026-08-17T12:30:00Z').toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }))
+    expect(screen.getByText((t) => norm(t) === pushed)).toBeInTheDocument()
+    // A component with no assets shows placeholders — not "0 B", not a 1970
+    // date from reducing over nothing.
+    const pkgBRow = screen.getByText('pkg-b').closest('div[style]')?.parentElement
+    expect(pkgBRow?.textContent).not.toContain('0 B')
+    expect(pkgBRow?.textContent).not.toContain('1970')
+    expect(pkgBRow?.textContent).toContain('—')
+    expect(screen.getByText('Size')).toBeInTheDocument()
+    expect(screen.getByText('Pushed')).toBeInTheDocument()
+  })
+
   it('paginates next and prev', async () => {
     const user = userEvent.setup()
     let lastOffset = '0'

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -37,7 +37,7 @@ interface Component {
   group: string
   version: string
   format: string
-  assets?: { id: string; path: string; fileSize: number; contentType: string }[]
+  assets?: { id: string; path: string; fileSize: number; contentType: string; lastModified?: string }[]
 }
 
 interface DockerDetailAsset {
@@ -407,6 +407,14 @@ function formatDateTime(iso: string | undefined | null): string {
   return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'medium' })
 }
 
+// A listing column, unlike the detail panels above, has no room for seconds.
+function formatPushDate(iso: string | undefined | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
 function nexusV2RegistryPath(
   imageRef: string | undefined,
   version: string | undefined,
@@ -454,11 +462,25 @@ const S = {
     fontSize: 14,
   },
   table: {
-    overflow: 'hidden' as const,
+    // Auto, not hidden: the fixed tracks alone need ~380px, and a clipped
+    // table would silently lose the Pushed and delete columns on a narrow
+    // (or deeply zoomed-in) viewport instead of scrolling.
+    overflowX: 'auto' as const,
   },
   thead: {
     display: 'grid',
-    gridTemplateColumns: '24px 2fr 1.5fr 1fr 1fr 2fr 32px',
+    // The header and every data row are independent grids kept in step only
+    // by sharing this template, so no fr-track cell may impose a min-content
+    // floor: a floor resolves in one grid but not the others, and the columns
+    // drift apart as the viewport (or zoom level) changes — #258. Truncated
+    // lifts the floor on every such cell (overflow:hidden zeroes the grid
+    // item's implicit minimum).
+    gridTemplateColumns: '24px 2fr 1.5fr 1fr 1fr 2fr 76px 150px 32px',
+    columnGap: 12,
+    // Shared with trow: below this the card scrolls horizontally instead of
+    // crushing the fr columns into nothing (the fixed tracks and gaps alone
+    // take ~410px).
+    minWidth: 640,
     padding: '10px 16px',
     background: 'rgba(255,255,255,0.03)',
     borderBottom: '1px solid rgba(255,255,255,0.07)',
@@ -470,7 +492,9 @@ const S = {
   },
   trow: {
     display: 'grid',
-    gridTemplateColumns: '24px 2fr 1.5fr 1fr 1fr 2fr 32px',
+    gridTemplateColumns: '24px 2fr 1.5fr 1fr 1fr 2fr 76px 150px 32px',
+    columnGap: 12,
+    minWidth: 640,
     padding: '11px 16px',
     borderBottom: '1px solid rgba(255,255,255,0.05)',
     fontSize: 13,
@@ -1625,11 +1649,13 @@ export default function BrowsePage() {
           <div className="holo-card" style={S.table}>
             <div style={S.thead}>
               <div />
-              <div>Name</div>
-              <div>Group</div>
-              <div>Version</div>
-              <div>Format</div>
-              <div>Assets</div>
+              <Truncated text="Name" />
+              <Truncated text="Group" />
+              <Truncated text="Version" />
+              <Truncated text="Format" />
+              <Truncated text="Assets" />
+              <Truncated text="Size" />
+              <Truncated text="Pushed" />
               <div />
             </div>
             {items.map((c) => {
@@ -1639,6 +1665,21 @@ export default function BrowsePage() {
               // name produced a prefix that matched nothing (npm) or an empty
               // path the server rejected (apt proxy) — see #75/#76.
               const assetPaths = (c.assets ?? []).map((a) => a.path).filter(Boolean)
+              // A component is several files (a conan recipe + binaries, a jar
+              // + pom); the sum is what "artifact size" means to a reader, and
+              // the newest lastModified is when it was last pushed — #257.
+              const totalSize = (c.assets ?? []).reduce((sum, a) => sum + (a.fileSize || 0), 0)
+              // Unparseable timestamps are skipped, not carried: once an
+              // invalid string became "best", every later NaN comparison
+              // would keep it there and a valid date would never surface.
+              const pushedAt = (c.assets ?? []).reduce<string | undefined>((best, a) => {
+                const t = a.lastModified ? new Date(a.lastModified).getTime() : NaN
+                if (Number.isNaN(t)) return best
+                return !best || t > new Date(best).getTime() ? a.lastModified : best
+              }, undefined)
+              const pathLabel = firstAsset
+                ? `${firstAsset.path}${c.assets!.length > 1 ? ` +${c.assets!.length - 1}` : ''}`
+                : '—'
               const isHighlighted = (!!highlightComponentId && c.id === highlightComponentId) ||
                 (!!highlightAssetPath && !!c.assets?.some((a) => a.path === highlightAssetPath))
               return (
@@ -1665,17 +1706,19 @@ export default function BrowsePage() {
                       style={{ cursor: 'pointer', accentColor: '#3b82f6' }}
                     />
                   </div>
-                  <div style={{ fontWeight: 600, color: 'var(--holo-text)' }}>{c.name}</div>
-                  <div style={S.muted}>{c.group || '—'}</div>
-                  <div>{c.version}</div>
-                  <div>
-                    <span style={S.badge(color)}>{c.format}</span>
+                  <Truncated text={c.name} style={{ fontWeight: 600, color: 'var(--holo-text)' }} />
+                  <Truncated text={c.group || '—'} style={S.muted} />
+                  <Truncated text={c.version} />
+                  <div style={{ minWidth: 0 }}>
+                    <Truncated
+                      as="span"
+                      text={c.format}
+                      style={{ ...S.badge(color), display: 'inline-block', maxWidth: '100%', verticalAlign: 'top' }}
+                    />
                   </div>
-                  <div style={S.path}>
-                    {firstAsset
-                      ? `${firstAsset.path}${c.assets!.length > 1 ? ` +${c.assets!.length - 1}` : ''}`
-                      : '—'}
-                  </div>
+                  <Truncated text={pathLabel} style={S.path} />
+                  <div style={S.muted}>{c.assets?.length ? formatBytes(totalSize) : '—'}</div>
+                  <Truncated text={formatPushDate(pushedAt)} style={S.muted} />
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     {canDeleteRepo && (
                       <GhostBtn danger onClick={() => setDeleteTarget({


### PR DESCRIPTION
Closes #257, closes #258.

## What

Two changes to the standard component listing in `BrowsePage`, one file plus its test:

**Size and Pushed columns (#257).** Both come from data the listing already fetches — `GET /service/rest/v1/components` embeds `fileSize` and `lastModified` per asset. Size is the sum over the component's assets (a conan recipe or a jar+pom is several files; the sum is what "artifact size" means to a reader), formatted with the existing `formatBytes()`. Pushed is the newest `lastModified` across the assets, so a re-push shows up; unparseable timestamps are skipped rather than carried, since one bad string winning the reduce would blank the cell for a component that has perfectly good dates. The formatter is a `timeStyle: 'short'` sibling of `formatDateTime()` — a listing column has no room for seconds.

**Stable column alignment (#258).** The header and every row are independent grids kept in step only by sharing a `gridTemplateColumns` string, so the fix is to make sure no fr-track cell can impose a min-content floor: a floor resolves in one grid but not the others, and the columns drift apart as the viewport (or zoom level) changes. Every fr-track cell — header labels included — now goes through the existing `Truncated` component (the #167/#169 ellipsis+hover-title pattern), whose `overflow: hidden` zeroes the grid item's implicit minimum. The format badge truncates inside its own pill rather than being clipped mid-glyph by the cell. With the floors gone the grids need a `columnGap` (an ellipsis flush against the next column's text reads as one string) and a shared `minWidth`, below which the card scrolls horizontally (`overflowX: auto`) instead of crushing the fr columns — previously an overflowing row silently lost its delete button to `overflow: hidden`.

## Verification

- Deployed against a live v1.38.0 instance with real conan/pypi/maven content: columns hold their alignment at 80–150% browser zoom, long `/v2/conans/…/revisions/…` paths ellipsize with the full path on hover, Size/Pushed populate from existing data.
- New test covers: sum-not-first-asset size, newest-not-first `lastModified`, an unparseable timestamp listed first (the reduce-poisoning case), and the asset-less component rendering placeholders instead of `0 B` / a 1970 date. The date assertion is whitespace-normalized on both sides so an ICU that emits U+202F before AM/PM cannot break it.
- Full frontend suite: no regressions (the only local failures are the pre-existing download/clipboard ones that need a real browser environment).

The docker/OCI and raw tree views are untouched — their listings are separate components with their own layout.
