### PR TITLE
feat(docker): instance-level /v2/_catalog; 404 the imageless tags/list (#261)

### DIFF
--- a/internal/api/handlers/docker_catalog.go
+++ b/internal/api/handlers/docker_catalog.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"net/http"
+	"sort"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/service"
+)
+
+// DockerCatalog serves GET /v2/_catalog — the instance-level catalog (#261).
+//
+// Before this route existed, the path fell into the /v2/:repoName dispatch as
+// a repository literally named "_catalog", and the failed lookup denied even
+// an nx-admin with a bare 403 — the admin bypass lives in CanAccessRepo,
+// which a missing repository never reaches.
+//
+// Entries are "<repository>/<image>" — the exact names this registry's /v2/
+// surface serves, so every catalog entry is something the caller could pass
+// to docker pull. The per-repository catalog (GET /v2/<repoName>/_catalog)
+// keeps answering with bare image names, because there the namespace prefix
+// is fixed by the URL.
+//
+// Visibility follows per-repository RBAC: the caller sees images only from
+// docker/oci repositories they may read, so an anonymous caller sees exactly
+// the allow_anonymous ones and a catalog probe leaks nothing about private
+// repositories. Pagination (?n=/?last=) matches the other list endpoints.
+func DockerCatalog(
+	repos repository.RepositoryRepo,
+	rbac *service.RBACService,
+	assets repository.AssetRepo,
+) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("Docker-Distribution-API-Version", "registry/2.0")
+		ctx := c.Request.Context()
+
+		all, err := repos.List(ctx, "", "")
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		registries := make([]domain.Repository, 0, len(all))
+		for _, r := range all {
+			if r.Format.IsOCIRegistry() && r.Online {
+				registries = append(registries, r)
+			}
+		}
+
+		userID := c.GetString("userID")
+		roles, _ := c.Get("roles")
+		rolesSlice, _ := roles.([]string)
+		readable := rbac.FilterRepos(ctx, userID, rolesSlice, registries)
+
+		// One query per readable registry rather than one for the union:
+		// ListOCIImageNames does not say which repository a name came from,
+		// and the entries need the repository prefix to be pullable.
+		var entries []string
+		for _, r := range readable {
+			names, err := assets.ListOCIImageNames(ctx, []string{r.Name})
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				return
+			}
+			for _, n := range names {
+				entries = append(entries, r.Name+"/"+n)
+			}
+		}
+		// Sorted in Go, not SQL, for the same reason the per-repo catalog is:
+		// the ?last= cursor compares Go strings, and a collation-ordered list
+		// searched byte-wise makes the cursor skip entries.
+		sort.Strings(entries)
+
+		params := oci.ParsePageParams(c)
+		page, more := oci.Paginate(entries, params)
+		oci.SetNextLink(c, params, page, more)
+		if page == nil {
+			page = []string{}
+		}
+		c.JSON(http.StatusOK, gin.H{"repositories": page})
+	}
+}

--- a/internal/api/handlers/docker_catalog.go
+++ b/internal/api/handlers/docker_catalog.go
@@ -34,13 +34,22 @@ func DockerCatalog(
 	rbac *service.RBACService,
 	assets repository.AssetRepo,
 ) gin.HandlerFunc {
+	internalError := func(c *gin.Context) {
+		// The registry error shape, and no internals: this route answers
+		// unauthenticated callers, and the request log already carries the
+		// real error via the 500 status.
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"errors": []gin.H{{"code": "UNKNOWN", "message": "internal error"}},
+		})
+	}
+
 	return func(c *gin.Context) {
 		c.Header("Docker-Distribution-API-Version", "registry/2.0")
 		ctx := c.Request.Context()
 
 		all, err := repos.List(ctx, "", "")
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			internalError(c)
 			return
 		}
 		registries := make([]domain.Repository, 0, len(all))
@@ -55,17 +64,32 @@ func DockerCatalog(
 		rolesSlice, _ := roles.([]string)
 		readable := rbac.FilterRepos(ctx, userID, rolesSlice, registries)
 
+		// A credential-less caller who can see nothing gets the challenge the
+		// sibling /v2/ surfaces give, not a 200 that reads as "the registry is
+		// empty" — a client holding credentials should be told to present them.
+		if userID == "" && len(readable) == 0 {
+			c.Header("WWW-Authenticate", `Basic realm="Nexspence"`)
+			c.JSON(http.StatusUnauthorized, gin.H{
+				"errors": []gin.H{{"code": "UNAUTHORIZED", "message": "authentication required"}},
+			})
+			return
+		}
+
 		// One query per readable registry rather than one for the union:
 		// ListOCIImageNames does not say which repository a name came from,
-		// and the entries need the repository prefix to be pullable.
+		// and the entries need the repository prefix to be pullable. Each
+		// repository's names then pass the caller's content selectors —
+		// FilterRepos alone ignores path clauses, and image names are exactly
+		// what a path-scoped selector is configured to hide.
 		var entries []string
-		for _, r := range readable {
+		for i := range readable {
+			r := &readable[i]
 			names, err := assets.ListOCIImageNames(ctx, []string{r.Name})
 			if err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+				internalError(c)
 				return
 			}
-			for _, n := range names {
+			for _, n := range rbac.FilterOCIImageNames(ctx, userID, rolesSlice, r, names) {
 				entries = append(entries, r.Name+"/"+n)
 			}
 		}

--- a/internal/api/handlers/docker_catalog_test.go
+++ b/internal/api/handlers/docker_catalog_test.go
@@ -1,0 +1,120 @@
+package handlers_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nexspence-oss/nexspence/internal/api/handlers"
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// buildCatalogRouter serves /v2/_catalog over two docker repos (one public,
+// one private), an npm repo (never listed), and an offline docker repo
+// (never listed). identity, when non-nil, plays the role OptionalAuth fills
+// in production.
+func buildCatalogRouter(t *testing.T, identity gin.HandlerFunc) *gin.Engine {
+	t.Helper()
+	repoRepo := testutil.NewRepoRepo(
+		&domain.Repository{ID: "r1", Name: "pub", Format: domain.FormatDocker, Type: domain.TypeHosted, Online: true, AllowAnonymous: true},
+		&domain.Repository{ID: "r2", Name: "priv", Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true},
+		&domain.Repository{ID: "r3", Name: "npm-hosted", Format: domain.FormatNPM, Type: domain.TypeHosted, Online: true, AllowAnonymous: true},
+		&domain.Repository{ID: "r4", Name: "parked", Format: domain.FormatDocker, Type: domain.TypeHosted, Online: false, AllowAnonymous: true},
+	)
+	assets := testutil.NewAssetRepo()
+	ctx := context.Background()
+	for _, a := range []*domain.Asset{
+		{Repository: "pub", Path: "/manifests/web/app/latest"},
+		{Repository: "pub", Path: "/manifests/web/app/v2"}, // same image, second tag — no duplicate entry
+		{Repository: "pub", Path: "/blobs/sha256:aa"},      // blobs name no image
+		{Repository: "priv", Path: "/manifests/secret/img/latest"},
+		{Repository: "parked", Path: "/manifests/gone/latest"},
+	} {
+		require.NoError(t, assets.Create(ctx, a))
+	}
+	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
+
+	r := gin.New()
+	hs := []gin.HandlerFunc{}
+	if identity != nil {
+		hs = append(hs, identity)
+	}
+	hs = append(hs, handlers.DockerCatalog(repoRepo, rbacSvc, assets))
+	r.GET("/v2/_catalog", hs...)
+	return r
+}
+
+func catalogGet(t *testing.T, r *gin.Engine, url string) (int, []string, string) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+	var body struct {
+		Repositories []string `json:"repositories"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	return w.Code, body.Repositories, w.Header().Get("Link")
+}
+
+func TestDockerCatalog_AnonymousSeesOnlyPublicRegistries(t *testing.T) {
+	r := buildCatalogRouter(t, nil)
+
+	code, got, _ := catalogGet(t, r, "/v2/_catalog")
+	require.Equal(t, http.StatusOK, code)
+	// pub/web/app once (two tags, one image); nothing from the private, npm,
+	// or offline repos — a catalog probe must not leak their contents.
+	assert.Equal(t, []string{"pub/web/app"}, got)
+}
+
+func TestDockerCatalog_AdminSeesEverythingOnline(t *testing.T) {
+	admin := func(c *gin.Context) {
+		c.Set("userID", "u-admin")
+		c.Set("roles", []string{"nx-admin"})
+	}
+	r := buildCatalogRouter(t, gin.HandlerFunc(admin))
+
+	code, got, _ := catalogGet(t, r, "/v2/_catalog")
+	require.Equal(t, http.StatusOK, code)
+	// Sorted, repository-prefixed — each entry is a pullable reference.
+	// The offline repo stays out even for an admin.
+	assert.Equal(t, []string{"priv/secret/img", "pub/web/app"}, got)
+}
+
+func TestDockerCatalog_Pagination(t *testing.T) {
+	admin := func(c *gin.Context) {
+		c.Set("userID", "u-admin")
+		c.Set("roles", []string{"nx-admin"})
+	}
+	r := buildCatalogRouter(t, gin.HandlerFunc(admin))
+
+	code, first, link := catalogGet(t, r, "/v2/_catalog?n=1")
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{"priv/secret/img"}, first)
+	require.Contains(t, link, `rel="next"`)
+	require.Contains(t, link, "last=")
+
+	code, second, link2 := catalogGet(t, r, "/v2/_catalog?n=1&last=priv/secret/img")
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{"pub/web/app"}, second)
+	assert.Empty(t, link2, "the final page carries no next link")
+}
+
+func TestDockerCatalog_EmptyIsAListNotNull(t *testing.T) {
+	repoRepo := testutil.NewRepoRepo()
+	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
+	r := gin.New()
+	r.GET("/v2/_catalog", handlers.DockerCatalog(repoRepo, rbacSvc, testutil.NewAssetRepo()))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"repositories":[]`)
+}

--- a/internal/api/handlers/docker_catalog_test.go
+++ b/internal/api/handlers/docker_catalog_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
@@ -107,14 +108,78 @@ func TestDockerCatalog_Pagination(t *testing.T) {
 	assert.Empty(t, link2, "the final page carries no next link")
 }
 
-func TestDockerCatalog_EmptyIsAListNotNull(t *testing.T) {
+func TestDockerCatalog_AuthenticatedEmptyIsAListNotNull(t *testing.T) {
 	repoRepo := testutil.NewRepoRepo()
+	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
+	r := gin.New()
+	r.GET("/v2/_catalog", func(c *gin.Context) {
+		c.Set("userID", "u1")
+		c.Set("roles", []string{"nx-admin"})
+	}, handlers.DockerCatalog(repoRepo, rbacSvc, testutil.NewAssetRepo()))
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil))
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"repositories":[]`)
+}
+
+// A credential-less caller who can see nothing gets the challenge the sibling
+// /v2/ surfaces give — not a 200 that reads as "the registry is empty".
+func TestDockerCatalog_AnonymousWithNothingVisible_Challenges401(t *testing.T) {
+	repoRepo := testutil.NewRepoRepo(
+		&domain.Repository{ID: "r1", Name: "priv", Format: domain.FormatDocker, Type: domain.TypeHosted, Online: true},
+	)
 	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
 	r := gin.New()
 	r.GET("/v2/_catalog", handlers.DockerCatalog(repoRepo, rbacSvc, testutil.NewAssetRepo()))
 
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil))
-	require.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"repositories":[]`)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Header().Get("WWW-Authenticate"), "Basic")
+	assert.Contains(t, w.Body.String(), "UNAUTHORIZED")
+}
+
+// privsRBACRepo hands every user the same fixed privilege set.
+type privsRBACRepo struct {
+	privs []repository.PrivilegeWithSelector
+}
+
+func (p *privsRBACRepo) GetUserPrivilegesWithSelectors(_ context.Context, _ string) ([]repository.PrivilegeWithSelector, error) {
+	return p.privs, nil
+}
+
+// Repo-level filtering is not enough for a listing of image NAMES: a caller
+// path-scoped by a content selector must not see the names the selector
+// hides — neither in the repo the selector scopes, nor anywhere else via a
+// path-only selector matching every repository.
+func TestDockerCatalog_PathScopedSelectorHidesOtherImages(t *testing.T) {
+	repoRepo := testutil.NewRepoRepo(
+		&domain.Repository{ID: "r1", Name: "priv", Format: domain.FormatDocker, Type: domain.TypeHosted, Online: true},
+		&domain.Repository{ID: "r2", Name: "priv2", Format: domain.FormatOCI, Type: domain.TypeHosted, Online: true},
+	)
+	assets := testutil.NewAssetRepo()
+	ctx := context.Background()
+	for _, a := range []*domain.Asset{
+		{Repository: "priv", Path: "/manifests/team-a/app/latest"},
+		{Repository: "priv", Path: "/manifests/team-b/secret/latest"},
+		{Repository: "priv2", Path: "/manifests/other/img/latest"},
+	} {
+		require.NoError(t, assets.Create(ctx, a))
+	}
+	rbac := &privsRBACRepo{privs: []repository.PrivilegeWithSelector{
+		{Actions: []string{"browse", "read"}, Expression: `repository == "priv" && path.startsWith("/team-a/")`},
+	}}
+	rbacSvc := service.NewRBACService(rbac, repoRepo, zap.NewNop().Sugar(), true)
+
+	r := gin.New()
+	r.GET("/v2/_catalog", func(c *gin.Context) {
+		c.Set("userID", "u-scoped")
+		c.Set("roles", []string{"developer"})
+	}, handlers.DockerCatalog(repoRepo, rbacSvc, assets))
+
+	code, got, _ := catalogGet(t, r, "/v2/_catalog")
+	require.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{"priv/team-a/app"}, got,
+		"team-b's and priv2's image names must stay hidden from a /team-a/-scoped caller")
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -718,6 +718,14 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	dockerV2Root := handlers.DockerV2Auth(userSvc, tokenSvc, repoRepo, rdb, cfg.Auth.AnonymousEnabled, loginGuard, log)
 	r.GET("/v2/", dockerV2Root)
 	r.HEAD("/v2/", dockerV2Root)
+	// Instance-level catalog (#261). A static route: without it the path fell
+	// into /v2/:repoName as a phantom repository named "_catalog", whose
+	// failed lookup denied even admins. On a subdomain host the rewriter still
+	// maps /v2/_catalog to that repository's own catalog, which is the right
+	// scope for a host that IS one repository.
+	r.GET("/v2/_catalog",
+		handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log),
+		handlers.DockerCatalog(repoRepo, rbacSvc, assetRepo))
 
 	dockerV2H := serveDockerV2(repoRepo, groupHandler, formatRegistry)
 	v2docker := r.Group("/v2/repository", handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log), handlers.RBACMiddleware(rbacSvc, repoRepo))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -723,9 +723,12 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	// failed lookup denied even admins. On a subdomain host the rewriter still
 	// maps /v2/_catalog to that repository's own catalog, which is the right
 	// scope for a host that IS one repository.
-	r.GET("/v2/_catalog",
+	dockerCatalogH := []gin.HandlerFunc{
 		handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log),
-		handlers.DockerCatalog(repoRepo, rbacSvc, assetRepo))
+		handlers.DockerCatalog(repoRepo, rbacSvc, assetRepo),
+	}
+	r.GET("/v2/_catalog", dockerCatalogH...)
+	r.HEAD("/v2/_catalog", dockerCatalogH...) // net/http drops the body for HEAD
 
 	dockerV2H := serveDockerV2(repoRepo, groupHandler, formatRegistry)
 	v2docker := r.Group("/v2/repository", handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log), handlers.RBACMiddleware(rbacSvc, repoRepo))

--- a/internal/formats/oci/catalog.go
+++ b/internal/formats/oci/catalog.go
@@ -53,9 +53,9 @@ func (h *Handler) handleCatalog(c *gin.Context, repoName string) {
 	// way and searched the other makes the cursor skip entries.
 	sort.Strings(names)
 
-	params := parsePageParams(c)
-	page, more := paginate(names, params)
-	setNextLink(c, params, page, more)
+	params := ParsePageParams(c)
+	page, more := Paginate(names, params)
+	SetNextLink(c, params, page, more)
 	if page == nil {
 		// An empty catalog must serialize as [] and not null: a null breaks
 		// clients that range over the list.

--- a/internal/formats/oci/groupindex.go
+++ b/internal/formats/oci/groupindex.go
@@ -321,9 +321,9 @@ func (h *Handler) PageGroupIndex(c *gin.Context, p string, merged []byte) ([]byt
 // header for a truncated one, exactly as the single-repository endpoints do —
 // the page is a page of the same sorted list either way.
 func pageMergedList(c *gin.Context, entries []string) []string {
-	params := parsePageParams(c)
-	page, more := paginate(entries, params)
-	setNextLink(c, params, page, more)
+	params := ParsePageParams(c)
+	page, more := Paginate(entries, params)
+	SetNextLink(c, params, page, more)
 	if page == nil {
 		page = []string{}
 	}

--- a/internal/formats/oci/groupindex.go
+++ b/internal/formats/oci/groupindex.go
@@ -66,6 +66,12 @@ func groupIndexKind(p string) (kind ociIndexKind, imageName string) {
 	}
 	switch {
 	case endsWithSegments(parts, "tags", "list"):
+		// ServeHTTP refuses the imageless /v2/<repoName>/tags/list with
+		// NAME_UNKNOWN; mirroring it keeps this classifier's invariant — a
+		// path is mergeable only as the document a member would produce.
+		if len(parts) == 2 {
+			return indexNone, ""
+		}
 		return indexTags, strings.Join(parts[:len(parts)-2], "/")
 	case referrersIndex(parts) >= 0:
 		return indexReferrers, ""

--- a/internal/formats/oci/groupindex_internal_test.go
+++ b/internal/formats/oci/groupindex_internal_test.go
@@ -1,0 +1,20 @@
+package oci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The imageless /v2/<repoName>/tags/list is not mergeable: ServeHTTP refuses
+// it with NAME_UNKNOWN, and the classifier must mirror that rather than
+// promising a tags document no member would produce.
+func TestGroupIndexKind_ImagelessTagsListIsNotMergeable(t *testing.T) {
+	kind, image := groupIndexKind("/v2/tags/list")
+	assert.Equal(t, indexNone, kind)
+	assert.Empty(t, image)
+
+	kind, image = groupIndexKind("/v2/myapp/tags/list")
+	assert.Equal(t, indexTags, kind)
+	assert.Equal(t, "myapp", image)
+}

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -109,6 +109,14 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 	switch {
 	case endsWithSegments(parts, "tags", "list"):
 		imageName := strings.Join(parts[:len(parts)-2], "/")
+		// /v2/<repoName>/tags/list names no image at all. Answering it with
+		// {"name":"","tags":[]} 200 (#261) reads as "an image with an empty
+		// name exists and has no tags"; the spec's answer for a name the
+		// registry does not serve is NAME_UNKNOWN.
+		if imageName == "" {
+			dockerError(c, http.StatusNotFound, "NAME_UNKNOWN", "repository name not known to registry")
+			return
+		}
 		h.handleTagsList(c, repoName, imageName)
 
 	// Before manifests and blobs: the shape is <name>/referrers/<digest>, and
@@ -194,9 +202,9 @@ func (h *Handler) handleTagsList(c *gin.Context, repoName, imageName string) {
 	// thing, and an unsorted list would make the ?last= cursor meaningless.
 	sort.Strings(tags)
 
-	params := parsePageParams(c)
-	page, more := paginate(tags, params)
-	setNextLink(c, params, page, more)
+	params := ParsePageParams(c)
+	page, more := Paginate(tags, params)
+	SetNextLink(c, params, page, more)
 	if page == nil {
 		page = []string{}
 	}

--- a/internal/formats/oci/handler_test.go
+++ b/internal/formats/oci/handler_test.go
@@ -241,6 +241,21 @@ func TestDocker_TagsList_Empty(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"tags"`)
 }
 
+// /v2/<repoName>/tags/list names no image: answering 200 with {"name":""}
+// read as "an image with an empty name exists" (#261); the spec's answer for
+// an unknown name is NAME_UNKNOWN.
+func TestDocker_TagsList_NoImageNameIs404(t *testing.T) {
+	repo := testutil.SimpleRepo("reg6b", "docker")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/reg6b/v2/tags/list", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "NAME_UNKNOWN")
+}
+
 func TestDocker_TagsList_AfterPush(t *testing.T) {
 	repo := testutil.SimpleRepo("reg7", "docker")
 	r := setup(repo)

--- a/internal/formats/oci/pagination.go
+++ b/internal/formats/oci/pagination.go
@@ -17,51 +17,51 @@ import (
 // Everything here is deliberately free of any knowledge of tags vs repository
 // names so the catalog endpoint can reuse it unchanged.
 
-// pageParams are the ?n= / ?last= arguments of a list request.
-type pageParams struct {
+// PageParams are the ?n= / ?last= arguments of a list request.
+type PageParams struct {
 	// n is the maximum number of entries to return; 0 means "no limit", which
 	// is what both an absent n and a non-positive one are treated as. The spec
 	// lets a registry reject a malformed n with 400, but returning the full
 	// list is the friendlier reading and matches what clients that omit n
 	// already get.
-	n int
+	N int
 	// last is the cursor: only entries strictly greater than it are returned.
-	last string
+	Last string
 }
 
-// parsePageParams reads the pagination arguments off a request.
-func parsePageParams(c *gin.Context) pageParams {
-	p := pageParams{last: c.Query("last")}
+// ParsePageParams reads the pagination arguments off a request.
+func ParsePageParams(c *gin.Context) PageParams {
+	p := PageParams{Last: c.Query("last")}
 	if raw := c.Query("n"); raw != "" {
 		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
-			p.n = n
+			p.N = n
 		}
 	}
 	return p
 }
 
-// paginate cuts one page out of a sorted, ascending list of entries. It returns
+// Paginate cuts one page out of a sorted, ascending list of entries. It returns
 // the page and whether entries remain after it.
 //
 // Entries equal to the cursor are skipped, not just the first one, so a list
 // that somehow holds duplicates still advances: every page ends on a strictly
 // larger entry than the cursor that produced it, which is what makes a client
 // following the Link headers terminate.
-func paginate(entries []string, p pageParams) (page []string, more bool) {
+func Paginate(entries []string, p PageParams) (page []string, more bool) {
 	// sort.SearchStrings finds the first entry >= last; the cursor is exclusive,
 	// so skip the run equal to it as well.
 	start := 0
-	if p.last != "" {
-		start = sort.SearchStrings(entries, p.last)
-		for start < len(entries) && entries[start] <= p.last {
+	if p.Last != "" {
+		start = sort.SearchStrings(entries, p.Last)
+		for start < len(entries) && entries[start] <= p.Last {
 			start++
 		}
 	}
 	rest := entries[start:]
-	if p.n <= 0 || len(rest) <= p.n {
+	if p.N <= 0 || len(rest) <= p.N {
 		return rest, false
 	}
-	return rest[:p.n], true
+	return rest[:p.N], true
 }
 
 // nextLink renders the RFC 8288 Link header value naming the next page of the
@@ -78,11 +78,11 @@ func nextLink(c *gin.Context, n int, last string) string {
 	return "<" + c.Request.URL.EscapedPath() + "?" + q.Encode() + `>; rel="next"`
 }
 
-// setNextLink attaches the Link header for a truncated page. Nothing is set for
+// SetNextLink attaches the Link header for a truncated page. Nothing is set for
 // a complete answer — the absence of the header is what tells a client to stop.
-func setNextLink(c *gin.Context, p pageParams, page []string, more bool) {
+func SetNextLink(c *gin.Context, p PageParams, page []string, more bool) {
 	if !more || len(page) == 0 {
 		return
 	}
-	c.Header("Link", nextLink(c, p.n, page[len(page)-1]))
+	c.Header("Link", nextLink(c, p.N, page[len(page)-1]))
 }

--- a/internal/service/rbac_service.go
+++ b/internal/service/rbac_service.go
@@ -224,6 +224,39 @@ func (s *RBACService) FilterDockerRows(ctx context.Context, userID string, roles
 	return result
 }
 
+// FilterOCIImageNames returns only the image names of one docker/oci
+// repository the caller may browse. Repo-level filtering (FilterRepos) is not
+// enough for a listing of image NAMES: it deliberately ignores content
+// selectors' path clauses, so a caller path-scoped to /team-a/ would see
+// team-b's image names — the exact thing the selector exists to hide. The
+// sample path is "/<name>/", the same convention FilterComponents uses so a
+// selector path.startsWith("/da/bas/") matches the image "da/bas/python".
+func (s *RBACService) FilterOCIImageNames(
+	ctx context.Context,
+	userID string, roles []string,
+	repo *domain.Repository,
+	names []string,
+) []string {
+	if isAdmin(roles) || s.anonymousAllowed(repo.AllowAnonymous) {
+		return names
+	}
+	if userID == "" {
+		return nil
+	}
+	privs, err := s.rbac.GetUserPrivilegesWithSelectors(ctx, userID)
+	if err != nil {
+		s.log.Warnw("failed to load privileges for catalog filter", "userID", userID, "err", err)
+		return nil
+	}
+	result := make([]string, 0, len(names))
+	for _, name := range names {
+		if matchPrivileges(privs, repo.Name, "/"+name+"/", "browse") {
+			result = append(result, name)
+		}
+	}
+	return result
+}
+
 // FilterComponents returns only the components the user may browse.
 // allowAnonByRepo maps repository-name → AllowAnonymous (caller pre-loads this).
 // Sample path for content-selector matching uses "/<name>/" so that a Docker


### PR DESCRIPTION
Closes #261.

## What

**Instance-level `GET|HEAD /v2/_catalog`.** Before, the path fell into the `/v2/:repoName` dispatch as a phantom repository named `_catalog`, and the failed lookup denied even an nx-admin with a bare 403 — the admin bypass lives in `CanAccessRepo`, which a missing repository never reaches. The new static route answers the distribution-spec catalog: entries are `<repository>/<image>` — the exact names this registry's `/v2/` surface serves, so every entry is something the caller could pass to `docker pull`. The per-repository catalog keeps answering bare image names, since there the namespace prefix is fixed by the URL; on a subdomain host the rewriter still maps `/v2/_catalog` to that repository's own catalog, which is the right scope for a host that *is* one repository. Pagination (`?n=`/`?last=` + `Link`) reuses the same helpers as the sibling list endpoints (now exported from the oci package).

Visibility is the part worth reviewing:

- repositories filter through `FilterRepos` (anonymous callers see exactly the `allow_anonymous` ones), **and each repository's image names then pass the caller's content selectors** via a new `RBACService.FilterOCIImageNames` — repo-level filtering alone would let a caller path-scoped to `/team-a/` see team-b's image names, the exact thing the selector exists to hide, and a path-only selector would have matched every repository. Sample-path convention matches `FilterComponents`.
- a credential-less caller who can see nothing gets `401 + WWW-Authenticate` like the sibling `/v2/` surfaces, not a `200 []` that reads as "the registry is empty".
- errors use the registry `errors[]` shape and don't echo internals to unauthenticated callers.

One trade-off stated plainly: the handler runs one `ListOCIImageNames` query per readable registry per request (the query does not attribute names to repositories, and entries need the prefix), and pagination trims after the fact. Bounded by the number of online docker/oci repositories; fine at that scale, and cheap to revisit with a repo-attributing query if it ever isn't.

**Imageless `tags/list` answers `NAME_UNKNOWN`.** A correction to the issue as filed: `GET /v2/<repo>/<image>/tags/list` already echoed the image name correctly — what I actually hit was `GET /v2/<repo>/tags/list` (no image at all), which answered `200 {"name":"","tags":[]}`, reading as "an image with an empty name exists". It now gets the spec's 404 `NAME_UNKNOWN`, and `groupIndexKind` mirrors the refusal so a group repository doesn't promise a tags document no member would produce.

## Verification

Live against real content: admin sees both repos' images prefixed and sorted; an anonymous caller sees only the `allow_anonymous` repo's (private names don't leak); `?n=1` pages with a properly URL-encoded `Link`; `HEAD /v2/_catalog` answers 200; the imageless `tags/list` 404s while the normal one is unchanged. Unit tests cover the RBAC matrix (anonymous / admin / path-scoped selector), pagination, the empty-vs-challenge split, and the classifier mirror.
