### PR TITLE
fix(repository): validate docker/oci repository names against the reference grammar (#262)

### DIFF
--- a/internal/service/repository_service.go
+++ b/internal/service/repository_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -82,6 +83,9 @@ func (s *RepositoryService) Create(ctx context.Context, r *domain.Repository) er
 	}
 	if r.Type == "" {
 		return fmt.Errorf("%w: type is required", ErrInvalidInput)
+	}
+	if err := validateNameForFormat(r.Name, r.Format); err != nil {
+		return err
 	}
 
 	// Check duplicate
@@ -260,6 +264,32 @@ func mergeProxyConfig(stored, updates map[string]any) map[string]any {
 		merged[domain.ProxyPasswordKey] = pw
 	}
 	return merged
+}
+
+// dockerPathComponent is the distribution reference grammar for one path
+// component. Docker-family clients parse image references with it, so a
+// docker/oci repository whose name fails it exists but can never be pushed to
+// or pulled from — `docker tag host/<name>/img` is not even parseable. (#262
+// was found via a repository named "docker test", created without complaint
+// and then silently unusable.)
+var dockerPathComponent = regexp.MustCompile(`^[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*$`)
+
+// validateNameForFormat rejects repository names the format's own clients
+// cannot address. Only the OCI-registry formats are gated: their grammar is
+// strict and a violating repository is dead on arrival, while other formats
+// merely produce percent-encoded URLs. Existing repositories are untouched —
+// this runs on create, where the trap is sprung.
+func validateNameForFormat(name string, format domain.RepoFormat) error {
+	if !format.IsOCIRegistry() {
+		return nil
+	}
+	if !dockerPathComponent.MatchString(name) {
+		return fmt.Errorf(
+			"%w: %q cannot be addressed by docker clients — use lowercase letters and digits, "+
+				"joined by '.', '_' or '-' (e.g. \"docker-test\")",
+			ErrInvalidInput, name)
+	}
+	return nil
 }
 
 // validateRemoteURL rejects a proxy config whose remote_url is missing or blank.

--- a/internal/service/repository_service_name_test.go
+++ b/internal/service/repository_service_name_test.go
@@ -1,0 +1,66 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A docker/oci repository whose name fails the distribution path-component
+// grammar exists but can never be pushed to or pulled from (#262), so Create
+// refuses it with an error naming the rule.
+func TestRepositoryService_Create_DockerNameGrammar(t *testing.T) {
+	rejected := []string{
+		"docker test", // the report's repository: a space
+		"Docker-Test", // uppercase
+		"-leading",    // separator first
+		"trailing.",   // separator last
+		"a..b",        // empty component between separators
+		"под-докер",   // non-ASCII
+	}
+	accepted := []string{
+		"docker-hosted",
+		"a",
+		"team.registry_2",
+		"a--b", // multiple dashes join as one separator run
+	}
+
+	for _, name := range rejected {
+		svc := newRepoSvcFull(testutil.NewRepoRepo(), testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+		err := svc.Create(context.Background(), &domain.Repository{
+			Name: name, Format: domain.FormatDocker, Type: domain.TypeHosted,
+		})
+		if !errors.Is(err, service.ErrInvalidInput) {
+			t.Errorf("Create(%q): got %v, want ErrInvalidInput", name, err)
+		}
+		if err != nil && !strings.Contains(err.Error(), "docker clients") {
+			t.Errorf("Create(%q): error %q does not explain the docker grammar", name, err)
+		}
+	}
+	for _, name := range accepted {
+		svc := newRepoSvcFull(testutil.NewRepoRepo(), testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+		if err := svc.Create(context.Background(), &domain.Repository{
+			Name: name, Format: domain.FormatOCI, Type: domain.TypeHosted,
+		}); err != nil {
+			t.Errorf("Create(%q): unexpected error %v", name, err)
+		}
+	}
+}
+
+// Only the OCI-registry formats are gated: other formats merely produce
+// percent-encoded URLs from an odd name, and existing deployments hold such
+// repositories that keep working.
+func TestRepositoryService_Create_OtherFormatsKeepLooseNames(t *testing.T) {
+	svc := newRepoSvcFull(testutil.NewRepoRepo(), testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+	err := svc.Create(context.Background(), &domain.Repository{
+		Name: "Gemma3", Format: domain.FormatConan, Type: domain.TypeHosted,
+	})
+	if err != nil {
+		t.Fatalf("Create(conan \"Gemma3\"): unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
Closes #262.

`Create` now validates docker/oci repository names against the distribution reference grammar's path component (`[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*`). A violating name — `docker test` with its space is how this was found — used to be accepted without complaint and then be silently unusable: `docker tag host/docker test/img` is not even parseable, so the repository exists, shows in listings, takes a quota, and can never be pushed to or pulled from. The error names the rule and suggests the fix (`"docker-test"`).

Scope decisions, both open to your judgement:

- **Only the OCI-registry formats are gated.** Other formats' clients survive odd names — they just produce percent-encoded URLs — and existing deployments hold such repositories that keep working (the instance this was found on has conan repos named `Gemma3` and `YoloV8s`). If you'd rather gate every format on some looser rule (say, no whitespace), happy to extend.
- **Create only.** `Update` cannot rename, and existing repositories are deliberately untouched — the trap is sprung at creation.

Tests cover the report's exact name, uppercase, leading/trailing separators, empty components, non-ASCII, the accepted shapes, and that a conan repo keeps its loose name.
