### PR TITLE
fix(replication): detach fire-and-forget goroutines from the request context (#254)

### DIFF
--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strconv"
@@ -70,7 +71,11 @@ func (h *ReplicationHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	go h.svc.ReloadRule(c.Request.Context(), rule.ID)
+	// Detached from the request context (like cleanup.go's RunAll): net/http
+	// cancels it the moment this handler returns, which silently killed the
+	// (re)scheduling this goroutine exists to perform — the API answered as if
+	// the rule was scheduled while its cron entry never materialized (#254).
+	go h.svc.ReloadRule(context.Background(), rule.ID)
 	c.JSON(http.StatusCreated, rule)
 }
 
@@ -95,7 +100,8 @@ func (h *ReplicationHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	go h.svc.ReloadRule(c.Request.Context(), rule.ID)
+	// Detached for the same reason as Create's — see the comment there (#254).
+	go h.svc.ReloadRule(context.Background(), rule.ID)
 	c.JSON(http.StatusOK, rule)
 }
 
@@ -120,8 +126,11 @@ func (h *ReplicationHandler) ManualRun(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	// Detached: a run outlives its 202 by design, and the request context is
+	// canceled the moment the handler returns — the run would abort almost
+	// immediately with no visible error (#254).
 	go func() {
-		_ = h.svc.RunRule(c.Request.Context(), id)
+		_ = h.svc.RunRule(context.Background(), id)
 	}()
 	c.JSON(http.StatusAccepted, gin.H{"message": "replication started"})
 }

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -1,9 +1,12 @@
 package handlers_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -202,4 +205,53 @@ func TestReplicationHandler_ListHistory_WithLimit_OK(t *testing.T) {
 	id := replicationCreate(t, r, "limit-history")
 	rec := do(t, r, http.MethodGet, "/api/v1/replication/rules/"+id+"/history?limit=5", nil)
 	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ── Request-context detachment (#254) ───────────────────────────────────────
+
+// ctxCapturingReplRepo records the context each GetRule call arrives with.
+type ctxCapturingReplRepo struct {
+	*testutil.ReplicationRepo
+	got chan context.Context
+}
+
+func (r *ctxCapturingReplRepo) GetRule(ctx context.Context, id string) (*domain.ReplicationRule, error) {
+	select {
+	case r.got <- ctx:
+	default:
+	}
+	return r.ReplicationRepo.GetRule(ctx, id)
+}
+
+// A manual run answers 202 and keeps going; net/http cancels the request
+// context the moment the handler returns, so the fire-and-forget goroutine
+// must not inherit it — with the old wiring the run aborted almost
+// immediately with no visible error (#254).
+func TestReplicationHandler_ManualRun_SurvivesRequestCancellation(t *testing.T) {
+	inner := testutil.NewReplicationRepo()
+	repo := &ctxCapturingReplRepo{ReplicationRepo: inner, got: make(chan context.Context, 2)}
+	svc := service.NewReplicationService(repo, testutil.NewAssetRepo(), testutil.NewBlobStore(), "test-secret", nil, cleanupNopLog())
+	h := handlers.NewReplicationHandler(svc)
+	r := gin.New()
+	r.POST("/api/v1/replication/rules/:id/run", h.ManualRun)
+
+	rule := &domain.ReplicationRule{Name: "det", SourceRepo: "src", TargetURL: "http://127.0.0.1:1/", TargetRepo: "dst"}
+	require.NoError(t, inner.CreateRule(context.Background(), rule))
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/replication/rules/"+rule.ID+"/run", nil).WithContext(reqCtx)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code)
+	cancel() // what a real net/http server does as soon as the handler returns
+
+	// The first GetRule is the handler's own synchronous existence check —
+	// request-scoped by design. The goroutine's is the one that must survive.
+	<-repo.got
+	select {
+	case got := <-repo.got:
+		assert.NoError(t, got.Err(), "the detached run's context must outlive the request")
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunRule goroutine never reached the repository")
+	}
 }

--- a/internal/service/replication_service.go
+++ b/internal/service/replication_service.go
@@ -34,6 +34,9 @@ type ReplicationService struct {
 	legacyKey  []byte // sha256(jwt_secret) fallback; nil when no dedicated key is set
 	log        logger.Logger
 
+	// running holds the rule IDs with an in-flight run (see RunRule).
+	running sync.Map
+
 	// newClient builds an HTTP client for a given timeout. Defaults to the
 	// SSRF-guarded netguard.Client (target URLs are user-configured); tests
 	// override it to reach loopback servers.
@@ -232,7 +235,15 @@ func (s *ReplicationService) StartCronScheduler(ctx context.Context) {
 
 // ReloadRule updates the cron entry for a single rule (call after Create/Update/Delete).
 func (s *ReplicationService) ReloadRule(ctx context.Context, ruleID string) {
-	rule, _ := s.repo.GetRule(ctx, ruleID)
+	rule, err := s.repo.GetRule(ctx, ruleID)
+	if err != nil && !errors.Is(err, repository.ErrNotFound) {
+		// A transient lookup failure must not unschedule the rule: keeping a
+		// possibly-stale cron entry beats a rule that silently never runs
+		// again until the next restart (#254). ErrNotFound is different — the
+		// rule really is gone, and its entry goes with it below.
+		s.log.Warn("replication: reload lookup failed, keeping existing schedule", "rule", ruleID, "err", err)
+		return
+	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -265,7 +276,18 @@ func (s *ReplicationService) addEntryLocked(rule domain.ReplicationRule) {
 }
 
 // RunRule executes a single replication rule immediately (used by cron and manual trigger).
+//
+// One run per rule per process: now that manual runs are detached from the
+// request context they no longer die by accident, so repeated POSTs to
+// .../run would otherwise pile up concurrent runs of the same rule pushing
+// the same assets. (Per-process is the honest scope of this guard; the cron
+// path has the same property today.)
 func (s *ReplicationService) RunRule(ctx context.Context, ruleID string) error {
+	if _, busy := s.running.LoadOrStore(ruleID, struct{}{}); busy {
+		return fmt.Errorf("replication rule %s is already running", ruleID)
+	}
+	defer s.running.Delete(ruleID)
+
 	rule, err := s.repo.GetRule(ctx, ruleID)
 	if err != nil {
 		return err

--- a/internal/service/replication_service_internal_test.go
+++ b/internal/service/replication_service_internal_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// One run per rule per process: detached from the request context (#254),
+// repeated POSTs to .../run would otherwise pile up concurrent runs of the
+// same rule pushing the same assets.
+func TestReplicationService_RunRule_RefusesConcurrentRun(t *testing.T) {
+	repRepo := testutil.NewReplicationRepo()
+	svc := NewReplicationService(repRepo, testutil.NewAssetRepo(), testutil.NewBlobStore(), "test-secret", nil, zap.NewNop().Sugar())
+
+	rule := &domain.ReplicationRule{Name: "solo", SourceRepo: "src", TargetURL: "http://127.0.0.1:1/", TargetRepo: "dst"}
+	require.NoError(t, repRepo.CreateRule(context.Background(), rule))
+
+	// Occupy the guard the way an in-flight run does.
+	svc.running.Store(rule.ID, struct{}{})
+	defer svc.running.Delete(rule.ID)
+
+	err := svc.RunRule(context.Background(), rule.ID)
+	require.ErrorContains(t, err, "already running")
+}


### PR DESCRIPTION
Closes #254.

The three fire-and-forget goroutines in `ReplicationHandler` (`Create`/`Update` → `ReloadRule`, `ManualRun` → `RunRule`) now run on a detached context, the way `cleanup.go`'s `RunAll` already does. `net/http` cancels the request context the moment the handler returns, so the old wiring meant a rule (re)schedule could be silently killed while the API answered 200/201, and a manual run could abort right after its 202 with no visible error — exactly as the issue describes.

Two adjacent holes in the same failure family, closed while here:

- **`RunRule` now refuses a second concurrent run of the same rule** (per process). Detached from the request context, manual runs no longer die by accident — so repeated POSTs to `.../run` would otherwise pile up concurrent runs pushing the same assets. The refusal is an error the caller of `RunRule` sees; the handler's 202 semantics are unchanged.
- **`ReloadRule` no longer unschedules a rule on a transient lookup failure.** It ignored the `GetRule` error, so a momentary DB hiccup during reload removed the cron entry and the rule silently never ran again until restart. `ErrNotFound` still unschedules — a deleted rule's entry should go — but any other error keeps the existing schedule and logs.

The test simulates what a real server does — cancels the request context as soon as the handler returns — and asserts the goroutine's context survives; it fails on the old wiring. The concurrent-run guard has its own test.
