### PR TITLE
fix(promotion): enforce that the rule actually applies to the component being promoted (#255)

### DIFF
--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -1360,6 +1360,10 @@ export default function BrowsePage() {
             setTreeCollapsed({})
             setDockerSelection(null)
             setRawSelection(null)
+            // Selection must not survive a repo switch: stale IDs from the
+            // previous repo would ride into "Promote selected", and the
+            // server now refuses such a mixed-repo batch (#255).
+            setSelectedComponentIDs(new Set())
             setUploadOpen(false)
           }}
           placeholder="— Select repository —"

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -68,18 +68,28 @@ func (s *PromotionService) WithWebhooks(w domain.WebhookDispatcher) *PromotionSe
 }
 
 // matchesPathFilter returns true when the component matches the rule's path filter.
-// An empty PathFilter matches everything.
+// An empty PathFilter matches everything; a filter that fails to compile or
+// evaluate matches nothing (the enforcement path reports that distinctly).
 func (s *PromotionService) matchesPathFilter(rule domain.PromotionRule, comp *domain.Component) bool {
+	matched, err := s.evalPathFilter(rule, comp)
+	return err == nil && matched
+}
+
+// evalPathFilter evaluates the rule's path filter against the component,
+// separating "did not match" from "the filter itself is broken" — a rule
+// whose filter errors must fail closed, but with an error that sends the
+// operator to the filter, not the component.
+func (s *PromotionService) evalPathFilter(rule domain.PromotionRule, comp *domain.Component) (bool, error) {
 	if rule.PathFilter == "" {
-		return true
+		return true, nil
 	}
 	ast, issues := s.celEnv.Compile(rule.PathFilter)
 	if issues != nil && issues.Err() != nil {
-		return false
+		return false, fmt.Errorf("path filter does not compile: %w", issues.Err())
 	}
 	prg, err := s.celEnv.Program(ast)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("path filter does not compile: %w", err)
 	}
 	path := "/" + comp.Group + "/" + comp.Name
 	vars := map[string]any{
@@ -89,10 +99,13 @@ func (s *PromotionService) matchesPathFilter(rule domain.PromotionRule, comp *do
 	}
 	out, _, err := prg.Eval(vars)
 	if err != nil {
-		return false
+		return false, fmt.Errorf("path filter failed to evaluate: %w", err)
 	}
-	matched, _ := out.Value().(bool)
-	return matched
+	matched, ok := out.Value().(bool)
+	if !ok {
+		return false, fmt.Errorf("path filter evaluates to %T, not a boolean", out.Value())
+	}
+	return matched, nil
 }
 
 // ruleAppliesTo reports whether the rule actually covers the component: the
@@ -108,7 +121,13 @@ func (s *PromotionService) ruleAppliesTo(rule *domain.PromotionRule, comp *domai
 		return fmt.Errorf("component %s lives in repository %q, which rule %q does not promote from (%q)",
 			comp.ID, comp.Repository, rule.Name, rule.FromRepo)
 	}
-	if !s.matchesPathFilter(*rule, comp) {
+	matched, err := s.evalPathFilter(*rule, comp)
+	if err != nil {
+		// Fail closed, but honestly: a broken filter is the rule's problem,
+		// and "does not match" would send the operator to the wrong place.
+		return fmt.Errorf("rule %q: %w", rule.Name, err)
+	}
+	if !matched {
 		return fmt.Errorf("component %s does not match rule %q's path filter", comp.ID, rule.Name)
 	}
 	return nil
@@ -136,8 +155,14 @@ func (s *PromotionService) CreateRule(ctx context.Context, rule *domain.Promotio
 		return fmt.Errorf("from_repo and to_repo must be different")
 	}
 	if rule.PathFilter != "" {
-		if _, issues := s.celEnv.Compile(rule.PathFilter); issues != nil && issues.Err() != nil {
+		ast, issues := s.celEnv.Compile(rule.PathFilter)
+		if issues != nil && issues.Err() != nil {
 			return fmt.Errorf("invalid path_filter CEL expression: %w", issues.Err())
+		}
+		// A filter that compiles to a non-bool (`path`, `"foo"`) would fail
+		// every applicability check downstream while looking valid here.
+		if ast.OutputType() != cel.BoolType {
+			return fmt.Errorf("invalid path_filter CEL expression: must evaluate to a boolean, not %s", ast.OutputType())
 		}
 	}
 	return s.promotionRepo.CreateRule(ctx, rule)
@@ -152,8 +177,12 @@ func (s *PromotionService) UpdateRule(ctx context.Context, rule *domain.Promotio
 		return fmt.Errorf("from_repo and to_repo must be different")
 	}
 	if rule.PathFilter != "" {
-		if _, issues := s.celEnv.Compile(rule.PathFilter); issues != nil && issues.Err() != nil {
+		ast, issues := s.celEnv.Compile(rule.PathFilter)
+		if issues != nil && issues.Err() != nil {
 			return fmt.Errorf("invalid path_filter CEL expression: %w", issues.Err())
+		}
+		if ast.OutputType() != cel.BoolType {
+			return fmt.Errorf("invalid path_filter CEL expression: must evaluate to a boolean, not %s", ast.OutputType())
 		}
 	}
 	return s.promotionRepo.UpdateRule(ctx, rule)
@@ -188,6 +217,26 @@ func (s *PromotionService) ListRequests(ctx context.Context, status string) ([]d
 	return s.promotionRepo.ListRequests(ctx, status)
 }
 
+// scanGate refuses promotion when the rule demands a clean scan and the
+// component's latest scan is missing or dirty. Malicious is checked alongside
+// the CVE tiers, not folded into them: a malicious-package report has no CVSS
+// level, so a gate reading only Critical/High would pass a compromised
+// release with a spotless CVE record straight into production.
+func (s *PromotionService) scanGate(ctx context.Context, rule *domain.PromotionRule, compID string) error {
+	if !rule.RequireScanPass {
+		return nil
+	}
+	scan, err := s.scanRepo.GetLatestByComponent(ctx, compID)
+	if err != nil || scan == nil {
+		return fmt.Errorf("component %s: scan required but not yet run", compID)
+	}
+	if scan.Malicious > 0 || scan.Critical > 0 || scan.High > 0 {
+		return fmt.Errorf("component %s: scan has %d malicious, %d critical, %d high findings",
+			compID, scan.Malicious, scan.Critical, scan.High)
+	}
+	return nil
+}
+
 // Promote creates promotion requests for each component. Auto-approves when require_manual_approval=false.
 func (s *PromotionService) Promote(ctx context.Context, ruleID string, componentIDs []string, requestedByID string) ([]domain.PromotionRequest, error) {
 	rule, err := s.promotionRepo.GetRule(ctx, ruleID)
@@ -195,10 +244,13 @@ func (s *PromotionService) Promote(ctx context.Context, ruleID string, component
 		return nil, fmt.Errorf("promotion rule not found: %s", ruleID)
 	}
 
-	var results []domain.PromotionRequest
+	// The whole batch is validated before anything is created or copied: with
+	// an auto-approve rule the loop below executes copies as it goes, so a
+	// mid-batch refusal would leave earlier components already promoted while
+	// the caller is told the batch failed. Refusing before any request row
+	// exists also spares reviewers pending requests nobody could legitimately
+	// approve.
 	for _, compID := range componentIDs {
-		// Refused before a request row exists: the caller gets a clean error
-		// instead of a pending request no reviewer could legitimately approve.
 		comp, cerr := s.componentRepo.Get(ctx, compID)
 		if cerr != nil || comp == nil {
 			return nil, fmt.Errorf("component not found: %s", compID)
@@ -206,22 +258,13 @@ func (s *PromotionService) Promote(ctx context.Context, ruleID string, component
 		if aerr := s.ruleAppliesTo(rule, comp); aerr != nil {
 			return nil, aerr
 		}
-
-		if rule.RequireScanPass {
-			scan, serr := s.scanRepo.GetLatestByComponent(ctx, compID)
-			if serr != nil || scan == nil {
-				return nil, fmt.Errorf("component %s: scan required but not yet run", compID)
-			}
-			// Malicious is checked alongside the CVE tiers, not folded into
-			// them: a malicious-package report has no CVSS level, so a gate
-			// reading only Critical/High would pass a compromised release with
-			// a spotless CVE record straight into production.
-			if scan.Malicious > 0 || scan.Critical > 0 || scan.High > 0 {
-				return nil, fmt.Errorf("component %s: scan has %d malicious, %d critical, %d high findings",
-					compID, scan.Malicious, scan.Critical, scan.High)
-			}
+		if serr := s.scanGate(ctx, rule, compID); serr != nil {
+			return nil, serr
 		}
+	}
 
+	var results []domain.PromotionRequest
+	for _, compID := range componentIDs {
 		req := &domain.PromotionRequest{
 			RuleID:      ruleID,
 			ComponentID: compID,
@@ -297,9 +340,13 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 		return fmt.Errorf("source component not found: %s", req.ComponentID)
 	}
 	// Re-checked at copy time, not just when the request was filed: Approve
-	// runs later, and the component may have moved (or the rule changed) in
-	// between — the invariant has to hold when the bytes actually move.
+	// runs later, and the component may have moved, the rule changed, or a
+	// scan found something while the request sat pending — the invariants
+	// have to hold when the bytes actually move.
 	if err := s.ruleAppliesTo(rule, comp); err != nil {
+		return err
+	}
+	if err := s.scanGate(ctx, rule, comp.ID); err != nil {
 		return err
 	}
 	toRepo, err := s.repoRepo.Get(ctx, rule.ToRepo)

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -95,6 +95,25 @@ func (s *PromotionService) matchesPathFilter(rule domain.PromotionRule, comp *do
 	return matched
 }
 
+// ruleAppliesTo reports whether the rule actually covers the component: the
+// component lives in the rule's from_repo and passes its path filter. This is
+// the same test ListRulesForComponent offers rules by — but offering is not
+// enforcing: Promote takes a caller-supplied (rule_id, component_id) pair, so
+// without this check any caller with promotion permission could promote an
+// arbitrary component with whichever rule has the laxest gates, bypassing a
+// stricter rule's require_scan_pass/require_manual_approval on the pair that
+// actually covers it (#255).
+func (s *PromotionService) ruleAppliesTo(rule *domain.PromotionRule, comp *domain.Component) error {
+	if comp.Repository != rule.FromRepo {
+		return fmt.Errorf("component %s lives in repository %q, which rule %q does not promote from (%q)",
+			comp.ID, comp.Repository, rule.Name, rule.FromRepo)
+	}
+	if !s.matchesPathFilter(*rule, comp) {
+		return fmt.Errorf("component %s does not match rule %q's path filter", comp.ID, rule.Name)
+	}
+	return nil
+}
+
 // ListRules returns all promotion rules.
 func (s *PromotionService) ListRules(ctx context.Context) ([]domain.PromotionRule, error) {
 	return s.promotionRepo.ListRules(ctx)
@@ -178,6 +197,16 @@ func (s *PromotionService) Promote(ctx context.Context, ruleID string, component
 
 	var results []domain.PromotionRequest
 	for _, compID := range componentIDs {
+		// Refused before a request row exists: the caller gets a clean error
+		// instead of a pending request no reviewer could legitimately approve.
+		comp, cerr := s.componentRepo.Get(ctx, compID)
+		if cerr != nil || comp == nil {
+			return nil, fmt.Errorf("component not found: %s", compID)
+		}
+		if aerr := s.ruleAppliesTo(rule, comp); aerr != nil {
+			return nil, aerr
+		}
+
 		if rule.RequireScanPass {
 			scan, serr := s.scanRepo.GetLatestByComponent(ctx, compID)
 			if serr != nil || scan == nil {
@@ -266,6 +295,12 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 	comp, err := s.componentRepo.Get(ctx, req.ComponentID)
 	if err != nil || comp == nil {
 		return fmt.Errorf("source component not found: %s", req.ComponentID)
+	}
+	// Re-checked at copy time, not just when the request was filed: Approve
+	// runs later, and the component may have moved (or the rule changed) in
+	// between — the invariant has to hold when the bytes actually move.
+	if err := s.ruleAppliesTo(rule, comp); err != nil {
+		return err
 	}
 	toRepo, err := s.repoRepo.Get(ctx, rule.ToRepo)
 	if err != nil || toRepo == nil {

--- a/internal/service/promotion_service_applies_test.go
+++ b/internal/service/promotion_service_applies_test.go
@@ -1,0 +1,127 @@
+package service_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// Promote takes a caller-supplied (rule_id, component_id) pair, so offering
+// only matching rules in ListRulesForComponent is not enforcement: without a
+// re-check, any caller with promotion permission could promote an arbitrary
+// component with whichever rule has the laxest gates (#255).
+func TestPromotionService_Promote_RefusesRuleFromAnotherRepo(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("sandbox", "raw"))
+
+	// The component lives in sandbox; the (lax, no-gates) rule promotes from
+	// staging. A stricter staging←sandbox rule with gates is beside the point —
+	// the attack is exactly that the caller picked a rule that skips them.
+	comp := &domain.Component{
+		ID: "comp-elsewhere", Repository: "sandbox", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	rule := &domain.PromotionRule{Name: "lax", FromRepo: "staging", ToRepo: "production"}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	_, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err == nil || !strings.Contains(err.Error(), `does not promote from`) {
+		t.Fatalf("expected from_repo mismatch refusal, got: %v", err)
+	}
+
+	// No request row may exist for the refused promotion — a pending request
+	// nobody could legitimately approve is just a trap for a reviewer.
+	reqs, lerr := promoRepo.ListRequests(ctx, "")
+	if lerr != nil {
+		t.Fatalf("ListRequests: %v", lerr)
+	}
+	if len(reqs) != 0 {
+		t.Fatalf("expected no promotion requests after refusal, got %d", len(reqs))
+	}
+}
+
+func TestPromotionService_Promote_RefusesComponentOutsidePathFilter(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+
+	comp := &domain.Component{
+		ID: "comp-outside", Repository: "staging", Format: "raw",
+		Group: "com/other", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	rule := &domain.PromotionRule{
+		Name: "scoped", FromRepo: "staging", ToRepo: "production",
+		PathFilter: `path.startsWith("/com/example/")`,
+	}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	_, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err == nil || !strings.Contains(err.Error(), "path filter") {
+		t.Fatalf("expected path-filter refusal, got: %v", err)
+	}
+}
+
+// Approve runs later than the request was filed, and the component may have
+// been moved (or re-created elsewhere) in between: the invariant has to hold
+// when the bytes actually move, so executeCopy re-checks it.
+func TestPromotionService_Approve_RefusesWhenComponentNoLongerApplies(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+
+	comp := &domain.Component{
+		ID: "comp-moving", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	rule := &domain.PromotionRule{
+		Name: "gated", FromRepo: "staging", ToRepo: "production",
+		RequireManualApproval: true,
+	}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	reqs, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err != nil || len(reqs) != 1 {
+		t.Fatalf("Promote: %v (%d requests)", err, len(reqs))
+	}
+
+	// The component moves out of staging while the request sits pending.
+	comp.Repository = "production"
+
+	err = svc.Approve(ctx, reqs[0].ID, "admin-1")
+	if err == nil || !strings.Contains(err.Error(), "does not promote from") {
+		t.Fatalf("expected Approve to surface the from_repo mismatch, got: %v", err)
+	}
+	got, err := promoRepo.GetRequest(ctx, reqs[0].ID)
+	if err != nil || got == nil {
+		t.Fatalf("GetRequest: %v", err)
+	}
+	if got.Status != domain.PromotionFailed {
+		t.Fatalf("status: got %s, want failed", got.Status)
+	}
+	if !strings.Contains(got.Error, "does not promote from") {
+		t.Fatalf("failure reason %q does not name the from_repo mismatch", got.Error)
+	}
+}

--- a/internal/service/promotion_service_applies_test.go
+++ b/internal/service/promotion_service_applies_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
@@ -123,5 +124,137 @@ func TestPromotionService_Approve_RefusesWhenComponentNoLongerApplies(t *testing
 	}
 	if !strings.Contains(got.Error, "does not promote from") {
 		t.Fatalf("failure reason %q does not name the from_repo mismatch", got.Error)
+	}
+}
+
+// With an auto-approve rule the execution loop copies as it goes, so batch
+// validation must run up front: a mid-batch refusal after copies had executed
+// would tell the caller "failed" while artifacts were already promoted.
+func TestPromotionService_Promote_BatchRefusedBeforeAnyCopy(t *testing.T) {
+	svc, promoRepo, compRepo, _, blobStore, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("sandbox", "raw"))
+
+	okComp := &domain.Component{
+		ID: "comp-ok", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	badComp := &domain.Component{
+		ID: "comp-bad", Repository: "sandbox", Format: "raw",
+		Group: "com/example", Name: "otherlib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(okComp)
+	compRepo.AddComponent(badComp)
+
+	rule := &domain.PromotionRule{Name: "auto", FromRepo: "staging", ToRepo: "production"}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	_, err := svc.Promote(ctx, rule.ID, []string{okComp.ID, badComp.ID}, "user-1")
+	if err == nil {
+		t.Fatal("expected the batch to be refused")
+	}
+	// Nothing may have been created or copied for the valid prefix either.
+	reqs, _ := promoRepo.ListRequests(ctx, "")
+	if len(reqs) != 0 {
+		t.Fatalf("expected no requests after batch refusal, got %d", len(reqs))
+	}
+	if keys, kerr := blobStore.ListKeys(ctx); kerr != nil || len(keys) != 0 {
+		t.Fatalf("expected no blobs copied after batch refusal, got %v (%v)", keys, kerr)
+	}
+}
+
+// A rule whose filter is broken (evaluates to a non-bool, or errors) must
+// fail closed with an error pointing at the FILTER, not at the component.
+func TestPromotionService_Promote_BrokenFilterNamesTheFilter(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+	comp := &domain.Component{
+		ID: "comp-1", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	// path.matches("(") compiles (the regexp is a runtime value) but errors at
+	// eval — the class of broken filter CreateRule cannot catch.
+	rule := &domain.PromotionRule{
+		Name: "broken", FromRepo: "staging", ToRepo: "production",
+		PathFilter: `path.matches("(")`,
+	}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	_, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err == nil || !strings.Contains(err.Error(), "path filter failed to evaluate") {
+		t.Fatalf("expected a filter-evaluation error naming the filter, got: %v", err)
+	}
+}
+
+// CreateRule/UpdateRule refuse a filter that compiles to a non-bool: it would
+// fail every applicability check downstream while looking valid.
+func TestPromotionService_CreateRule_NonBoolFilterRejected(t *testing.T) {
+	svc, _, _, _, _, _, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	err := svc.CreateRule(ctx, &domain.PromotionRule{
+		Name: "non-bool", FromRepo: "staging", ToRepo: "production",
+		PathFilter: `path`,
+	})
+	if err == nil || !strings.Contains(err.Error(), "must evaluate to a boolean") {
+		t.Fatalf("expected non-bool filter rejection, got: %v", err)
+	}
+}
+
+// The scan gate is re-evaluated when the bytes actually move: a scan that
+// found something while the request sat pending must stop the approval.
+func TestPromotionService_Approve_ReRunsScanGate(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, scanRepo := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+	comp := &domain.Component{
+		ID: "comp-scan", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	rule := &domain.PromotionRule{
+		Name: "gated", FromRepo: "staging", ToRepo: "production",
+		RequireScanPass: true, RequireManualApproval: true,
+	}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	// Clean at request time…
+	if err := scanRepo.Insert(ctx, &domain.ScanResultRow{ComponentID: comp.ID, Scanner: "osv", Status: "completed", ScannedAt: time.Now().Add(-time.Hour)}); err != nil {
+		t.Fatalf("Insert scan: %v", err)
+	}
+	reqs, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err != nil || len(reqs) != 1 {
+		t.Fatalf("Promote: %v (%d requests)", err, len(reqs))
+	}
+
+	// …dirty by approval time.
+	if err := scanRepo.Insert(ctx, &domain.ScanResultRow{ComponentID: comp.ID, Scanner: "osv", Status: "completed", Critical: 1, ScannedAt: time.Now()}); err != nil {
+		t.Fatalf("Insert dirty scan: %v", err)
+	}
+
+	err = svc.Approve(ctx, reqs[0].ID, "admin-1")
+	if err == nil || !strings.Contains(err.Error(), "critical") {
+		t.Fatalf("expected the approval to hit the scan gate, got: %v", err)
+	}
+	got, _ := promoRepo.GetRequest(ctx, reqs[0].ID)
+	if got == nil || got.Status != domain.PromotionFailed {
+		t.Fatalf("request status: got %v, want failed", got)
 	}
 }


### PR DESCRIPTION
Closes #255.

`Promote` and `executeCopy` now enforce what `ListRulesForComponent` only offered: the component actually lives in the rule's `from_repo` and passes its path filter (`ruleAppliesTo`). Offering is not enforcing — `Promote` takes a caller-supplied `(rule_id, component_id)` pair, so any caller with promotion permission could promote an arbitrary component with whichever rule had the laxest gates, bypassing a stricter rule's `require_scan_pass`/`require_manual_approval` on the pair that actually covers it.

Where the checks run, and why there:

- **The whole batch is validated before anything is created or copied.** With an auto-approve rule the execution loop copies as it goes, so a mid-batch refusal would leave earlier components already promoted while the caller is told the batch failed. This also hoists the existing scan gate out of the execution loop — the same partial-batch hazard predated this change there. Refusing before any request row exists also spares reviewers pending requests nobody could legitimately approve.
- **`executeCopy` re-checks applicability *and* the scan gate.** `Approve` runs later than the request was filed: the component may have moved, the rule changed, or a scan found something while the request sat pending — the invariants have to hold when the bytes actually move.
- **Broken filters fail closed, but honestly.** A filter can compile yet fail at eval (`path.matches("(")`) or produce a non-bool — the old silent-`false` would have refused every promotion under such a rule with a misleading "does not match". Evaluation errors now name the filter, and `CreateRule`/`UpdateRule` reject filters whose CEL output type isn't boolean up front.
- **The browse UI clears its checkbox selection on repository switch.** It didn't, and a stale selection from the previous repo used to ride into "Promote selected" — a flow that previously exercised this very bug silently and would now hit the refusal mid-batch.

Tests cover the from_repo bypass (with the assertion that no request row survives a refusal), the path-filter refusal, batch atomicity (no copies, no requests when one component fails), Approve-time re-checks for both a moved component and a scan that turned dirty while pending, the broken-filter error naming the filter, and the non-bool rejection.
