### PR TITLE
fix(migration): give BlobStoreMigration the json tags its API contract requires (#253)

### DIFF
--- a/internal/api/handlers/blob_store_migration_test.go
+++ b/internal/api/handlers/blob_store_migration_test.go
@@ -1,0 +1,28 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// The struct is serialized directly, so its tags ARE the API contract: the
+// frontend reads camelCase keys, and untagged PascalCase left the migration
+// progress UI reading undefined everywhere (#253).
+func TestBlobStoreMigration_SerializesTheFrontendContract(t *testing.T) {
+	m := domain.BlobStoreMigration{ID: "m1", RepositoryName: "repo", SourceStoreID: "s1", TargetStoreID: "s2", Status: "running", TotalAssets: 10, DoneAssets: 3}
+	raw, err := json.Marshal(m)
+	require.NoError(t, err)
+	for _, key := range []string{
+		`"id"`, `"repositoryName"`, `"sourceStoreId"`, `"targetStoreId"`, `"status"`,
+		`"totalAssets"`, `"doneAssets"`, `"totalBytes"`, `"doneBytes"`,
+		// Nullable fields serialize as null, not disappear: the frontend
+		// types them `| null` and a missing key reads as undefined.
+		`"errorMessage":null`, `"startedAt":null`, `"finishedAt":null`,
+	} {
+		require.Contains(t, string(raw), key)
+	}
+}

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -608,21 +608,27 @@ type MigrationAssetRow struct {
 }
 
 // BlobStoreMigration tracks progress of a background blob store migration for one repository.
+//
+// Serialized directly by the blob-store-migration handlers, so the tags ARE
+// the API contract (frontend/src/api/client.ts BlobStoreMigration). The
+// nullable pointers carry no omitempty — the frontend types them `| null`,
+// and a dropped key reads as undefined instead (#253, the same fix #210
+// made for the replication types).
 type BlobStoreMigration struct {
-	ID             string
-	RepositoryName string
-	SourceStoreID  string
-	TargetStoreID  string
-	Status         string
-	TotalAssets    int
-	DoneAssets     int
-	TotalBytes     int64
-	DoneBytes      int64
-	ErrorMessage   *string
-	StartedAt      *time.Time
-	FinishedAt     *time.Time
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID             string     `json:"id"`
+	RepositoryName string     `json:"repositoryName"`
+	SourceStoreID  string     `json:"sourceStoreId"`
+	TargetStoreID  string     `json:"targetStoreId"`
+	Status         string     `json:"status"`
+	TotalAssets    int        `json:"totalAssets"`
+	DoneAssets     int        `json:"doneAssets"`
+	TotalBytes     int64      `json:"totalBytes"`
+	DoneBytes      int64      `json:"doneBytes"`
+	ErrorMessage   *string    `json:"errorMessage"`
+	StartedAt      *time.Time `json:"startedAt"`
+	FinishedAt     *time.Time `json:"finishedAt"`
+	CreatedAt      time.Time  `json:"createdAt"`
+	UpdatedAt      time.Time  `json:"updatedAt"`
 }
 
 // ── Search params ────────────────────────────────────────────


### PR DESCRIPTION
Closes #253.

`domain.BlobStoreMigration` is serialized directly by the blob-store-migration handlers, so its tags *are* the API contract — and it had none, so the response carried Go's PascalCase field names while the frontend (`client.ts`'s `BlobStoreMigration`) reads camelCase: every field of the migration progress UI came back `undefined`. Same failure mode #210 fixed for the replication types, same fix: tags matching the frontend interface, and no `omitempty` on the nullable pointers — the frontend types them `| null`, and a dropped key reads as `undefined` instead.

The test pins the contract by marshaling the struct and asserting the frontend's exact keys, including that the nullable fields serialize as `null` rather than disappearing.
