### PR TITLE
fix(promotion): resolve the default blob store to its real row id (#256)

### DIFF
--- a/internal/api/handlers/promotion_extra_test.go
+++ b/internal/api/handlers/promotion_extra_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/service"
-	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
@@ -28,8 +27,7 @@ func mountPromotion2(t *testing.T) (*gin.Engine, *testutil.PromotionRepo, *testu
 	blobRepo := testutil.NewBlobStoreRepo()
 	scanRepo := testutil.NewScanResultRepo()
 	repoRepo := testutil.NewRepoRepo()
-	registry := storage.NewRegistry(blobStore)
-	svc, err := service.NewPromotionService(promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, blobStore, registry)
+	svc, err := service.NewPromotionService(promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, testutil.NewFakeResolver(blobStore))
 	require.NoError(t, err)
 	h := handlers.NewPromotionHandler(svc)
 

--- a/internal/api/handlers/promotion_handler_test.go
+++ b/internal/api/handlers/promotion_handler_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/service"
-	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
@@ -25,8 +24,7 @@ func newTestPromotionHandler(t *testing.T) *handlers.PromotionHandler {
 	blobRepo := testutil.NewBlobStoreRepo()
 	scanRepo := testutil.NewScanResultRepo()
 	repoRepo := testutil.NewRepoRepo()
-	registry := storage.NewRegistry(blobStore)
-	svc, err := service.NewPromotionService(promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, blobStore, registry)
+	svc, err := service.NewPromotionService(promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, testutil.NewFakeResolver(blobStore))
 	if err != nil {
 		t.Fatalf("NewPromotionService: %v", err)
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -196,7 +196,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	go replSvc.StartCronScheduler(ctx)
 
 	promotionSvc, err := service.NewPromotionService(
-		promotionRepo, componentRepo, assetRepo, repoRepo, blobRepo, scanRepo, localBlob, blobRegistry,
+		promotionRepo, componentRepo, assetRepo, repoRepo, blobRepo, scanRepo, blobRegistry,
 	)
 	if err != nil {
 		panic("promotion service init: " + err.Error())

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -21,8 +22,7 @@ type PromotionService struct {
 	repoRepo      repository.RepositoryRepo
 	blobRepo      repository.BlobStoreRepo
 	scanRepo      repository.ScanResultRepo
-	blobStore     storage.BlobStore
-	blobRegistry  *storage.Registry
+	blobResolver  StoreResolver
 	webhooks      domain.WebhookDispatcher
 
 	celEnv *cel.Env
@@ -37,8 +37,7 @@ func NewPromotionService(
 	repoRepo repository.RepositoryRepo,
 	blobRepo repository.BlobStoreRepo,
 	scanRepo repository.ScanResultRepo,
-	blobStore storage.BlobStore,
-	blobRegistry *storage.Registry,
+	blobResolver StoreResolver,
 ) (*PromotionService, error) {
 	env, err := cel.NewEnv(
 		cel.Variable("format", cel.StringType),
@@ -55,8 +54,7 @@ func NewPromotionService(
 		repoRepo:      repoRepo,
 		blobRepo:      blobRepo,
 		scanRepo:      scanRepo,
-		blobStore:     blobStore,
-		blobRegistry:  blobRegistry,
+		blobResolver:  blobResolver,
 		celEnv:        env,
 	}, nil
 }
@@ -377,37 +375,36 @@ func promotedExtra(extra map[string]any) map[string]any {
 	return out
 }
 
-// resolveStore returns the physical BlobStore for a given blobStoreID pointer,
-// and the id to record on the copied assets.
+// resolveStore returns the physical BlobStore for a given blobStoreID
+// pointer, and the id to record on the copied assets.
 //
-// The id is never empty: assets.blob_store_id is a NOT NULL foreign key, so
-// the "use the default store" case (a repository with no explicit
-// blobStoreID — the common one) must resolve to the real seeded row's UUID,
-// the same lookup resolveBlobStoreRef performs for ordinary uploads. The old
-// empty-string answer made every promotion touching a default-store
-// repository fail with a raw constraint error (#256).
+// Both branches resolve the physical store from the DB row, the way every
+// other data path does: in a stock local deployment the seeded default row's
+// store lives under its own subdirectory, not at the process store's root, so
+// answering the implicit-default case with the injected default instance
+// would write the copied blobs where no download will ever look for them.
+// The id is never empty — assets.blob_store_id is a NOT NULL foreign key,
+// and the old empty-string answer made every promotion touching a
+// default-store repository fail with a raw constraint error (#256).
 func (s *PromotionService) resolveStore(ctx context.Context, blobStoreID *string) (storage.BlobStore, string, error) {
-	if blobStoreID == nil || *blobStoreID == "" {
-		// The physical store is the process's configured default (s.blobStore,
-		// exactly what the old code used); only the id must come from the
-		// seeded "default" row — migration 001 always creates it.
-		bsMeta, err := s.blobRepo.Get(ctx, "default")
-		if err != nil {
-			return nil, "", fmt.Errorf("blob store: %w", err)
-		}
-		if bsMeta == nil {
+	implicit := blobStoreID == nil || *blobStoreID == ""
+	var bsMeta *domain.BlobStore
+	var err error
+	if implicit {
+		bsMeta, err = s.blobRepo.Get(ctx, "default")
+	} else {
+		bsMeta, err = s.blobRepo.GetByID(ctx, *blobStoreID)
+	}
+	if errors.Is(err, repository.ErrNotFound) || (err == nil && bsMeta == nil) {
+		if implicit {
 			return nil, "", fmt.Errorf("default blob store not found (seed blob_stores or assign repository.blobStoreId)")
 		}
-		return s.blobStore, bsMeta.ID, nil
+		return nil, "", fmt.Errorf("blob store id %q not found", *blobStoreID)
 	}
-	bsMeta, err := s.blobRepo.GetByID(ctx, *blobStoreID)
 	if err != nil {
 		return nil, "", fmt.Errorf("blob store: %w", err)
 	}
-	if bsMeta == nil {
-		return nil, "", fmt.Errorf("blob store id %q not found", *blobStoreID)
-	}
-	bs, err := s.blobRegistry.Get(ctx, storage.BlobStoreDescriptor{
+	bs, err := s.blobResolver.Get(ctx, storage.BlobStoreDescriptor{
 		ID:     bsMeta.ID,
 		Type:   bsMeta.Type,
 		Config: bsMeta.Config,

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -272,7 +272,10 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 		return fmt.Errorf("target repository not found: %s", rule.ToRepo)
 	}
 
-	toStore, toBlobStoreID := s.resolveStore(ctx, toRepo.BlobStoreID)
+	toStore, toBlobStoreID, err := s.resolveStore(ctx, toRepo.BlobStoreID)
+	if err != nil {
+		return fmt.Errorf("target %s: %w", toRepo.Name, err)
+	}
 
 	assets, err := s.assetRepo.ListByComponentID(ctx, req.ComponentID)
 	if err != nil {
@@ -295,7 +298,10 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 
 	for _, asset := range assets {
 		blobStoreID := asset.BlobStoreID
-		fromStore, _ := s.resolveStore(ctx, &blobStoreID)
+		fromStore, _, err := s.resolveStore(ctx, &blobStoreID)
+		if err != nil {
+			return fmt.Errorf("source asset %s: %w", asset.Path, err)
+		}
 
 		newBlobKey := base.BlobKey(toRepo.Name, asset.Path)
 
@@ -371,14 +377,35 @@ func promotedExtra(extra map[string]any) map[string]any {
 	return out
 }
 
-// resolveStore returns the physical BlobStore for a given blobStoreID pointer.
-func (s *PromotionService) resolveStore(ctx context.Context, blobStoreID *string) (storage.BlobStore, string) {
+// resolveStore returns the physical BlobStore for a given blobStoreID pointer,
+// and the id to record on the copied assets.
+//
+// The id is never empty: assets.blob_store_id is a NOT NULL foreign key, so
+// the "use the default store" case (a repository with no explicit
+// blobStoreID — the common one) must resolve to the real seeded row's UUID,
+// the same lookup resolveBlobStoreRef performs for ordinary uploads. The old
+// empty-string answer made every promotion touching a default-store
+// repository fail with a raw constraint error (#256).
+func (s *PromotionService) resolveStore(ctx context.Context, blobStoreID *string) (storage.BlobStore, string, error) {
 	if blobStoreID == nil || *blobStoreID == "" {
-		return s.blobStore, ""
+		// The physical store is the process's configured default (s.blobStore,
+		// exactly what the old code used); only the id must come from the
+		// seeded "default" row — migration 001 always creates it.
+		bsMeta, err := s.blobRepo.Get(ctx, "default")
+		if err != nil {
+			return nil, "", fmt.Errorf("blob store: %w", err)
+		}
+		if bsMeta == nil {
+			return nil, "", fmt.Errorf("default blob store not found (seed blob_stores or assign repository.blobStoreId)")
+		}
+		return s.blobStore, bsMeta.ID, nil
 	}
 	bsMeta, err := s.blobRepo.GetByID(ctx, *blobStoreID)
-	if err != nil || bsMeta == nil {
-		return s.blobStore, ""
+	if err != nil {
+		return nil, "", fmt.Errorf("blob store: %w", err)
+	}
+	if bsMeta == nil {
+		return nil, "", fmt.Errorf("blob store id %q not found", *blobStoreID)
 	}
 	bs, err := s.blobRegistry.Get(ctx, storage.BlobStoreDescriptor{
 		ID:     bsMeta.ID,
@@ -386,7 +413,7 @@ func (s *PromotionService) resolveStore(ctx context.Context, blobStoreID *string
 		Config: bsMeta.Config,
 	})
 	if err != nil {
-		return s.blobStore, ""
+		return nil, "", fmt.Errorf("blob store %q: %w", bsMeta.Name, err)
 	}
-	return bs, bsMeta.ID
+	return bs, bsMeta.ID, nil
 }

--- a/internal/service/promotion_service_defaultstore_test.go
+++ b/internal/service/promotion_service_defaultstore_test.go
@@ -1,0 +1,67 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// Promotion between repositories on the implicit default blob store — the
+// common case — must record the seeded default row's UUID on the copied
+// assets: assets.blob_store_id is a NOT NULL foreign key, and the old
+// empty-string answer from resolveStore failed every such promotion with a
+// raw constraint error (#256).
+func TestPromotionService_DefaultStoreRepos_PromoteRecordsRealStoreID(t *testing.T) {
+	svc, promoRepo, compRepo, assetRepo, blobStore, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	// Both repos use the implicit default store (no BlobStoreID).
+	fromRepo := testutil.SimpleRepo("staging", "raw")
+	toRepo := testutil.SimpleRepo("production", "raw")
+	repoRepo.Create(ctx, fromRepo)
+	repoRepo.Create(ctx, toRepo)
+
+	comp := &domain.Component{
+		ID: "comp-default-store", RepositoryID: fromRepo.ID, Repository: "staging",
+		Format: "raw", Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	blobKey := "staging:mylib-1.0.0.jar"
+	if err := blobStore.PutBytes(ctx, blobKey, []byte("bytes")); err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+	assetRepo.Create(ctx, &domain.Asset{
+		ComponentID: comp.ID, RepositoryID: fromRepo.ID, Repository: "staging",
+		Path: "mylib-1.0.0.jar", BlobKey: blobKey, SizeBytes: 5,
+	})
+
+	rule := &domain.PromotionRule{Name: "auto", FromRepo: "staging", ToRepo: "production"}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	reqs, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].Status != domain.PromotionCompleted {
+		t.Fatalf("expected one completed request, got %+v", reqs)
+	}
+
+	// The copied asset carries the seeded default row's UUID, never "".
+	copied, err := assetRepo.ListByRepoAndPath(ctx, "production", "")
+	if err != nil {
+		t.Fatalf("ListByRepoAndPath: %v", err)
+	}
+	if len(copied) == 0 {
+		t.Fatal("no asset was copied into production")
+	}
+	for _, a := range copied {
+		if a.BlobStoreID != "00000000-0000-0000-0000-000000000001" {
+			t.Fatalf("copied asset blob_store_id: got %q, want the seeded default store UUID", a.BlobStoreID)
+		}
+	}
+}

--- a/internal/service/promotion_service_defaultstore_test.go
+++ b/internal/service/promotion_service_defaultstore_test.go
@@ -2,9 +2,11 @@ package service_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
@@ -63,5 +65,47 @@ func TestPromotionService_DefaultStoreRepos_PromoteRecordsRealStoreID(t *testing
 		if a.BlobStoreID != "00000000-0000-0000-0000-000000000001" {
 			t.Fatalf("copied asset blob_store_id: got %q, want the seeded default store UUID", a.BlobStoreID)
 		}
+	}
+}
+
+// The "default blob store not found" diagnostic must actually be reachable:
+// the postgres repo reports a missing row as ErrNotFound, not (nil, nil), and
+// an err-first check would bury the actionable message under a bare
+// "not found" (the default row is deletable via the blobstore API when
+// nothing references it).
+func TestPromotionService_MissingDefaultStoreRow_NamesTheFix(t *testing.T) {
+	promoRepo := testutil.NewPromotionRepo()
+	compRepo := testutil.NewComponentRepo()
+	assetRepo := testutil.NewAssetRepo()
+	blobStore := testutil.NewBlobStore()
+	// Seeding a non-default row keeps the constructor from creating "default".
+	blobRepo := testutil.NewBlobStoreRepo(&domain.BlobStore{ID: "bs-other", Name: "other", Type: "local"})
+	repoRepo := testutil.NewRepoRepo()
+	svc, err := service.NewPromotionService(
+		promoRepo, compRepo, assetRepo, repoRepo, blobRepo, testutil.NewScanResultRepo(), testutil.NewFakeResolver(blobStore),
+	)
+	if err != nil {
+		t.Fatalf("NewPromotionService: %v", err)
+	}
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+	comp := &domain.Component{ID: "c1", Repository: "staging", Format: "raw", Group: "g", Name: "n", Version: "1"}
+	compRepo.AddComponent(comp)
+	rule := &domain.PromotionRule{Name: "auto", FromRepo: "staging", ToRepo: "production"}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	reqs, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err != nil || len(reqs) != 1 {
+		t.Fatalf("Promote: %v (%d requests)", err, len(reqs))
+	}
+	if reqs[0].Status != domain.PromotionFailed {
+		t.Fatalf("status: got %s, want failed", reqs[0].Status)
+	}
+	if !strings.Contains(reqs[0].Error, "default blob store not found") {
+		t.Fatalf("error %q does not carry the actionable diagnostic", reqs[0].Error)
 	}
 }

--- a/internal/service/promotion_service_test.go
+++ b/internal/service/promotion_service_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/service"
-	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
@@ -30,10 +29,9 @@ func newTestPromotionSvc(t *testing.T) (
 	blobRepo := testutil.NewBlobStoreRepo()
 	scanRepo := testutil.NewScanResultRepo()
 	repoRepo := testutil.NewRepoRepo()
-	registry := storage.NewRegistry(blobStore)
 
 	svc, err := service.NewPromotionService(
-		promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, blobStore, registry,
+		promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, testutil.NewFakeResolver(blobStore),
 	)
 	if err != nil {
 		t.Fatalf("NewPromotionService: %v", err)


### PR DESCRIPTION
Closes #256.

`resolveStore` answered the implicit-default case — a repository with no explicit `blobStoreId`, the common one — with an empty store id, and `assets.blob_store_id` is a `NOT NULL` foreign key: every promotion touching a default-store repository failed with a raw Postgres constraint error.

Both branches now resolve the same way every other data path does: fetch the blob-store **row** (the seeded `default` by name, or the explicit id), record its UUID, and resolve the physical store from the row's descriptor through the registry. The row-resolution half matters as much as the UUID half: in a stock local deployment the default row's store lives under `./data/blobs/default` while the process-level store is rooted at `./data/blobs` — an earlier draft of this fix paired the row's UUID with the process store, which would have written promoted blobs where no download ever looks, with the promotion reported `Completed`. The service's direct default-store handle is gone entirely (`NewPromotionService` loses a parameter, and takes the existing `StoreResolver` interface instead of the concrete registry), so that mispairing is now structurally impossible.

The signature change also removes a silent fallback: an *explicit* `blob_store_id` that fails to resolve used to quietly fall back to the default store and the same doomed empty id — reading blobs from the wrong store on the way. Both `executeCopy` call sites now surface the error into the promotion request's `error` column. Missing rows are routed via `errors.Is(err, repository.ErrNotFound)` so the actionable diagnostics ("default blob store not found (seed blob_stores or assign repository.blobStoreId)") actually surface — the postgres repo never returns `(nil, nil)`, and an err-first check would bury them under a bare "not found".

Tests: promotion between two implicit-default repositories completes and the copied asset carries the seeded default row's real UUID; a deleted `default` row (possible via the blobstore API when unreferenced) fails the request with the actionable message, not a constraint error.

Note: lands in the same file as #267, different functions — merges cleanly in either order.
