### PR TITLE
fix: unify the /v2/ challenge, reserve its route names, refuse overlapping replication runs

### DIFF
--- a/internal/api/handlers/docker_catalog.go
+++ b/internal/api/handlers/docker_catalog.go
@@ -67,8 +67,12 @@ func DockerCatalog(
 		// A credential-less caller who can see nothing gets the challenge the
 		// sibling /v2/ surfaces give, not a 200 that reads as "the registry is
 		// empty" — a client holding credentials should be told to present them.
+		// The same Bearer challenge the ping and the data routes emit: a Basic
+		// challenge here would send a token-family client down a scheme it
+		// cannot satisfy on a surface where every sibling points at /v2/token
+		// (see dockerChallenge).
 		if userID == "" && len(readable) == 0 {
-			c.Header("WWW-Authenticate", `Basic realm="Nexspence"`)
+			dockerChallenge(c)
 			c.JSON(http.StatusUnauthorized, gin.H{
 				"errors": []gin.H{{"code": "UNAUTHORIZED", "message": "authentication required"}},
 			})

--- a/internal/api/handlers/docker_catalog_test.go
+++ b/internal/api/handlers/docker_catalog_test.go
@@ -136,7 +136,10 @@ func TestDockerCatalog_AnonymousWithNothingVisible_Challenges401(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/v2/_catalog", nil))
 	require.Equal(t, http.StatusUnauthorized, w.Code)
-	assert.Contains(t, w.Header().Get("WWW-Authenticate"), "Basic")
+	// Bearer, like the ping and the data routes: a Basic challenge here would
+	// send a token-family client down a scheme it cannot satisfy.
+	assert.Contains(t, w.Header().Get("WWW-Authenticate"), "Bearer realm=")
+	assert.Contains(t, w.Header().Get("WWW-Authenticate"), "/v2/token")
 	assert.Contains(t, w.Body.String(), "UNAUTHORIZED")
 }
 

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -126,6 +126,13 @@ func (h *ReplicationHandler) ManualRun(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	// One run per rule: RunRule refuses an overlapping run, and that refusal
+	// is invisible from inside the goroutine below — answering 202 for a run
+	// that never starts is worse than saying so.
+	if h.svc.Running(id) {
+		c.JSON(http.StatusConflict, gin.H{"error": "replication rule is already running"})
+		return
+	}
 	// Detached: a run outlives its 202 by design, and the request context is
 	// canceled the moment the handler returns — the run would abort almost
 	// immediately with no visible error (#254).

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -254,4 +255,58 @@ func TestReplicationHandler_ManualRun_SurvivesRequestCancellation(t *testing.T) 
 	case <-time.After(2 * time.Second):
 		t.Fatal("RunRule goroutine never reached the repository")
 	}
+}
+
+// blockingReplRepo blocks the Nth GetRule call until the test releases it,
+// which parks an in-flight run inside RunRule with the guard held.
+type blockingReplRepo struct {
+	*testutil.ReplicationRepo
+	calls   atomic.Int32
+	blockOn int32
+	release chan struct{}
+}
+
+func (r *blockingReplRepo) GetRule(ctx context.Context, id string) (*domain.ReplicationRule, error) {
+	if r.calls.Add(1) == r.blockOn {
+		<-r.release
+	}
+	return r.ReplicationRepo.GetRule(ctx, id)
+}
+
+// A second manual run while the first is still going is refused visibly:
+// RunRule drops the overlapping run, and a 202 for a run that never starts
+// tells the operator the opposite of what happened.
+func TestReplicationHandler_ManualRun_ConcurrentRunIs409(t *testing.T) {
+	inner := testutil.NewReplicationRepo()
+	// Call 1 is the first POST's synchronous existence check, call 2 is its
+	// detached run — that is the one to park. Call 3 is the second POST's
+	// existence check and must not block.
+	repo := &blockingReplRepo{ReplicationRepo: inner, blockOn: 2, release: make(chan struct{})}
+	defer close(repo.release)
+	svc := service.NewReplicationService(repo, testutil.NewAssetRepo(), testutil.NewBlobStore(), "test-secret", nil, cleanupNopLog())
+	h := handlers.NewReplicationHandler(svc)
+	r := gin.New()
+	r.POST("/api/v1/replication/rules/:id/run", h.ManualRun)
+
+	rule := &domain.ReplicationRule{Name: "busy", SourceRepo: "src", TargetURL: "http://127.0.0.1:1/", TargetRepo: "dst"}
+	require.NoError(t, inner.CreateRule(context.Background(), rule))
+	path := "/api/v1/replication/rules/" + rule.ID + "/run"
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPost, path, nil))
+	require.Equal(t, http.StatusAccepted, w.Code)
+
+	// The detached run has to reach the guard before the second POST asks.
+	deadline := time.Now().Add(2 * time.Second)
+	for !svc.Running(rule.ID) {
+		if time.Now().After(deadline) {
+			t.Fatal("the detached run never took the guard")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, httptest.NewRequest(http.MethodPost, path, nil))
+	assert.Equal(t, http.StatusConflict, w2.Code)
+	assert.Contains(t, w2.Body.String(), "already running")
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -705,15 +705,16 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	// Gin static-segment priority ensures /v2/repository/... always matches the long-path
 	// group first; the short-path group catches everything else under /v2/.
 	// GET/HEAD /v2/ — OCI version check. The unauthenticated ping always
-	// answers 401 with a Bearer challenge pointing at /v2/token (plus Basic
-	// for non-token clients): a 200 here makes docker treat the registry as
-	// public and silently drop stored credentials on subsequent requests
-	// (#260) — which then fail RBAC as "anonymous" and surface to users as
-	// push/pull failures even though `docker login` reported success. The
-	// token endpoint keeps anonymous `docker pull` working (see Phase 26):
-	// credential-less clients receive an anonymous token there, and per-repo
-	// RBAC decides their reads exactly as before. A side effect: "token" is a
-	// reserved name on the /v2/ surface, like "repository" already is.
+	// answers 401 with a Bearer challenge pointing at /v2/token — Bearer
+	// alone, never Basic alongside (see dockerChallenge for why). A 200 here
+	// makes docker treat the registry as public and silently drop stored
+	// credentials on subsequent requests (#260) — which then fail RBAC as
+	// "anonymous" and surface to users as push/pull failures even though
+	// `docker login` reported success. The token endpoint keeps anonymous
+	// `docker pull` working (see Phase 26): credential-less clients receive an
+	// anonymous token there, and per-repo RBAC decides their reads exactly as
+	// before. A side effect: "token" is a reserved name on the /v2/ surface,
+	// like "repository" already is — validateNameForFormat refuses both.
 	dockerV2Root := handlers.DockerV2Auth(userSvc, tokenSvc, loginGuard, log)
 	r.GET("/v2/", dockerV2Root)
 	r.HEAD("/v2/", dockerV2Root)

--- a/internal/service/cleanup_service_test.go
+++ b/internal/service/cleanup_service_test.go
@@ -675,7 +675,9 @@ func TestCleanupLock_IsScopedPerPolicy(t *testing.T) {
 
 	require.NoError(t, svc.RunAll(ctx))
 
-	assert.Equal(t, []string{
+	// ElementsMatch, not Equal: the policies are collected from a map, so the
+	// order they are locked in is not part of the contract — the scoping is.
+	assert.ElementsMatch(t, []string{
 		"nexspence:lock:cleanup:policy:p-one",
 		"nexspence:lock:cleanup:policy:p-two",
 	}, lk.acquired())

--- a/internal/service/replication_service.go
+++ b/internal/service/replication_service.go
@@ -275,6 +275,14 @@ func (s *ReplicationService) addEntryLocked(rule domain.ReplicationRule) {
 	s.entryIDs[rule.ID] = id
 }
 
+// Running reports whether a run of the rule is in flight in this process.
+// The manual-run endpoint asks before answering so a second POST is refused
+// visibly instead of returning 202 for a run that RunRule then drops.
+func (s *ReplicationService) Running(ruleID string) bool {
+	_, busy := s.running.Load(ruleID)
+	return busy
+}
+
 // RunRule executes a single replication rule immediately (used by cron and manual trigger).
 //
 // One run per rule per process: now that manual runs are detached from the

--- a/internal/service/repository_service.go
+++ b/internal/service/repository_service.go
@@ -274,6 +274,17 @@ func mergeProxyConfig(stored, updates map[string]any) map[string]any {
 // and then silently unusable.)
 var dockerPathComponent = regexp.MustCompile(`^[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*$`)
 
+// reservedV2Names are the static routes registered under /v2/ (see
+// internal/api/router.go). Gin matches a static segment before the
+// /v2/:repoName parameter, so a repository named after one is created
+// successfully and then shadowed on the short docker URL — the same silent
+// dead end #262 is about, one path segment up.
+var reservedV2Names = map[string]bool{
+	"repository": true, // the long-form /v2/repository/<repoName>/... dispatch
+	"token":      true, // the token endpoint the /v2/ ping challenges towards
+	"_catalog":   true, // the instance-level catalog (also fails the grammar above)
+}
+
 // validateNameForFormat rejects repository names the format's own clients
 // cannot address. Only the OCI-registry formats are gated: their grammar is
 // strict and a violating repository is dead on arrival, while other formats
@@ -287,6 +298,12 @@ func validateNameForFormat(name string, format domain.RepoFormat) error {
 		return fmt.Errorf(
 			"%w: %q cannot be addressed by docker clients — use lowercase letters and digits, "+
 				"joined by '.', '_' or '-' (e.g. \"docker-test\")",
+			ErrInvalidInput, name)
+	}
+	if reservedV2Names[name] {
+		return fmt.Errorf(
+			"%w: %q is a registry-level endpoint on the /v2/ surface, so a repository of that "+
+				"name could never be reached — pick another name",
 			ErrInvalidInput, name)
 	}
 	return nil

--- a/internal/service/repository_service_name_test.go
+++ b/internal/service/repository_service_name_test.go
@@ -64,3 +64,28 @@ func TestRepositoryService_Create_OtherFormatsKeepLooseNames(t *testing.T) {
 		t.Fatalf("Create(conan \"Gemma3\"): unexpected error %v", err)
 	}
 }
+
+// The /v2/ surface has static routes (the long-form dispatch, the token
+// endpoint, the instance catalog): gin matches those before /v2/:repoName, so
+// a repository named after one is created successfully and then unreachable
+// on the short docker URL — the same dead end #262 is about.
+func TestRepositoryService_Create_RejectsReservedV2Names(t *testing.T) {
+	for _, name := range []string{"repository", "token", "_catalog"} {
+		svc := newRepoSvcFull(testutil.NewRepoRepo(), testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+		err := svc.Create(context.Background(), &domain.Repository{
+			Name: name, Format: domain.FormatDocker, Type: domain.TypeHosted,
+		})
+		if !errors.Is(err, service.ErrInvalidInput) {
+			t.Errorf("Create(%q): got %v, want ErrInvalidInput", name, err)
+		}
+	}
+
+	// Only the /v2/ surface is gated: an npm repository named "token" is
+	// addressed under /repository/<name>/ and works fine.
+	svc := newRepoSvcFull(testutil.NewRepoRepo(), testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+	if err := svc.Create(context.Background(), &domain.Repository{
+		Name: "token", Format: domain.FormatNPM, Type: domain.TypeHosted,
+	}); err != nil {
+		t.Fatalf("Create(npm \"token\"): unexpected error %v", err)
+	}
+}


### PR DESCRIPTION
Follow-ups found while reviewing #259/#263–#269 together. Each is small and independent.

## `/v2/_catalog` challenged with Basic

#264 and #263 were written in parallel: #263 moved every `/v2/` surface to a `Bearer realm=".../v2/token"` challenge and documents at length why a Basic challenge must never ride along, while #264's catalog answered the credential-less caller with `WWW-Authenticate: Basic`. Merged together, the catalog was the one surface pointing token clients at a scheme they cannot satisfy. It now calls `dockerChallenge` like its siblings.

The route-registration comment in `router.go` also still promised "plus Basic for non-token clients", which the code deliberately does not do.

## `token` and `repository` were addressable names

#265 refuses docker/oci repository names the distribution grammar cannot parse. `token` and `repository` pass that grammar and are still unreachable: gin matches a static `/v2/` segment before the `:repoName` parameter, so the repository is created without complaint and then shadowed on the short docker URL — the same dead end #262 reported, one path segment up. `_catalog` already fails the grammar and is listed with them so the set is the whole `/v2/` route table.

## An overlapping manual replication run answered 202

#266 added a one-run-per-rule guard in `RunRule`, but `ManualRun` discards the error inside its detached goroutine, so a second POST was told the run had started when it had been dropped. The handler now asks `svc.Running` before answering and returns 409. The goroutine keeps its own guard — two simultaneous POSTs can both pass the check.

## A flaky assertion

`TestCleanupLock_IsScopedPerPolicy` compared the acquired lock keys with `Equal`, but the policies come from a map: the assertion reddened at random (it did, locally, during this review). `ElementsMatch` asserts the scoping without the accidental ordering.

## Verification

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` clean; `go test ./internal/...` — 2189 passed, the single failure being the pre-existing sandbox-only `TestWebhookHandler_Test_200` (outbound dial blocked). The new 409 test ran 5× under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMeaf1p9QmzaNv15qhmYV5