### PR TITLE
feat!: image scanning now requires a Trivy you supply

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,19 +41,6 @@ RUN apk add --no-cache ca-certificates tzdata wget
 # below would otherwise be empty.
 ARG VERSION=dev
 
-# Trivy (optional CVE scans from Security UI / ScanService)
-ARG TRIVY_VERSION=0.70.0
-ARG TARGETARCH=amd64
-RUN set -eu; \
-  case "$TARGETARCH" in \
-    amd64) TRIVY_ARCH=64bit ;; \
-    arm64) TRIVY_ARCH=ARM64 ;; \
-    *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
-  esac; \
-  wget -qO- "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-${TRIVY_ARCH}.tar.gz" \
-    | tar -xzf - -C /usr/local/bin trivy; \
-  chmod +x /usr/local/bin/trivy
-
 WORKDIR /app
 
 COPY --from=builder /nexspence /app/nexspence
@@ -77,14 +64,16 @@ LABEL org.opencontainers.image.title="Nexspence" \
       org.opencontainers.image.documentation="https://github.com/nexspence/nexspence#readme" \
       org.opencontainers.image.version="${VERSION}"
 
-# Run as a non-root user (uid/gid 1000). Pre-create the dirs the app and the
-# bundled trivy write to (default blob path /app/data/blobs, trivy cache) and
-# hand /app to the unprivileged user. Creating /app/data/blobs in the image is
-# what lets a FRESH named volume mounted there inherit uid-1000 ownership
-# (Docker only copies the image dir's ownership into an empty named volume when
-# the mountpoint dir exists in the image). HOME=/app keeps trivy's fallback cache
-# under a writable path; TRIVY_CACHE_DIR pins it explicitly (correct env var
-# for modern trivy ≥0.x).
+# Run as a non-root user (uid/gid 1000). Pre-create the dirs the app writes to
+# (default blob path /app/data/blobs) and hand /app to the unprivileged user.
+# Creating /app/data/blobs in the image is what lets a FRESH named volume
+# mounted there inherit uid-1000 ownership (Docker only copies the image dir's
+# ownership into an empty named volume when the mountpoint dir exists in the
+# image).
+#
+# HOME and TRIVY_CACHE_DIR stay even though this image ships no Trivy: an
+# operator who supplies one (see docs/scanning.md) needs its cache on a
+# writable path, and pinning it here means they do not have to know that.
 RUN addgroup -g 1000 nexspence && adduser -D -u 1000 -G nexspence nexspence \
     && mkdir -p /app/data/blobs /app/.cache /app/secrets \
     && chmod +x /app/entrypoint.sh \

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Published on the [Terraform Registry](https://registry.terraform.io/providers/ne
 - Cleanup policies — by age, last-downloaded, retain-N-versions; cron scheduler; dry-run
 - Per-repository export / import (streaming `.tar.gz`); full system backup / restore
 - Live migration from a running Nexus instance — repositories, artifacts, container images, privileges/roles/users, routing rules; pausable, resumable, restart-safe ([guide](docs/nexus-migration.md))
-- Vulnerability scanning — Trivy (Docker) + OSV.dev (Maven/npm/PyPI/Cargo)
+- Vulnerability scanning — OSV.dev for Maven/npm/PyPI/Cargo out of the box; Docker/OCI images with a Trivy you supply ([setup](docs/scanning.md))
 - Audit log — every action logged; NDJSON streaming export; 90-day partition rotation
 - Webhooks — HMAC-SHA256 signed; `artifact.published`, `artifact.deleted`, repo events
 - Content Replication — push to remote instance on cron schedule

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -134,8 +134,7 @@ gc:
 docker:
   max_upload_bytes: 10737418240   # 10 GiB per blob upload session
 
-# Automatic vulnerability scanning (Trivy for docker/oci, OSV.dev for
-# npm/maven/pypi/cargo).
+# Automatic vulnerability scanning.
 # Every upload is queued for a background scan; the queue is bounded and drops
 # rather than delaying an upload, so the periodic full re-scan below is also the
 # safety net for what a burst skips. It re-checks already-scanned components
@@ -143,6 +142,26 @@ docker:
 scan:
   enabled: true              # false leaves scanning entirely on-demand (API only)
   schedule: "0 3 * * *"      # cron: daily 03:00; empty disables only the bulk re-scan
+
+  # Image scanning (Docker/OCI) runs Trivy, which nexspence does NOT ship:
+  # no binary in the image, no wrapper for one. You supply it — on the host, or
+  # copied into the container by an initContainer / one-shot service. See
+  # docs/scanning.md for a complete procedure per deployment type.
+  #
+  # Package scanning (Maven, npm, PyPI, Cargo) uses OSV.dev over HTTPS, needs
+  # nothing installed, and is unaffected by everything below.
+  trivy:
+    enabled: false           # true turns image scanning on; it stays unavailable until a binary is found
+    bin: "trivy"             # path to the binary, or a name resolved through PATH
+    # Where Trivy reads its vulnerability database. Empty means Trivy's own
+    # defaults (ghcr.io). A nexspence proxy repository in front of ghcr.io works
+    # here — trivy-db is an ordinary OCI artifact:
+    #   db_repository:
+    #     - nexspence.example.com/repository/ghcr-proxy/aquasecurity/trivy-db:2
+    db_repository: []
+    java_db_repository: []
+    skip_db_update: false    # true in an air-gapped deployment where the DB is seeded by hand
+    cache_dir: ""            # empty keeps TRIVY_CACHE_DIR / Trivy's default
 
 # Audit log retention.
 # Events live in monthly PostgreSQL partitions.

--- a/deploy/helm/nexspence/README.md
+++ b/deploy/helm/nexspence/README.md
@@ -200,6 +200,29 @@ Leaving `config.metricsPublic=false` keeps the token requirement — add an
 
 ---
 
+## Image Scanning (Trivy)
+
+The nexspence image contains no scanner. Scanning of Docker and OCI *images*
+needs a Trivy binary you supply; package scanning (Maven, npm, PyPI, Cargo)
+uses OSV.dev and needs nothing.
+
+```yaml
+scanning:
+  enabled: true
+```
+
+That adds a `trivy-copy` initContainer which copies the binary out of
+`aquasec/trivy` into an `emptyDir` shared with the app, and sets
+`NEXSPENCE_SCAN_TRIVY_ENABLED` / `NEXSPENCE_SCAN_TRIVY_BIN` for you. Pin the
+Trivy version under `scanning.image.tag`, and size the shared volume with
+`scanning.volumeSize` (default 300Mi — the binary alone is ~150 MB; the
+vulnerability database lands in the existing cache volume).
+
+Check it afterwards: `GET /api/v1/security/scanner` answers `ready` with the
+version, or names what is wrong. Full reference: [docs/scanning.md](../../../docs/scanning.md).
+
+---
+
 ## Upgrading
 
 ```bash
@@ -210,6 +233,10 @@ helm upgrade nexspence \
 ```
 
 Database migrations run automatically on pod start — no manual step needed.
+
+**Upgrading to 2.0.0:** the image no longer bundles Trivy. Image scanning
+stops until you set `scanning.enabled: true` (see above); everything else
+upgrades unchanged, and scan results already in the database stay visible.
 
 ---
 

--- a/deploy/helm/nexspence/templates/deployment.yaml
+++ b/deploy/helm/nexspence/templates/deployment.yaml
@@ -97,7 +97,8 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             # readOnlyRootFilesystem makes the container fs read-only, so every
-            # path the app / bundled trivy writes to needs a writable mount.
+            # path the app — or the Trivy the operator supplies — writes to
+            # needs a writable mount.
             - name: tmp
               mountPath: /tmp
             - name: cache

--- a/deploy/helm/nexspence/templates/deployment.yaml
+++ b/deploy/helm/nexspence/templates/deployment.yaml
@@ -33,6 +33,31 @@ spec:
       serviceAccountName: {{ include "nexspence.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.scanning.enabled }}
+      initContainers:
+        # Nexspence ships no scanner. This copies the operator's chosen Trivy
+        # into a shared volume; the application execs it from there.
+        - name: trivy-copy
+          image: "{{ .Values.scanning.image.repository }}:{{ .Values.scanning.image.tag }}"
+          imagePullPolicy: {{ .Values.scanning.image.pullPolicy }}
+          command: ["sh", "-c", "cp /usr/local/bin/trivy /opt/trivy/trivy && chmod 0755 /opt/trivy/trivy"]
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          volumeMounts:
+            - name: trivy-bin
+              mountPath: /opt/trivy
+      {{- end }}
       containers:
         - name: nexspence
           securityContext:
@@ -53,6 +78,12 @@ spec:
               value: /app
             - name: TRIVY_CACHE_DIR
               value: /app/.cache/trivy
+            {{- if .Values.scanning.enabled }}
+            - name: NEXSPENCE_SCAN_TRIVY_ENABLED
+              value: "true"
+            - name: NEXSPENCE_SCAN_TRIVY_BIN
+              value: /opt/trivy/trivy
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "nexspence.fullname" . }}
@@ -75,6 +106,11 @@ spec:
             - name: blobs
               mountPath: {{ .Values.storage.local.mountPath }}
             {{- end }}
+            {{- if .Values.scanning.enabled }}
+            - name: trivy-bin
+              mountPath: /opt/trivy
+              readOnly: true
+            {{- end }}
       volumes:
         # Writable scratch dirs (rootfs is read-only). The trivy cache lives at
         # /app/.cache (HOME=/app, TRIVY_CACHE_DIR=/app/.cache/trivy in the image).
@@ -86,6 +122,11 @@ spec:
         - name: blobs
           persistentVolumeClaim:
             claimName: {{ include "nexspence.fullname" . }}-blobs
+        {{- end }}
+        {{- if .Values.scanning.enabled }}
+        - name: trivy-bin
+          emptyDir:
+            sizeLimit: {{ .Values.scanning.volumeSize }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -202,3 +202,25 @@ postgresql:
 # -- External PostgreSQL DSN (used when postgresql.enabled=false)
 externalDatabase:
   dsn: "postgres://nexspence:nexspence@external-postgres:5432/nexspence?sslmode=disable"
+
+# Image scanning (Trivy).
+#
+# Nexspence ships no scanner. Turning this on renders an initContainer that
+# copies the Trivy binary out of the image below into a shared volume, and
+# points nexspence at it. The image is pulled by your cluster from a third
+# party; you choose the version and you own updating it.
+#
+# Off means image scanning is unavailable and the UI says so. Scanning of
+# Maven, npm, PyPI and Cargo packages goes to OSV.dev over HTTPS and is
+# unaffected either way.
+scanning:
+  enabled: false
+  image:
+    repository: aquasec/trivy
+    # -- Pin to a digest for reproducible pulls, e.g. "0.70.0@sha256:...", same
+    # convention as the top-level image.tag.
+    tag: "0.70.0"
+    pullPolicy: IfNotPresent
+  # The binary is ~150 MB; the vulnerability database it downloads on first use
+  # lands in the existing cache volume.
+  volumeSize: 300Mi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,9 @@ services:
         condition: service_healthy
       minio-init:
         condition: service_completed_successfully
+      trivy-init:
+        condition: service_completed_successfully
+        required: false
       keycloak:
         condition: service_healthy
         required: false
@@ -108,6 +111,9 @@ services:
       NEXSPENCE_STORAGE_LOCAL_BASE_PATH: "/app/data/blobs"
       NEXSPENCE_LOG_LEVEL: "info"
       NEXSPENCE_LOG_FORMAT: "json"
+      # Image scanning is off unless the `scanning` profile supplied a binary.
+      NEXSPENCE_SCAN_TRIVY_ENABLED: "${NEXSPENCE_SCAN_TRIVY_ENABLED:-false}"
+      NEXSPENCE_SCAN_TRIVY_BIN: "/opt/trivy/trivy"
       # ── OIDC (Keycloak dev IdP, active when OIDC_ENABLED=true) ──────
       NEXSPENCE_OIDC_ENABLED: "${OIDC_ENABLED:-false}"
       NEXSPENCE_OIDC_DISPLAY_NAME: "Keycloak"
@@ -141,6 +147,7 @@ services:
       - nexspence_blobs:/app/data/blobs
       - nexspence_secrets:/app/secrets
       - ${CONFIG_FILE:-./config.yaml}:/app/config.yaml:ro
+      - trivy_bin:/opt/trivy:ro
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8081/service/rest/v1/status/check"]
       interval: 10s
@@ -184,6 +191,16 @@ services:
         mc mb --ignore-existing local/nexspence-s3-2 &&
         echo 'all buckets ready'
       "
+    restart: "no"
+
+  # Nexspence ships no scanner. This copies Trivy into a shared volume so the
+  # application can exec it. Opt-in: `docker compose --profile scanning up`.
+  trivy-init:
+    profiles: ["scanning"]
+    image: aquasec/trivy:0.70.0
+    entrypoint: ["sh", "-c", "cp /usr/local/bin/trivy /opt/trivy/trivy && chmod 0755 /opt/trivy/trivy"]
+    volumes:
+      - trivy_bin:/opt/trivy
     restart: "no"
 
   # ── Frontend dev server (Vite) ────────────────────────────────
@@ -266,3 +283,4 @@ volumes:
   frontend_node_modules:
   prometheus_data:
   grafana_data:
+  trivy_bin:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,7 @@ Pure business logic; no HTTP concerns; depend only on repository interfaces.
 | `BackupService` | Full tar.gz export (metadata + blobs); non-destructive restore with UUID remapping |
 | `ContentSelectorService` | CEL program compilation + cache; Variant B gate evaluation |
 | `WebhookService` | Async delivery with HMAC-SHA256; retry; inactive hook skip |
-| `ScanService` | Trivy for `docker`/`oci`, OSV.dev for `maven`/`npm`/`pypi`/`cargo`; auto-scan queued on upload plus a nightly bulk re-scan; results cached in `components.extra` and persisted to `scan_results`; CSV/JSON export |
+| `ScanService` | Trivy (operator-supplied, see [scanning.md](scanning.md)) for `docker`/`oci`, OSV.dev for `maven`/`npm`/`pypi`/`cargo`; auto-scan queued on upload plus a nightly bulk re-scan; results cached in `components.extra` and persisted to `scan_results`; CSV/JSON export |
 | `RBACService` | Role → privilege → content-selector evaluation for a caller, path and action |
 | `RoutingRuleService` | Path allow/block rules applied to group-repository fan-out |
 | `PromotionService` | Staging → production promotion with a scan-pass gate and optional manual approval |
@@ -270,7 +270,7 @@ API routes:
 ### Phase 8 — Security & Compliance
 
 Shipped: OIDC (with PKCE), SAML, LDAP bind + group sync, rate limiting, and
-vulnerability scanning — Trivy for `docker`/`oci` images and OSV.dev for
+vulnerability scanning — an operator-supplied Trivy for `docker`/`oci` images and OSV.dev for
 `maven`/`npm`/`pypi`/`cargo`, queued automatically on upload with a nightly bulk
 re-scan, results in `components.extra` and the `scan_results` table.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -129,6 +129,17 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 
 ---
 
+## Image scanning (Trivy)
+
+Image scanning is not included. Nexspence ships no scanner binary; to scan
+Docker and OCI images you supply Trivy yourself — see [scanning.md](scanning.md)
+for the complete per-deployment procedure (Helm: `scanning.enabled: true`;
+compose: `docker compose --profile scanning up -d` with
+`NEXSPENCE_SCAN_TRIVY_ENABLED=true`). Scanning of Maven/npm/PyPI/Cargo packages
+uses OSV.dev and works with nothing installed.
+
+---
+
 ## Configuration Reference
 
 `config.yaml` is the primary configuration file. Every key can be overridden via an environment variable using the pattern `NEXSPENCE_<SECTION>_<KEY>` (uppercase, underscore-separated).
@@ -156,6 +167,8 @@ Five networking options (nginx, Traefik, Cilium ingress, Istio Gateway, Cilium G
 | `auth.rate_limit_rps` / `auth.rate_limit_burst` | `50` / `100` | Sustained rate and burst for the above |
 | `bootstrap.enabled` | `true` | Create the admin account on start. Set to `false` once real accounts exist to stop keeping admin credentials in the config — see [Removing the bootstrap admin credentials](#removing-the-bootstrap-admin-credentials). |
 | `bootstrap.admin_password` | `admin123` | Auto-created admin password — **change this** |
+| `scan.trivy.enabled` | `false` | Image scanning switch. Requires a Trivy binary you supply — see [scanning.md](scanning.md). |
+| `scan.trivy.bin` | `trivy` | Path to the Trivy binary, or a name resolved through `PATH` |
 | `cleanup.default_schedule` | `0 2 * * *` | Default cron for cleanup policies |
 | `audit.retention_days` | `90` | Audit log partition retention |
 | `metrics.public` | `false` | Serve `GET /metrics` without authentication. Default requires a Bearer token; see [Prometheus](#prometheus). |

--- a/docs/install-local.md
+++ b/docs/install-local.md
@@ -5,6 +5,11 @@ the web UI embedded; it requires an **external PostgreSQL** database (13+).
 
 > Prefer Docker? See [deployment.md](deployment.md). For Kubernetes, see the Helm chart.
 
+> **Image scanning is not included.** Nexspence ships no scanner binary; to scan
+> Docker and OCI images you supply Trivy yourself — see [scanning.md](scanning.md)
+> (for a native install: package-manager install + `scan.trivy.enabled: true`).
+> Scanning of Maven/npm/PyPI/Cargo packages works out of the box via OSV.dev.
+
 ## 1. Prerequisites — PostgreSQL
 
 Provision PostgreSQL (any reachable host), then create a database and role:

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -1,0 +1,343 @@
+# Image Scanning — Supplying Trivy
+
+Starting with this version, nexspence no longer includes Trivy. Scanning of
+Docker and OCI images stops working after the upgrade until you complete one of
+the procedures below. Scanning of Maven, npm, PyPI and Cargo packages is
+unaffected and needs nothing from you.
+
+Why: Trivy is third-party software and no longer ships inside the nexspence
+image. Nexspence carries no scanner binary and no wrapper for one — you supply
+the binary, nexspence runs it.
+
+[Trivy](https://trivy.dev) is an open-source vulnerability scanner by Aqua
+Security. Nexspence executes it against stored Docker/OCI images and shows the
+CVEs it finds on the **Security → CVE Scan** page.
+
+## Which procedure applies to you
+
+| You run nexspence via | Go to |
+|---|---|
+| Kubernetes (Helm chart) | [Kubernetes (Helm)](#kubernetes-helm) |
+| docker-compose | [docker-compose](#docker-compose) |
+| plain `docker run` | [Plain docker run](#plain-docker-run) |
+| from source / native install (`.deb`, `.rpm`, macOS, Windows) | [From source or native install](#from-source-or-native-install) |
+
+## Kubernetes (Helm)
+
+The chart does the whole job for you. Setting `scanning.enabled: true` renders
+an *initContainer* — a helper container Kubernetes runs before nexspence starts —
+named `trivy-copy`. It copies the Trivy binary out of the `aquasec/trivy` image
+into a small shared volume, and the chart points nexspence at that copy via
+environment variables. You never touch the binary yourself.
+
+Add this to your values file (these are the chart's actual keys and defaults —
+only `enabled` needs changing):
+
+```yaml
+scanning:
+  enabled: true
+  image:
+    repository: aquasec/trivy
+    # Pin to a digest for reproducible pulls, e.g. "0.70.0@sha256:...", same
+    # convention as the top-level image.tag.
+    tag: "0.70.0"
+    pullPolicy: IfNotPresent
+  # The binary is ~150 MB; the vulnerability database it downloads on first use
+  # lands in the existing cache volume.
+  volumeSize: 300Mi
+```
+
+Then upgrade the release:
+
+```bash
+helm upgrade nexspence deploy/helm/nexspence \
+  -f your-values.yaml \
+  --namespace nexspence
+```
+
+Verify the pod restarted with the initContainer and the scanner probe passed:
+
+```bash
+kubectl -n nexspence get pods
+# the nexspence pod shows "Init:0/1" briefly, then Running
+
+kubectl -n nexspence logs deploy/nexspence | grep "image scanner"
+# expect: ... "image scanner" state=ready message="Trivy 0.70.0 — /opt/trivy/trivy"
+```
+
+Then do the UI check in [Checking that it worked](#checking-that-it-worked).
+
+## docker-compose
+
+The shipped `docker-compose.yml` is already wired for this. You do exactly two
+things:
+
+1. Set `NEXSPENCE_SCAN_TRIVY_ENABLED=true` — either export it in your shell or
+   put the line in a `.env` file next to `docker-compose.yml`:
+
+   ```bash
+   echo "NEXSPENCE_SCAN_TRIVY_ENABLED=true" >> .env
+   ```
+
+2. Start with the `scanning` profile:
+
+   ```bash
+   docker compose --profile scanning up -d
+   ```
+
+The profile adds a one-shot service that copies the binary into a shared volume
+before nexspence starts. For reference, this is what the shipped file contains
+(you do not need to add any of it):
+
+```yaml
+  # Nexspence ships no scanner. This copies Trivy into a shared volume so the
+  # application can exec it. Opt-in: `docker compose --profile scanning up`.
+  trivy-init:
+    profiles: ["scanning"]
+    image: aquasec/trivy:0.70.0
+    entrypoint: ["sh", "-c", "cp /usr/local/bin/trivy /opt/trivy/trivy && chmod 0755 /opt/trivy/trivy"]
+    volumes:
+      - trivy_bin:/opt/trivy
+    restart: "no"
+```
+
+and on the `nexspence` service:
+
+```yaml
+    environment:
+      # Image scanning is off unless the `scanning` profile supplied a binary.
+      NEXSPENCE_SCAN_TRIVY_ENABLED: "${NEXSPENCE_SCAN_TRIVY_ENABLED:-false}"
+      NEXSPENCE_SCAN_TRIVY_BIN: "/opt/trivy/trivy"
+    volumes:
+      - trivy_bin:/opt/trivy:ro
+```
+
+**HA compose users:** `docker-compose.ha.yml` does not include the `scanning`
+profile. Adapt the same pattern by hand: add the `trivy_bin` volume and the
+`trivy-init` one-shot service exactly as above, then add the two environment
+variables and the read-only `trivy_bin:/opt/trivy:ro` mount to the shared
+`&nexspence_base` YAML anchor so both replicas get them.
+
+## Plain docker run
+
+Create a volume and copy the Trivy binary into it from the official image (this
+is the reliable way to get a binary that runs inside the nexspence container —
+see [Traps](#traps) for why a host-installed binary usually will not):
+
+```bash
+docker volume create nexspence_trivy
+docker run --rm -v nexspence_trivy:/out --entrypoint sh aquasec/trivy:0.70.0 \
+  -c 'cp /usr/local/bin/trivy /out/trivy && chmod 0755 /out/trivy'
+```
+
+Then run nexspence with the volume mounted read-only and the two scan variables
+set. A complete minimal run (adjust the database DSN to your PostgreSQL):
+
+```bash
+docker run -d --name nexspence \
+  -p 8081:8081 -p 5001:5000 \
+  -e NEXSPENCE_DATABASE_DSN="postgres://nexspence:nexspence@your-postgres-host:5432/nexspence?sslmode=disable" \
+  -e NEXSPENCE_STORAGE_LOCAL_BASE_PATH=/app/data/blobs \
+  -e NEXSPENCE_SCAN_TRIVY_ENABLED=true \
+  -e NEXSPENCE_SCAN_TRIVY_BIN=/opt/trivy/trivy \
+  -v nexspence_blobs:/app/data/blobs \
+  -v nexspence_secrets:/app/secrets \
+  -v nexspence_trivy:/opt/trivy:ro \
+  ghcr.io/nexspence/nexspence:latest
+```
+
+If you already have a `docker run` command you use, keep it and add only these
+three lines to it:
+
+```
+  -e NEXSPENCE_SCAN_TRIVY_ENABLED=true \
+  -e NEXSPENCE_SCAN_TRIVY_BIN=/opt/trivy/trivy \
+  -v nexspence_trivy:/opt/trivy:ro \
+```
+
+## From source or native install
+
+When nexspence runs directly on the host (built from source, or installed from
+a `.deb`/`.rpm`/macOS/Windows package), there is no container boundary — any
+normally installed Trivy works. Install it with your package manager:
+
+```bash
+# macOS
+brew install trivy
+
+# Debian / Ubuntu (official Aqua Security repository)
+sudo apt-get install -y wget gnupg
+wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | \
+  gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | \
+  sudo tee /etc/apt/sources.list.d/trivy.list
+sudo apt-get update && sudo apt-get install -y trivy
+
+# RHEL / Fedora
+cat <<'EOF' | sudo tee /etc/yum.repos.d/trivy.repo
+[trivy]
+name=Trivy repository
+baseurl=https://aquasecurity.github.io/trivy-repo/rpm/releases/$basearch/
+gpgcheck=1
+gpgkey=https://aquasecurity.github.io/trivy-repo/rpm/public.key
+enabled=1
+EOF
+sudo dnf install -y trivy
+```
+
+Then turn image scanning on in `config.yaml`:
+
+```yaml
+scan:
+  trivy:
+    enabled: true
+```
+
+That is all: `scan.trivy.bin` defaults to `trivy`, which is resolved through
+`PATH`, so a package-manager install is found automatically. If you put the
+binary somewhere unusual, set `scan.trivy.bin` to its absolute path. Restart
+nexspence (or wait up to 60 seconds — the binary probe re-runs on its own).
+
+## Checking that it worked
+
+Open the web UI, go to **Security → CVE Scan**. Under the **Scan** button there
+is a status line. Success looks like this (version and path vary with how you
+supplied the binary):
+
+```
+Trivy 0.70.0 — /opt/trivy/trivy
+```
+
+and the Scan button is active. Any other message means one of the steps above
+is incomplete:
+
+| Status line | What it means | What to revisit |
+|---|---|---|
+| `Image scanning is disabled by the administrator` | `scan.trivy.enabled` is still `false` — nexspence has not even looked for a binary. | The enable switch: `NEXSPENCE_SCAN_TRIVY_ENABLED=true` (compose / docker run), `scanning.enabled: true` (Helm), or `scan.trivy.enabled: true` (config file). |
+| `Trivy not found: looked for …` | Scanning is enabled but there is no file at the configured location (or no `trivy` on `PATH`). | The supply step: did `trivy-init` / `trivy-copy` run? Is the volume mounted at the path `scan.trivy.bin` points to? |
+| `Trivy found at … but will not run: …` | A file is there but it does not execute: wrong architecture, wrong libc, truncated download, or missing execute permission. | Replace the binary with one copied from the `aquasec/trivy` image — see [Traps](#traps). |
+
+Without the UI, ask the API as an admin:
+
+```bash
+curl -s -H "Authorization: Bearer <admin token>" \
+  http://localhost:8081/api/v1/security/scanner
+# {"state":"ready","version":"0.70.0","path":"/opt/trivy/trivy","message":"Trivy 0.70.0 — /opt/trivy/trivy"}
+```
+
+Nexspence also logs one `image scanner` line at startup with the same state and
+message, so `docker compose logs nexspence | grep "image scanner"` (or
+`journalctl -u nexspence | grep "image scanner"`) answers the question too.
+
+The status is re-probed at most once every 60 seconds, so a fix shows up within
+a minute without a restart.
+
+## Traps
+
+**A host-installed binary will not run inside the container.** The nexspence
+image is Alpine-based (musl libc). Trivy builds from Linux distribution
+packages, Homebrew, or macOS are linked against a different libc or a different
+OS entirely, and inside the container they fail with the
+`Trivy found at … but will not run` status. If you want to mount a binary from
+the host instead of copying it out of the `aquasec/trivy` image, it must be the
+official static tarball build from
+[Trivy's GitHub releases](https://github.com/aquasecurity/trivy/releases)
+(`trivy_<version>_Linux-64bit.tar.gz`). When in doubt, copy from the
+`aquasec/trivy` image — that binary is known to run in the container as uid 1000.
+
+**Budget ~150 MB for the binary.** The Trivy binary itself is around 150 MB;
+the Helm chart sizes its volume at 300 Mi for headroom. The vulnerability
+database (a further few hundred MB) goes to the cache directory
+(`TRIVY_CACHE_DIR=/app/.cache/trivy` inside the image), not to the binary volume.
+
+**The first scan is slow.** On first use Trivy downloads its vulnerability
+database, which typically takes 1–3 minutes on top of the scan itself.
+Subsequent scans reuse the cached database and are fast. A first scan that sits
+in "running" for a couple of minutes is normal, not stuck.
+
+## The vulnerability database
+
+Nothing needs to be present at first start — the database is fetched by the
+first scan, not at boot. Three setups:
+
+**1. Defaults (most deployments).** Do nothing. Trivy downloads its database
+from its own default location (`ghcr.io`) on first scan and refreshes it as
+needed. Requires outbound HTTPS to `ghcr.io`.
+
+**2. Through a nexspence proxy repository.** `trivy-db` is an ordinary OCI
+artifact, so a nexspence Docker/OCI *proxy* repository in front of `ghcr.io`
+works as the source. Create one (e.g. named `ghcr-proxy` with remote
+`https://ghcr.io`), then point Trivy at it:
+
+```yaml
+scan:
+  trivy:
+    enabled: true
+    db_repository:
+      - nexspence.example.com/repository/ghcr-proxy/aquasecurity/trivy-db:2
+    java_db_repository:
+      - nexspence.example.com/repository/ghcr-proxy/aquasecurity/trivy-java-db:1
+```
+
+As environment variables the lists are comma-separated:
+`NEXSPENCE_SCAN_TRIVY_DB_REPOSITORY=host/repo/a:2,host/repo/b:2`.
+
+**3. Fully air-gapped.** On a machine with internet access, copy the database
+artifacts into a nexspence *hosted* Docker/OCI repository with `oras`, `crane`
+or `skopeo`:
+
+```bash
+# with oras
+oras cp ghcr.io/aquasecurity/trivy-db:2 nexspence.example.com/repository/trivy-mirror/trivy-db:2
+
+# or with crane
+crane copy ghcr.io/aquasecurity/trivy-db:2 nexspence.example.com/repository/trivy-mirror/trivy-db:2
+```
+
+Then point at the mirror and stop Trivy from trying to update over the
+internet:
+
+```yaml
+scan:
+  trivy:
+    enabled: true
+    db_repository:
+      - nexspence.example.com/repository/trivy-mirror/trivy-db:2
+    skip_db_update: false   # first scan pulls from the mirror above
+```
+
+Once the cache is populated (or if you seed the cache directory by hand), set
+`skip_db_update: true` so Trivy never attempts a refresh; re-seed the mirror
+and flip it back to refresh.
+
+## Where the switch lives
+
+| Setting | config.yaml key | Environment variable | Helm value |
+|---|---|---|---|
+| Enable image scanning | `scan.trivy.enabled` | `NEXSPENCE_SCAN_TRIVY_ENABLED` | `scanning.enabled` (sets the env var to `true` for you) |
+| Path to the binary | `scan.trivy.bin` | `NEXSPENCE_SCAN_TRIVY_BIN` | set automatically to `/opt/trivy/trivy` when `scanning.enabled` is on |
+| DB source (list) | `scan.trivy.db_repository` | `NEXSPENCE_SCAN_TRIVY_DB_REPOSITORY` (comma-separated) | via config file / env |
+| Java DB source (list) | `scan.trivy.java_db_repository` | `NEXSPENCE_SCAN_TRIVY_JAVA_DB_REPOSITORY` (comma-separated) | via config file / env |
+| Skip DB refresh | `scan.trivy.skip_db_update` | `NEXSPENCE_SCAN_TRIVY_SKIP_DB_UPDATE` | via config file / env |
+| Cache directory | `scan.trivy.cache_dir` | `NEXSPENCE_SCAN_TRIVY_CACHE_DIR` | via config file / env (image default: `TRIVY_CACHE_DIR=/app/.cache/trivy`) |
+
+Every `config.yaml` key maps to its environment variable as
+`NEXSPENCE_<SECTION>_<KEY>` (uppercase, dots become underscores).
+
+## Rolling back
+
+If you need image scanning working right now and cannot supply a binary yet,
+pin the previous image tag: **v1.38.0** is the last release whose image still
+bundles Trivy.
+
+```bash
+# docker / compose
+image: ghcr.io/nexspence/nexspence:v1.38.0
+
+# Helm
+helm upgrade nexspence deploy/helm/nexspence --set image.tag=v1.38.0 --namespace nexspence
+```
+
+No data is lost either way: scan results already in the database stay visible
+in the UI whether or not a scanner binary is currently available, and rolling
+forward again later requires nothing beyond this document's procedures.

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -350,15 +350,15 @@ Every `config.yaml` key maps to its environment variable as
 ## Rolling back
 
 If you need image scanning working right now and cannot supply a binary yet,
-pin the previous image tag: **v1.38.0** is the last release whose image still
+pin the previous image tag: **v1.39.0** is the last release whose image still
 bundles Trivy.
 
 ```bash
 # docker / compose
-image: ghcr.io/nexspence/nexspence:v1.38.0
+image: ghcr.io/nexspence/nexspence:v1.39.0
 
 # Helm
-helm upgrade nexspence deploy/helm/nexspence --set image.tag=v1.38.0 --namespace nexspence
+helm upgrade nexspence deploy/helm/nexspence --set image.tag=v1.39.0 --namespace nexspence
 ```
 
 Note for compose users: the shipped `docker-compose.yml` builds the image from

--- a/docs/scanning.md
+++ b/docs/scanning.md
@@ -62,7 +62,7 @@ kubectl -n nexspence get pods
 # the nexspence pod shows "Init:0/1" briefly, then Running
 
 kubectl -n nexspence logs deploy/nexspence | grep "image scanner"
-# expect: ... "image scanner" state=ready message="Trivy 0.70.0 — /opt/trivy/trivy"
+# expect one JSON log record at startup containing "image scanner" with state=ready
 ```
 
 Then do the UI check in [Checking that it worked](#checking-that-it-worked).
@@ -73,10 +73,10 @@ The shipped `docker-compose.yml` is already wired for this. You do exactly two
 things:
 
 1. Set `NEXSPENCE_SCAN_TRIVY_ENABLED=true` — either export it in your shell or
-   put the line in a `.env` file next to `docker-compose.yml`:
+   add this line to a `.env` file next to `docker-compose.yml`:
 
-   ```bash
-   echo "NEXSPENCE_SCAN_TRIVY_ENABLED=true" >> .env
+   ```
+   NEXSPENCE_SCAN_TRIVY_ENABLED=true
    ```
 
 2. Start with the `scanning` profile:
@@ -185,7 +185,9 @@ EOF
 sudo dnf install -y trivy
 ```
 
-Then turn image scanning on in `config.yaml`:
+Then turn image scanning on in the config file — `/etc/nexspence/config.yaml`
+for a `.deb`/`.rpm` install, or the `config.yaml` next to the binary when you
+run from source:
 
 ```yaml
 scan:
@@ -193,10 +195,19 @@ scan:
     enabled: true
 ```
 
-That is all: `scan.trivy.bin` defaults to `trivy`, which is resolved through
-`PATH`, so a package-manager install is found automatically. If you put the
-binary somewhere unusual, set `scan.trivy.bin` to its absolute path. Restart
-nexspence (or wait up to 60 seconds — the binary probe re-runs on its own).
+`scan.trivy.bin` defaults to `trivy`, which is resolved through `PATH`, so a
+package-manager install is found automatically. If you put the binary somewhere
+unusual, set `scan.trivy.bin` to its absolute path.
+
+The config file is read only at startup — there is no hot reload — so restart
+nexspence to apply the change:
+
+```bash
+sudo systemctl restart nexspence    # .deb / .rpm install
+# from source: stop and start your own nexspence process
+```
+
+Then continue with [Checking that it worked](#checking-that-it-worked).
 
 ## Checking that it worked
 
@@ -225,24 +236,27 @@ curl -s -H "Authorization: Bearer <admin token>" \
 # {"state":"ready","version":"0.70.0","path":"/opt/trivy/trivy","message":"Trivy 0.70.0 — /opt/trivy/trivy"}
 ```
 
-Nexspence also logs one `image scanner` line at startup with the same state and
-message, so `docker compose logs nexspence | grep "image scanner"` (or
+Nexspence also writes one log record at startup containing `image scanner`
+with the current state (`state=ready` when everything works), so
+`docker compose logs nexspence | grep "image scanner"` (or
 `journalctl -u nexspence | grep "image scanner"`) answers the question too.
 
-The status is re-probed at most once every 60 seconds, so a fix shows up within
-a minute without a restart.
+With scanning already enabled, the binary probe re-runs at most once every 60
+seconds, so supplying or replacing the binary shows up within a minute without
+a restart. Changing configuration — including `scan.trivy.enabled` itself — is
+picked up only at startup: restart nexspence after any config edit.
 
 ## Traps
 
-**A host-installed binary will not run inside the container.** The nexspence
-image is Alpine-based (musl libc). Trivy builds from Linux distribution
-packages, Homebrew, or macOS are linked against a different libc or a different
-OS entirely, and inside the container they fail with the
-`Trivy found at … but will not run` status. If you want to mount a binary from
-the host instead of copying it out of the `aquasec/trivy` image, it must be the
-official static tarball build from
+**A host binary works in the container only if it is the official static
+build.** Trivy binaries from community distribution packages, Homebrew, or
+macOS are built for a different environment than the nexspence container and
+fail there with the `Trivy found at … but will not run` status. If you want to
+mount a binary from the host instead of copying it out of the `aquasec/trivy`
+image, use Aqua Security's official static Linux build: the tarball from
 [Trivy's GitHub releases](https://github.com/aquasecurity/trivy/releases)
-(`trivy_<version>_Linux-64bit.tar.gz`). When in doubt, copy from the
+(`trivy_<version>_Linux-64bit.tar.gz`), or an install from Aqua's own apt/yum
+repositories, which ship the same static build. When in doubt, copy from the
 `aquasec/trivy` image — that binary is known to run in the container as uid 1000.
 
 **Budget ~150 MB for the binary.** The Trivy binary itself is around 150 MB;
@@ -289,10 +303,17 @@ or `skopeo`:
 ```bash
 # with oras
 oras cp ghcr.io/aquasecurity/trivy-db:2 nexspence.example.com/repository/trivy-mirror/trivy-db:2
+oras cp ghcr.io/aquasecurity/trivy-java-db:1 nexspence.example.com/repository/trivy-mirror/trivy-java-db:1
 
 # or with crane
 crane copy ghcr.io/aquasecurity/trivy-db:2 nexspence.example.com/repository/trivy-mirror/trivy-db:2
+crane copy ghcr.io/aquasecurity/trivy-java-db:1 nexspence.example.com/repository/trivy-mirror/trivy-java-db:1
 ```
+
+Mirror both: the main database covers OS and language packages, and the Java
+database is fetched separately the first time an image containing Java
+artifacts is scanned — without a mirror for it, that scan tries `ghcr.io` and
+fails in an air-gapped network.
 
 Then point at the mirror and stop Trivy from trying to update over the
 internet:
@@ -303,7 +324,9 @@ scan:
     enabled: true
     db_repository:
       - nexspence.example.com/repository/trivy-mirror/trivy-db:2
-    skip_db_update: false   # first scan pulls from the mirror above
+    java_db_repository:
+      - nexspence.example.com/repository/trivy-mirror/trivy-java-db:1
+    skip_db_update: false   # first scan pulls from the mirrors above
 ```
 
 Once the cache is populated (or if you seed the cache directory by hand), set
@@ -337,6 +360,10 @@ image: ghcr.io/nexspence/nexspence:v1.38.0
 # Helm
 helm upgrade nexspence deploy/helm/nexspence --set image.tag=v1.38.0 --namespace nexspence
 ```
+
+Note for compose users: the shipped `docker-compose.yml` builds the image from
+source with a `build:` block — to pin a version, replace that block on the
+`nexspence` service with the `image:` line above.
 
 No data is lost either way: scan results already in the database stay visible
 in the UI whether or not a scanner binary is currently available, and rolling

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -180,6 +180,13 @@ export interface OCIReferrersResponse {
   referrers: OCIReferrer[]
 }
 
+export interface ScannerStatus {
+  state: 'disabled' | 'missing' | 'broken' | 'ready'
+  version?: string
+  path?: string
+  message: string
+}
+
 export interface ReplicationRuleInput {
   name: string
   source_repo: string
@@ -484,6 +491,10 @@ export const nexspenceApi = {
       `/api/v1/components/${encodeURIComponent(componentId)}/scan`,
       body ?? {},
     ),
+
+  // Whether image scanning is available at all. Nexspence ships no scanner:
+  // the binary is supplied by the operator, so the UI has to ask.
+  getScannerStatus: () => apiClient.get<ScannerStatus>('/api/v1/security/scanner'),
 
   // Scan-result exports — same endpoints, ?export= switches them to a file
   // download of the whole filtered set rather than a page.

--- a/frontend/src/pages/SecurityPage.test.tsx
+++ b/frontend/src/pages/SecurityPage.test.tsx
@@ -386,6 +386,75 @@ describe('SecurityPage', () => {
     expect(await screen.findByText('trivy unavailable')).toBeInTheDocument()
   })
 
+  it('disables the scan button and explains why when scanning is off', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/v1/security/scanner', () =>
+        HttpResponse.json({ state: 'disabled', message: 'Image scanning is disabled by the administrator' }),
+      ),
+    )
+    renderWithProviders(<SecurityPage />)
+    await screen.findByText('nx-admin')
+    await user.click(screen.getByRole('button', { name: 'CVE Scan' }))
+    await screen.findByText('Trivy Vulnerability Scan')
+
+    expect(await screen.findByText('Image scanning is disabled by the administrator')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Scan' })).toBeDisabled()
+    expect(screen.queryByRole('link', { name: /how to enable image scanning/i })).toBeNull()
+  })
+
+  it('names the path it looked for when the binary is missing', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/v1/security/scanner', () =>
+        HttpResponse.json({ state: 'missing', message: 'Trivy not found: looked for /opt/trivy/trivy' }),
+      ),
+    )
+    renderWithProviders(<SecurityPage />)
+    await screen.findByText('nx-admin')
+    await user.click(screen.getByRole('button', { name: 'CVE Scan' }))
+    await screen.findByText('Trivy Vulnerability Scan')
+
+    expect(await screen.findByText(/Trivy not found: looked for \/opt\/trivy\/trivy/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Scan' })).toBeDisabled()
+    const doc = screen.getByRole('link', { name: /how to enable image scanning/i })
+    expect(doc).toHaveAttribute('href', expect.stringContaining('docs/scanning.md'))
+  })
+
+  it('shows the version and path when the scanner is ready', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.get('/api/v1/security/scanner', () =>
+        HttpResponse.json({ state: 'ready', version: '0.70.0', path: '/opt/trivy/trivy', message: 'Trivy 0.70.0 \u2014 /opt/trivy/trivy' }),
+      ),
+    )
+    renderWithProviders(<SecurityPage />)
+    await screen.findByText('nx-admin')
+    await user.click(screen.getByRole('button', { name: 'CVE Scan' }))
+    await screen.findByText('Trivy Vulnerability Scan')
+
+    expect(await screen.findByText(/Trivy 0\.70\.0 \u2014 \/opt\/trivy\/trivy/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Scan' })).toBeEnabled()
+  })
+
+  it('leaves the scan button usable when the scanner status cannot be fetched', async () => {
+    const user = userEvent.setup()
+    let asked = false
+    server.use(
+      http.get('/api/v1/security/scanner', () => {
+        asked = true
+        return HttpResponse.json({ error: 'boom' }, { status: 500 })
+      }),
+    )
+    renderWithProviders(<SecurityPage />)
+    await screen.findByText('nx-admin')
+    await user.click(screen.getByRole('button', { name: 'CVE Scan' }))
+    await screen.findByText('Trivy Vulnerability Scan')
+
+    await waitFor(() => expect(asked).toBe(true))
+    expect(screen.getByRole('button', { name: 'Scan' })).toBeEnabled()
+  })
+
   /* ── Vulnerability Dashboard tab ── */
   it('switches to Vulnerability Dashboard and shows rows', async () => {
     const user = userEvent.setup()

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { Shield, RefreshCw, Webhook, AlertTriangle, CheckCircle, Loader, Trash2, Plus, Bug, Zap, Pencil, Download } from 'lucide-react'
-import { nexusApi, nexspenceApi, apiClient, apiErrorMessage } from '@/api/client'
+import { nexusApi, nexspenceApi, apiClient, apiErrorMessage, type ScannerStatus } from '@/api/client'
 import { saveBlob, exportFilename } from '@/api/download'
 import { UsersTab } from './UsersPage'
 import { useAuthStore } from '@/store/authStore'
@@ -553,6 +553,13 @@ function ScanTab() {
   const [error, setError] = useState('')
   const [severityFilter, setSeverityFilter] = useState('ALL')
   const [elapsed, setElapsed] = useState(0)
+  const [scanner, setScanner] = useState<ScannerStatus | null>(null)
+
+  useEffect(() => {
+    nexspenceApi.getScannerStatus()
+      .then(r => setScanner(r.data))
+      .catch(() => setScanner(null))
+  }, [])
 
   useEffect(() => {
     if (!scanning) { setElapsed(0); return }
@@ -608,11 +615,19 @@ function ScanTab() {
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' as const }}>
           <HoloInput style={{ flex: '1 1 180px' }} placeholder="Component ID (UUID)" value={componentId} onChange={e => setComponentId(e.target.value)} />
           <HoloInput style={{ flex: '2 1 260px' }} placeholder="Image ref override (optional, e.g. alpine:3.18)" value={imageRef} onChange={e => setImageRef(e.target.value)} />
-          <HoloButton variant="primary" onClick={runScan} disabled={scanning}>
+          <HoloButton variant="primary" onClick={runScan} disabled={scanning || (scanner !== null && scanner.state !== 'ready')}>
             {scanning ? <Loader size={14} className="spin" /> : <Shield size={14} />}
             {scanning ? `Scanning… ${fmtElapsedSec(elapsed)}` : 'Scan'}
           </HoloButton>
         </div>
+        {scanner && (
+          <div style={{ marginTop: 8, fontSize: 12, lineHeight: 1.5, color: scanner.state === 'ready' ? 'var(--holo-text-dim)' : '#f59e0b' }}>
+            {scanner.message}
+            {(scanner.state === 'missing' || scanner.state === 'broken') && (
+              <> — see <a href="https://github.com/nexspence/nexspence/blob/main/docs/scanning.md" target="_blank" rel="noreferrer" style={{ color: 'inherit' }}>how to enable image scanning</a></>
+            )}
+          </div>
+        )}
         {scanning && (
           <div style={{ marginTop: 8, fontSize: 12, color: 'var(--holo-text-faint)', lineHeight: 1.5 }}>
             Running Trivy vulnerability scan{elapsed >= 20 ? ' — first run downloads the vulnerability DB, this may take 1–3 minutes' : ''}

--- a/frontend/src/test/msw/handlers.ts
+++ b/frontend/src/test/msw/handlers.ts
@@ -192,4 +192,7 @@ export const handlers = [
   http.get('/api/v1/components/:id/scan', () =>
     new HttpResponse(null, { status: 204 })
   ),
+  http.get('/api/v1/security/scanner', () =>
+    HttpResponse.json({ state: 'ready', version: '0.70.0', path: '/usr/local/bin/trivy', message: 'Trivy 0.70.0 \u2014 /usr/local/bin/trivy' })
+  ),
 ]

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -135,6 +135,16 @@ func (h *ScanHandler) Vulnerabilities(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"items": items, "total": total})
 }
 
+// ScannerStatus reports whether image scanning is available and, when it is,
+// which binary is providing it.
+// GET /api/v1/security/scanner
+//
+// Admin-only, the same gate as triggering a scan: whoever may scan may see what
+// they are scanning with, and the resolved path is not handed to everyone.
+func (h *ScanHandler) ScannerStatus(c *gin.Context) {
+	c.JSON(http.StatusOK, h.svc.Scanner(c.Request.Context()))
+}
+
 // BulkScanHandler triggers a synchronous bulk scan across all components (or one repo).
 // POST /api/v1/security/scan/bulk
 // Body (optional): {"repo": "my-repo"}

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -34,8 +34,12 @@ func (h *ScanHandler) Scan(c *gin.Context) {
 
 	result, err := h.svc.Scan(c.Request.Context(), id, body.ImageRef)
 	if err != nil {
-		if errors.Is(err, service.ErrTrivyNotInstalled) {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
+		var unavailable *service.ScannerUnavailableError
+		if errors.As(err, &unavailable) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{
+				"error":   unavailable.Status.Message,
+				"scanner": unavailable.Status,
+			})
 			return
 		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/internal/api/handlers/scan_handler_test.go
+++ b/internal/api/handlers/scan_handler_test.go
@@ -56,7 +56,7 @@ func TestScanHandler_TrivyNotInstalled(t *testing.T) {
 	comps.Create(context.Background(), comp) // Create assigns comp.ID
 
 	svc := service.NewScanService(comps, "")
-	svc.TrivyBin = "/no/such/trivy-binary"
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/trivy-binary"})
 
 	r := buildScanRouter(svc)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/components/"+comp.ID+"/scan", strings.NewReader(`{}`))
@@ -79,7 +79,7 @@ func TestScanHandler_TrivyNotInstalled(t *testing.T) {
 // TestScanHandler_ComponentNotFound verifies 400 for a missing component.
 func TestScanHandler_ComponentNotFound(t *testing.T) {
 	svc := service.NewScanService(testutil.NewComponentRepo(), "")
-	svc.TrivyBin = "/no/such/binary"
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/binary"})
 
 	r := buildScanRouter(svc)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/components/no-such-id/scan", strings.NewReader(`{}`))
@@ -99,7 +99,7 @@ func TestScanHandler_NonDockerComponent(t *testing.T) {
 	comps.Create(context.Background(), comp)
 
 	svc := service.NewScanService(comps, "")
-	svc.TrivyBin = "/no/such/binary"
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/binary"})
 
 	r := buildScanRouter(svc)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/components/maven-1/scan", strings.NewReader(`{}`))
@@ -122,7 +122,7 @@ func TestScanHandler_SuccessfulScan(t *testing.T) {
 	comps.Create(context.Background(), comp)
 
 	svc := service.NewScanService(comps, "")
-	svc.TrivyBin = fakeTrivyBin(t, minimalTrivyJSON)
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: fakeTrivyBin(t, minimalTrivyJSON)})
 
 	r := buildScanRouter(svc)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/components/"+comp.ID+"/scan",

--- a/internal/api/handlers/scan_handler_test.go
+++ b/internal/api/handlers/scan_handler_test.go
@@ -33,12 +33,15 @@ func newDockerComponent(id string) *domain.Component {
 	return &domain.Component{ID: id, Format: "docker", Name: "nginx", Version: "latest", Repository: "docker-hosted"}
 }
 
-// fakeTrivyBin creates a shell script in a temp dir that outputs the given JSON and exits 0.
+// fakeTrivyBin creates a shell script in a temp dir that answers the probe's
+// --version call and otherwise outputs the given JSON, exiting 0 either way.
 func fakeTrivyBin(t *testing.T, stdout string) string {
 	t.Helper()
 	dir := t.TempDir()
 	bin := filepath.Join(dir, "trivy")
-	script := "#!/bin/sh\nprintf '%s' '" + strings.ReplaceAll(stdout, "'", "'\\''") + "'\n"
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'Version: 0.70.0'; exit 0; fi\n" +
+		"cat <<'NEXSPENCE_EOF'\n" + stdout + "\nNEXSPENCE_EOF\n"
 	if err := os.WriteFile(bin, []byte(script), 0755); err != nil {
 		t.Fatalf("fakeTrivyBin: %v", err)
 	}
@@ -49,7 +52,8 @@ const minimalTrivyJSON = `{"SchemaVersion":2,"Results":[{"Target":"nginx:latest"
 	`{"VulnerabilityID":"CVE-2022-1234","PkgName":"busybox","InstalledVersion":"1.34.0","FixedVersion":"1.34.1","Severity":"HIGH","Title":"rce in sh"}` +
 	`]}]}`
 
-// TestScanHandler_TrivyNotInstalled verifies 503 + error body when trivy binary is missing.
+// TestScanHandler_TrivyNotInstalled verifies 503 + the scanner status body when
+// the trivy binary is missing.
 func TestScanHandler_TrivyNotInstalled(t *testing.T) {
 	comps := testutil.NewComponentRepo()
 	comp := newDockerComponent("")
@@ -67,12 +71,21 @@ func TestScanHandler_TrivyNotInstalled(t *testing.T) {
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("want 503 got %d body=%s", w.Code, w.Body.String())
 	}
-	var body map[string]string
+	var body struct {
+		Error   string `json:"error"`
+		Scanner struct {
+			State   string `json:"state"`
+			Message string `json:"message"`
+		} `json:"scanner"`
+	}
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("decode body: %v", err)
 	}
-	if !strings.Contains(body["error"], "trivy") {
-		t.Fatalf("want trivy error message, got %q", body["error"])
+	if !strings.Contains(body.Error, "Trivy not found") {
+		t.Fatalf("want the probe's message, got %q", body.Error)
+	}
+	if body.Scanner.State != string(service.ScannerMissing) {
+		t.Fatalf("want scanner state %q, got %q", service.ScannerMissing, body.Scanner.State)
 	}
 }
 

--- a/internal/api/handlers/scan_handler_test.go
+++ b/internal/api/handlers/scan_handler_test.go
@@ -26,6 +26,7 @@ func buildScanRouter(svc *service.ScanService) *gin.Engine {
 	r.GET("/api/v1/security/summary", h.Summary)
 	r.GET("/api/v1/security/vulnerabilities", h.Vulnerabilities)
 	r.POST("/api/v1/security/scan/bulk", h.BulkScanHandler)
+	r.GET("/api/v1/security/scanner", h.ScannerStatus)
 	return r
 }
 

--- a/internal/api/handlers/scan_test.go
+++ b/internal/api/handlers/scan_test.go
@@ -274,3 +274,56 @@ func TestScanHandler_BulkScan_RepoError_500(t *testing.T) {
 	rec := do(t, r, http.MethodPost, "/api/v1/security/scan/bulk", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// ── ScannerStatus ──────────────────────────────────────────────────────────────
+
+func TestScannerStatus_ReportsDisabled(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081").WithTrivy(service.TrivyOptions{Enabled: false})
+	r := buildScanRouter(svc)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/security/scanner", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["state"] != "disabled" {
+		t.Errorf("state = %v, want disabled", body["state"])
+	}
+	if _, ok := body["path"]; ok {
+		t.Error("a disabled scanner must not report a filesystem path")
+	}
+	if msg, ok := body["message"].(string); !ok || msg == "" {
+		t.Error("message must be a complete sentence the UI can render as-is")
+	}
+}
+
+func TestScannerStatus_ReportsReadyWithVersionAndPath(t *testing.T) {
+	bin := fakeTrivyBin(t, "")
+	svc := service.NewScanService(nil, "http://localhost:8081").WithTrivy(service.TrivyOptions{Enabled: true, Bin: bin})
+	r := buildScanRouter(svc)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/api/v1/security/scanner", nil))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["state"] != "ready" {
+		t.Errorf("state = %v, want ready", body["state"])
+	}
+	if body["path"] != bin {
+		t.Errorf("path = %v, want %q", body["path"], bin)
+	}
+	if body["version"] != "0.70.0" {
+		t.Errorf("version = %v, want 0.70.0", body["version"])
+	}
+}

--- a/internal/api/handlers/scan_test.go
+++ b/internal/api/handlers/scan_test.go
@@ -36,7 +36,7 @@ func mountScan(t *testing.T) (*gin.Engine, *testutil.ComponentRepo, *testutil.Sc
 
 	svc := service.NewScanService(comps, "http://localhost").WithScanResults(scanRepo)
 	svc.OSVClient = &service.OSVClient{BaseURL: osvSrv.URL, HTTPClient: osvSrv.Client()}
-	svc.TrivyBin = "/nonexistent/trivy-binary-xyz" // force ErrTrivyNotInstalled on Docker path
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/nonexistent/trivy-binary-xyz"}) // force ErrTrivyNotInstalled on Docker path
 	svc.TrivyTimeout = 5 * time.Second
 
 	h := handlers.NewScanHandler(svc)

--- a/internal/api/handlers/scan_test.go
+++ b/internal/api/handlers/scan_test.go
@@ -21,7 +21,7 @@ import (
 // mountScan wires the real ScanService (over mocks) as router.go does.
 // The OSV client is pointed at a local httptest server so the non-Docker scan path
 // is exercised without a live network call. The Trivy binary is forced to a
-// nonexistent path so the Docker path resolves to ErrTrivyNotInstalled (503).
+// nonexistent path so the Docker path resolves to ScannerMissing (503).
 func mountScan(t *testing.T) (*gin.Engine, *testutil.ComponentRepo, *testutil.ScanResultRepo, *httptest.Server) {
 	t.Helper()
 	comps := testutil.NewComponentRepo()
@@ -36,7 +36,7 @@ func mountScan(t *testing.T) (*gin.Engine, *testutil.ComponentRepo, *testutil.Sc
 
 	svc := service.NewScanService(comps, "http://localhost").WithScanResults(scanRepo)
 	svc.OSVClient = &service.OSVClient{BaseURL: osvSrv.URL, HTTPClient: osvSrv.Client()}
-	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/nonexistent/trivy-binary-xyz"}) // force ErrTrivyNotInstalled on Docker path
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/nonexistent/trivy-binary-xyz"}) // force ScannerMissing on Docker path
 	svc.TrivyTimeout = 5 * time.Second
 
 	h := handlers.NewScanHandler(svc)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -229,7 +229,11 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	// Say once, at boot, what image scanning can do here. Without this the only
 	// way to learn that the binary is missing is to press a button in the UI.
 	st := scanSvc.Scanner(ctx)
-	log.Info("image scanner", "state", st.State, "message", st.Message)
+	// Infow, not Info: logger.Logger is a *zap.SugaredLogger, whose Info
+	// concatenates its arguments into the message — the keys and values only
+	// become fields through the …w form, and scanning.md tells operators to
+	// read `state` off this record.
+	log.Infow("image scanner", "state", st.State, "message", st.Message)
 	// A nil trigger in Deps is what disables scan-on-upload, so the config
 	// switch is applied by not wiring the service rather than by a flag the
 	// storage layer would have to consult.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -226,6 +226,10 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 			SkipDBUpdate:     cfg.Scan.Trivy.SkipDBUpdate,
 			CacheDir:         cfg.Scan.Trivy.CacheDir,
 		})
+	// Say once, at boot, what image scanning can do here. Without this the only
+	// way to learn that the binary is missing is to press a button in the UI.
+	st := scanSvc.Scanner(ctx)
+	log.Info("image scanner", "state", st.State, "message", st.Message)
 	// A nil trigger in Deps is what disables scan-on-upload, so the config
 	// switch is applied by not wiring the service rather than by a flag the
 	// storage layer would have to consult.
@@ -616,6 +620,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		admin.GET("/api/v1/security/summary", scanH.Summary)
 		admin.GET("/api/v1/security/vulnerabilities", scanH.Vulnerabilities)
 		admin.POST("/api/v1/security/scan/bulk", scanH.BulkScanHandler)
+		admin.GET("/api/v1/security/scanner", scanH.ScannerStatus)
 
 		// ── System ────────────────────────────────────────────
 		admin.GET("/service/rest/v1/tasks", tasksH.List)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -217,7 +217,15 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	// every handler keeps a nil copy of it.
 	scanSvc := service.NewScanService(componentRepo, cfg.HTTP.BaseURL).
 		WithScanResults(scanRepo).
-		WithCredentials(cfg.Bootstrap.AdminUsername, cfg.Bootstrap.AdminPassword)
+		WithCredentials(cfg.Bootstrap.AdminUsername, cfg.Bootstrap.AdminPassword).
+		WithTrivy(service.TrivyOptions{
+			Enabled:          cfg.Scan.Trivy.Enabled,
+			Bin:              cfg.Scan.Trivy.Bin,
+			DBRepository:     cfg.Scan.Trivy.DBRepository,
+			JavaDBRepository: cfg.Scan.Trivy.JavaDBRepository,
+			SkipDBUpdate:     cfg.Scan.Trivy.SkipDBUpdate,
+			CacheDir:         cfg.Scan.Trivy.CacheDir,
+		})
 	// A nil trigger in Deps is what disables scan-on-upload, so the config
 	// switch is applied by not wiring the service rather than by a flag the
 	// storage layer would have to consult.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -410,6 +410,29 @@ type ScanConfig struct {
 	// ones against newly published CVEs. Empty disables the periodic run while
 	// leaving scan-on-upload in place.
 	Schedule string `mapstructure:"schedule"`
+	// Trivy governs image scanning, which nexspence does not ship a scanner for.
+	Trivy TrivyConfig `mapstructure:"trivy"`
+}
+
+// TrivyConfig points nexspence at a Trivy binary the operator supplies, and at
+// the vulnerability database that binary should read.
+//
+// Nexspence ships no scanner: the image carries no Trivy and no wrapper for
+// one. Enabled=false is the default because a product must not offer what it
+// does not deliver — see docs/scanning.md for how an operator supplies it.
+//
+// Every database and cache field is empty by default and an empty value means
+// "do not pass the flag at all", so Trivy's own defaults apply. Restating them
+// here would freeze a copy that rots the first time upstream changes one.
+// Bin is the exception: it defaults to "trivy" resolved through PATH, since an
+// empty bin is not a flag omission but a missing executable to run.
+type TrivyConfig struct {
+	Enabled          bool     `mapstructure:"enabled"`
+	Bin              string   `mapstructure:"bin"`
+	DBRepository     []string `mapstructure:"db_repository"`
+	JavaDBRepository []string `mapstructure:"java_db_repository"`
+	SkipDBUpdate     bool     `mapstructure:"skip_db_update"`
+	CacheDir         string   `mapstructure:"cache_dir"`
 }
 
 // AuditConfig controls audit-log retention, soft cap, and partition rotation.
@@ -495,6 +518,17 @@ func Load(path string) (*Config, error) {
 	// Nightly, off-peak: a full re-scan re-queries OSV.dev per component and
 	// re-runs Trivy per image.
 	v.SetDefault("scan.schedule", "0 3 * * *")
+	// Every key gets a default even when the default is the zero value: viper's
+	// AutomaticEnv + Unmarshal silently skips keys that are absent from
+	// AllKeys, so a key with no default is unreachable from an environment
+	// variable when no config file is present. The same reason as the
+	// database.dsn / auth.jwt_secret block above.
+	v.SetDefault("scan.trivy.enabled", false)
+	v.SetDefault("scan.trivy.bin", "trivy")
+	v.SetDefault("scan.trivy.db_repository", []string{})
+	v.SetDefault("scan.trivy.java_db_repository", []string{})
+	v.SetDefault("scan.trivy.skip_db_update", false)
+	v.SetDefault("scan.trivy.cache_dir", "")
 	v.SetDefault("audit.retention_days", 90)
 	v.SetDefault("audit.soft_cap", int64(1_000_000))
 	v.SetDefault("audit.rotation_interval", "24h")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -406,3 +406,57 @@ func TestLoad_BootstrapDisabledViaEnv(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, cfg.Bootstrap.Enabled)
 }
+
+// Nexspence ships no scanner binary, so a product must not claim to offer
+// what it does not deliver: scan.trivy.enabled defaults to false even though
+// scan.enabled itself defaults to true.
+func TestLoad_TrivyDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.False(t, cfg.Scan.Trivy.Enabled,
+		"scan.trivy.enabled must default to false — the product must not promise a scanner it does not ship")
+	assert.Equal(t, "trivy", cfg.Scan.Trivy.Bin)
+	assert.Empty(t, cfg.Scan.Trivy.DBRepository,
+		"scan.trivy.db_repository must default to empty (means: do not pass the flag)")
+	assert.Empty(t, cfg.Scan.Trivy.JavaDBRepository, "scan.trivy.java_db_repository must default to empty")
+	assert.False(t, cfg.Scan.Trivy.SkipDBUpdate, "scan.trivy.skip_db_update must default to false")
+	assert.Empty(t, cfg.Scan.Trivy.CacheDir, "scan.trivy.cache_dir must default to empty")
+}
+
+func TestLoad_TrivyFromEnv(t *testing.T) {
+	// Viper skips keys with no default when unmarshalling with AutomaticEnv,
+	// so this also guards the SetDefault calls that make these env vars
+	// resolvable.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "" +
+		"database:\n  dsn: \"postgres://u:p@localhost:5432/db?sslmode=disable\"\n" +
+		"auth:\n  jwt_secret: \"a-unique-production-secret-at-least-32b\"\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	t.Setenv("NEXSPENCE_SCAN_TRIVY_ENABLED", "true")
+	t.Setenv("NEXSPENCE_SCAN_TRIVY_BIN", "/opt/trivy/trivy")
+	t.Setenv("NEXSPENCE_SCAN_TRIVY_SKIP_DB_UPDATE", "true")
+	t.Setenv("NEXSPENCE_SCAN_TRIVY_CACHE_DIR", "/var/cache/trivy")
+	// Confirmed empirically (and consistent with TestLoad_TrustedProxies_EnvOverride
+	// above): viper's default Unmarshal decode hooks split a comma-separated env
+	// value into a []string via mapstructure.StringToSliceHookFunc(","). A single
+	// value with no comma yields a one-element slice.
+	t.Setenv("NEXSPENCE_SCAN_TRIVY_DB_REPOSITORY", "mirror1.example.com/trivy-db,mirror2.example.com/trivy-db")
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.True(t, cfg.Scan.Trivy.Enabled, "NEXSPENCE_SCAN_TRIVY_ENABLED was not applied")
+	assert.Equal(t, "/opt/trivy/trivy", cfg.Scan.Trivy.Bin)
+	assert.True(t, cfg.Scan.Trivy.SkipDBUpdate, "NEXSPENCE_SCAN_TRIVY_SKIP_DB_UPDATE was not applied")
+	assert.Equal(t, "/var/cache/trivy", cfg.Scan.Trivy.CacheDir)
+	assert.Equal(t, []string{"mirror1.example.com/trivy-db", "mirror2.example.com/trivy-db"}, cfg.Scan.Trivy.DBRepository,
+		"NEXSPENCE_SCAN_TRIVY_DB_REPOSITORY was not applied")
+}

--- a/internal/service/scan_autoscan_test.go
+++ b/internal/service/scan_autoscan_test.go
@@ -95,7 +95,7 @@ func TestScanService_TriggerAsync_SkipsDigestAliases(t *testing.T) {
 	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
 	// Point Trivy at a binary that does not exist: if the alias is scanned after
 	// all, it shells out and the assertion below catches it either way.
-	svc.TrivyBin = "nexspence-no-such-trivy"
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "nexspence-no-such-trivy"})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/service/scan_autoscan_test.go
+++ b/internal/service/scan_autoscan_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -119,6 +120,85 @@ func TestScanService_TriggerAsync_SkipsDigestAliases(t *testing.T) {
 	}
 	if c.Extra["scan_result"] != nil {
 		t.Error("a digest-aliased component must not get a cached scan result")
+	}
+}
+
+// A capability the operator has not provided is not an upload failure: an
+// image component queued while the scanner is disabled must be skipped, not
+// counted as failed.
+func TestBulkScan_SkipsImagesWhenTheScannerIsNotReady(t *testing.T) {
+	dockerComp := &domain.Component{Repository: "dockerhosted", Format: "docker", Name: "alpine", Version: "latest"}
+	npmComp := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "lodash", Version: "4.17.20"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), dockerComp)
+	comps.Create(context.Background(), npmComp)
+
+	svc := service.NewScanService(comps, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: false})
+	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
+
+	scanned, failed, err := svc.BulkScan(context.Background(), "")
+	if err != nil {
+		t.Fatalf("BulkScan: %v", err)
+	}
+	if failed != 0 {
+		t.Errorf("failed = %d, want 0 — an image with no scanner is skipped, not failed", failed)
+	}
+	if scanned != 1 {
+		t.Errorf("scanned = %d, want 1 — the npm component still scans via OSV", scanned)
+	}
+}
+
+// The same rule applies on the upload-triggered queue path: a docker component
+// queued while the scanner is disabled must not produce a Scan attempt (and
+// therefore no scan result row), the same way a digest alias or an
+// unsupported format does not.
+func TestScanService_TriggerAsync_SkipsImagesWhenTheScannerIsNotReady(t *testing.T) {
+	dockerComp := &domain.Component{Repository: "dockerhosted", Format: "docker", Name: "alpine", Version: "latest"}
+	// Queued behind it: once this one has been scanned the docker component
+	// has demonstrably had its turn in the queue.
+	marker := &domain.Component{Repository: "npmhosted", Format: "npm", Name: "lodash", Version: "4.17.20"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), dockerComp)
+	comps.Create(context.Background(), marker)
+
+	scanRepo := testutil.NewScanResultRepo()
+	svc := service.NewScanService(comps, "http://localhost:8081").WithScanResults(scanRepo)
+	svc.OSVClient.BaseURL = osvServerWithOneVuln(t).URL
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: false})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Scan's own gate refuses a not-ready scanner before persisting anything,
+	// so an unchanged scanRepo can't tell a working skip from a plain refusal.
+	// The one thing that differs is drainQueue's "auto-scan skipped" log line,
+	// which only fires when skipAutoScan does NOT catch the component first.
+	out := captureLog(t, func() {
+		go svc.StartScheduler(ctx, "")
+
+		svc.TriggerAsync(dockerComp.ID)
+		svc.TriggerAsync(marker.ID)
+
+		waitFor(t, "the queue to reach the scannable component", func() bool {
+			return len(scanRepo.Rows()) > 0
+		})
+	})
+
+	if strings.Contains(out, "auto-scan skipped") {
+		t.Errorf("log %q must not report an auto-scan skip for a component with no scanner available — skipAutoScan should have caught it silently", out)
+	}
+	for _, row := range scanRepo.Rows() {
+		if row.ComponentID == dockerComp.ID {
+			t.Error("a docker component must not be scanned while the scanner is disabled")
+		}
+	}
+	c, err := comps.Get(context.Background(), dockerComp.ID)
+	if err != nil {
+		t.Fatalf("get docker component: %v", err)
+	}
+	if c.Extra["scan_result"] != nil {
+		t.Error("a docker component must not get a cached scan result while the scanner is disabled")
 	}
 }
 

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -20,7 +20,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/repository"
 )
 
-// ErrTrivyNotInstalled is returned when the trivy executable is missing (not found in PATH or at TrivyBin).
+// ErrTrivyNotInstalled is returned when the trivy executable is missing (not found in PATH or at the configured Trivy bin).
 var ErrTrivyNotInstalled = errors.New("trivy not installed; install trivy or use Docker image with trivy pre-bundled")
 
 func trivyExecMissing(err error) bool {
@@ -108,12 +108,15 @@ func httpBaseURLInsecure(baseURL string) bool {
 type ScanService struct {
 	Components   repository.ComponentRepo
 	HTTPBaseURL  string                    // e.g. http://localhost:8081 — used to build registry pull refs for hosted images
-	TrivyBin     string                    // path to trivy binary; defaults to "trivy"
 	TrivyTimeout time.Duration             // per-scan wall-clock limit (0 = no extra timeout); default 10m
 	ScanResults  repository.ScanResultRepo // may be nil; if set, each scan is persisted here
 	OSVClient    *OSVClient                // used for non-Docker formats
 	scanUsername string                    // registry credentials passed to trivy --username
 	scanPassword string
+
+	// trivy is the operator's scanner: nexspence ships none, so everything
+	// about it — whether it exists at all, where it is — comes from config.
+	trivy TrivyOptions
 
 	// trivyMu serializes Trivy CLI runs. Trivy's on-disk cache (BoltDB) is not safe for concurrent
 	// processes; parallel scans caused "cache may be in use by another process: timeout".
@@ -135,7 +138,7 @@ func NewScanService(components repository.ComponentRepo, httpBaseURL string) *Sc
 	return &ScanService{
 		Components:   components,
 		HTTPBaseURL:  strings.TrimSpace(httpBaseURL),
-		TrivyBin:     "trivy",
+		trivy:        TrivyOptions{Bin: "trivy"},
 		TrivyTimeout: 10 * time.Minute,
 		OSVClient:    NewOSVClient(),
 		queue:        make(chan string, autoScanQueueSize),
@@ -244,6 +247,15 @@ func (s *ScanService) WithCredentials(username, password string) *ScanService {
 	return s
 }
 
+// WithTrivy sets the operator-supplied scanner options and returns s.
+func (s *ScanService) WithTrivy(opts TrivyOptions) *ScanService {
+	s.trivy = opts
+	return s
+}
+
+// TrivyOptions returns the scanner options in force.
+func (s *ScanService) TrivyOptions() TrivyOptions { return s.trivy }
+
 // Scan runs trivy against imageRef, persists the result in component.Extra["scan_result"],
 // and returns it. Components of the two OCI Distribution formats (docker, oci) go to
 // Trivy, a few language formats go to OSV, and anything else gets a clear error.
@@ -285,10 +297,7 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 		ImageRef:  ref,
 	}
 
-	bin := s.TrivyBin
-	if bin == "" {
-		bin = "trivy"
-	}
+	bin := s.trivy.BinOrDefault()
 
 	// #nosec G204 — ref is built from DB / authenticated override; argv is not user-controlled shell.
 	args := []string{

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -57,7 +57,7 @@ func (s *ScanService) TrivyErrorMessage(runErr error, stderr string) string {
 	return scanTrivyErrorMessage(runErr, stderr)
 }
 
-// trivyDBFailure recognises the database-download failure among Trivy's error
+// trivyDBFailure recognizes the database-download failure among Trivy's error
 // output. Matching on substrings is fragile by nature, so it is deliberately
 // broad: a false positive still says "database", which is where the operator
 // should look, and a false negative only loses the friendlier wording.

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -245,6 +245,15 @@ func (s *ScanService) StartScheduler(ctx context.Context, schedule string) {
 	s.drainQueue(ctx)
 }
 
+// isImageFormat reports whether a component is scanned by Trivy rather than by OSV.
+func isImageFormat(format string) bool {
+	switch strings.ToLower(format) {
+	case "docker", "oci":
+		return true
+	}
+	return false
+}
+
 // skipAutoScan reports whether a queued component is not worth a scanner run.
 //
 // A component that cannot be read is left to Scan to report — this only filters
@@ -254,7 +263,12 @@ func (s *ScanService) skipAutoScan(ctx context.Context, componentID string) bool
 	if err != nil || comp == nil {
 		return false
 	}
-	return isDigestAlias(comp.Version)
+	if isDigestAlias(comp.Version) {
+		return true
+	}
+	// No scanner, no scan — and no error per artifact either. A capability the
+	// operator has not provided is not an upload failure.
+	return isImageFormat(comp.Format) && !s.Scanner(ctx).Ready()
 }
 
 // drainQueue scans queued components sequentially until ctx is done.
@@ -310,14 +324,15 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 	if comp == nil {
 		return nil, fmt.Errorf("component %s not found", componentID)
 	}
-	switch strings.ToLower(comp.Format) {
-	case "docker", "oci":
+	format := strings.ToLower(comp.Format)
+	switch {
+	case isImageFormat(format):
 		// Falls through to the Trivy path below. An oci repository holds the same
 		// content a docker one does — an ORAS artifact is an image by structure —
 		// so refusing it on its format label would be wrong. A non-image artifact
 		// (a chart, a signature) surfaces as a Trivy error instead of being
 		// refused up front, which is the more honest answer.
-	case "maven", "npm", "pypi", "cargo":
+	case format == "maven" || format == "npm" || format == "pypi" || format == "cargo":
 		return s.scanOSV(ctx, comp)
 	default:
 		return nil, fmt.Errorf("vulnerability scanning is not supported for format %q", comp.Format)
@@ -535,6 +550,9 @@ func (s *ScanService) BulkScan(ctx context.Context, repoName string) (scanned in
 	}
 	for _, comp := range page.Items {
 		if isDigestAlias(comp.Version) {
+			continue
+		}
+		if isImageFormat(comp.Format) && !s.Scanner(ctx).Ready() {
 			continue
 		}
 		_, scanErr := s.Scan(ctx, comp.ID, "")

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -19,26 +18,6 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 )
-
-// ErrTrivyNotInstalled is returned when the trivy executable is missing (not found in PATH or at the configured Trivy bin).
-var ErrTrivyNotInstalled = errors.New("trivy not installed; install trivy or use Docker image with trivy pre-bundled")
-
-func trivyExecMissing(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, exec.ErrNotFound) {
-		return true
-	}
-	var pe *os.PathError
-	if errors.As(err, &pe) && errors.Is(pe.Err, os.ErrNotExist) {
-		return true
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "executable file not found") ||
-		strings.Contains(msg, "no such file or directory") ||
-		strings.Contains(msg, "cannot find the file")
-}
 
 // scanTrivyErrorMessage returns a concise error string from a failed Trivy run.
 // It detects well-known OCI registry errors and returns a human-readable message
@@ -111,7 +90,7 @@ type ScanService struct {
 	TrivyTimeout time.Duration             // per-scan wall-clock limit (0 = no extra timeout); default 10m
 	ScanResults  repository.ScanResultRepo // may be nil; if set, each scan is persisted here
 	OSVClient    *OSVClient                // used for non-Docker formats
-	scanUsername string                    // registry credentials passed to trivy --username
+	scanUsername string                    // registry credentials handed to Trivy via TRIVY_USERNAME/TRIVY_PASSWORD (see TrivyEnv)
 	scanPassword string
 
 	// trivy is the operator's scanner: nexspence ships none, so everything
@@ -294,6 +273,14 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 		return nil, fmt.Errorf("vulnerability scanning is not supported for format %q", comp.Format)
 	}
 
+	// The capability is checked before any work: a component that cannot be
+	// scanned should cost nothing and should say why. A binary that vanishes
+	// within the ready-cache TTL surfaces as a failed scan result rather than
+	// a refusal — deliberate, it self-heals at the next probe.
+	if st := s.Scanner(ctx); !st.Ready() {
+		return nil, &ScannerUnavailableError{Status: st}
+	}
+
 	ref := strings.TrimSpace(imageRef)
 	if ref == "" {
 		if full := DockerScanImageRef(s.HTTPBaseURL, comp.Repository, comp.Name, comp.Version); full != "" {
@@ -312,23 +299,7 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 	}
 
 	bin := s.trivy.BinOrDefault()
-
-	// #nosec G204 — ref is built from DB / authenticated override; argv is not user-controlled shell.
-	args := []string{
-		"image",
-		"--format", "json",
-		"--exit-code", "0", // do not use non-zero exit when CVEs exist; we rely on JSON
-		"--quiet",
-		"--no-progress",
-		"--image-src", "remote", // no Docker/containerd socket inside the container
-	}
-	if httpBaseURLInsecure(s.HTTPBaseURL) {
-		args = append(args, "--insecure")
-	}
-	if s.scanUsername != "" {
-		args = append(args, "--username", s.scanUsername, "--password", s.scanPassword)
-	}
-	args = append(args, ref)
+	args := TrivyScanArgs(s.trivy, ref, httpBaseURLInsecure(s.HTTPBaseURL))
 
 	// Apply per-scan timeout to guard against trivy hanging (e.g. on first DB download).
 	scanCtx := ctx
@@ -344,25 +315,23 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 	func() {
 		s.trivyMu.Lock()
 		defer s.trivyMu.Unlock()
+		// #nosec G204 — argv is built from config and DB state, never from a shell string.
 		cmd := exec.CommandContext(scanCtx, bin, args...)
+		cmd.Env = TrivyEnv(os.Environ(), s.scanUsername, s.scanPassword)
 		cmd.Stderr = &stderrBuf
 		out, runErr = cmd.Output()
 	}()
 
-	if runErr != nil {
-		if len(out) == 0 && trivyExecMissing(runErr) {
-			return nil, ErrTrivyNotInstalled
-		}
-		// Trivy may exit non-zero when vulnerabilities are found — still parse stdout if present.
-		// Empty stdout + error usually means a real failure; details are on stderr.
-		if len(out) == 0 {
-			msg := scanTrivyErrorMessage(runErr, stderrBuf.String())
-			log.Printf("nexor: trivy scan failed component=%s imageRef=%q: %s", componentID, ref, msg)
-			result.Status = domain.ScanStatusFailed
-			result.Error = truncateScanError(msg)
-			s.persist(ctx, comp, result, "trivy")
-			return result, nil
-		}
+	if runErr != nil && len(out) == 0 {
+		// Trivy may exit non-zero when vulnerabilities are found — stdout is
+		// still parsed below when present. Empty stdout plus an error is a real
+		// failure, and the details are on stderr.
+		msg := scanTrivyErrorMessage(runErr, stderrBuf.String())
+		log.Printf("nexor: trivy scan failed component=%s imageRef=%q: %s", componentID, ref, msg)
+		result.Status = domain.ScanStatusFailed
+		result.Error = truncateScanError(msg)
+		s.persist(ctx, comp, result, "trivy")
+		return result, nil
 	}
 
 	result.Findings, result.Summary = parseTrivyJSON(out)

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -118,6 +118,13 @@ type ScanService struct {
 	// about it — whether it exists at all, where it is — comes from config.
 	trivy TrivyOptions
 
+	// Probe cache. nowFn is a seam so tests can hold time still; it is
+	// nil-safe through the now() helper.
+	statusMu sync.Mutex
+	status   ScannerStatus
+	statusAt time.Time
+	nowFn    func() time.Time
+
 	// trivyMu serializes Trivy CLI runs. Trivy's on-disk cache (BoltDB) is not safe for concurrent
 	// processes; parallel scans caused "cache may be in use by another process: timeout".
 	trivyMu sync.Mutex
@@ -127,6 +134,13 @@ type ScanService struct {
 	// refused because one is behind. What the queue drops, the daily bulk scan
 	// picks up.
 	queue chan string
+}
+
+func (s *ScanService) now() time.Time {
+	if s.nowFn != nil {
+		return s.nowFn()
+	}
+	return time.Now()
 }
 
 // autoScanQueueSize bounds the outstanding automatic scans. Past this, uploads

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -43,6 +43,56 @@ func scanTrivyErrorMessage(runErr error, stderr string) string {
 	return msg
 }
 
+// TrivyErrorMessage turns a failed Trivy run into one sentence an operator can
+// act on. It is a method rather than a function because the database failure is
+// only actionable with the repositories that were actually tried.
+func (s *ScanService) TrivyErrorMessage(runErr error, stderr string) string {
+	if trivyDBFailure(stderr) {
+		msg := "could not fetch the vulnerability database from " + s.dbRepositoriesForMessage()
+		if cause := firstStderrLine(stderr); cause != "" {
+			msg += " (" + cause + ")"
+		}
+		return msg
+	}
+	return scanTrivyErrorMessage(runErr, stderr)
+}
+
+// trivyDBFailure recognises the database-download failure among Trivy's error
+// output. Matching on substrings is fragile by nature, so it is deliberately
+// broad: a false positive still says "database", which is where the operator
+// should look, and a false negative only loses the friendlier wording.
+func trivyDBFailure(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "vulnerability db") ||
+		strings.Contains(lower, "vulnerability database") ||
+		strings.Contains(lower, "db error") ||
+		strings.Contains(lower, "failed to download db") ||
+		strings.Contains(lower, "java db")
+}
+
+// firstStderrLine returns the first non-empty, trimmed line of stderr — the
+// root cause Trivy reports before its usually-noisier detail lines.
+func firstStderrLine(stderr string) string {
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func (s *ScanService) dbRepositoriesForMessage() string {
+	msg := "the Trivy defaults"
+	if len(s.trivy.DBRepository) > 0 {
+		msg = strings.Join(s.trivy.DBRepository, ", ")
+	}
+	if len(s.trivy.JavaDBRepository) > 0 {
+		msg += "; Java DB from " + strings.Join(s.trivy.JavaDBRepository, ", ")
+	}
+	return msg
+}
+
 const scanErrorMaxLen = 8000
 
 func truncateScanError(s string) string {
@@ -326,7 +376,7 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 		// Trivy may exit non-zero when vulnerabilities are found — stdout is
 		// still parsed below when present. Empty stdout plus an error is a real
 		// failure, and the details are on stderr.
-		msg := scanTrivyErrorMessage(runErr, stderrBuf.String())
+		msg := s.TrivyErrorMessage(runErr, stderrBuf.String())
 		log.Printf("nexor: trivy scan failed component=%s imageRef=%q: %s", componentID, ref, msg)
 		result.Status = domain.ScanStatusFailed
 		result.Error = truncateScanError(msg)

--- a/internal/service/scan_service_extra_test.go
+++ b/internal/service/scan_service_extra_test.go
@@ -399,3 +399,61 @@ func TestScanExtra_ParseTrivyJSON_AllSeverities(t *testing.T) {
 		t.Errorf("expected Total=5, got %d", summary.Total)
 	}
 }
+
+// ── TrivyErrorMessage ────────────────────────────────────────────────────
+
+func TestScanExtra_TrivyErrorMessage_NamesTheDatabaseFailure(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{
+			Enabled:      true,
+			DBRepository: []string{"nexspence.example.com/repository/ghcr/aquasecurity/trivy-db:2"},
+		})
+
+	stderr := `FATAL	init error: DB error: failed to download vulnerability DB: ` +
+		`oci download error: failed to fetch the layer: GET https://nexspence.example.com/v2/...: TOOMANYREQUESTS`
+
+	msg := svc.TrivyErrorMessage(errors.New("exit status 1"), stderr)
+
+	if !strings.Contains(msg, "vulnerability database") {
+		t.Errorf("msg = %q, want it to name the database as the thing that failed", msg)
+	}
+	if !strings.Contains(msg, "nexspence.example.com/repository/ghcr/aquasecurity/trivy-db:2") {
+		t.Errorf("msg = %q, want it to name the repository that was tried", msg)
+	}
+	if !strings.Contains(msg, "TOOMANYREQUESTS") {
+		t.Errorf("msg = %q, want the root cause from stderr to survive", msg)
+	}
+}
+
+func TestScanExtra_TrivyErrorMessage_DatabaseDefaultsAreNamedAsSuch(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true})
+
+	msg := svc.TrivyErrorMessage(errors.New("exit status 1"), "FATAL	init error: DB error: failed to download vulnerability DB")
+
+	if !strings.Contains(msg, "Trivy defaults") {
+		t.Errorf("msg = %q, want it to say the default repositories were used", msg)
+	}
+}
+
+func TestScanExtra_TrivyErrorMessage_NamesTheJavaDBRepository(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{
+			Enabled:          true,
+			JavaDBRepository: []string{"nexspence.example.com/repository/ghcr/aquasecurity/trivy-java-db:1"},
+		})
+
+	msg := svc.TrivyErrorMessage(errors.New("exit status 1"), "FATAL failed to download Java DB")
+
+	if !strings.Contains(msg, "nexspence.example.com/repository/ghcr/aquasecurity/trivy-java-db:1") {
+		t.Errorf("msg = %q, want it to name the Java DB repository that was tried", msg)
+	}
+}
+
+func TestScanExtra_TrivyErrorMessage_LeavesOtherFailuresAlone(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081")
+	msg := svc.TrivyErrorMessage(errors.New("exit status 1"), "MANIFEST_UNKNOWN")
+	if !strings.Contains(msg, "re-push the image") {
+		t.Errorf("msg = %q, want the existing manifest message untouched", msg)
+	}
+}

--- a/internal/service/scan_service_extra_test.go
+++ b/internal/service/scan_service_extra_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -40,10 +41,8 @@ func TestScanExtra_TrivyErrorMessage_KnownPatterns(t *testing.T) {
 }
 
 func TestScanExtra_TrivyErrorMessage_ViaFailedScan(t *testing.T) {
-	// Use a script-based fake trivy: write a tiny shell that outputs a known
-	// stderr string and exits 1. We cannot rely on a real trivy binary here.
-	// Instead verify that a missing binary returns ErrTrivyNotInstalled and
-	// a non-zero exit with output still produces a result (not a hard error).
+	// A missing binary must be refused up front with the probe's status —
+	// the exec never happens, so no exec error can leak out of Scan.
 	comp := newDockerComp("docker-hosted", "myapp", "1.0")
 	comps := testutil.NewComponentRepo()
 	_ = comps.Create(context.Background(), comp)
@@ -52,11 +51,12 @@ func TestScanExtra_TrivyErrorMessage_ViaFailedScan(t *testing.T) {
 	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/trivy"})
 
 	_, err := svc.Scan(context.Background(), comp.ID, "myapp:1.0")
-	if err == nil {
-		t.Fatal("expected error for missing trivy binary")
+	var unavailable *service.ScannerUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected *ScannerUnavailableError for missing trivy binary, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "trivy") {
-		t.Errorf("expected trivy-related error, got: %v", err)
+	if !strings.Contains(err.Error(), "Trivy not found") {
+		t.Errorf("expected the probe's message, got: %v", err)
 	}
 }
 

--- a/internal/service/scan_service_extra_test.go
+++ b/internal/service/scan_service_extra_test.go
@@ -49,7 +49,7 @@ func TestScanExtra_TrivyErrorMessage_ViaFailedScan(t *testing.T) {
 	_ = comps.Create(context.Background(), comp)
 
 	svc := service.NewScanService(comps, "http://localhost:8081")
-	svc.TrivyBin = "/no/such/trivy"
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/trivy"})
 
 	_, err := svc.Scan(context.Background(), comp.ID, "myapp:1.0")
 	if err == nil {

--- a/internal/service/scan_service_test.go
+++ b/internal/service/scan_service_test.go
@@ -81,7 +81,7 @@ func TestScanService_TrivyNotInstalled(t *testing.T) {
 	comps.Create(context.Background(), comp)
 
 	svc := service.NewScanService(comps, "")
-	svc.TrivyBin = "/no/such/binary"
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/binary"})
 
 	_, err := svc.Scan(context.Background(), comp.ID, "alpine:latest")
 	if err == nil {
@@ -106,7 +106,7 @@ func TestScanService_OCIFormat_ReachesTrivy(t *testing.T) {
 	comps.Create(context.Background(), comp)
 
 	svc := service.NewScanService(comps, "")
-	svc.TrivyBin = "/no/such/binary"
+	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/binary"})
 
 	_, err := svc.Scan(context.Background(), comp.ID, "")
 	if err == nil {

--- a/internal/service/scan_service_test.go
+++ b/internal/service/scan_service_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -84,11 +86,12 @@ func TestScanService_TrivyNotInstalled(t *testing.T) {
 	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/binary"})
 
 	_, err := svc.Scan(context.Background(), comp.ID, "alpine:latest")
-	if err == nil {
-		t.Fatal("expected ErrTrivyNotInstalled")
+	var unavailable *service.ScannerUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected *ScannerUnavailableError, got %v", err)
 	}
-	if !errors.Is(err, service.ErrTrivyNotInstalled) {
-		t.Fatalf("expected ErrTrivyNotInstalled, got %v", err)
+	if unavailable.Status.State != service.ScannerMissing {
+		t.Fatalf("State = %q, want %q", unavailable.Status.State, service.ScannerMissing)
 	}
 }
 
@@ -109,11 +112,12 @@ func TestScanService_OCIFormat_ReachesTrivy(t *testing.T) {
 	svc = svc.WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/no/such/binary"})
 
 	_, err := svc.Scan(context.Background(), comp.ID, "")
-	if err == nil {
-		t.Fatal("expected ErrTrivyNotInstalled")
-	}
-	if !errors.Is(err, service.ErrTrivyNotInstalled) {
+	var unavailable *service.ScannerUnavailableError
+	if !errors.As(err, &unavailable) {
 		t.Fatalf("an oci component must reach the Trivy path, got %v", err)
+	}
+	if unavailable.Status.State != service.ScannerMissing {
+		t.Fatalf("State = %q, want %q", unavailable.Status.State, service.ScannerMissing)
 	}
 }
 
@@ -186,6 +190,110 @@ func TestScanService_GetResult_AfterPersist(t *testing.T) {
 // via the service package's test-visible wrapper.
 func exportParseTrivyJSON(data []byte) ([]domain.CVEFinding, domain.ScanSummary) {
 	return service.ParseTrivyJSONForTest(data)
+}
+
+// Scan must refuse before doing any work when the operator has not enabled
+// image scanning, and say so through the same status the probe reports.
+func TestScan_RefusesWhenDisabled(t *testing.T) {
+	comp := newDockerComp("docker-hosted", "alpine", "latest")
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	svc := service.NewScanService(comps, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: false})
+
+	_, err := svc.Scan(context.Background(), comp.ID, "")
+	var unavailable *service.ScannerUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want *ScannerUnavailableError", err)
+	}
+	if unavailable.Status.State != service.ScannerDisabled {
+		t.Errorf("State = %q, want %q", unavailable.Status.State, service.ScannerDisabled)
+	}
+}
+
+func TestScan_RefusesWhenBinaryMissing(t *testing.T) {
+	comp := newDockerComp("docker-hosted", "alpine", "latest")
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	svc := service.NewScanService(comps, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/nonexistent/trivy"})
+
+	_, err := svc.Scan(context.Background(), comp.ID, "")
+	var unavailable *service.ScannerUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("err = %v, want *ScannerUnavailableError", err)
+	}
+	if unavailable.Status.State != service.ScannerMissing {
+		t.Errorf("State = %q, want %q", unavailable.Status.State, service.ScannerMissing)
+	}
+}
+
+// A binary that probes fine but fails the scan itself must come back as a
+// failed scan result carrying the stderr-derived message — not a hard error.
+func TestScan_FailedRunRecordsTheStderrMessage(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skip fake-trivy shell script test in CI (no /bin/sh guarantee)")
+	}
+	comp := newDockerComp("docker-hosted", "alpine", "latest")
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "trivy")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'Version: 0.70.0'; exit 0; fi\n" +
+		"echo 'MANIFEST_UNKNOWN: manifest unknown' >&2\n" +
+		"exit 1\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake trivy: %v", err)
+	}
+
+	svc := service.NewScanService(comps, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: bin})
+
+	result, err := svc.Scan(context.Background(), comp.ID, "")
+	if err != nil {
+		t.Fatalf("a failed run must be a result, not an error: %v", err)
+	}
+	if result.Status != domain.ScanStatusFailed {
+		t.Errorf("Status = %q, want %q", result.Status, domain.ScanStatusFailed)
+	}
+	if !strings.Contains(result.Error, "image manifest not found") {
+		t.Errorf("Error = %q, want the stderr-derived MANIFEST_UNKNOWN mapping", result.Error)
+	}
+}
+
+// The scanner switch governs image scanning only: OSV-backed formats must not
+// be refused when Trivy is disabled — they never needed it.
+func TestScan_OSVFormatsIgnoreTheScannerSwitch(t *testing.T) {
+	comp := &domain.Component{
+		ID: "comp-scan-npm", Repository: "npm-hosted", Format: "npm", Name: "lodash", Version: "4.17.21",
+	}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"vulns": []any{}})
+	}))
+	defer srv.Close()
+
+	svc := service.NewScanService(comps, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: false})
+	svc.OSVClient.BaseURL = srv.URL
+
+	result, err := svc.Scan(context.Background(), comp.ID, "")
+	var unavailable *service.ScannerUnavailableError
+	if errors.As(err, &unavailable) {
+		t.Fatalf("an npm scan must not be refused by the image-scanner switch, got %v", err)
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != domain.ScanStatusOK {
+		t.Errorf("Status = %q, want %q", result.Status, domain.ScanStatusOK)
+	}
 }
 
 func TestScanService_WithScanResults_InsertsCalled(t *testing.T) {

--- a/internal/service/scanner_status.go
+++ b/internal/service/scanner_status.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// ScannerState is what nexspence can honestly say about image scanning right now.
+type ScannerState string
+
+const (
+	// ScannerDisabled — the operator has not turned the capability on.
+	ScannerDisabled ScannerState = "disabled"
+	// ScannerMissing — turned on, but no binary at the configured location.
+	ScannerMissing ScannerState = "missing"
+	// ScannerBroken — a binary is there and will not run: wrong architecture,
+	// truncated download, no execute permission. A different problem from
+	// ScannerMissing, and pointing an operator at the wrong one costs an evening.
+	ScannerBroken ScannerState = "broken"
+	// ScannerReady — it runs, and reported its version.
+	ScannerReady ScannerState = "ready"
+)
+
+// ScannerStatus is the answer to "can we scan, and what do we tell the user".
+// Message is a finished sentence: the frontend renders it rather than
+// reassembling one from State, so the wording lives in one place.
+type ScannerStatus struct {
+	State   ScannerState `json:"state"`
+	Version string       `json:"version,omitempty"`
+	Path    string       `json:"path,omitempty"`
+	Message string       `json:"message"`
+}
+
+// Ready reports whether a scan can be attempted.
+func (s ScannerStatus) Ready() bool { return s.State == ScannerReady }
+
+// ScannerUnavailableError is returned by Scan when the capability is not ready.
+// It carries the status so the API can answer with the same sentence the status
+// endpoint would have given.
+type ScannerUnavailableError struct{ Status ScannerStatus }
+
+func (e *ScannerUnavailableError) Error() string { return e.Status.Message }
+
+// scannerStatusTTL bounds how stale the probe may be. It exists because a
+// binary can appear on a running system — an operator installs a package on the
+// host — and demanding a restart for that would be rude; and because
+// `trivy --version` costs ~200ms, which is too much per page render.
+const scannerStatusTTL = 60 * time.Second
+
+// trivyVersionRe matches the first line of `trivy --version`: "Version: 0.70.0".
+var trivyVersionRe = regexp.MustCompile(`(?m)^Version:\s*(\S+)`)
+
+// Scanner returns the current capability, probing at most once per TTL.
+// statusMu is held across the probe on purpose: concurrent callers wait for
+// one probe rather than each spawning their own; worst case is one 30s stall
+// per TTL window.
+func (s *ScanService) Scanner(ctx context.Context) ScannerStatus {
+	s.statusMu.Lock()
+	defer s.statusMu.Unlock()
+
+	if !s.statusAt.IsZero() && s.now().Sub(s.statusAt) < scannerStatusTTL {
+		return s.status
+	}
+	s.status = s.probeScanner(ctx)
+	s.statusAt = s.now()
+	return s.status
+}
+
+// probeScanner runs `<bin> --version`, which answers three questions at once:
+// is the file there, will it execute here, and which version is it.
+func (s *ScanService) probeScanner(ctx context.Context) ScannerStatus {
+	if !s.trivy.Enabled {
+		return ScannerStatus{
+			State:   ScannerDisabled,
+			Message: "Image scanning is disabled by the administrator",
+		}
+	}
+
+	bin := s.trivy.BinOrDefault()
+	looked := bin
+	if !strings.ContainsRune(bin, '/') {
+		looked = fmt.Sprintf("%q on PATH", bin)
+	}
+
+	resolved, err := exec.LookPath(bin)
+	if err != nil {
+		return ScannerStatus{
+			State:   ScannerMissing,
+			Message: "Trivy not found: looked for " + looked,
+		}
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(probeCtx, resolved, "--version").CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return ScannerStatus{
+			State:   ScannerBroken,
+			Message: "Trivy found at " + resolved + " but will not run: " + truncateScanError(detail),
+		}
+	}
+
+	version := ""
+	if m := trivyVersionRe.FindStringSubmatch(string(out)); len(m) == 2 {
+		version = m[1]
+	}
+	name := "Trivy"
+	if version != "" {
+		name += " " + version
+	}
+	return ScannerStatus{
+		State:   ScannerReady,
+		Version: version,
+		Path:    resolved,
+		Message: name + " — " + resolved,
+	}
+}

--- a/internal/service/scanner_status.go
+++ b/internal/service/scanner_status.go
@@ -94,7 +94,9 @@ func (s *ScanService) probeScanner(ctx context.Context) ScannerStatus {
 		}
 	}
 
-	probeCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	// The probe result is a shared cache, so one caller's cancellation must
+	// not poison it for everyone: probe on a caller-independent context.
+	probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(probeCtx, resolved, "--version").CombinedOutput()
 	if err != nil {

--- a/internal/service/scanner_status.go
+++ b/internal/service/scanner_status.go
@@ -98,6 +98,8 @@ func (s *ScanService) probeScanner(ctx context.Context) ScannerStatus {
 	// not poison it for everyone: probe on a caller-independent context.
 	probeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 	defer cancel()
+	// #nosec G204 — the binary is an operator-configured path resolved through
+	// LookPath, and the only argument is the literal "--version".
 	out, err := exec.CommandContext(probeCtx, resolved, "--version").CombinedOutput()
 	if err != nil {
 		detail := strings.TrimSpace(string(out))

--- a/internal/service/scanner_status_internal_test.go
+++ b/internal/service/scanner_status_internal_test.go
@@ -40,3 +40,31 @@ func TestScanner_ReprobesAfterTTL(t *testing.T) {
 		t.Error("statusAt was not refreshed by the post-TTL probe")
 	}
 }
+
+// The probe result is a shared cache: a caller that hangs up while the probe
+// runs must not get its cancellation recorded as ScannerBroken for everyone
+// else in the TTL window.
+func TestProbeScanner_CallerCancellationDoesNotPoisonTheCache(t *testing.T) {
+	if os.Getenv("CI") != "" {
+		t.Skip("skip fake-trivy shell script test in CI (no /bin/sh guarantee)")
+	}
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "trivy")
+	script := "#!/bin/sh\necho 'Version: 0.70.0'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake trivy: %v", err)
+	}
+
+	s := &ScanService{trivy: TrivyOptions{Enabled: true, Bin: bin}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the caller is already gone when the probe starts
+
+	st := s.probeScanner(ctx)
+	if st.State != ScannerReady {
+		t.Fatalf("State = %q (message %q), want %q: one caller's cancellation poisoned the shared probe result", st.State, st.Message, ScannerReady)
+	}
+	if st.Version != "0.70.0" {
+		t.Errorf("Version = %q, want 0.70.0", st.Version)
+	}
+}

--- a/internal/service/scanner_status_internal_test.go
+++ b/internal/service/scanner_status_internal_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestScanner_ReprobesAfterTTL pins the refresh branch: once the TTL has
+// passed, Scanner must run a fresh probe and see the world as it now is.
+// It lives in package service because the nowFn seam is private.
+func TestScanner_ReprobesAfterTTL(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho 'Version: 0.70.0'\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	svc := NewScanService(nil, "http://localhost:8081").
+		WithTrivy(TrivyOptions{Enabled: true, Bin: bin})
+
+	now := time.Now()
+	svc.nowFn = func() time.Time { return now }
+
+	if st := svc.Scanner(context.Background()); st.State != ScannerReady {
+		t.Fatalf("first probe: %q", st.State)
+	}
+	firstAt := svc.statusAt
+
+	if err := os.Remove(bin); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	now = now.Add(scannerStatusTTL + time.Second)
+
+	if st := svc.Scanner(context.Background()); st.State != ScannerMissing {
+		t.Fatalf("post-TTL probe = %q, want %q", st.State, ScannerMissing)
+	}
+	if !svc.statusAt.After(firstAt) {
+		t.Error("statusAt was not refreshed by the post-TTL probe")
+	}
+}

--- a/internal/service/scanner_status_test.go
+++ b/internal/service/scanner_status_test.go
@@ -1,0 +1,133 @@
+package service_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/service"
+)
+
+// fakeTrivy writes an executable shell script that prints the given version.
+func fakeTrivy(t *testing.T, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "trivy")
+	script := "#!/bin/sh\necho 'Version: " + version + "'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("fakeTrivy: %v", err)
+	}
+	return bin
+}
+
+func TestScanner_Disabled(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: false, Bin: fakeTrivy(t, "0.70.0")})
+
+	st := svc.Scanner(context.Background())
+	if st.State != service.ScannerDisabled {
+		t.Fatalf("State = %q, want %q", st.State, service.ScannerDisabled)
+	}
+	if st.Version != "" || st.Path != "" {
+		t.Error("a disabled scanner must not report a version or a path — it was never probed")
+	}
+	if !strings.Contains(st.Message, "disabled") {
+		t.Errorf("Message = %q, want it to say the capability is disabled", st.Message)
+	}
+}
+
+func TestScanner_Missing(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/nonexistent/trivy"})
+
+	st := svc.Scanner(context.Background())
+	if st.State != service.ScannerMissing {
+		t.Fatalf("State = %q, want %q", st.State, service.ScannerMissing)
+	}
+	if !strings.Contains(st.Message, "/nonexistent/trivy") {
+		t.Errorf("Message = %q, want it to name the path that was looked for", st.Message)
+	}
+}
+
+func TestScanner_Broken(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "trivy")
+	// Present and executable, but exits non-zero — the shape of a wrong-arch
+	// or truncated binary as far as the caller can tell.
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho 'exec format error' >&2\nexit 1\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: bin})
+
+	st := svc.Scanner(context.Background())
+	if st.State != service.ScannerBroken {
+		t.Fatalf("State = %q, want %q", st.State, service.ScannerBroken)
+	}
+	if !strings.Contains(st.Message, "exec format error") {
+		t.Errorf("Message = %q, want it to carry the binary's own error output", st.Message)
+	}
+	if !strings.Contains(st.Message, bin) {
+		t.Errorf("Message = %q, want it to name the resolved path %q", st.Message, bin)
+	}
+}
+
+func TestScanner_ReadyWithoutVersionLine(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "trivy")
+	// Runs fine but prints no "Version:" line — the Message must still be a
+	// clean sentence, not "Trivy  — /path" with a doubled space.
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\necho 'no version here'\n"), 0o755); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: bin})
+
+	st := svc.Scanner(context.Background())
+	if st.State != service.ScannerReady {
+		t.Fatalf("State = %q, want %q (message: %s)", st.State, service.ScannerReady, st.Message)
+	}
+	if st.Version != "" {
+		t.Errorf("Version = %q, want empty", st.Version)
+	}
+	if want := "Trivy — " + bin; st.Message != want {
+		t.Errorf("Message = %q, want %q", st.Message, want)
+	}
+}
+
+func TestScanner_Ready(t *testing.T) {
+	bin := fakeTrivy(t, "0.70.0")
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: bin})
+
+	st := svc.Scanner(context.Background())
+	if st.State != service.ScannerReady {
+		t.Fatalf("State = %q, want %q (message: %s)", st.State, service.ScannerReady, st.Message)
+	}
+	if st.Version != "0.70.0" {
+		t.Errorf("Version = %q, want 0.70.0", st.Version)
+	}
+	if st.Path != bin {
+		t.Errorf("Path = %q, want %q", st.Path, bin)
+	}
+}
+
+func TestScanner_CachesWithinTTL(t *testing.T) {
+	bin := fakeTrivy(t, "0.70.0")
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: bin})
+
+	if st := svc.Scanner(context.Background()); st.State != service.ScannerReady {
+		t.Fatalf("first probe: %q", st.State)
+	}
+	// Remove the binary. Within the TTL the answer must not change: re-probing
+	// on every call would spawn a process per page render.
+	if err := os.Remove(bin); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if st := svc.Scanner(context.Background()); st.State != service.ScannerReady {
+		t.Errorf("second probe within TTL = %q, want the cached %q", st.State, service.ScannerReady)
+	}
+}

--- a/internal/service/trivy_args.go
+++ b/internal/service/trivy_args.go
@@ -1,5 +1,7 @@
 package service
 
+import "strings"
+
 // TrivyOptions is everything the scanner needs from configuration: where the
 // operator's binary is, and where that binary should read its vulnerability
 // database from.
@@ -27,4 +29,52 @@ func (o TrivyOptions) BinOrDefault() string {
 		return "trivy"
 	}
 	return o.Bin
+}
+
+// TrivyScanArgs builds the argv for one image scan.
+//
+// Credentials are deliberately absent: they travel in the environment (see
+// TrivyEnv), because anything in argv is readable through the process table,
+// and Trivy's own help says as much about --password.
+func TrivyScanArgs(o TrivyOptions, imageRef string, insecureRegistry bool) []string {
+	args := []string{
+		"image",
+		"--format", "json",
+		"--exit-code", "0", // do not use non-zero exit when CVEs exist; we rely on JSON
+		"--quiet",
+		"--no-progress",
+		"--image-src", "remote", // no Docker/containerd socket inside the container
+	}
+	if insecureRegistry {
+		args = append(args, "--insecure")
+	}
+	if len(o.DBRepository) > 0 {
+		args = append(args, "--db-repository", strings.Join(o.DBRepository, ","))
+	}
+	if len(o.JavaDBRepository) > 0 {
+		args = append(args, "--java-db-repository", strings.Join(o.JavaDBRepository, ","))
+	}
+	if o.SkipDBUpdate {
+		// Both databases: an air-gapped contour that pre-seeds one and lets the
+		// other reach out would fail on the Java scan alone, which reads as a
+		// broken scanner rather than as a deliberate setting.
+		args = append(args, "--skip-db-update", "--skip-java-db-update")
+	}
+	if o.CacheDir != "" {
+		args = append(args, "--cache-dir", o.CacheDir)
+	}
+	return append(args, imageRef)
+}
+
+// TrivyEnv returns the child environment for a Trivy run: the parent
+// environment plus registry credentials, which must not be passed as flags.
+func TrivyEnv(parent []string, username, password string) []string {
+	env := append([]string(nil), parent...)
+	if username != "" {
+		env = append(env, "TRIVY_USERNAME="+username)
+	}
+	if password != "" {
+		env = append(env, "TRIVY_PASSWORD="+password)
+	}
+	return env
 }

--- a/internal/service/trivy_args.go
+++ b/internal/service/trivy_args.go
@@ -55,7 +55,7 @@ func TrivyScanArgs(o TrivyOptions, imageRef string, insecureRegistry bool) []str
 		args = append(args, "--java-db-repository", strings.Join(o.JavaDBRepository, ","))
 	}
 	if o.SkipDBUpdate {
-		// Both databases: an air-gapped contour that pre-seeds one and lets the
+		// Both databases: an air-gapped deployment that pre-seeds one and lets the
 		// other reach out would fail on the Java scan alone, which reads as a
 		// broken scanner rather than as a deliberate setting.
 		args = append(args, "--skip-db-update", "--skip-java-db-update")

--- a/internal/service/trivy_args.go
+++ b/internal/service/trivy_args.go
@@ -1,0 +1,30 @@
+package service
+
+// TrivyOptions is everything the scanner needs from configuration: where the
+// operator's binary is, and where that binary should read its vulnerability
+// database from.
+//
+// It mirrors config.TrivyConfig without importing it — the service layer is
+// reachable from tests and from the CLI, neither of which should have to build
+// a whole configuration to run a scan.
+//
+// An empty DB/cache value means "do not pass the corresponding flag", which
+// leaves Trivy's own default in force. Bin is the exception: it defaults to
+// "trivy" resolved through PATH.
+type TrivyOptions struct {
+	Enabled          bool
+	Bin              string
+	DBRepository     []string
+	JavaDBRepository []string
+	SkipDBUpdate     bool
+	CacheDir         string
+}
+
+// BinOrDefault is the executable to run: the configured path, or "trivy"
+// resolved through PATH.
+func (o TrivyOptions) BinOrDefault() string {
+	if o.Bin == "" {
+		return "trivy"
+	}
+	return o.Bin
+}

--- a/internal/service/trivy_args_test.go
+++ b/internal/service/trivy_args_test.go
@@ -1,6 +1,7 @@
 package service_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nexspence-oss/nexspence/internal/service"
@@ -35,5 +36,72 @@ func TestBinOrDefault(t *testing.T) {
 	}
 	if got := (service.TrivyOptions{Bin: "/x"}).BinOrDefault(); got != "/x" {
 		t.Errorf("Bin=/x: BinOrDefault() = %q, want \"/x\"", got)
+	}
+}
+
+func TestTrivyArgs_OmitsEveryUnsetFlag(t *testing.T) {
+	args := service.TrivyScanArgs(service.TrivyOptions{Enabled: true, Bin: "trivy"}, "reg/img:1", false)
+
+	for _, unwanted := range []string{"--db-repository", "--java-db-repository", "--skip-db-update", "--skip-java-db-update", "--cache-dir", "--insecure"} {
+		for _, got := range args {
+			if got == unwanted {
+				t.Errorf("argv carries %s for an unset option; an empty value must mean \"do not pass the flag\"", unwanted)
+			}
+		}
+	}
+	if args[len(args)-1] != "reg/img:1" {
+		t.Errorf("last arg = %q, want the image reference", args[len(args)-1])
+	}
+}
+
+func TestTrivyArgs_PassesConfiguredDatabases(t *testing.T) {
+	args := service.TrivyScanArgs(service.TrivyOptions{
+		Enabled:          true,
+		DBRepository:     []string{"nexspence.example.com/repository/ghcr/aquasecurity/trivy-db:2", "ghcr.io/aquasecurity/trivy-db:2"},
+		JavaDBRepository: []string{"nexspence.example.com/repository/ghcr/aquasecurity/trivy-java-db:1"},
+		SkipDBUpdate:     true,
+		CacheDir:         "/var/cache/trivy",
+	}, "reg/img:1", true)
+
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"--db-repository nexspence.example.com/repository/ghcr/aquasecurity/trivy-db:2,ghcr.io/aquasecurity/trivy-db:2",
+		"--java-db-repository nexspence.example.com/repository/ghcr/aquasecurity/trivy-java-db:1",
+		"--skip-db-update",
+		"--skip-java-db-update",
+		"--cache-dir /var/cache/trivy",
+		"--insecure",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("argv %q is missing %q", joined, want)
+		}
+	}
+}
+
+func TestTrivyEnv_CarriesCredentialsOutOfArgv(t *testing.T) {
+	env := service.TrivyEnv([]string{"PATH=/usr/bin"}, "scanner", "s3cr3t")
+
+	joined := strings.Join(env, " ")
+	if !strings.Contains(joined, "TRIVY_USERNAME=scanner") || !strings.Contains(joined, "TRIVY_PASSWORD=s3cr3t") {
+		t.Errorf("env = %v, want the credentials in it", env)
+	}
+	if !strings.Contains(joined, "PATH=/usr/bin") {
+		t.Error("the parent environment must be preserved — dropping PATH breaks the binary lookup")
+	}
+
+	args := service.TrivyScanArgs(service.TrivyOptions{Enabled: true}, "reg/img:1", false)
+	for _, a := range args {
+		if strings.Contains(a, "s3cr3t") || a == "--password" {
+			t.Error("the password must never reach argv: it is readable through the process table")
+		}
+	}
+}
+
+func TestTrivyEnv_OmitsEmptyCredentials(t *testing.T) {
+	env := service.TrivyEnv([]string{"PATH=/usr/bin"}, "", "")
+	for _, e := range env {
+		if strings.HasPrefix(e, "TRIVY_USERNAME=") || strings.HasPrefix(e, "TRIVY_PASSWORD=") {
+			t.Errorf("env carries %q for empty credentials; an empty username must not authenticate as one", e)
+		}
 	}
 }

--- a/internal/service/trivy_args_test.go
+++ b/internal/service/trivy_args_test.go
@@ -1,0 +1,30 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/service"
+)
+
+func TestWithTrivy_ReplacesTheDefaults(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: "/opt/trivy/trivy"})
+
+	got := svc.TrivyOptions()
+	if !got.Enabled {
+		t.Error("Enabled was not carried through")
+	}
+	if got.Bin != "/opt/trivy/trivy" {
+		t.Errorf("Bin = %q, want /opt/trivy/trivy", got.Bin)
+	}
+}
+
+func TestNewScanService_DefaultBinIsTrivyOnPath(t *testing.T) {
+	svc := service.NewScanService(nil, "http://localhost:8081")
+	if got := svc.TrivyOptions().Bin; got != "trivy" {
+		t.Errorf("default Bin = %q, want \"trivy\"", got)
+	}
+	if svc.TrivyOptions().Enabled {
+		t.Error("scanning must be off until an operator turns it on")
+	}
+}

--- a/internal/service/trivy_args_test.go
+++ b/internal/service/trivy_args_test.go
@@ -28,3 +28,12 @@ func TestNewScanService_DefaultBinIsTrivyOnPath(t *testing.T) {
 		t.Error("scanning must be off until an operator turns it on")
 	}
 }
+
+func TestBinOrDefault(t *testing.T) {
+	if got := (service.TrivyOptions{}).BinOrDefault(); got != "trivy" {
+		t.Errorf("empty Bin: BinOrDefault() = %q, want \"trivy\"", got)
+	}
+	if got := (service.TrivyOptions{Bin: "/x"}).BinOrDefault(); got != "/x" {
+		t.Errorf("Bin=/x: BinOrDefault() = %q, want \"/x\"", got)
+	}
+}

--- a/internal/service/trivy_args_test.go
+++ b/internal/service/trivy_args_test.go
@@ -89,6 +89,8 @@ func TestTrivyEnv_CarriesCredentialsOutOfArgv(t *testing.T) {
 		t.Error("the parent environment must be preserved — dropping PATH breaks the binary lookup")
 	}
 
+	// Regression guard: TrivyScanArgs takes no credentials today, so this can
+	// only fail if a future signature change routes them back into argv.
 	args := service.TrivyScanArgs(service.TrivyOptions{Enabled: true}, "reg/img:1", false)
 	for _, a := range args {
 		if strings.Contains(a, "s3cr3t") || a == "--password" {

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -147,7 +147,9 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
 .doc-table tr:last-child td{border-bottom:none}
 .doc-table tr:hover td{background:rgba(255,255,255,.02)}
 .doc-table .y{color:var(--green);font-weight:600}.doc-table .n{color:var(--red)}.doc-table .p{color:var(--amber)}
+.alert-info a,.alert-warn a{color:#7dd3fc;text-decoration:underline}
 .alert-info{background:rgba(59,130,246,.06);border:1px solid rgba(59,130,246,.2);border-radius:8px;padding:12px 16px;font-size:.78rem;color:var(--dim);line-height:1.6;margin-bottom:14px}
+.alert-warn{background:rgba(245,158,11,.07);border:1px solid rgba(245,158,11,.28);border-radius:8px;padding:12px 16px;font-size:.78rem;color:var(--dim);line-height:1.6;margin-bottom:14px}
 .alert-info strong{color:var(--blue)}
 .doc-shot{margin:6px 0 22px}
 .doc-shot img{display:block;width:100%;max-width:960px;height:auto;border:1px solid var(--border);border-radius:12px;box-shadow:0 12px 40px rgba(0,0,0,.35)}
@@ -364,6 +366,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
         <a class="dsb-link" href="#sec-migration">Migration from Nexus</a>
         <div class="dsb-label">Advanced</div>
         <a class="dsb-link" href="#sec-monitoring">Monitoring</a>
+        <a class="dsb-link" href="#sec-scanning">Image Scanning</a>
         <a class="dsb-link" href="#sec-promotion">Build Promotion</a>
         <a class="dsb-link" href="#sec-replication">Content Replication</a>
         <div class="dsb-label">Terraform Provider</div>
@@ -839,6 +842,7 @@ server {
 
   <div class="inst-sep" data-i18n="upg.before.sep">Before You Upgrade</div>
   <div class="alert-info" data-i18n="upg.before.info"><strong>Migrations run automatically, and only forward.</strong> Every start applies pending schema migrations before the server accepts traffic. There is no automatic downgrade, so take a database dump first — that dump is what a rollback to an older release depends on.</div>
+  <div class="alert-warn" data-i18n="upg.v2.alert"><strong>Upgrading to v2.0.0 — image scanning needs a Trivy you supply.</strong> The v2.0.0 image no longer contains Trivy. Everything else upgrades as usual, but scanning of Docker and OCI images stops until you supply the binary — see <strong>Image Scanning</strong> under Advanced. Package scanning (Maven, npm, PyPI, Cargo) is unaffected: it uses OSV.dev and never needed Trivy. Existing scan results stay in the database and stay visible.</div>
   <div class="cb"><div class="cb-bar"><span data-i18n="upg.before.dump.bar">shell — back up PostgreSQL first</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
   <div class="cb-body">pg_dump "postgres://nexspence:***@db.example.com:5432/nexspence" \
   --format=custom --file nexspence-$(date +%Y%m%d).dump</div></div>
@@ -869,7 +873,7 @@ docker compose logs -f nexspence     # wait for: migrations OK</div></div>
     <div class="inst-pnl" data-pnl="upg-docker">
       <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="upg.docker.desc">Recreate the container from the new image with the same volumes, environment and database. Keeping the volume mounts identical is the whole trick — the container is disposable, its volumes are not.</p>
       <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
-      <div class="cb-body">docker pull ghcr.io/nexspence/nexspence:v1.35.3
+      <div class="cb-body">docker pull ghcr.io/nexspence/nexspence:v2.0.0
 
 docker stop nexspence &amp;&amp; docker rm nexspence
 
@@ -878,7 +882,7 @@ docker run -d --name nexspence \
   -e NEXSPENCE_DATABASE_DSN="postgres://nexspence:***@db:5432/nexspence?sslmode=disable" \
   -v nexspence_blobs:/app/data/blobs \
   -v nexspence_secrets:/app/secrets \
-  ghcr.io/nexspence/nexspence:v1.35.3</div></div>
+  ghcr.io/nexspence/nexspence:v2.0.0</div></div>
     </div>
 
     <!-- ══ KUBERNETES ══ -->
@@ -886,7 +890,7 @@ docker run -d --name nexspence \
       <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="upg.helm.desc">Each release publishes a chart version matching the app version. <code>--reuse-values</code> keeps your existing overrides; drop it and pass your values file if you prefer an explicit upgrade.</p>
       <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
       <div class="cb-body">helm upgrade nexspence oci://ghcr.io/nexspence/charts/nexspence \
-  --version 1.35.3 \
+  --version 2.0.0 \
   --namespace nexspence --reuse-values
 
 kubectl -n nexspence rollout status deploy/nexspence</div></div>
@@ -903,10 +907,10 @@ kubectl -n nexspence rollout status deploy/nexspence</div></div>
       <div class="inst-vpnl active" data-vpnl="upg-linux-pkg">
         <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
         <div class="cb-body"># Debian / Ubuntu
-sudo dpkg -i nexspence_1.35.3_linux_amd64.deb
+sudo dpkg -i nexspence_2.0.0_linux_amd64.deb
 
 # RHEL / Fedora / SUSE
-sudo dnf upgrade ./nexspence-1.35.3.x86_64.rpm
+sudo dnf upgrade ./nexspence-2.0.0.x86_64.rpm
 
 sudo systemctl restart nexspence
 journalctl -u nexspence -f</div></div>
@@ -915,8 +919,8 @@ journalctl -u nexspence -f</div></div>
 
       <div class="inst-vpnl" data-vpnl="upg-linux-tar">
         <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
-        <div class="cb-body">curl -fsSLO https://github.com/nexspence/nexspence/releases/download/v1.35.3/nexspence_1.35.3_linux_amd64.tar.gz
-tar xzf nexspence_1.35.3_linux_amd64.tar.gz
+        <div class="cb-body">curl -fsSLO https://github.com/nexspence/nexspence/releases/download/v2.0.0/nexspence_2.0.0_linux_amd64.tar.gz
+tar xzf nexspence_2.0.0_linux_amd64.tar.gz
 
 sudo systemctl stop nexspence
 sudo install -m 0755 nexspence /usr/bin/nexspence
@@ -927,7 +931,7 @@ sudo systemctl start nexspence</div></div>
     <!-- ══ MACOS ══ -->
     <div class="inst-pnl" data-pnl="upg-macos">
       <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
-      <div class="cb-body">tar xzf nexspence_1.35.3_darwin_arm64.tar.gz     # or darwin_amd64 on Intel
+      <div class="cb-body">tar xzf nexspence_2.0.0_darwin_arm64.tar.gz     # or darwin_amd64 on Intel
 
 sudo launchctl unload -w /Library/LaunchDaemons/com.nexspence.server.plist
 sudo install -m 0755 nexspence /usr/local/bin/nexspence
@@ -941,7 +945,7 @@ tail -f /usr/local/var/log/nexspence.err.log</div></div>
       <div class="cb"><div class="cb-bar"><span data-i18n="upg.windows.bar">PowerShell — as Administrator</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
       <div class="cb-body">Stop-Service nexspence
 
-Expand-Archive .\nexspence_1.35.3_windows_amd64.zip -DestinationPath $env:TEMP\nexspence-new -Force
+Expand-Archive .\nexspence_2.0.0_windows_amd64.zip -DestinationPath $env:TEMP\nexspence-new -Force
 Copy-Item $env:TEMP\nexspence-new\nexspence.exe 'C:\Program Files\Nexspence\nexspence.exe' -Force
 
 Start-Service nexspence
@@ -953,7 +957,7 @@ Get-Content C:\ProgramData\Nexspence\logs\nexspence.log -Tail 40 -Wait</div></di
   <div class="inst-sep" data-i18n="upg.verify.sep">Verifying the Upgrade</div>
   <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
   <div class="cb-body">curl -s -u admin:$ADMIN_PASSWORD http://localhost:8081/api/v1/system/info
-# {"product":"Nexspence","version":"v1.35.3"}
+# {"product":"Nexspence","version":"v2.0.0"}
 
 curl -sf http://localhost:8081/service/rest/v1/status/check</div></div>
   <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="upg.verify.note">The running version also appears under System Admin → Info and at the bottom of the sidebar. The startup log line <code>migrations OK</code> confirms the schema is current; a failure there stops the server before it serves a single request, so a silent half-migrated state is not a state you can reach.</p>
@@ -1412,6 +1416,87 @@ def verify(secret: str, body: bytes, header: str) -&gt; bool:
   http://localhost:8081/metrics</div></div>
   <div class="alert-info" data-i18n="mon.public"><strong>Note:</strong> <code>/metrics</code> shares the listener with the API, so it requires a Bearer token by default — an anonymous scrape publishes install size, artifact and download counts and the Go runtime fingerprint. Since v1.35.0 you can set <code>metrics.public: true</code> (or <code>NEXSPENCE_METRICS_PUBLIC</code>, or <code>--set config.metricsPublic=true</code> in the Helm chart) to serve it without authentication, for deployments whose listener is only reachable from a trusted network. A Prometheus <code>ServiceMonitor</code> then needs no token Secret.</div>
       </section>
+      <section id="sec-scanning" class="doc-section" hidden>
+  <div class="doc-section-title" data-i18n="scan.title">Image Scanning</div>
+  <div class="doc-section-sub" data-i18n="scan.sub">Nexspence scans Maven, npm, PyPI and Cargo packages against OSV.dev out of the box. Scanning Docker and OCI <em>images</em> uses Trivy, which you supply — the nexspence image does not contain it.</div>
+
+  <div class="alert-info" data-i18n="scan.why"><strong>Why you supply it:</strong> Trivy is ~150 MB of third-party software that used to ride inside every nexspence image whether or not anyone scanned, pinned to a version nobody chose and unchangeable without a nexspence release. Supplying it yourself means you pick the version and update it on your own schedule.</div>
+
+  <div class="inst-sep" data-i18n="scan.states.sep">What Nexspence Reports</div>
+  <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="scan.states.desc">The scanner is probed with <code>&lt;bin&gt; --version</code>, which answers three questions at once: is the file there, will it run here, and which version is it. The answer is one of four states, visible in <strong>Admin → Security → CVE Scan</strong>, at <code>GET /api/v1/security/scanner</code>, and in one log record at startup.</p>
+  <table class="doc-table">
+    <thead><tr><th data-i18n="scan.th.state">State</th><th data-i18n="scan.th.meaning">What it means</th></tr></thead>
+    <tbody>
+      <tr><td><code>disabled</code></td><td data-i18n="scan.st.disabled"><code>scan.trivy.enabled</code> is <code>false</code> — nexspence has not even looked for a binary.</td></tr>
+      <tr><td><code>missing</code></td><td data-i18n="scan.st.missing">Enabled, but there is no file at the configured location and no <code>trivy</code> on <code>PATH</code>.</td></tr>
+      <tr><td><code>broken</code></td><td data-i18n="scan.st.broken">A file is there and will not execute: wrong architecture, truncated download, or no execute bit.</td></tr>
+      <tr><td><code>ready</code></td><td data-i18n="scan.st.ready">It runs and reported its version — scanning works.</td></tr>
+    </tbody>
+  </table>
+  <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="scan.states.note">A scan requested while the scanner is unavailable is refused with that sentence instead of failing obscurely, and automatic scan-on-upload skips image components rather than filling the history with errors. Once scanning is enabled the binary probe re-runs at most once a minute, so supplying or replacing the binary is picked up without a restart — configuration changes, including the switch itself, are read only at startup.</p>
+
+  <div class="inst-sep" data-i18n="scan.setup.sep">Supplying Trivy</div>
+  <div class="inst-platform">
+    <div class="inst-platform-row">
+      <button type="button" class="inst-ptab active" onclick="installPlatform('scan-k8s',this)"><span class="ptab-icon">☸️</span> <span data-i18n="scan.tab.k8s">Kubernetes / Helm</span></button>
+      <button type="button" class="inst-ptab" onclick="installPlatform('scan-compose',this)"><span class="ptab-icon">🐳</span> <span data-i18n="scan.tab.compose">Docker Compose</span></button>
+      <button type="button" class="inst-ptab" onclick="installPlatform('scan-native',this)"><span class="ptab-icon">🐧</span> <span data-i18n="scan.tab.native">Native install</span></button>
+    </div>
+
+    <div class="inst-pnl active" data-pnl="scan-k8s">
+      <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="scan.k8s.desc">One value switches it on. The chart then adds an initContainer named <code>trivy-copy</code> that copies the binary out of the <code>aquasec/trivy</code> image into a shared <code>emptyDir</code>, and points nexspence at it.</p>
+      <div class="cb"><div class="cb-bar"><span>values.yaml</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+      <div class="cb-body">scanning:
+  enabled: true
+  trivy:
+    image:
+      repository: aquasec/trivy
+      tag: "0.70.0"</div></div>
+      <p style="font-size:.8rem;color:var(--dim);margin-top:14px;line-height:1.6" data-i18n="scan.k8s.note">Budget ~150 MB for the shared volume — that is the binary alone. The vulnerability database lives in the cache volume, not this one.</p>
+    </div>
+
+    <div class="inst-pnl" data-pnl="scan-compose">
+      <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="scan.compose.desc">The shipped <code>docker-compose.yml</code> is already wired: a one-shot <code>trivy-init</code> service in the <code>scanning</code> profile fills a named volume that nexspence mounts read-only. You do two things.</p>
+      <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+      <div class="cb-body">echo "NEXSPENCE_SCAN_TRIVY_ENABLED=true" &gt;&gt; .env
+
+docker compose --profile scanning up -d</div></div>
+    </div>
+
+    <div class="inst-pnl" data-pnl="scan-native">
+      <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="scan.native.desc">Outside a container any normally installed Trivy works — <code>scan.trivy.bin</code> defaults to <code>trivy</code>, resolved through <code>PATH</code>, so a package-manager install is found on its own. Restart nexspence after the config edit.</p>
+      <div class="cb"><div class="cb-bar"><span>shell</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+      <div class="cb-body">sudo apt-get install -y trivy        # or: dnf install trivy, brew install trivy
+
+# /etc/nexspence/config.yaml
+scan:
+  trivy:
+    enabled: true
+
+sudo systemctl restart nexspence</div></div>
+    </div>
+  </div>
+
+  <div class="inst-sep" data-i18n="scan.check.sep">Checking That It Worked</div>
+  <div class="cb"><div class="cb-bar"><span>curl — scanner status</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">curl -s -u admin:*** http://localhost:8081/api/v1/security/scanner
+
+# {"state":"ready","version":"0.70.0","path":"/opt/trivy/trivy",
+#  "message":"Trivy 0.70.0 — /opt/trivy/trivy"}</div></div>
+
+  <div class="inst-sep" data-i18n="scan.db.sep">Where the Vulnerability Database Comes From</div>
+  <p style="font-size:.85rem;color:var(--dim);margin:0 0 12px;line-height:1.7" data-i18n="scan.db.desc">By default Trivy pulls it from <code>ghcr.io</code> on first use, which is why the first scan takes a minute or two. In an air-gapped network, mirror it into a nexspence repository and point Trivy at the mirror. Mirror <em>both</em> databases: the Java one is fetched separately the first time an image containing Java artifacts is scanned, and an unmirrored one dials <code>ghcr.io</code> and fails.</p>
+  <div class="cb"><div class="cb-bar"><span>config.yaml</span><button type="button" class="cb-copy" onclick="copyCode(this)">Copy</button></div>
+  <div class="cb-body">scan:
+  trivy:
+    db_repository:
+      - nexspence.example.com/repository/trivy-mirror/trivy-db:2
+    java_db_repository:
+      - nexspence.example.com/repository/trivy-mirror/trivy-java-db:1
+    skip_db_update: false   # first scan pulls from the mirrors above</div></div>
+
+  <div class="alert-info" data-i18n="scan.trap"><strong>Trap — a host binary in a container.</strong> Only Aqua Security's official static Linux build runs inside the nexspence container. Trivy from community distribution packages, Homebrew, or macOS is built for a different environment and lands in the <code>broken</code> state. When in doubt, copy the binary out of the <code>aquasec/trivy</code> image, which is known to run there as uid 1000. Full reference, including every configuration key: <a href="https://github.com/nexspence/nexspence/blob/main/docs/scanning.md" target="_blank" rel="noreferrer">docs/scanning.md</a>.</div>
+      </section>
       <section id="sec-promotion" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="promo.title">Build Promotion</div>
   <div class="doc-section-sub" data-i18n="promo.sub">Promote artifacts through environments (e.g. staging → production) with optional vulnerability scan gates and approval workflows.</div>
@@ -1733,7 +1818,7 @@ const TRANSLATIONS={
     'crumb.formats':'formats','crumb.changelog':'changelog','crumb.api':'api reference',
     'crumb.repositories':'repositories','crumb.formats-guide':'format setup','crumb.browse-search':'browse & search',
     'crumb.users':'users & tokens','crumb.rbac':'roles & privileges','crumb.cleanup':'cleanup policies',
-    'crumb.webhooks':'webhooks','crumb.migration':'migration','crumb.monitoring':'monitoring',
+    'crumb.webhooks':'webhooks','crumb.migration':'migration','crumb.monitoring':'monitoring','crumb.scanning':'image scanning',
     'crumb.promotion':'build promotion','crumb.replication':'content replication','crumb.terraform':'terraform provider',
     'sb.tf-overview':'Overview','sb.tf-auth':'Authentication','sb.tf-resources':'Resources','sb.tf-data':'Data Sources','sb.tf-examples':'Examples',
     'crumb.tf-overview':'terraform overview','crumb.tf-auth':'terraform auth','crumb.tf-resources':'terraform resources','crumb.tf-data':'terraform data sources','crumb.tf-examples':'terraform examples',
@@ -2042,6 +2127,29 @@ const TRANSLATIONS={
     'api.auth.title':'Authentication',
     'api.auth.desc':'JWT Bearer token (from <code>POST /api/v1/auth/login</code>), API tokens (<code>nxs_*</code> prefix via Bearer or Basic password), or HTTP Basic with username + password.',
     'api.spec':'<strong>Full OpenAPI 3.1 spec</strong> is included in the release zip as <code>docs/api-spec.yaml</code>.',
+    'sb.scanning':'Image Scanning',
+    'scan.title':'Image Scanning',
+    'scan.sub':'Nexspence scans Maven, npm, PyPI and Cargo packages against OSV.dev out of the box. Scanning Docker and OCI <em>images</em> uses Trivy, which you supply — the nexspence image does not contain it.',
+    'scan.why':'<strong>Why you supply it:</strong> Trivy is ~150 MB of third-party software that used to ride inside every nexspence image whether or not anyone scanned, pinned to a version nobody chose and unchangeable without a nexspence release. Supplying it yourself means you pick the version and update it on your own schedule.',
+    'scan.states.sep':'What Nexspence Reports',
+    'scan.states.desc':'The scanner is probed with <code>&lt;bin&gt; --version</code>, which answers three questions at once: is the file there, will it run here, and which version is it. The answer is one of four states, visible in <strong>Admin → Security → CVE Scan</strong>, at <code>GET /api/v1/security/scanner</code>, and in one log record at startup.',
+    'scan.th.state':'State','scan.th.meaning':'What it means',
+    'scan.st.disabled':'<code>scan.trivy.enabled</code> is <code>false</code> — nexspence has not even looked for a binary.',
+    'scan.st.missing':'Enabled, but there is no file at the configured location and no <code>trivy</code> on <code>PATH</code>.',
+    'scan.st.broken':'A file is there and will not execute: wrong architecture, truncated download, or no execute bit.',
+    'scan.st.ready':'It runs and reported its version — scanning works.',
+    'scan.states.note':'A scan requested while the scanner is unavailable is refused with that sentence instead of failing obscurely, and automatic scan-on-upload skips image components rather than filling the history with errors. Once scanning is enabled the binary probe re-runs at most once a minute, so supplying or replacing the binary is picked up without a restart — configuration changes, including the switch itself, are read only at startup.',
+    'scan.setup.sep':'Supplying Trivy',
+    'scan.tab.k8s':'Kubernetes / Helm','scan.tab.compose':'Docker Compose','scan.tab.native':'Native install',
+    'scan.k8s.desc':'One value switches it on. The chart then adds an initContainer named <code>trivy-copy</code> that copies the binary out of the <code>aquasec/trivy</code> image into a shared <code>emptyDir</code>, and points nexspence at it.',
+    'scan.k8s.note':'Budget ~150 MB for the shared volume — that is the binary alone. The vulnerability database lives in the cache volume, not this one.',
+    'scan.compose.desc':'The shipped <code>docker-compose.yml</code> is already wired: a one-shot <code>trivy-init</code> service in the <code>scanning</code> profile fills a named volume that nexspence mounts read-only. You do two things.',
+    'scan.native.desc':'Outside a container any normally installed Trivy works — <code>scan.trivy.bin</code> defaults to <code>trivy</code>, resolved through <code>PATH</code>, so a package-manager install is found on its own. Restart nexspence after the config edit.',
+    'scan.check.sep':'Checking That It Worked',
+    'scan.db.sep':'Where the Vulnerability Database Comes From',
+    'scan.db.desc':'By default Trivy pulls it from <code>ghcr.io</code> on first use, which is why the first scan takes a minute or two. In an air-gapped network, mirror it into a nexspence repository and point Trivy at the mirror. Mirror <em>both</em> databases: the Java one is fetched separately the first time an image containing Java artifacts is scanned, and an unmirrored one dials <code>ghcr.io</code> and fails.',
+    'scan.trap':'<strong>Trap — a host binary in a container.</strong> Only Aqua Security\'s official static Linux build runs inside the nexspence container. Trivy from community distribution packages, Homebrew, or macOS is built for a different environment and lands in the <code>broken</code> state. When in doubt, copy the binary out of the <code>aquasec/trivy</code> image, which is known to run there as uid 1000. Full reference, including every configuration key: <a href="https://github.com/nexspence/nexspence/blob/main/docs/scanning.md" target="_blank" rel="noreferrer">docs/scanning.md</a>.',
+    'upg.v2.alert':'<strong>Upgrading to v2.0.0 — image scanning needs a Trivy you supply.</strong> The v2.0.0 image no longer contains Trivy. Everything else upgrades as usual, but scanning of Docker and OCI images stops until you supply the binary — see <strong>Image Scanning</strong> under Advanced. Package scanning (Maven, npm, PyPI, Cargo) is unaffected: it uses OSV.dev and never needed Trivy. Existing scan results stay in the database and stay visible.',
   },
   ru:{
     'page.stag':'Документация',
@@ -2062,7 +2170,7 @@ const TRANSLATIONS={
     'sb.promotion':'Продвижение сборок','sb.replication':'Репликация контента','sb.terraform':'Провайдер Terraform',
     'crumb.repositories':'репозитории','crumb.formats-guide':'настройка форматов','crumb.browse-search':'обзор и поиск',
     'crumb.users':'пользователи и токены','crumb.rbac':'роли и привилегии','crumb.cleanup':'политики очистки',
-    'crumb.webhooks':'вебхуки','crumb.migration':'миграция','crumb.monitoring':'мониторинг',
+    'crumb.webhooks':'вебхуки','crumb.migration':'миграция','crumb.monitoring':'мониторинг','crumb.scanning':'сканирование образов',
     'crumb.promotion':'продвижение сборок','crumb.replication':'репликация контента','crumb.terraform':'провайдер terraform',
     'tabg.releases':'Changelog','tabg.getting-started':'С чего начать','tabg.using':'Использование',
     'tabg.admin':'Администрирование','tabg.advanced':'Расширенные','tabg.terraform':'Terraform','tabg.reference':'Справочник',
@@ -2394,6 +2502,29 @@ const TRANSLATIONS={
     'api.auth.title':'Аутентификация',
     'api.auth.desc':'JWT Bearer-токен (из <code>POST /api/v1/auth/login</code>), API-токены (префикс <code>nxs_*</code> через Bearer или Basic-пароль) или HTTP Basic.',
     'api.spec':'<strong>Полная спецификация OpenAPI 3.1</strong> включена в архив релиза как <code>docs/api-spec.yaml</code>.',
+    'sb.scanning':'Сканирование образов',
+    'scan.title':'Сканирование образов',
+    'scan.sub':'Пакеты Maven, npm, PyPI и Cargo Nexspence сканирует через OSV.dev из коробки. Для Docker- и OCI-<em>образов</em> используется Trivy, который вы предоставляете сами — в образе nexspence его нет.',
+    'scan.why':'<strong>Почему вы предоставляете его сами:</strong> Trivy — это ~150 МБ стороннего софта, который раньше ехал внутри каждого образа nexspence независимо от того, сканирует кто-нибудь или нет, зафиксированный в версии, которую никто не выбирал, и необновляемый без релиза nexspence. Предоставляя его сами, вы выбираете версию и обновляете её по своему графику.',
+    'scan.states.sep':'Что сообщает Nexspence',
+    'scan.states.desc':'Сканер проверяется командой <code>&lt;bin&gt; --version</code>, которая сразу отвечает на три вопроса: есть ли файл, запустится ли он здесь и какая это версия. Ответ — одно из четырёх состояний, видное в <strong>Admin → Security → CVE Scan</strong>, в <code>GET /api/v1/security/scanner</code> и в одной записи лога при старте.',
+    'scan.th.state':'Состояние','scan.th.meaning':'Что означает',
+    'scan.st.disabled':'<code>scan.trivy.enabled</code> равно <code>false</code> — nexspence даже не искал бинарь.',
+    'scan.st.missing':'Включено, но по указанному пути файла нет и <code>trivy</code> нет в <code>PATH</code>.',
+    'scan.st.broken':'Файл есть, но не запускается: не та архитектура, оборванная закачка или нет бита исполнения.',
+    'scan.st.ready':'Запускается и сообщил версию — сканирование работает.',
+    'scan.states.note':'Запрос скана при недоступном сканере отклоняется с этой же фразой, а не падает непонятно почему; автоматическое сканирование при загрузке пропускает образы, вместо того чтобы забивать историю ошибками. Когда сканирование уже включено, проверка бинаря повторяется не чаще раза в минуту — появление или замена бинаря подхватываются без перезапуска. Изменения конфигурации, включая сам переключатель, читаются только при старте.',
+    'scan.setup.sep':'Как предоставить Trivy',
+    'scan.tab.k8s':'Kubernetes / Helm','scan.tab.compose':'Docker Compose','scan.tab.native':'Нативная установка',
+    'scan.k8s.desc':'Включается одним значением. Чарт добавляет initContainer <code>trivy-copy</code>, который копирует бинарь из образа <code>aquasec/trivy</code> в общий <code>emptyDir</code> и указывает на него nexspence.',
+    'scan.k8s.note':'Заложите ~150 МБ на общий том — это только сам бинарь. База уязвимостей живёт в томе кэша, а не здесь.',
+    'scan.compose.desc':'Поставляемый <code>docker-compose.yml</code> уже готов: одноразовый сервис <code>trivy-init</code> в профиле <code>scanning</code> наполняет именованный том, который nexspence монтирует только на чтение. От вас — два действия.',
+    'scan.native.desc':'Вне контейнера подойдёт любой обычно установленный Trivy — <code>scan.trivy.bin</code> по умолчанию равен <code>trivy</code> и разрешается через <code>PATH</code>, так что установка пакетным менеджером находится сама. После правки конфигурации перезапустите nexspence.',
+    'scan.check.sep':'Проверка, что всё заработало',
+    'scan.db.sep':'Откуда берётся база уязвимостей',
+    'scan.db.desc':'По умолчанию Trivy тянет её с <code>ghcr.io</code> при первом использовании — поэтому первый скан идёт минуту-две. В изолированной сети зеркалируйте её в репозиторий nexspence и укажите Trivy на зеркало. Зеркалируйте <em>обе</em> базы: Java-база скачивается отдельно при первом сканировании образа с Java-артефактами, и без зеркала этот скан пойдёт на <code>ghcr.io</code> и упадёт.',
+    'scan.trap':'<strong>Ловушка — хостовый бинарь в контейнере.</strong> Внутри контейнера nexspence работает только официальная статическая Linux-сборка Aqua Security. Trivy из community-пакетов дистрибутивов, Homebrew или macOS собран для другого окружения и попадёт в состояние <code>broken</code>. Если сомневаетесь — скопируйте бинарь из образа <code>aquasec/trivy</code>: он заведомо работает там под uid 1000. Полный справочник, включая все ключи конфигурации: <a href="https://github.com/nexspence/nexspence/blob/main/docs/scanning.md" target="_blank" rel="noreferrer">docs/scanning.md</a>.',
+    'upg.v2.alert':'<strong>Обновление до v2.0.0 — сканированию образов нужен ваш Trivy.</strong> В образе v2.0.0 больше нет Trivy. Всё остальное обновляется как обычно, но сканирование Docker- и OCI-образов не работает, пока вы не предоставите бинарь — см. <strong>Сканирование образов</strong> в разделе Advanced. Сканирования пакетов (Maven, npm, PyPI, Cargo) это не касается: оно идёт через OSV.dev и никогда не требовало Trivy. Уже сохранённые результаты сканов остаются в базе и остаются видны.',
   }
 };
 
@@ -2425,6 +2556,7 @@ const SECTIONS=[
   {key:'webhooks'},
   {key:'migration'},
   {key:'monitoring'},
+  {key:'scanning'},
   {key:'promotion'},
   {key:'replication'},
   {key:'tf-overview'},
@@ -2444,6 +2576,7 @@ let FEATURE_BADGE={
   'replication':'v1.3.0',
   'promotion':'v1.8.1',
   'monitoring':'v1.9.0',
+  'scanning':'v2.0.0',
   'migration':'v1.33.0',
   'security':'v1.18.0',
   'upgrade':'v1.18.0',
@@ -2469,6 +2602,7 @@ const SIDEBAR_GROUPS=[
   {id:'advanced',items:[
     {key:'migration',   icon:'<svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/></svg>'},
     {key:'monitoring',  icon:'<svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>'},
+    {key:'scanning',    icon:'<svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><circle cx="12" cy="11" r="2.5"/><path d="M13.8 12.8L16 15"/></svg>'},
     {key:'promotion',   icon:'<svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="17 11 21 7 17 3"/><line x1="21" y1="7" x2="9" y2="7"/><polyline points="7 21 3 17 7 13"/><line x1="15" y1="17" x2="3" y2="17"/></svg>'},
     {key:'replication', icon:'<svg fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>'},
   ]},

--- a/website/index.html
+++ b/website/index.html
@@ -483,7 +483,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
       <div class="card fc rev d3">
         <div class="fic" style="background:rgba(239,68,68,.1)"><svg fill="none" stroke="#ef4444" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></div>
         <div class="fn">Audit Log &amp; CVE Scan</div>
-        <div class="fd">90-day audit trail with NDJSON streaming export. Trivy-powered Docker image scanning and OSV.dev for Maven/npm/PyPI/Cargo.</div>
+        <div class="fd">90-day audit trail with NDJSON streaming export. Docker image scanning with a Trivy you supply, OSV.dev for Maven/npm/PyPI/Cargo.</div>
       </div>
       <div class="card fc rev d1">
         <div class="fic" style="background:rgba(139,92,246,.12)"><svg fill="none" stroke="#8b5cf6" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg></div>
@@ -715,7 +715,7 @@ resource <span style="color:#7dd3fc">"nexspence_repository"</span> <span style="
       </div>
       <div class="card rev-r" style="padding:24px">
         <div style="font-size:.9rem;font-weight:700;margin-bottom:8px">CVE Scanning + Audit Logs</div>
-        <div style="font-size:.8rem;color:var(--dim);margin-bottom:14px;line-height:1.6">Trivy for Docker/OCI images, OSV.dev for Maven/npm/PyPI/Cargo. 90-day audit trail with NDJSON export.</div>
+        <div style="font-size:.8rem;color:var(--dim);margin-bottom:14px;line-height:1.6">A Trivy you supply for Docker/OCI images, OSV.dev for Maven/npm/PyPI/Cargo. 90-day audit trail with NDJSON export.</div>
         <ul class="cl">
           <li>Scanned automatically on upload, plus a nightly re-scan against newly published CVEs</li>
           <li>Malicious-package reports (OSV <code style="font-family:'JetBrains Mono',monospace;font-size:.7rem;background:var(--glasm);padding:1px 5px;border-radius:4px">MAL-*</code>) get their own severity tier, above Critical</li>
@@ -1073,7 +1073,7 @@ resource <span style="color:#7dd3fc">"nexspence_repository"</span> <span style="
           <tr><td>LDAP Authentication</td><td class="y">Built-in</td><td class="y">Built-in</td></tr>
           <tr><td>Docker OCI v2</td><td class="y">Full spec</td><td class="y">Full spec</td></tr>
           <tr><td>S3 Blob Store</td><td class="y">Any S3-compatible</td><td class="n">Paid tier only</td></tr>
-          <tr><td>Vulnerability Scanning</td><td class="y">Trivy + OSV.dev (built-in)</td><td class="n">Paid add-on</td></tr>
+          <tr><td>Vulnerability Scanning</td><td class="y">OSV.dev built in, Trivy you supply</td><td class="n">Paid add-on</td></tr>
           <tr><td>Webhooks</td><td class="y">Built-in async</td><td class="n">Paid tier only</td></tr>
           <tr><td>Per-repo Export / Import</td><td class="y">Streaming tar.gz</td><td>Admin UI</td></tr>
           <tr><td>Go Modules (GOPROXY)</td><td class="y">Native</td><td class="n">Community plugin</td></tr>


### PR DESCRIPTION
**Breaking.** The nexspence image no longer contains Trivy. Image scanning keeps working, but the operator supplies the binary — see [docs/scanning.md](docs/scanning.md), added here, for every supported way to do that.

Trivy is ~150 MB of third-party software that was riding inside every nexspence image whether or not anyone scanned. It also meant we shipped a scanner version nobody chose and could not update without a nexspence release.

## What the server does now

`scan.trivy.*` configures the capability: `enabled` (default `false`), `bin` (default `trivy`, resolved through `PATH`), `db_repository`, `java_db_repository`, `skip_db_update`, `cache_dir` — each with the usual `NEXSPENCE_SCAN_TRIVY_*` environment override.

A probe answers with **four honest states** rather than one boolean, because pointing an operator at the wrong one costs an evening:

| state | meaning |
|---|---|
| `disabled` | the operator has not turned it on |
| `missing` | on, but nothing at the configured location |
| `broken` | a file is there and will not execute — wrong architecture, truncated download, no `+x` |
| `ready` | it runs, and reported its version |

The probe is `<bin> --version`, which answers all three questions at once, cached for 60s so a binary appearing on a running system is picked up without a restart. `GET /api/v1/security/scanner` returns the state; one record is logged at boot; a scan requested while unavailable is refused `503` with the same sentence instead of exec'ing a path that isn't there; automatic scan-on-upload skips image components instead of filling the history with failures.

Argv construction moved out of the scan path into `TrivyScanArgs`, and registry credentials moved from argv into the environment — anything in argv is readable through the process table.

## What operators do

- **Helm**: `scanning.enabled=true` adds a `trivy-copy` initContainer that copies the binary out of `aquasec/trivy` into a shared `emptyDir` and sets the two env vars.
- **Compose**: the shipped file is already wired — `NEXSPENCE_SCAN_TRIVY_ENABLED=true` and `--profile scanning`.
- **Native install**: `apt`/`dnf`/`brew install trivy`, then `scan.trivy.enabled: true`.

Air-gapped setups mirror `trivy-db` **and** `trivy-java-db`; the doc says why the second one is not optional.

## Verification

`build`, `vet`, `golangci-lint`, `go test ./internal/...` (only the sandbox-only `TestWebhookHandler_Test_200` fails, as on `main`), per-package coverage 82.9% / 83.9% / 89.9%, frontend `tsc` + `eslint` + 527 tests.

End-to-end against the compose stack, both states:

- no profile → `{"state":"disabled"}`, button inactive, a scan request refused `503` with the reason
- `--profile scanning` → `{"state":"ready","version":"0.70.0","path":"/opt/trivy/trivy"}`, and `alpine:3.19` pushed to a hosted docker repo scanned to 10 findings (2 high, 5 medium, 3 low)

That run also caught the one thing no test could: the boot log used `Info` on a `*zap.SugaredLogger`, which concatenates its arguments, so the documented `state` field was never a field. Fixed to `Infow` — note the same pattern exists in ~50 other call sites on `main`, which I have left alone here.

## Rollback

`v1.39.0` is the last image bundling Trivy; pinning it restores the old behavior. No data is lost either way — existing scan results stay visible regardless of whether a binary is currently available.

Expected version on merge: **v2.0.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMeaf1p9QmzaNv15qhmYV5