### PR TITLE
docs(site): put every section in the address bar, and point at scanning

### DIFF
--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -432,7 +432,8 @@ docker compose up -d
 open http://localhost:8081  <span class="cc"># default login: admin / admin123</span></div>
   </div>
   <div class="alert-info" data-i18n="qs.note"><strong>Note:</strong> Since v1.18.0 the server refuses to start with the shipped defaults (<code>admin123</code> / the example <code>jwt_secret</code>) unless <code>auth.allow_insecure_defaults: true</code> is set. The dev compose sets this so the quick-start boots; for production set a real <code>admin_password</code> and <code>jwt_secret</code> (e.g. via <code>NEXSPENCE_AUTH_JWT_SECRET</code>) instead.</div>
-      </section>
+        <div class="alert-info" data-i18n="qs.scanning.pointer"><strong>Scanning Docker/OCI images?</strong> That needs a Trivy binary you supply — nexspence does not ship one. It is one Helm value or one compose profile: see <a href="#sec-scanning">Image Scanning</a>. Package formats (Maven, npm, PyPI, Cargo) scan against OSV.dev with no setup at all.</div>
+</section>
       <section id="sec-install" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="inst.title">Installation</div>
   <div class="doc-section-sub" data-i18n="inst.sub">Docker image: <code>ghcr.io/nexspence/nexspence:latest</code> — linux/amd64 and linux/arm64. Download the release zip from <a href="https://github.com/nexspence/nexspence/releases/latest" target="_blank" rel="noopener" style="color:var(--blue)">GitHub Releases</a>.</div>
@@ -1516,6 +1517,7 @@ sudo systemctl restart nexspence</div></div>
     "rule_id": "rule-456",
     "note": "Approved for production"
   }'</div></div>
+  <div class="alert-info" data-i18n="promo.scan.needs"><strong>The scan gate needs a scanner.</strong> For Docker and OCI images that means a Trivy binary you supply — see <a href="#sec-scanning">Image Scanning</a>. Without one, a rule requiring a passing scan refuses every promotion of an image, because there is no scan to pass.</div>
   <div class="alert-info" data-i18n="promo.scan.note"><strong>Scan gate:</strong> If <em>Require scan pass</em> is enabled on the rule, components with HIGH or CRITICAL vulnerabilities are blocked from promotion until the issues are resolved.</div>
       </section>
       <section id="sec-replication" class="doc-section" hidden>
@@ -1651,6 +1653,7 @@ resource <span class="cs">"nexspence_blobstore"</span> <span class="cs">"s3"</sp
   <div class="doc-section-title" data-i18n="sec.title">Security &amp; Hardening</div>
   <div class="doc-section-sub" data-i18n="sec.sub">Nexspence ships secure by default. The server refuses to start with shipped dev secrets, blocks server-side request forgery, revokes JWTs on account changes, and runs as a non-root, capability-dropped container.</div>
 
+  <div class="alert-info" data-i18n="sec.scanning.pointer"><strong>Looking for vulnerability scanning?</strong> Maven, npm, PyPI and Cargo packages are scanned against OSV.dev with no setup. Docker and OCI <em>images</em> need a Trivy binary you supply — the whole procedure is on the <a href="#sec-scanning">Image Scanning</a> page.</div>
   <div class="inst-sep" data-i18n="sec.failclosed.sep">Fail-Closed Defaults</div>
   <div class="alert-info" style="background:rgba(239,68,68,.06);border-color:rgba(239,68,68,.2)" data-i18n="sec.failclosed.info"><strong style="color:var(--red)">The server will not start</strong> if <code>auth.jwt_secret</code> is the shipped dev default, or if <code>bootstrap.admin_password</code> is still <code>admin123</code>. Production must set a real 32+ character <code>jwt_secret</code> and a strong admin password. To boot anyway for local development only, set <code>auth.allow_insecure_defaults: true</code>.</div>
   <p style="font-size:.8rem;color:var(--dim);margin-bottom:14px;line-height:1.6" data-i18n="sec.failclosed.dev">The dev Docker Compose stack sets <code>NEXSPENCE_AUTH_ALLOW_INSECURE_DEFAULTS=true</code> so the quick-start still boots out of the box — never use that override in production.</p>
@@ -2150,6 +2153,9 @@ const TRANSLATIONS={
     'scan.db.desc':'By default Trivy pulls it from <code>ghcr.io</code> on first use, which is why the first scan takes a minute or two. In an air-gapped network, mirror it into a nexspence repository and point Trivy at the mirror. Mirror <em>both</em> databases: the Java one is fetched separately the first time an image containing Java artifacts is scanned, and an unmirrored one dials <code>ghcr.io</code> and fails.',
     'scan.trap':'<strong>Trap — a host binary in a container.</strong> Only Aqua Security\'s official static Linux build runs inside the nexspence container. Trivy from community distribution packages, Homebrew, or macOS is built for a different environment and lands in the <code>broken</code> state. When in doubt, copy the binary out of the <code>aquasec/trivy</code> image, which is known to run there as uid 1000. Full reference, including every configuration key: <a href="https://github.com/nexspence/nexspence/blob/main/docs/scanning.md" target="_blank" rel="noreferrer">docs/scanning.md</a>.',
     'upg.v2.alert':'<strong>Upgrading to v2.0.0 — image scanning needs a Trivy you supply.</strong> The v2.0.0 image no longer contains Trivy. Everything else upgrades as usual, but scanning of Docker and OCI images stops until you supply the binary — see <strong>Image Scanning</strong> under Advanced. Package scanning (Maven, npm, PyPI, Cargo) is unaffected: it uses OSV.dev and never needed Trivy. Existing scan results stay in the database and stay visible.',
+    'sec.scanning.pointer':'<strong>Looking for vulnerability scanning?</strong> Maven, npm, PyPI and Cargo packages are scanned against OSV.dev with no setup. Docker and OCI <em>images</em> need a Trivy binary you supply — the whole procedure is on the <a href="#sec-scanning">Image Scanning</a> page.',
+    'promo.scan.needs':'<strong>The scan gate needs a scanner.</strong> For Docker and OCI images that means a Trivy binary you supply — see <a href="#sec-scanning">Image Scanning</a>. Without one, a rule requiring a passing scan refuses every promotion of an image, because there is no scan to pass.',
+    'qs.scanning.pointer':'<strong>Scanning Docker/OCI images?</strong> That needs a Trivy binary you supply — nexspence does not ship one. It is one Helm value or one compose profile: see <a href="#sec-scanning">Image Scanning</a>. Package formats (Maven, npm, PyPI, Cargo) scan against OSV.dev with no setup at all.',
   },
   ru:{
     'page.stag':'Документация',
@@ -2525,6 +2531,9 @@ const TRANSLATIONS={
     'scan.db.desc':'По умолчанию Trivy тянет её с <code>ghcr.io</code> при первом использовании — поэтому первый скан идёт минуту-две. В изолированной сети зеркалируйте её в репозиторий nexspence и укажите Trivy на зеркало. Зеркалируйте <em>обе</em> базы: Java-база скачивается отдельно при первом сканировании образа с Java-артефактами, и без зеркала этот скан пойдёт на <code>ghcr.io</code> и упадёт.',
     'scan.trap':'<strong>Ловушка — хостовый бинарь в контейнере.</strong> Внутри контейнера nexspence работает только официальная статическая Linux-сборка Aqua Security. Trivy из community-пакетов дистрибутивов, Homebrew или macOS собран для другого окружения и попадёт в состояние <code>broken</code>. Если сомневаетесь — скопируйте бинарь из образа <code>aquasec/trivy</code>: он заведомо работает там под uid 1000. Полный справочник, включая все ключи конфигурации: <a href="https://github.com/nexspence/nexspence/blob/main/docs/scanning.md" target="_blank" rel="noreferrer">docs/scanning.md</a>.',
     'upg.v2.alert':'<strong>Обновление до v2.0.0 — сканированию образов нужен ваш Trivy.</strong> В образе v2.0.0 больше нет Trivy. Всё остальное обновляется как обычно, но сканирование Docker- и OCI-образов не работает, пока вы не предоставите бинарь — см. <strong>Сканирование образов</strong> в разделе Advanced. Сканирования пакетов (Maven, npm, PyPI, Cargo) это не касается: оно идёт через OSV.dev и никогда не требовало Trivy. Уже сохранённые результаты сканов остаются в базе и остаются видны.',
+    'sec.scanning.pointer':'<strong>Ищете сканирование уязвимостей?</strong> Пакеты Maven, npm, PyPI и Cargo сканируются через OSV.dev без какой-либо настройки. Для Docker- и OCI-<em>образов</em> нужен бинарь Trivy, который вы предоставляете сами — вся процедура на странице <a href="#sec-scanning">Сканирование образов</a>.',
+    'promo.scan.needs':'<strong>Проверке скана нужен сканер.</strong> Для Docker- и OCI-образов это бинарь Trivy, который вы предоставляете сами — см. <a href="#sec-scanning">Сканирование образов</a>. Без него правило с требованием успешного скана отклонит любое продвижение образа: проходить просто нечего.',
+    'qs.scanning.pointer':'<strong>Сканируете Docker/OCI-образы?</strong> Для этого нужен бинарь Trivy, который вы предоставляете сами — nexspence его не поставляет. Это одно значение в Helm или один профиль compose: см. <a href="#sec-scanning">Сканирование образов</a>. Пакетные форматы (Maven, npm, PyPI, Cargo) сканируются через OSV.dev вообще без настройки.',
   }
 };
 
@@ -2737,6 +2746,18 @@ function setTab(tabId){
   state.activeTab=tabId;
   setSection(firstSectionOfTab(tabId));
 }
+// One handler for every way the hash can change under us: Back/forward
+// (popstate), and an in-page <a href="#sec-…"> or a pasted hash (hashchange).
+// The latter is what makes cross-links between sections work at all — the
+// sections are rendered by script, so an anchor alone would move the address
+// bar and nothing else.
+function onHashNavigation(){
+  const raw=(location.hash||'').replace(/^#/,'').replace(/^sec-/,'');
+  const target=raw==='terraform'?'tf-overview':raw;
+  if(target&&target!==state.activeSection&&SECTIONS.some(x=>x.key===target))setSection(target,{fromHistory:true});
+}
+window.addEventListener('popstate',onHashNavigation);
+window.addEventListener('hashchange',onHashNavigation);
 function renderSubnav(activeTab,activeSection){
   const aside=document.querySelector('.docs-sidebar');
   const layout=document.querySelector('.docs-layout');
@@ -2832,9 +2853,21 @@ function renderStaticSection(key){
   if(bad){const span=document.createElement('span');span.className='vbadge-inline';span.textContent='in '+bad;title.appendChild(span);}
 }
 
-function setSection(key){
+// syncHash keeps the address bar on the section being read, so every page is
+// linkable and the browser's Back button walks the sections. `replace` is for
+// navigation the reader did not ask for — the initial render, and restoring a
+// section from history — which must not add an entry of its own.
+function syncHash(key,replace){
+  const want='#sec-'+key;
+  if(location.hash===want)return;
+  try{history[replace?'replaceState':'pushState'](null,'',want);}
+  catch(_){location.hash=want;}   // file:// and other opaque origins refuse the History API
+}
+function setSection(key,opts){
+  const o=opts||{};
   state.activeSection=key;
   state.activeTab=tabOfSection(key);
+  if(!o.fromHistory)syncHash(key,!!o.replace);
   document.getElementById('breadcrumb-current').textContent=t('crumb.'+key);
   document.getElementById('mob-active-page').textContent=(key==='changelog')?t('tab.changelog'):t('sb.'+key);
   renderTabs(state.activeTab);
@@ -2911,9 +2944,13 @@ document.addEventListener('click',function(e){
 
   // Deep-link: /docs/#<section-key> opens that section; legacy #terraform → Terraform Provider tab.
   const _hash=(location.hash||'').replace(/^#/,'').replace(/^sec-/,'');
-  if(_hash){
-    const _target=_hash==='terraform'?'tf-overview':_hash;
-    if(SECTIONS.some(s=>s.key===_target))setSection(_target);
+  const _target=_hash==='terraform'?'tf-overview':_hash;
+  if(_target&&SECTIONS.some(s=>s.key===_target)){
+    setSection(_target,{replace:true});
+  }else{
+    // No (or unknown) hash: still put the section in the address bar, so a
+    // copied URL reopens what the reader is looking at rather than the default.
+    syncHash('changelog',true);
   }
 
   // Releases load in the background for the version bar + changelog section.

--- a/website/index.html
+++ b/website/index.html
@@ -483,7 +483,7 @@ body{font-family:'Inter',system-ui,sans-serif;background:var(--bg);color:var(--t
       <div class="card fc rev d3">
         <div class="fic" style="background:rgba(239,68,68,.1)"><svg fill="none" stroke="#ef4444" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></div>
         <div class="fn">Audit Log &amp; CVE Scan</div>
-        <div class="fd">90-day audit trail with NDJSON streaming export. Docker image scanning with a Trivy you supply, OSV.dev for Maven/npm/PyPI/Cargo.</div>
+        <div class="fd">90-day audit trail with NDJSON streaming export. Docker image scanning with a Trivy you supply (<a href="/docs/#sec-scanning" style="color:#7dd3fc">setup</a>), OSV.dev for Maven/npm/PyPI/Cargo.</div>
       </div>
       <div class="card fc rev d1">
         <div class="fic" style="background:rgba(139,92,246,.12)"><svg fill="none" stroke="#8b5cf6" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true"><polyline points="17 1 21 5 17 9"/><path d="M3 11V9a4 4 0 0 1 4-4h14"/><polyline points="7 23 3 19 7 15"/><path d="M21 13v2a4 4 0 0 1-4 4H3"/></svg></div>
@@ -722,6 +722,7 @@ resource <span style="color:#7dd3fc">"nexspence_repository"</span> <span style="
           <li>On-demand via <code style="font-family:'JetBrains Mono',monospace;font-size:.7rem;background:var(--glasm);padding:1px 5px;border-radius:4px">GET /api/v1/components/:id/scan</code>; export the dashboard as CSV or JSON</li>
           <li>Audit log: date/user filters, NDJSON streaming export</li>
           <li>90-day retention via monthly partition rotation</li>
+          <li>Image scanning needs a Trivy you supply — <a href="/docs/#sec-scanning" style="color:#7dd3fc">how to set it up</a> (one Helm value or one compose profile)</li>
         </ul>
       </div>
       <div class="card rev-l" style="padding:24px">
@@ -1073,7 +1074,7 @@ resource <span style="color:#7dd3fc">"nexspence_repository"</span> <span style="
           <tr><td>LDAP Authentication</td><td class="y">Built-in</td><td class="y">Built-in</td></tr>
           <tr><td>Docker OCI v2</td><td class="y">Full spec</td><td class="y">Full spec</td></tr>
           <tr><td>S3 Blob Store</td><td class="y">Any S3-compatible</td><td class="n">Paid tier only</td></tr>
-          <tr><td>Vulnerability Scanning</td><td class="y">OSV.dev built in, Trivy you supply</td><td class="n">Paid add-on</td></tr>
+          <tr><td>Vulnerability Scanning</td><td class="y">OSV.dev built in, <a href="/docs/#sec-scanning" style="color:inherit;text-decoration:underline">Trivy you supply</a></td><td class="n">Paid add-on</td></tr>
           <tr><td>Webhooks</td><td class="y">Built-in async</td><td class="n">Paid tier only</td></tr>
           <tr><td>Per-repo Export / Import</td><td class="y">Streaming tar.gz</td><td>Admin UI</td></tr>
           <tr><td>Go Modules (GOPROXY)</td><td class="y">Native</td><td class="n">Community plugin</td></tr>


### PR DESCRIPTION
## Every section is linkable

The docs page read a `#sec-…` hash on load but never wrote one: the URL stayed `/docs/` whatever you were reading, so there was nothing to copy or send, and Back left the page.

`setSection` now writes the section into history — `pushState` for a click, `replaceState` for navigation the reader did not ask for (the first render, and restoring a section from history). Landing on `/docs/` with no hash still gets a path, so a copied URL reopens what is on screen.

One handler serves `popstate` and `hashchange`. The `hashchange` half is load-bearing: sections are rendered by script, so an in-page `<a href="#sec-…">` previously moved the address bar and nothing else. The static no-JS sidebar links were dead for the same reason and now work.

## Scanning says where to read

Image scanning is the one feature that now needs a step from the operator, so the places a reader arrives from say so and link to the page: Quick Start, Security & Hardening, and the promotion scan gate (which silently refuses every image promotion without a scanner). On the marketing site the CVE feature card, the CVE block and the comparison row link to the setup rather than just asserting the feature.

EN and RU both — 517 keys a side, verified equal, every `data-i18n` resolving.

## Verification

Driven in a real (headless) browser rather than reasoned about:

```
initial: #sec-changelog
Getting Started -> #sec-quickstart      Advanced -> #sec-migration
Quick Start     -> #sec-quickstart      Image Scanning -> #sec-scanning
Installation    -> #sec-install         Content Replication -> #sec-replication
Reference       -> #sec-security        API Reference -> #sec-api
after back: #sec-security | visible: sec-security
after clicking the scanning pointer -> #sec-scanning | visible: sec-scanning
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JMeaf1p9QmzaNv15qhmYV5