### PR TITLE
fix(api): close seven input-validation gaps across paginated and write endpoints

### DIFF
--- a/internal/api/handlers/audit.go
+++ b/internal/api/handlers/audit.go
@@ -53,9 +53,36 @@ func parseAuditQuery(c *gin.Context) (repository.AuditQuery, error) {
 		}
 		q.To = &t
 	}
-	q.Limit, _ = strconv.Atoi(c.DefaultQuery("limit", "100"))
-	q.Offset, _ = strconv.Atoi(c.DefaultQuery("offset", "0"))
+	// Both are rejected rather than silently coerced: a negative offset reaches
+	// Postgres as a rejected OFFSET and surfaces as a 500 with raw SQL text,
+	// where the caller sent bad input and deserves a 400. AuditRepo.List clamps
+	// the page size itself, but a non-numeric limit would otherwise be read as
+	// "use the default" without the caller ever hearing about it.
+	var err error
+	if q.Limit, err = parseNonNegative(c, "limit", 100); err != nil {
+		return q, err
+	}
+	if q.Offset, err = parseNonNegative(c, "offset", 0); err != nil {
+		return q, err
+	}
 	return q, nil
+}
+
+// parseNonNegative reads query parameter name as a non-negative int, returning
+// def when it is absent.
+func parseNonNegative(c *gin.Context, name string, def int) (int, error) {
+	raw := c.Query(name)
+	if raw == "" {
+		return def, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid '%s' value: %w", name, err)
+	}
+	if v < 0 {
+		return 0, fmt.Errorf("invalid '%s' value: must be >= 0", name)
+	}
+	return v, nil
 }
 
 // parseDate accepts either an ISO date (2026-04-01) or RFC3339 (2026-04-01T12:00:00Z).

--- a/internal/api/handlers/audit_test.go
+++ b/internal/api/handlers/audit_test.go
@@ -152,6 +152,17 @@ func TestAuditList_TotalReflectsAllMatches_NotPage(t *testing.T) {
 	assert.Len(t, body.Items, 2, "page is limited")
 }
 
+// A negative or non-numeric offset would reach Postgres as a rejected OFFSET
+// and come back as a 500 carrying raw SQL text; the caller sent bad input, so
+// it is answered the same way an unparseable 'from'/'to' already is.
+func TestAuditList_BadPaging_400(t *testing.T) {
+	r, _ := mountAudit(t)
+	for _, qs := range []string{"offset=-1", "offset=abc", "limit=-5", "limit=abc"} {
+		rec := do(t, r, http.MethodGet, "/service/rest/v1/audit?"+qs, nil)
+		assert.Equal(t, http.StatusBadRequest, rec.Code, qs)
+	}
+}
+
 func TestAuditList_NDJSON_Export(t *testing.T) {
 	r, repo := mountAudit(t)
 	seed(t, repo, []domain.AuditEvent{

--- a/internal/api/handlers/cleanup.go
+++ b/internal/api/handlers/cleanup.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/robfig/cron/v3"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/repository"
@@ -62,22 +63,40 @@ func (h *CleanupHandler) Get(c *gin.Context) {
 	c.JSON(http.StatusOK, p)
 }
 
-// Create POST /service/rest/v1/cleanup-policies
-func (h *CleanupHandler) Create(c *gin.Context) {
+// bindPolicy decodes a policy body and applies the input contract shared by
+// Create and Update: a name is required, a missing format means "all formats",
+// criteria default to empty, and a schedule that the cron scheduler cannot
+// parse is rejected here rather than silently dropped at scheduling time.
+func bindPolicy(c *gin.Context) (domain.CleanupPolicy, bool) {
 	var p domain.CleanupPolicy
 	if err := c.ShouldBindJSON(&p); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
+		return p, false
 	}
 	if p.Name == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
-		return
+		return p, false
+	}
+	if p.ScheduleCron != "" {
+		if _, err := cron.ParseStandard(p.ScheduleCron); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid scheduleCron: " + err.Error()})
+			return p, false
+		}
 	}
 	if p.Format == "" {
 		p.Format = "*"
 	}
 	if p.Criteria == nil {
 		p.Criteria = map[string]any{}
+	}
+	return p, true
+}
+
+// Create POST /service/rest/v1/cleanup-policies
+func (h *CleanupHandler) Create(c *gin.Context) {
+	p, ok := bindPolicy(c)
+	if !ok {
+		return
 	}
 	if err := h.policies.Create(c.Request.Context(), &p); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -89,9 +108,8 @@ func (h *CleanupHandler) Create(c *gin.Context) {
 
 // Update PUT /service/rest/v1/cleanup-policies/:id
 func (h *CleanupHandler) Update(c *gin.Context) {
-	var p domain.CleanupPolicy
-	if err := c.ShouldBindJSON(&p); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	p, ok := bindPolicy(c)
+	if !ok {
 		return
 	}
 	p.ID = c.Param("id")

--- a/internal/api/handlers/cleanup_test.go
+++ b/internal/api/handlers/cleanup_test.go
@@ -265,3 +265,48 @@ func TestCleanupHandler_Preview_NotFound_500(t *testing.T) {
 	rec := do(t, r, http.MethodPost, "/api/v1/cleanup-policies/ghost/preview", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
+
+// Update must apply the same input contract as Create: a blank name is rejected
+// and a missing format defaults to "*", instead of silently blanking the policy.
+func TestCleanupHandler_Update_EmptyName_400(t *testing.T) {
+	r, policies, _, _ := mountCleanup(t)
+	p := &domain.CleanupPolicy{Name: "keep-me", Format: "*", Criteria: map[string]any{}}
+	require.NoError(t, policies.Create(testContext(), p))
+
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/cleanup-policies/"+p.ID,
+		map[string]any{"name": "", "format": "maven2"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+	stored, err := policies.Get(testContext(), p.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "keep-me", stored.Name)
+}
+
+func TestCleanupHandler_Update_DefaultsFormat(t *testing.T) {
+	r, policies, _, _ := mountCleanup(t)
+	p := &domain.CleanupPolicy{Name: "old", Format: "npm", Criteria: map[string]any{}}
+	require.NoError(t, policies.Create(testContext(), p))
+
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/cleanup-policies/"+p.ID,
+		map[string]any{"name": "new"})
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got domain.CleanupPolicy
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "*", got.Format)
+	assert.NotNil(t, got.Criteria)
+}
+
+// An unparseable schedule would be dropped by the scheduler with only a log
+// line, so both write paths reject it up front.
+func TestCleanupHandler_InvalidScheduleCron_400(t *testing.T) {
+	r, policies, _, _ := mountCleanup(t)
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/cleanup-policies",
+		map[string]any{"name": "p", "scheduleCron": "not-a-cron"})
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+
+	p := &domain.CleanupPolicy{Name: "p", Format: "*", Criteria: map[string]any{}}
+	require.NoError(t, policies.Create(testContext(), p))
+	rec = do(t, r, http.MethodPut, "/service/rest/v1/cleanup-policies/"+p.ID,
+		map[string]any{"name": "p", "scheduleCron": "not-a-cron"})
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/api/handlers/components.go
+++ b/internal/api/handlers/components.go
@@ -73,7 +73,9 @@ func (h *ComponentHandler) List(c *gin.Context) {
 		}
 	}
 	if tok := c.Query("continuationToken"); tok != "" {
-		if v, err := strconv.Atoi(tok); err == nil {
+		// Same guard as ?offset= above: the token is just an offset, and a
+		// negative one reaches Postgres as a rejected OFFSET.
+		if v, err := strconv.Atoi(tok); err == nil && v >= 0 {
 			offset = v
 		}
 	}

--- a/internal/api/handlers/components_test.go
+++ b/internal/api/handlers/components_test.go
@@ -227,6 +227,18 @@ func TestComponentHandler_List_ContinuationTokenWinsOverOffset(t *testing.T) {
 }
 
 // A first page that has more rows behind it advertises the next token.
+// A hand-crafted negative token is ignored the same way a negative ?offset= is,
+// instead of reaching Postgres as a rejected OFFSET and surfacing as a 500.
+func TestComponentHandler_List_NegativeContinuationTokenIgnored(t *testing.T) {
+	r, comps, _, repos := mountComponents(t)
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "raw-host", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	require.NoError(t, comps.Create(testContext(), &domain.Component{Name: "a", Repository: "raw-host"}))
+	rec := do(t, r, http.MethodGet,
+		"/service/rest/v1/components?repository=raw-host&limit=3&continuationToken=-5", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 0, comps.LastListOffset, "negative continuation token must not reach the repo layer")
+}
+
 func TestComponentHandler_List_ContinuationTokenEmitted(t *testing.T) {
 	r, comps, _, repos := mountComponents(t)
 	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "raw-host", Format: domain.FormatRaw, Type: domain.TypeHosted})

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -89,6 +89,13 @@ func (h *ScanHandler) Summary(c *gin.Context) {
 	c.JSON(http.StatusOK, summary)
 }
 
+// maxVulnPageSize caps one page of vulnerability rows, the same ceiling
+// AuditRepo.List and the component listing apply. Without it a client-set limit
+// reaches the SQL LIMIT clause unbounded and one request can serialize every
+// scanned component in the registry. The ?export= path is unaffected: it sets
+// its own (much higher) row cap after this parsing.
+const maxVulnPageSize = 1000
+
 // Vulnerabilities returns a paginated list of vulnerability rows.
 // GET /api/v1/security/vulnerabilities?repo=&severity=&format=&limit=&offset=
 //
@@ -105,6 +112,9 @@ func (h *ScanHandler) Vulnerabilities(c *gin.Context) {
 	offset := 0
 	if v := c.Query("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > maxVulnPageSize {
+				n = maxVulnPageSize
+			}
 			limit = n
 		}
 	}

--- a/internal/api/handlers/scan_test.go
+++ b/internal/api/handlers/scan_test.go
@@ -239,6 +239,28 @@ func TestScanHandler_Vulnerabilities_BadLimitOffset_UsesDefaults(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 }
 
+// A client-set limit is capped before it reaches the SQL LIMIT clause, so one
+// request cannot pull every scanned component in the registry.
+func TestScanHandler_Vulnerabilities_LimitClamped(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	rec := do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities?limit=5000000", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1000, scanRepo.LastFilter.Limit)
+
+	rec = do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities?limit=10", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 10, scanRepo.LastFilter.Limit, "a normal page size is untouched")
+}
+
+// The export path carries its own, much larger row cap and must not be pulled
+// down to the paging ceiling.
+func TestScanHandler_VulnerabilitiesExport_NotClampedToPageSize(t *testing.T) {
+	r, _, scanRepo, _ := mountScan(t)
+	rec := do(t, r, http.MethodGet, "/api/v1/security/vulnerabilities?export=csv&limit=5000000", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Greater(t, scanRepo.LastFilter.Limit, 1000)
+}
+
 func TestScanHandler_Vulnerabilities_RepoError_500(t *testing.T) {
 	r, _, scanRepo, _ := mountScan(t)
 	scanRepo.Err = errors.New("list down")

--- a/internal/api/handlers/users.go
+++ b/internal/api/handlers/users.go
@@ -96,6 +96,10 @@ func (h *UserHandler) Update(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 			return
 		}
+		if isAlreadyExists(err) {
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/users_test.go
+++ b/internal/api/handlers/users_test.go
@@ -260,6 +260,54 @@ func TestUserHandler_Create_Duplicate_409(t *testing.T) {
 	assert.Equal(t, http.StatusConflict, rec.Code)
 }
 
+// Email uniqueness is enforced only by the DB, so a duplicate used to escape as
+// a raw constraint error and be answered with a 500 carrying SQL internals.
+func TestUserHandler_Create_DuplicateEmail_409(t *testing.T) {
+	r, users, _ := mountUsers(t)
+	require.NoError(t, users.Create(testContext(), &domain.User{
+		Username: "erin", Email: "shared@test.com",
+		Status: domain.UserStatusActive, Source: domain.UserSourceLocal,
+	}))
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/security/users", map[string]any{
+		"userId":       "erin-svc",
+		"emailAddress": "shared@test.com",
+		"password":     "pw",
+	})
+	require.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), "email")
+	assert.NotContains(t, rec.Body.String(), "SQLSTATE")
+}
+
+// The same collision on the sibling verb: moving one account onto another's
+// email is a conflict, not an internal failure.
+func TestUserHandler_Update_DuplicateEmail_409(t *testing.T) {
+	r, users, _ := mountUsers(t)
+	for _, u := range []*domain.User{
+		{Username: "u1", Email: "taken@test.com", Status: domain.UserStatusActive, Source: domain.UserSourceLocal},
+		{Username: "u2", Email: "own@test.com", Status: domain.UserStatusActive, Source: domain.UserSourceLocal},
+	} {
+		require.NoError(t, users.Create(testContext(), u))
+	}
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/security/users/u2", map[string]any{
+		"emailAddress": "taken@test.com",
+	})
+	require.Equal(t, http.StatusConflict, rec.Code)
+	assert.NotContains(t, rec.Body.String(), "SQLSTATE")
+}
+
+// Any number of email-less accounts stays legal — the DB index is partial.
+func TestUserHandler_Create_EmptyEmailsDoNotCollide(t *testing.T) {
+	r, users, _ := mountUsers(t)
+	require.NoError(t, users.Create(testContext(), &domain.User{
+		Username: "ldap-a", Status: domain.UserStatusActive, Source: domain.UserSourceLocal,
+	}))
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/security/users", map[string]any{
+		"userId":   "ldap-b",
+		"password": "pw",
+	})
+	assert.Equal(t, http.StatusCreated, rec.Code)
+}
+
 func TestUserHandler_Create_RepoError_500(t *testing.T) {
 	r, users, _ := mountUsers(t)
 	users.Err = errors.New("db down")

--- a/internal/repository/errors.go
+++ b/internal/repository/errors.go
@@ -6,3 +6,21 @@ import "errors"
 // when no matching row exists. Callers should test for it with errors.Is and
 // translate it into the appropriate not-found behavior (e.g. HTTP 404).
 var ErrNotFound = errors.New("not found")
+
+// ErrAlreadyExists is returned by repository write methods when the row would
+// violate a uniqueness constraint (e.g. a second user with the same email).
+// Callers translate it into the appropriate conflict behavior (e.g. HTTP 409)
+// rather than letting a raw driver error surface as a 500 carrying SQL internals.
+var ErrAlreadyExists = errors.New("already exists")
+
+// UniqueViolationError is an ErrAlreadyExists that names the field which
+// collided, so callers can report which one without parsing driver text.
+type UniqueViolationError struct {
+	Field string
+}
+
+func (e *UniqueViolationError) Error() string { return e.Field + " already exists" }
+
+// Is makes every UniqueViolationError match ErrAlreadyExists, so callers that
+// only care that the row exists can test for the sentinel.
+func (e *UniqueViolationError) Is(target error) bool { return target == ErrAlreadyExists }

--- a/internal/repository/postgres/component_repo.go
+++ b/internal/repository/postgres/component_repo.go
@@ -28,9 +28,24 @@ func (r *componentRepo) List(ctx context.Context, repoName string, limit, offset
 	return r.ListByRepoNames(ctx, []string{repoName}, limit, offset)
 }
 
+// maxComponentPageSize caps how many components one listing request can pull,
+// mirroring the ceiling AuditRepo.List already applies. Without it a client-set
+// limit goes straight into the SQL LIMIT clause, and a single request can pull —
+// and serialize — an entire registry.
+const maxComponentPageSize = 1000
+
+// ListByRepoNames returns a page of components across repoNames. The page size
+// is clamped to [1, maxComponentPageSize]; callers page on with the returned
+// continuation token.
 func (r *componentRepo) ListByRepoNames(ctx context.Context, repoNames []string, limit, offset int) (*domain.Page[domain.Component], error) {
 	if len(repoNames) == 0 {
 		return &domain.Page[domain.Component]{Items: []domain.Component{}}, nil
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+	if limit > maxComponentPageSize {
+		limit = maxComponentPageSize
 	}
 	ph := make([]string, len(repoNames))
 	args := make([]any, 0, len(repoNames)+2)

--- a/internal/repository/postgres/component_repo_integration_test.go
+++ b/internal/repository/postgres/component_repo_integration_test.go
@@ -412,6 +412,46 @@ func TestComponentRepo_ListByRepoNames_UnionAcrossRepos(t *testing.T) {
 	}
 }
 
+// A caller-supplied page size is capped before it reaches the SQL LIMIT clause,
+// so one request cannot pull (and serialize) an entire registry.
+func TestComponentRepo_ListByRepoNames_ClampsPageSize(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+
+	p := makeCompParent(t, ctx, "lbrn_clamp")
+	repo := NewComponentRepo(pool)
+
+	// One statement instead of 1001 round trips: this test only cares that the
+	// table holds more rows than the ceiling.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO components (repository_id, format, name, version)
+		SELECT $1, 'raw', 'clamp-lib-' || lpad(g::text, 5, '0'), '1.0'
+		FROM generate_series(1, 1001) g`, p.RepositoryID); err != nil {
+		t.Fatalf("seed components: %v", err)
+	}
+
+	page, err := repo.ListByRepoNames(ctx, []string{p.RepoName}, 5_000_000, 0)
+	if err != nil {
+		t.Fatalf("ListByRepoNames: %v", err)
+	}
+	if len(page.Items) != maxComponentPageSize {
+		t.Errorf("expected the page clamped to %d items, got %d", maxComponentPageSize, len(page.Items))
+	}
+	if page.ContinuationToken == nil {
+		t.Error("expected a continuation token so the caller can page on")
+	}
+
+	// A page size under the ceiling is untouched.
+	page, err = repo.ListByRepoNames(ctx, []string{p.RepoName}, 10, 0)
+	if err != nil {
+		t.Fatalf("ListByRepoNames(10): %v", err)
+	}
+	if len(page.Items) != 10 {
+		t.Errorf("expected 10 items, got %d", len(page.Items))
+	}
+}
+
 func TestComponentRepo_ListByRepoNames_EmptyListReturnsEmpty(t *testing.T) {
 	pool := pgtest.Pool(t)
 	pgtest.Truncate(t, pool, "blob_stores", "repositories")

--- a/internal/repository/postgres/user_repo.go
+++ b/internal/repository/postgres/user_repo.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
@@ -82,15 +83,42 @@ func (r *userRepo) GetByID(ctx context.Context, id string) (*domain.User, error)
 	return u, nil
 }
 
+// pgerrUniqueViolation is Postgres' SQLSTATE for a unique-constraint violation.
+const pgerrUniqueViolation = "23505"
+
+// uniqueUserFields maps the users table's unique constraints to the field name
+// a caller would recognize. A violation is a client-visible conflict, not an
+// internal failure, so it is translated instead of surfacing as a raw driver
+// error — see translateUserUnique.
+var uniqueUserFields = map[string]string{
+	"users_username_key":       "username",
+	"users_email_nonempty_key": "email",
+}
+
+// translateUserUnique converts a Postgres unique-violation on the users table
+// into repository.ErrAlreadyExists naming the offending field. Any other error
+// passes through untouched.
+func translateUserUnique(err error) error {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != pgerrUniqueViolation {
+		return err
+	}
+	field, ok := uniqueUserFields[pgErr.ConstraintName]
+	if !ok {
+		return err
+	}
+	return &repository.UniqueViolationError{Field: field}
+}
+
 func (r *userRepo) Create(ctx context.Context, u *domain.User) error {
-	return r.db.QueryRow(ctx, `
+	return translateUserUnique(r.db.QueryRow(ctx, `
 		INSERT INTO users (username, email, password_hash, first_name, last_name, status, source,
 		                   must_reset_password)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
 		RETURNING id, created_at, updated_at`,
 		u.Username, nilIfEmpty(u.Email), nilIfEmpty(u.PasswordHash),
 		u.FirstName, u.LastName, u.Status, u.Source, u.MustResetPassword,
-	).Scan(&u.ID, &u.CreatedAt, &u.UpdatedAt)
+	).Scan(&u.ID, &u.CreatedAt, &u.UpdatedAt))
 }
 
 func (r *userRepo) Update(ctx context.Context, u *domain.User) error {
@@ -99,7 +127,7 @@ func (r *userRepo) Update(ctx context.Context, u *domain.User) error {
 		WHERE username=$5`,
 		nilIfEmpty(u.Email), u.FirstName, u.LastName, u.Status, u.Username,
 	)
-	return err
+	return translateUserUnique(err)
 }
 
 // UpdatePassword sets a new hash and clears must_reset_password: choosing a

--- a/internal/repository/postgres/user_repo_integration_test.go
+++ b/internal/repository/postgres/user_repo_integration_test.go
@@ -140,8 +140,41 @@ func TestUserRepo_Create_DuplicateUsername_Errors(t *testing.T) {
 		t.Fatalf("first Create: %v", err)
 	}
 	u2 := makeUser("dup_user", "dup2@test.com")
-	if err := repo.Create(ctx, u2); err == nil {
+	err := repo.Create(ctx, u2)
+	if err == nil {
 		t.Fatal("expected error for duplicate username, got nil")
+	}
+	if !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatalf("want ErrAlreadyExists, got %v", err)
+	}
+}
+
+// A duplicate email must come back as a recognizable conflict naming the field,
+// not as a raw driver error that callers can only answer with a 500.
+func TestUserRepo_Create_DuplicateEmail_ReturnsAlreadyExists(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "users", "roles")
+	ctx := context.Background()
+	repo := NewUserRepo(pool)
+
+	if err := repo.Create(ctx, makeUser("dup_email_a", "shared@test.com")); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	err := repo.Create(ctx, makeUser("dup_email_b", "shared@test.com"))
+	if !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatalf("want ErrAlreadyExists, got %v", err)
+	}
+	var uv *repository.UniqueViolationError
+	if !errors.As(err, &uv) || uv.Field != "email" {
+		t.Fatalf("want the email field named, got %v", err)
+	}
+
+	// The index is partial: email-less accounts never collide.
+	if err := repo.Create(ctx, makeUser("dup_email_none_a", "")); err != nil {
+		t.Fatalf("Create(no email): %v", err)
+	}
+	if err := repo.Create(ctx, makeUser("dup_email_none_b", "")); err != nil {
+		t.Fatalf("Create(second no email): %v", err)
 	}
 }
 

--- a/internal/service/replication_service.go
+++ b/internal/service/replication_service.go
@@ -522,8 +522,26 @@ func (s *ReplicationService) GetRule(ctx context.Context, id string) (*domain.Re
 	return rule, nil
 }
 
+// validateCronExpr rejects a schedule the cron scheduler cannot parse. An empty
+// expression is allowed and means "no schedule" — the rule only runs when it is
+// triggered manually. Anything else, left unvalidated, would be dropped by
+// addEntryLocked with nothing but a log line, leaving the rule permanently
+// unscheduled while the API reported success.
+func validateCronExpr(expr string) error {
+	if expr == "" {
+		return nil
+	}
+	if _, err := cron.ParseStandard(expr); err != nil {
+		return fmt.Errorf("invalid cron_expr %q: %w", expr, err)
+	}
+	return nil
+}
+
 // CreateRule encrypts the password and persists the rule.
 func (s *ReplicationService) CreateRule(ctx context.Context, rule *domain.ReplicationRule, plainPassword string) error {
+	if err := validateCronExpr(rule.CronExpr); err != nil {
+		return err
+	}
 	enc, err := s.EncryptPassword(plainPassword)
 	if err != nil {
 		return err
@@ -534,6 +552,9 @@ func (s *ReplicationService) CreateRule(ctx context.Context, rule *domain.Replic
 
 // UpdateRule encrypts the password if provided (non-empty), otherwise keeps existing.
 func (s *ReplicationService) UpdateRule(ctx context.Context, rule *domain.ReplicationRule, plainPassword string) error {
+	if err := validateCronExpr(rule.CronExpr); err != nil {
+		return err
+	}
 	if plainPassword != "" {
 		enc, err := s.EncryptPassword(plainPassword)
 		if err != nil {

--- a/internal/service/replication_service_test.go
+++ b/internal/service/replication_service_test.go
@@ -308,6 +308,53 @@ func TestReplicationService_Decrypt_NoFallbackWithoutKey(t *testing.T) {
 	}
 }
 
+// An expression the scheduler cannot parse is rejected at the write, instead of
+// being persisted and then dropped by addEntryLocked with only a log line —
+// which left a rule that never ran and an API that reported success.
+func TestReplicationService_RuleWrites_RejectInvalidCronExpr(t *testing.T) {
+	ctx := context.Background()
+	repo := testutil.NewReplicationRepo()
+	svc := service.NewReplicationService(repo, testutil.NewAssetRepo(), testutil.NewBlobStore(),
+		"test-jwt-secret-32-bytes-long!!!", nil, nopReplLog())
+
+	bad := &domain.ReplicationRule{Name: "r1", SourceRepo: "raw-hosted",
+		TargetURL: "http://example", TargetRepo: "raw", CronExpr: "not-a-cron"}
+	if err := svc.CreateRule(ctx, bad, ""); err == nil {
+		t.Fatal("CreateRule accepted an unparseable cron_expr")
+	}
+	rules, err := repo.ListRules(ctx)
+	if err != nil {
+		t.Fatalf("ListRules: %v", err)
+	}
+	if len(rules) != 0 {
+		t.Fatalf("rejected rule was persisted anyway: %d rules", len(rules))
+	}
+
+	good := &domain.ReplicationRule{Name: "r1", SourceRepo: "raw-hosted",
+		TargetURL: "http://example", TargetRepo: "raw", CronExpr: "0 2 * * *"}
+	if err := svc.CreateRule(ctx, good, ""); err != nil {
+		t.Fatalf("CreateRule(valid): %v", err)
+	}
+
+	good.CronExpr = "*/5 * * * * * *"
+	if err := svc.UpdateRule(ctx, good, ""); err == nil {
+		t.Fatal("UpdateRule accepted an unparseable cron_expr")
+	}
+	stored, err := repo.GetRule(ctx, good.ID)
+	if err != nil {
+		t.Fatalf("GetRule: %v", err)
+	}
+	if stored.CronExpr != "0 2 * * *" {
+		t.Fatalf("stored schedule was overwritten: %q", stored.CronExpr)
+	}
+
+	// An empty expression stays legal: it means "manual runs only".
+	good.CronExpr = ""
+	if err := svc.UpdateRule(ctx, good, ""); err != nil {
+		t.Fatalf("UpdateRule(empty cron_expr): %v", err)
+	}
+}
+
 func TestReplicationService_ReEncryptCredentials_MigratesAndIsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	repo := testutil.NewReplicationRepo()

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -269,6 +269,14 @@ func (s *UserService) Create(ctx context.Context, u *domain.User, plainPassword 
 	}
 
 	if err := s.users.Create(ctx, u); err != nil {
+		// The username was pre-checked above, but email uniqueness is enforced
+		// only by the DB (a partial index, so any number of email-less users is
+		// still fine). Without this, a duplicate email escaped as a raw driver
+		// error and the handler answered 500 with SQL internals instead of 409.
+		var uv *repository.UniqueViolationError
+		if errors.As(err, &uv) {
+			return fmt.Errorf("%w: user with this %s", ErrAlreadyExists, uv.Field)
+		}
 		return err
 	}
 	if len(u.Roles) > 0 {
@@ -304,6 +312,11 @@ func (s *UserService) Update(ctx context.Context, username string, updates *doma
 	}
 
 	if err := s.users.Update(ctx, u); err != nil {
+		// Same email collision as Create's, on the sibling verb.
+		var uv *repository.UniqueViolationError
+		if errors.As(err, &uv) {
+			return nil, fmt.Errorf("%w: user with this %s", ErrAlreadyExists, uv.Field)
+		}
 		return nil, err
 	}
 	// Revoke existing JWTs when the account transitions to non-active.

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -1400,6 +1400,15 @@ func (r *UserRepo) Create(_ context.Context, u *domain.User) error {
 	if r.Err != nil {
 		return r.Err
 	}
+	// Mirror the real table's constraints: username is unique, and email is
+	// unique only when non-empty (users_email_nonempty_key is a partial index,
+	// so any number of email-less users is fine).
+	if _, exists := r.users[u.Username]; exists {
+		return &repository.UniqueViolationError{Field: "username"}
+	}
+	if err := r.checkEmailFreeLocked(u.Email, u.Username); err != nil {
+		return err
+	}
 	r.nextID++
 	if u.ID == "" {
 		u.ID = fmt.Sprintf("user-%d", r.nextID)
@@ -1408,11 +1417,29 @@ func (r *UserRepo) Create(_ context.Context, u *domain.User) error {
 	r.byID[u.ID] = u
 	return nil
 }
+
+// checkEmailFreeLocked reports the users_email_nonempty_key violation that the
+// real table would raise. Caller must hold r.mu.
+func (r *UserRepo) checkEmailFreeLocked(email, ownUsername string) error {
+	if email == "" {
+		return nil
+	}
+	for name, existing := range r.users {
+		if name != ownUsername && existing.Email == email {
+			return &repository.UniqueViolationError{Field: "email"}
+		}
+	}
+	return nil
+}
+
 func (r *UserRepo) Update(_ context.Context, u *domain.User) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.Err != nil {
 		return r.Err
+	}
+	if err := r.checkEmailFreeLocked(u.Email, u.Username); err != nil {
+		return err
 	}
 	r.users[u.Username] = u
 	r.byID[u.ID] = u


### PR DESCRIPTION
Closes #273, #274, #275, #276, #277, #278, #279 — seven separately reported gaps that share one shape: a request the API accepted without checking, answered either by silently writing bad state or by handing the caller a raw Postgres error as a 500.

## Write contracts

- **#273** — `CleanupHandler.Update` now applies the same contract as `Create`: a blank `name` is rejected instead of permanently blanking the policy, and a missing `format` still defaults to `"*"`. Both verbs share one `bindPolicy` helper so they cannot drift again.
- **#275** — replication rules validate `cron_expr` with `cron.ParseStandard`, the parser the scheduler itself uses. An unparseable expression used to be persisted and then dropped by `addEntryLocked` with nothing but a log line, leaving a rule that never ran while the API reported success. An empty expression still means "manual runs only".
- **#274** — creating *or updating* a user with an email another account already holds returns `409` naming the field, instead of a `500` carrying the constraint name and SQLSTATE. Email uniqueness is enforced only by the DB (`users_email_nonempty_key` is a partial index — any number of email-less accounts is still fine), so `userRepo` translates the unique violation into `repository.ErrAlreadyExists` and `UserService` maps it onto the same "already exists" path a username collision already used. Nexus migration's `createMigratedUser` goes through `UserService.Create`, so it inherits the clean error too.

## Paging bounds

- **#276** — component listing clamps its page size to 1000, the ceiling `AuditRepo.List` already applied.
- **#277** — the vulnerability listing clamps the same way.
- **#278** — a negative `continuationToken` on component listing is ignored like a negative `offset` already was.
- **#279** — the audit listing rejects a negative or non-numeric `limit`/`offset` with a `400`, through the same path its `from`/`to` parse errors already use.

## Notes for review

Three deliberate departures from the reported suggested fixes:

1. **#277 is clamped in the handler, not `scanResultRepo.List`.** `exportVulnerabilities` sets `f.Limit = exportMaxRows` (50000) *after* the paging parse; clamping in the repository would have silently truncated every CSV/JSON export to 1000 rows and suppressed the truncation header. A test pins both halves of this.
2. **#274 is translated at the repository boundary** rather than pre-checked in the service. A pre-check is racy; the DB constraint is the only real arbiter, so its violation is mapped to a typed `repository.UniqueViolationError` and the fix covers `Update` as well as `Create`.
3. **Cleanup policies also validate `scheduleCron`** — not filed, but the same defect class as #275 in the file #273 already touches. There it falls back to the default schedule rather than skipping, so a policy silently ran on a schedule its owner never chose.

The `testutil.UserRepo` mock now mirrors the real table's constraints (unique username, unique *non-empty* email), so the conflict path is covered without a live database.

## Testing

- `go test ./...` — green (the one failure, `TestWebhookHandler_Test_200`, is a pre-existing sandbox network denial, unrelated and also failing on `main`).
- `golangci-lint run` — clean.
- The two repository-level changes (#274, #276) carry integration tests against real Postgres, verified with `go vet -tags=integration` locally and left for CI to run — Docker is unavailable in this environment.
- Every unit test was confirmed to fail against the unfixed code before the fix was applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZasUK9neHh8p3by4Pcqe