### PR TITLE
fix(migrations): let the database decide who may migrate a repository's blobs

### DIFF
--- a/internal/api/handlers/blob_store_migration.go
+++ b/internal/api/handlers/blob_store_migration.go
@@ -36,7 +36,7 @@ func (h *BlobStoreMigrationHandler) Start(c *gin.Context) {
 	if err != nil {
 		msg := err.Error()
 		switch {
-		case strings.Contains(msg, "already running"):
+		case errors.Is(err, service.ErrMigrationAlreadyRunning):
 			c.JSON(http.StatusConflict, gin.H{"error": msg})
 		case strings.Contains(msg, "not found"), strings.Contains(msg, "same as"):
 			c.JSON(http.StatusBadRequest, gin.H{"error": msg})

--- a/internal/api/handlers/blob_store_migration_handler_test.go
+++ b/internal/api/handlers/blob_store_migration_handler_test.go
@@ -29,6 +29,23 @@ func newMigSvc(t *testing.T, repoName, sourceID, targetID string) *service.BlobS
 	return service.NewBlobStoreMigrationService(migRepo, assetRepo, repoRepo, blobRepo, reg)
 }
 
+// newMigSvcWithActive is newMigSvc with a migration already running for the
+// repository — the state a second concurrent request runs into.
+func newMigSvcWithActive(t *testing.T, repoName, sourceID, targetID string) *service.BlobStoreMigrationService {
+	t.Helper()
+	repoRepo := testutil.NewRepoRepo(&domain.Repository{ID: "r1", Name: repoName, BlobStoreID: &sourceID})
+	blobRepo := testutil.NewBlobStoreRepo(
+		&domain.BlobStore{ID: sourceID, Name: "source", Type: "local", Config: map[string]any{"path": t.TempDir()}},
+		&domain.BlobStore{ID: targetID, Name: "target", Type: "local", Config: map[string]any{"path": t.TempDir()}},
+	)
+	migRepo := testutil.NewBlobStoreMigrationRepo(&domain.BlobStoreMigration{
+		ID: "mig-active", RepositoryName: repoName,
+		SourceStoreID: sourceID, TargetStoreID: targetID, Status: "running",
+	})
+	reg := storage.NewRegistry(testutil.NewBlobStore())
+	return service.NewBlobStoreMigrationService(migRepo, testutil.NewAssetRepo(), repoRepo, blobRepo, reg)
+}
+
 func buildMigRouter(svc *service.BlobStoreMigrationService) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
@@ -65,29 +82,24 @@ func TestBlobStoreMigrationHandler_Start_201(t *testing.T) {
 	}
 }
 
-// TestBlobStoreMigrationHandler_Start_409 verifies 409 when an active migration already exists.
+// TestBlobStoreMigrationHandler_Start_409 verifies 409 when an active migration
+// already exists. The active migration is seeded rather than started by a first
+// request: an empty repository migrates in microseconds, so a first-then-second
+// request pair raced its own completion — once the first finished, the second
+// saw the repository already pointing at the target and got 400 ("same as")
+// instead of the conflict under test.
 func TestBlobStoreMigrationHandler_Start_409(t *testing.T) {
-	svc := newMigSvc(t, "my-repo", "src-store", "tgt-store")
+	svc := newMigSvcWithActive(t, "my-repo", "src-store", "tgt-store")
 	r := buildMigRouter(svc)
 
-	// Start first migration.
-	body := `{"targetStoreId":"tgt-store"}`
-	req1 := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/my-repo/migrate-blob-store", strings.NewReader(body))
-	req1.Header.Set("Content-Type", "application/json")
-	w1 := httptest.NewRecorder()
-	r.ServeHTTP(w1, req1)
-	if w1.Code != http.StatusCreated {
-		t.Fatalf("first Start: want 201 got %d body=%s", w1.Code, w1.Body.String())
-	}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/my-repo/migrate-blob-store",
+		strings.NewReader(`{"targetStoreId":"tgt-store"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
 
-	// Second start should conflict.
-	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/my-repo/migrate-blob-store", strings.NewReader(body))
-	req2.Header.Set("Content-Type", "application/json")
-	w2 := httptest.NewRecorder()
-	r.ServeHTTP(w2, req2)
-
-	if w2.Code != http.StatusConflict {
-		t.Fatalf("want 409 got %d body=%s", w2.Code, w2.Body.String())
+	if w.Code != http.StatusConflict {
+		t.Fatalf("want 409 got %d body=%s", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/db/migrations/027_blob_store_migration_unique_active.sql
+++ b/internal/db/migrations/027_blob_store_migration_unique_active.sql
@@ -1,0 +1,41 @@
+-- One active blob-store migration per repository, enforced by the database.
+--
+-- The service checked for an existing active migration with a SELECT and then
+-- INSERTed, with nothing between the two. The distributed lock that was meant
+-- to cover that window is a NoopLocker whenever Redis is not configured — the
+-- documented default — so two genuinely simultaneous requests both passed the
+-- check and both ran, each copying the whole dataset to its own destination and
+-- leaving the loser's copy orphaned but fully accounted for in used_bytes.
+--
+-- A partial unique index makes the second INSERT fail instead, which the
+-- repository translates into the same "already running" conflict the pre-check
+-- already returns. Finished rows are unconstrained: a repository can be
+-- migrated any number of times, one after another.
+
+-- +goose Up
+
+-- Any duplicates already in the table would block the index. They are the very
+-- rows this index exists to prevent, so all but the newest per repository are
+-- retired — the newest is the one whose destination the repository was left
+-- pointing at.
+UPDATE blob_store_migrations m
+SET status        = 'failed',
+    error_message = COALESCE(error_message, 'superseded by a concurrent migration of the same repository'),
+    finished_at   = COALESCE(finished_at, now()),
+    updated_at    = now()
+WHERE m.status IN ('pending', 'running')
+  AND m.id <> (
+      SELECT x.id
+      FROM blob_store_migrations x
+      WHERE x.repository_name = m.repository_name
+        AND x.status IN ('pending', 'running')
+      ORDER BY x.created_at DESC, x.id DESC
+      LIMIT 1
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS blob_store_migrations_one_active_per_repo
+    ON blob_store_migrations (repository_name)
+    WHERE status IN ('pending', 'running');
+
+-- +goose Down
+DROP INDEX IF EXISTS blob_store_migrations_one_active_per_repo;

--- a/internal/repository/postgres/blob_store_migration_repo.go
+++ b/internal/repository/postgres/blob_store_migration_repo.go
@@ -21,18 +21,29 @@ func NewBlobStoreMigrationRepo(db *pgxpool.Pool) *blobStoreMigrationRepo {
 	return &blobStoreMigrationRepo{db: db}
 }
 
+// activeMigrationConstraint is the partial unique index that allows only one
+// pending/running migration per repository (migration 027). It is the only real
+// guard on the check-then-insert in BlobStoreMigrationService.Start: without
+// Redis the distributed lock is a no-op, so two simultaneous requests otherwise
+// both pass the pre-check.
+const activeMigrationConstraint = "blob_store_migrations_one_active_per_repo"
+
 func (r *blobStoreMigrationRepo) Create(ctx context.Context, m *domain.BlobStoreMigration) error {
 	var sourceID *string
 	if m.SourceStoreID != "" {
 		sourceID = &m.SourceStoreID
 	}
-	return r.db.QueryRow(ctx, `
+	err := r.db.QueryRow(ctx, `
 		INSERT INTO blob_store_migrations
 		  (repository_name, source_store_id, target_store_id, status)
 		VALUES ($1, $2, $3, $4)
 		RETURNING id, created_at, updated_at`,
 		m.RepositoryName, sourceID, m.TargetStoreID, m.Status,
 	).Scan(&m.ID, &m.CreatedAt, &m.UpdatedAt)
+	if constraint, ok := uniqueViolation(err); ok && constraint == activeMigrationConstraint {
+		return &repository.UniqueViolationError{Field: "repository_name"}
+	}
+	return err
 }
 
 func (r *blobStoreMigrationRepo) Get(ctx context.Context, id string) (*domain.BlobStoreMigration, error) {

--- a/internal/repository/postgres/blob_store_migration_repo_integration_test.go
+++ b/internal/repository/postgres/blob_store_migration_repo_integration_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
@@ -58,6 +59,115 @@ func TestBlobStoreMigrationRepo_Create_PopulatesIDAndTimestamps(t *testing.T) {
 	}
 	if m.UpdatedAt.IsZero() {
 		t.Error("Create did not populate UpdatedAt")
+	}
+}
+
+// Migration 027's partial unique index is the only real guard on the
+// check-then-insert in BlobStoreMigrationService.Start — without Redis the
+// distributed lock is a no-op, so two simultaneous requests both pass the
+// pre-check and, before this index existed, both ran.
+func TestBlobStoreMigrationRepo_Create_OneActivePerRepo(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_store_migrations", "blob_stores")
+	ctx := context.Background()
+	bsRepo := NewBlobStoreRepo(pool)
+	repo := NewBlobStoreMigrationRepo(pool)
+
+	srcID, dstID := makeBSMParents(t, ctx, bsRepo, "one_active")
+
+	first := &domain.BlobStoreMigration{
+		RepositoryName: "one_active_repo", SourceStoreID: srcID,
+		TargetStoreID: dstID, Status: "pending",
+	}
+	if err := repo.Create(ctx, first); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	second := &domain.BlobStoreMigration{
+		RepositoryName: "one_active_repo", SourceStoreID: srcID,
+		TargetStoreID: dstID, Status: "pending",
+	}
+	err := repo.Create(ctx, second)
+	if !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatalf("second Create: want ErrAlreadyExists, got %v", err)
+	}
+
+	// 'running' collides with 'pending' too — both count as active.
+	if err := repo.UpdateStatus(ctx, first.ID, "running", nil); err != nil {
+		t.Fatalf("UpdateStatus(running): %v", err)
+	}
+	if err := repo.Create(ctx, second); !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatalf("Create against a running migration: want ErrAlreadyExists, got %v", err)
+	}
+
+	// Once it finishes, the repository can be migrated again, any number of
+	// times — the index only constrains active rows.
+	if err := repo.FinishMigration(ctx, first.ID, "done", nil); err != nil {
+		t.Fatalf("FinishMigration: %v", err)
+	}
+	if err := repo.Create(ctx, second); err != nil {
+		t.Fatalf("Create after the previous migration finished: %v", err)
+	}
+	third := &domain.BlobStoreMigration{
+		RepositoryName: "one_active_repo", SourceStoreID: srcID,
+		TargetStoreID: dstID, Status: "pending",
+	}
+	if err := repo.Create(ctx, third); !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatalf("third Create: want ErrAlreadyExists, got %v", err)
+	}
+
+	// A different repository is unaffected.
+	other := &domain.BlobStoreMigration{
+		RepositoryName: "one_active_other_repo", SourceStoreID: srcID,
+		TargetStoreID: dstID, Status: "pending",
+	}
+	if err := repo.Create(ctx, other); err != nil {
+		t.Fatalf("Create for a different repository: %v", err)
+	}
+}
+
+// The same guarantee under genuinely simultaneous inserts, which is how the bug
+// was reproduced: barrier-synchronized requests, no pre-check in between.
+func TestBlobStoreMigrationRepo_Create_ConcurrentInsertsOnlyOneWins(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_store_migrations", "blob_stores")
+	ctx := context.Background()
+	bsRepo := NewBlobStoreRepo(pool)
+	repo := NewBlobStoreMigrationRepo(pool)
+
+	srcID, dstID := makeBSMParents(t, ctx, bsRepo, "concurrent")
+
+	const racers = 8
+	start := make(chan struct{})
+	results := make(chan error, racers)
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			results <- repo.Create(ctx, &domain.BlobStoreMigration{
+				RepositoryName: "concurrent_repo", SourceStoreID: srcID,
+				TargetStoreID: dstID, Status: "pending",
+			})
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	won := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			won++
+		case errors.Is(err, repository.ErrAlreadyExists):
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if won != 1 {
+		t.Fatalf("want exactly 1 winning insert, got %d", won)
 	}
 }
 

--- a/internal/repository/postgres/errors.go
+++ b/internal/repository/postgres/errors.go
@@ -1,0 +1,22 @@
+package postgres
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// pgerrUniqueViolation is Postgres' SQLSTATE for a unique-constraint violation.
+const pgerrUniqueViolation = "23505"
+
+// uniqueViolation reports whether err is a unique-constraint violation and, if
+// so, which constraint raised it. A violation is a client-visible conflict, not
+// an internal failure, so repositories translate it instead of letting a raw
+// driver error — constraint name, SQLSTATE and all — reach the caller.
+func uniqueViolation(err error) (constraint string, ok bool) {
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != pgerrUniqueViolation {
+		return "", false
+	}
+	return pgErr.ConstraintName, true
+}

--- a/internal/repository/postgres/user_repo.go
+++ b/internal/repository/postgres/user_repo.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
@@ -83,13 +82,8 @@ func (r *userRepo) GetByID(ctx context.Context, id string) (*domain.User, error)
 	return u, nil
 }
 
-// pgerrUniqueViolation is Postgres' SQLSTATE for a unique-constraint violation.
-const pgerrUniqueViolation = "23505"
-
 // uniqueUserFields maps the users table's unique constraints to the field name
-// a caller would recognize. A violation is a client-visible conflict, not an
-// internal failure, so it is translated instead of surfacing as a raw driver
-// error — see translateUserUnique.
+// a caller would recognize.
 var uniqueUserFields = map[string]string{
 	"users_username_key":       "username",
 	"users_email_nonempty_key": "email",
@@ -99,12 +93,12 @@ var uniqueUserFields = map[string]string{
 // into repository.ErrAlreadyExists naming the offending field. Any other error
 // passes through untouched.
 func translateUserUnique(err error) error {
-	var pgErr *pgconn.PgError
-	if !errors.As(err, &pgErr) || pgErr.Code != pgerrUniqueViolation {
+	constraint, ok := uniqueViolation(err)
+	if !ok {
 		return err
 	}
-	field, ok := uniqueUserFields[pgErr.ConstraintName]
-	if !ok {
+	field, known := uniqueUserFields[constraint]
+	if !known {
 		return err
 	}
 	return &repository.UniqueViolationError{Field: field}

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -13,6 +13,11 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/storage"
 )
 
+// ErrMigrationAlreadyRunning is returned by Start when the repository already
+// has a pending or running migration — whether the pre-check saw it or the
+// database's partial unique index refused the insert.
+var ErrMigrationAlreadyRunning = errors.New("a migration is already running for this repository")
+
 // BlobStoreMigrationService manages background migrations of repository blobs
 // from one blob store to another.
 type BlobStoreMigrationService struct {
@@ -75,13 +80,18 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 		return nil, fmt.Errorf("target blob store is the same as the repository's current store")
 	}
 
-	// Enforce single active migration per repo.
+	// Enforce single active migration per repo. This pre-check answers the
+	// common case with a clear error; it is not the guarantee. Two simultaneous
+	// requests both pass it, and the distributed lock below cannot stop them
+	// either when Redis is absent — the default deployment, where the locker is
+	// a no-op. The database's partial unique index is what actually decides,
+	// and Create translates its violation into this same error.
 	active, err := s.migrations.GetActiveByRepo(ctx, repoName)
 	if err != nil && !errors.Is(err, repository.ErrNotFound) {
 		return nil, err
 	}
 	if active != nil {
-		return nil, fmt.Errorf("a migration is already running for this repository")
+		return nil, ErrMigrationAlreadyRunning
 	}
 
 	// Capture source store ID for the history record.
@@ -117,6 +127,12 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 		// blocked for the rest of its TTL.
 		if migLock != nil {
 			_ = migLock.Release(ctx)
+		}
+		// The request that lost the insert race: the row another request just
+		// wrote is exactly what the pre-check above looks for, so it gets the
+		// same answer it would have got a moment later.
+		if errors.Is(err, repository.ErrAlreadyExists) {
+			return nil, ErrMigrationAlreadyRunning
 		}
 		return nil, fmt.Errorf("create migration record: %w", err)
 	}

--- a/internal/service/blob_store_migration_service_test.go
+++ b/internal/service/blob_store_migration_service_test.go
@@ -2,11 +2,14 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
@@ -261,5 +264,96 @@ func TestBlobStoreMigration_CompletesWithBlobCopyAndResume(t *testing.T) {
 	_ = m
 	if final.Status != "done" {
 		t.Errorf("final status = %q; want %q", final.Status, "done")
+	}
+}
+
+// The pre-check is not the guarantee: two simultaneous requests both pass it,
+// and without Redis the distributed lock is a no-op. The request that loses the
+// insert race must get the same conflict, not a raw constraint error — and only
+// one migration may exist, since both would otherwise copy the whole dataset,
+// each to its own destination.
+func TestBlobStoreMigration_StartLosesInsertRace_ReportsConflict(t *testing.T) {
+	ctx := context.Background()
+
+	sourceID := "store-src-001"
+	targetID := "store-tgt-002"
+	bsID := sourceID
+	repo := &domain.Repository{
+		ID: "repo-001", Name: "my-repo", Format: domain.RepoFormat("raw"),
+		Type: domain.TypeHosted, Online: true, BlobStoreID: &bsID,
+	}
+
+	migRepo := testutil.NewBlobStoreMigrationRepo()
+	// The pre-check finds nothing (no row yet), so the conflict can only come
+	// from the insert — exactly the state of the request that arrives second.
+	migRepo.CreateErr = &repository.UniqueViolationError{Field: "repository_name"}
+
+	svc := service.NewBlobStoreMigrationService(
+		migRepo, testutil.NewAssetRepo(), testutil.NewRepoRepo(repo),
+		testutil.NewBlobStoreRepo(
+			&domain.BlobStore{ID: sourceID, Name: "source-store", Type: "local"},
+			&domain.BlobStore{ID: targetID, Name: "target-store", Type: "local"},
+		),
+		storage.NewRegistry(testutil.NewBlobStore()),
+	)
+
+	_, err := svc.Start(ctx, "my-repo", targetID)
+	if !errors.Is(err, service.ErrMigrationAlreadyRunning) {
+		t.Fatalf("want ErrMigrationAlreadyRunning, got %v", err)
+	}
+}
+
+// Barrier-synchronized concurrent starts: whichever layer catches it, exactly
+// one migration may be created.
+func TestBlobStoreMigration_ConcurrentStarts_OnlyOneWins(t *testing.T) {
+	ctx := context.Background()
+
+	sourceID := "store-src-001"
+	bsID := sourceID
+	repo := &domain.Repository{
+		ID: "repo-001", Name: "my-repo", Format: domain.RepoFormat("raw"),
+		Type: domain.TypeHosted, Online: true, BlobStoreID: &bsID,
+	}
+	migRepo := testutil.NewBlobStoreMigrationRepo()
+	svc := service.NewBlobStoreMigrationService(
+		migRepo, testutil.NewAssetRepo(), testutil.NewRepoRepo(repo),
+		testutil.NewBlobStoreRepo(
+			&domain.BlobStore{ID: sourceID, Name: "source-store", Type: "local"},
+			&domain.BlobStore{ID: "store-tgt-a", Name: "target-a", Type: "local"},
+			&domain.BlobStore{ID: "store-tgt-b", Name: "target-b", Type: "local"},
+		),
+		storage.NewRegistry(testutil.NewBlobStore()),
+	)
+
+	// Two different destinations, the way two operators would pick them.
+	targets := []string{"store-tgt-a", "store-tgt-b"}
+	start := make(chan struct{})
+	results := make(chan error, len(targets))
+	var wg sync.WaitGroup
+	for _, target := range targets {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := svc.Start(ctx, "my-repo", target)
+			results <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	created := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			created++
+		case errors.Is(err, service.ErrMigrationAlreadyRunning):
+		default:
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if created != 1 {
+		t.Fatalf("want exactly 1 migration created, got %d", created)
 	}
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -2101,6 +2101,16 @@ func (r *BlobStoreMigrationRepo) Create(_ context.Context, m *domain.BlobStoreMi
 	if r.CreateErr != nil {
 		return r.CreateErr
 	}
+	// Mirror migration 027's partial unique index: at most one pending/running
+	// migration per repository, with finished rows unconstrained.
+	if m.Status == "pending" || m.Status == "running" {
+		for _, existing := range r.migrations {
+			if existing.RepositoryName == m.RepositoryName &&
+				(existing.Status == "pending" || existing.Status == "running") {
+				return &repository.UniqueViolationError{Field: "repository_name"}
+			}
+		}
+	}
 	if m.ID == "" {
 		m.ID = fmt.Sprintf("mig-%d", len(r.migrations)+1)
 	}


### PR DESCRIPTION
Closes #286.

`Start` guarded "one active migration per repository" with a `SELECT` (`GetActiveByRepo`) followed by an `INSERT`, with nothing in between. The `distlock.Locker` meant to cover that window is a `NoopLocker` whenever Redis is not configured — the documented default — so two genuinely simultaneous requests both passed the pre-check and both ran, each copying the entire dataset to its own destination. The repository was left pointing at whichever finished last, with the loser's copy orphaned but still counted in `used_bytes`.

## The fix

Migration **027** adds a partial unique index on `repository_name` for rows in `pending`/`running`, so the second `INSERT` fails instead. `blobStoreMigrationRepo.Create` translates that violation into `repository.ErrAlreadyExists`, and `Start` answers with the same `ErrMigrationAlreadyRunning` the pre-check already returns.

The pre-check stays: it answers the ordinary, non-racing case without making the database raise an error. It just isn't the guarantee any more.

Finished rows are unconstrained — a repository can still be migrated any number of times in sequence.

**Applying to a database that already hit this bug:** the migration retires duplicate active rows before creating the index (all but the newest per repository — the one whose destination the repository was left pointing at), so `CREATE UNIQUE INDEX` cannot fail on existing data.

## Also in here

- The unique-violation decoding that `user_repo.go` carried (from #287) moves to a shared `postgres/errors.go`, now that a second repository needs it.
- The handler classifies the conflict with `errors.Is` instead of `strings.Contains(msg, "already running")`.
- `testutil`'s migration repo mirrors the new constraint, so the guarantee is exercised without a live database.
- **A flaky test fixed:** `TestBlobStoreMigrationHandler_Start_409` started a first migration and expected the second request to conflict — but an empty repository migrates in microseconds, so once the first finished, the repository already pointed at the target and the second request got `400` ("same as") instead of the conflict under test. It fails reproducibly under `-race` on `main`. It now seeds the active migration instead of racing its own fixture.

## What I did not change

`NoopLocker` stays a no-op. The issue offered giving it in-process exclusion as an alternative, but it backs several unrelated features, and turning a lock that always succeeds into one that can block has a much wider blast radius than an index that constrains exactly the rows in question. With the index in place, both layers now stop the race independently when Redis *is* configured.

## Testing

- `go test ./...` — green (`TestWebhookHandler_Test_200` fails from a sandbox network denial, on `main` as well).
- `golangci-lint run` — clean.
- Two new integration tests against real Postgres: one covering the pending/running/finished transitions and repository isolation, one firing 8 barrier-synchronized concurrent inserts and asserting exactly one wins. Left for CI to run — Docker is unavailable in this environment.
- The service-level concurrency test was run against the unfixed code and reproduced the reported bug exactly (2 migrations created); the insert-race mapping test failed with the raw constraint error before the fix.

One pre-existing `-race` failure remains on `main`, untouched here: `TestExtraCleanup_ReloadPolicy_DisabledRemovesEntry` mutates the policy struct the scheduler goroutine is reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZasUK9neHh8p3by4Pcqe