### PR TITLE
fix(ui): stop async responses from landing in the wrong slot after a selection change

### DIFF
--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -527,6 +527,52 @@ describe('AdminPage — Replication tab', () => {
     expect(await screen.findByText('Started')).toBeInTheDocument()
   })
 
+  // The history viewer kept one shared array, so a request for the rule that was
+  // open first resolved later and overwrote it — rendering the earlier rule's
+  // runs under the newly opened rule's header, which misattributes a broken
+  // target's failures to a healthy one and the other way round.
+  it('never renders one rule\'s history under another rule\'s header', async () => {
+    const user = userEvent.setup()
+    const ruleB = { ...repRule, id: 're-2', name: 'mirror-b', source_repo: 'npm-hosted' }
+    let releaseA: (() => void) | undefined
+    const aHeld = new Promise<void>((resolve) => { releaseA = resolve })
+    const run = (id: string, pushed: number) => ({
+      id, rule_id: id, started_at: new Date().toISOString(), finished_at: null,
+      duration_ms: 1500, pushed_count: pushed, skipped_count: 0, failed_count: 0,
+      transferred_bytes: 2048, error: '',
+    })
+
+    server.use(
+      http.get('/api/v1/replication/rules', () => HttpResponse.json([repRule, ruleB])),
+      http.get('/api/v1/replication/rules/:id/history', async ({ params }) => {
+        if (params.id === 're-1') {
+          await aHeld
+          return HttpResponse.json([run('h-a', 111)])
+        }
+        return HttpResponse.json([run('h-b', 222)])
+      }),
+    )
+
+    renderAdmin('replication')
+    await screen.findByText('mirror')
+
+    // Open rule A, then switch to rule B before A's history has arrived.
+    const historyButtons = screen.getAllByTitle('History')
+    await user.click(historyButtons[0])
+    await user.click(historyButtons[1])
+    expect(await screen.findByText('222')).toBeInTheDocument()
+
+    // A's response lands afterwards and must not reach B's panel.
+    releaseA?.()
+    await waitFor(() => expect(screen.queryByText('Loading history…')).not.toBeInTheDocument())
+    expect(screen.queryByText('111')).not.toBeInTheDocument()
+    expect(screen.getByText('222')).toBeInTheDocument()
+
+    // Reopening A shows A's own runs.
+    await user.click(screen.getAllByTitle('History')[0])
+    expect(await screen.findByText('111')).toBeInTheDocument()
+  })
+
   it('runs and tests a rule', async () => {
     const user = userEvent.setup()
     let ran = false

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -347,8 +347,13 @@ function ReplicationTab() {
   const [modalOpen, setModalOpen] = useState(false)
   const [editing, setEditing] = useState<ReplicationRule | null>(null)
   const [expandedId, setExpandedId] = useState<string | null>(null)
-  const [history, setHistory] = useState<ReplicationHistory[]>([])
-  const [histLoading, setHistLoading] = useState(false)
+  // Keyed by rule id, not a single shared array: a history request that resolves
+  // after the user has closed one rule and opened another used to overwrite the
+  // shared array unconditionally, so the earlier rule's runs were rendered under
+  // the newly expanded rule's header — misattributing a broken target's failures
+  // to a healthy one, or the reverse.
+  const [history, setHistory] = useState<Record<string, ReplicationHistory[]>>({})
+  const [histLoadingId, setHistLoadingId] = useState<string | null>(null)
   const [testResult, setTestResult] = useState<Record<string, string>>({})
 
   const [form, setForm] = useState<ReplicationRuleInput>({
@@ -401,12 +406,14 @@ function ReplicationTab() {
   async function toggleHistory(rule: ReplicationRule) {
     if (expandedId === rule.id) { setExpandedId(null); return }
     setExpandedId(rule.id)
-    setHistLoading(true)
+    setHistLoadingId(rule.id)
     try {
       const r = await nexspenceApi.listReplicationHistory(rule.id)
-      setHistory(r.data ?? [])
+      // Stored under the rule this request was made for, whatever is expanded
+      // by the time it resolves.
+      setHistory(prev => ({ ...prev, [rule.id]: r.data ?? [] }))
     } finally {
-      setHistLoading(false)
+      setHistLoadingId(cur => (cur === rule.id ? null : cur))
     }
   }
 
@@ -503,11 +510,11 @@ function ReplicationTab() {
 
           {expandedId === rule.id && (
             <div style={{ marginTop: 12, borderTop: '1px solid rgba(255,255,255,0.06)', paddingTop: 10 }}>
-              {histLoading && <p style={{ color: '#64748b', fontSize: 12 }}>Loading history…</p>}
-              {!histLoading && history.length === 0 && (
+              {histLoadingId === rule.id && <p style={{ color: '#64748b', fontSize: 12 }}>Loading history…</p>}
+              {histLoadingId !== rule.id && (history[rule.id]?.length ?? 0) === 0 && (
                 <p style={{ color: '#64748b', fontSize: 12 }}>No runs recorded yet.</p>
               )}
-              {!histLoading && history.length > 0 && (
+              {histLoadingId !== rule.id && (history[rule.id]?.length ?? 0) > 0 && (
                 <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
                   <thead>
                     <tr style={{ color: '#64748b', textAlign: 'left' }}>
@@ -521,7 +528,7 @@ function ReplicationTab() {
                     </tr>
                   </thead>
                   <tbody>
-                    {history.map(h => (
+                    {(history[rule.id] ?? []).map(h => (
                       <tr key={h.id} style={{ color: '#94a3b8', borderTop: '1px solid rgba(255,255,255,0.04)' }}>
                         <td style={{ padding: '4px 8px' }}>{fmtDate(h.started_at)}</td>
                         <td style={{ padding: '4px 8px' }}>{fmtDur(h.duration_ms)}</td>

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { screen, waitFor, fireEvent, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
+import { QueryClient } from '@tanstack/react-query'
 import BrowsePage from './BrowsePage'
 import { renderWithProviders, seedAuthAsAdmin } from '@/test/renderUtils'
 import { server } from '@/test/msw/server'
@@ -15,8 +16,11 @@ const repos = [
   fixtures.repository({ id: 'r4', name: 'oci-hosted', format: 'oci', type: 'hosted' }),
 ]
 
-function renderBrowse(search = '') {
-  return renderWithProviders(<BrowsePage />, { routerProps: { initialEntries: [`/browse${search}`] } })
+function renderBrowse(search = '', queryClient?: QueryClient) {
+  return renderWithProviders(<BrowsePage />, {
+    routerProps: { initialEntries: [`/browse${search}`] },
+    queryClient,
+  })
 }
 
 function seedRepos() {
@@ -399,6 +403,7 @@ describe('BrowsePage — Docker tree', () => {
             {
               kind: 'folder', label: 'Tags', path: '/myapp/Tags', children: [
                 { kind: 'tag', label: 'latest', path: '/myapp/Tags/latest', imageRef: 'myapp', version: 'latest', componentId: 'dc1' },
+                { kind: 'tag', label: 'stable', path: '/myapp/Tags/stable', imageRef: 'myapp', version: 'stable', componentId: 'dc2' },
               ],
             },
           ],
@@ -416,7 +421,14 @@ describe('BrowsePage — Docker tree', () => {
   function seedDocker() {
     server.use(
       http.get('/api/v1/browse/repositories/:name/docker-tree', () => HttpResponse.json(dockerTree)),
-      http.get('/service/rest/v1/components/:id', () => HttpResponse.json(dockerDetail)),
+      // The detail follows the requested id, so selecting a second tag really
+      // changes what the panel is describing.
+      http.get('/service/rest/v1/components/:id', ({ params }) =>
+        HttpResponse.json(
+          params.id === 'dc1'
+            ? dockerDetail
+            : { ...dockerDetail, id: String(params.id), version: 'stable' },
+        )),
     )
   }
 
@@ -534,6 +546,82 @@ describe('BrowsePage — Docker tree', () => {
     await user.click(screen.getByRole('button', { name: /Scan now/ }))
     expect(await screen.findByText('CRITICAL: 1')).toBeInTheDocument()
     expect(screen.getByText('openssl')).toBeInTheDocument()
+  })
+
+  // A scan can take minutes, and the detail panel is not remounted when another
+  // tag is selected — so its mutation used to resolve into a render describing a
+  // different component and write the finished scan into that component's cache
+  // entry, which then displayed another image's vulnerabilities as its own.
+  it('never writes a finished scan into the tag selected while it ran', async () => {
+    const user = userEvent.setup()
+    seedDocker()
+    let releaseScan: (() => void) | undefined
+    const scanStarted = new Promise<void>((resolve) => { releaseScan = resolve })
+    const latestResult = {
+      scannedAt: new Date().toISOString(), imageRef: 'myapp:latest', status: 'ok',
+      summary: { critical: 1, high: 0, medium: 0, low: 0, unknown: 0, total: 1 },
+      findings: [{ id: 'CVE-LATEST-ONLY', severity: 'CRITICAL', pkgName: 'openssl', installedVersion: '1.0', fixedVersion: '1.1', title: 'bad' }],
+    }
+    let latestScanned = false
+    server.use(
+      // Like the real endpoint: a result exists only for a component that has
+      // actually been scanned.
+      http.get('/api/v1/components/:id/scan', ({ params }) =>
+        params.id === 'dc1' && latestScanned
+          ? HttpResponse.json(latestResult)
+          : new HttpResponse(null, { status: 204 })),
+      http.post('/api/v1/components/:id/scan', async () => {
+        // Held open until the test has switched tags, standing in for the real
+        // multi-minute scan.
+        await scanStarted
+        latestScanned = true
+        return HttpResponse.json(latestResult)
+      }),
+    )
+
+    // The shared test client sets gcTime: 0, which drops a component's detail
+    // the moment it loses its observer — so every tag switch would remount the
+    // panel and, with it, tear down the in-flight scan. Real users have the
+    // default cache, where the panel survives the switch. That survival is the
+    // whole precondition for this bug, so this test keeps a real cache.
+    const qc = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    })
+    renderBrowse('?repo=docker-hosted', qc)
+    await user.click(await screen.findByText('myapp'))
+    await user.click(await screen.findByText('Tags'))
+
+    // Visit both tags first so their details are cached: that is what keeps the
+    // detail panel — and the scan row inside it — mounted across the switch
+    // below, instead of remounting through a loading state.
+    await user.click(await screen.findByText('stable'))
+    await screen.findByText('Vulnerability scan')
+    await user.click(screen.getByText('latest'))
+    await screen.findByText('Vulnerability scan')
+
+    await user.click(screen.getByRole('button', { name: /Scan now/ }))
+
+    // Switch to the other tag while the scan is still running.
+    await user.click(screen.getByText('stable'))
+    expect(await screen.findByText('Not scanned yet')).toBeInTheDocument()
+
+    releaseScan?.()
+
+    // The result lands on the tag it was started for — which also waits for the
+    // scan to have settled.
+    await user.click(screen.getByText('latest'))
+    expect(await screen.findByText('CRITICAL: 1')).toBeInTheDocument()
+
+    // The scan landed in the cache entry of the component it was started for,
+    // and nothing was written into the one selected while it ran.
+    expect(qc.getQueryData(['scanResult', 'dc1'])).toBeTruthy()
+    expect(qc.getQueryData(['scanResult', 'dc2'])).toBeFalsy()
+
+    // And 'stable' still shows its own state, not the finished scan of 'latest'.
+    await user.click(screen.getByText('stable'))
+    expect(await screen.findByText('Not scanned yet')).toBeInTheDocument()
+    expect(screen.queryByText('CVE-LATEST-ONLY')).not.toBeInTheDocument()
+    expect(screen.queryByText('CRITICAL: 1')).not.toBeInTheDocument()
   })
 
   // A malicious-package report has no CVSS severity. Without a badge of its own

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -215,13 +215,24 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
     retry: false,
   })
 
+  // The scanned component id travels with the mutation instead of being read
+  // from the closure. This row survives a selection change — it has no key tied
+  // to the selected component — so a scan that takes minutes resolves into a
+  // render whose componentId is whatever is selected by then. Closing over it
+  // wrote one image's vulnerabilities into another image's cache entry, which
+  // then displayed them as its own: an admin could read an image as clean, or
+  // as carrying CVEs, that belong to something else entirely. React Query pins
+  // mutation variables to the call that started them, so they cannot drift.
   const scanMutation = useMutation({
-    mutationFn: () => nexspenceApi.scanComponent(componentId),
-    onSuccess: (response) => {
+    mutationFn: (id: string) => nexspenceApi.scanComponent(id),
+    onSuccess: (response, scannedId) => {
+      queryClient.setQueryData(['scanResult', scannedId], response.data as ScanResult)
+      // Local view state belongs to the row on screen, so it is only reset when
+      // the result that arrived is the one being displayed.
+      if (scannedId !== componentId) return
       setMutationError(null)
       setSevFilter('ALL')
       setElapsed(0)
-      queryClient.setQueryData(queryKey, response.data as ScanResult)
     },
     onError: (e: unknown) => {
       const msg =
@@ -231,11 +242,15 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
     },
   })
 
+  // "Scanning…" belongs to the component the in-flight scan was started for, not
+  // to whichever one is selected while it runs.
+  const isScanningThis = scanMutation.isPending && scanMutation.variables === componentId
+
   useEffect(() => {
-    if (!scanMutation.isPending) { setElapsed(0); return }
+    if (!isScanningThis) { setElapsed(0); return }
     const t = setInterval(() => setElapsed((n) => n + 1), 1000)
     return () => clearInterval(t)
-  }, [scanMutation.isPending])
+  }, [isScanningThis])
 
   const s = scanResult?.summary
   const findings = scanResult?.findings ?? []
@@ -247,7 +262,7 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
         <ShieldAlert size={14} style={{ color: '#60a5fa', flexShrink: 0 }} />
         <span style={{ fontSize: 12, color: 'var(--holo-text-dim)' }}>Vulnerability scan</span>
-        {!scanMutation.isPending && scanResult && (
+        {!isScanningThis && scanResult && (
           <span style={{ fontSize: 11, color: 'var(--holo-text-faint)' }}>
             {new Date(scanResult.scannedAt).toLocaleString()}
           </span>
@@ -256,29 +271,29 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
           variant="primary"
           onClick={() => {
             setMutationError(null)
-            scanMutation.mutate()
+            scanMutation.mutate(componentId)
           }}
-          disabled={scanMutation.isPending}
+          disabled={isScanningThis}
           style={{ marginLeft: 'auto', fontSize: 11, padding: '3px 10px' }}
         >
-          {scanMutation.isPending ? `Scanning… ${fmtElapsed(elapsed)}` : 'Scan now'}
+          {isScanningThis ? `Scanning… ${fmtElapsed(elapsed)}` : 'Scan now'}
         </HoloButton>
       </div>
       {mutationError && (
         <span style={{ fontSize: 11, color: '#ef4444' }}>Error: {mutationError}</span>
       )}
-      {scanMutation.isPending && (
+      {isScanningThis && (
         <span style={{ fontSize: 11, color: 'var(--holo-text-faint)', lineHeight: 1.4 }}>
           Running Trivy vulnerability scan
           {elapsed >= 20 && ' — first run downloads the vulnerability DB (~2 min)'}
           {elapsed >= 90 && '; please wait…'}
         </span>
       )}
-      {!scanMutation.isPending && isLoading ? (
+      {!isScanningThis && isLoading ? (
         <span style={{ fontSize: 11, color: 'var(--holo-text-faint)' }}>Loading…</span>
-      ) : !scanMutation.isPending && scanResult?.status === 'failed' ? (
+      ) : !isScanningThis && scanResult?.status === 'failed' ? (
         <span style={{ fontSize: 11, color: '#ef4444' }}>Scan failed: {scanResult.error}</span>
-      ) : !scanMutation.isPending && s ? (
+      ) : !isScanningThis && s ? (
         <>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
             <CveBadge label="MALICIOUS" count={s.malicious} color={SEV_COLOR.malicious} />
@@ -381,7 +396,7 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
             </div>
           )}
         </>
-      ) : !scanMutation.isPending ? (
+      ) : !isScanningThis ? (
         <span style={{ fontSize: 11, color: 'var(--holo-text-faint)' }}>Not scanned yet</span>
       ) : null}
     </div>


### PR DESCRIPTION
Closes #280 — two unrelated components with one root cause: a component that survives a selection change launches a request, then re-renders with new props before it resolves, and the success path writes the response into whichever slot is selected by then instead of the one it belongs to.

## Instance 1 — a scan result attributed to the wrong image

`ScanBadgeRow`'s mutation closed over `componentId` and its derived query key. A real scan takes minutes — longer on the first run, which downloads the vulnerability DB — and the detail panel is not remounted when an already-cached tag is selected, so the mutation resolved into a render describing a different component and cached the finished scan under it. That panel then displayed another image's vulnerabilities as its own: an admin could read an image as clean, or as carrying particular CVEs, when the data belonged to something else.

The scanned id now travels as the mutation's variable — React Query pins those to the call that started them — and the cache write is keyed off that. Two smaller consequences of the same drift are fixed alongside: the row's local view state (severity filter, error, elapsed timer) is only reset when the arriving result is the one on screen, and `Scanning…` now shows on the component actually being scanned rather than on whichever one is selected while it runs.

## Instance 2 — replication history under a different rule's header

`toggleHistory` kept one shared array with no sequence guard or abort, so a request for the rule opened first could resolve after the user opened another and overwrite it — rendering the earlier rule's runs under the newly opened rule's header, misattributing a broken target's failures to a healthy one or the reverse. History is now keyed by rule id, the way `SecurityPage`'s `rolePrivCache` already does it, and the loading flag names the rule it belongs to.

## Notes for review

The scan test earns its length. Two things had to be true before it could see the bug at all, and I only found them by running it against the unfixed code:

1. **It asserts the cache slots directly** (`qc.getQueryData(['scanResult', 'dc2'])`), not just the rendered panel. At the render level the wrong write was masked — the other component's own scan GET refetched and cleared it a moment later — so a purely visual assertion passed against the broken code.
2. **It uses a real `QueryClient`** instead of the suite's shared one. `renderUtils` sets `gcTime: 0`, which drops a component's detail the instant it loses its observer, so every tag switch remounted the panel and tore down the in-flight mutation — the callback never fired, and nothing could be observed. Real users have the default cache, where the panel survives the switch; that survival is the precondition for the bug.

`renderBrowse` now takes an optional client so this one test can opt out; every other test keeps the shared one.

## Testing

- `npm test` — 529 tests across 30 files, green.
- `tsc --noEmit` and `eslint` — clean.
- Both new tests were run against the unfixed code and failed; the reverted fixes were then restored and they pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZasUK9neHh8p3by4Pcqe