### PR TITLE
fix(replication): read each asset from the store it actually lives on

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -193,6 +193,9 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	}
 
 	replSvc := service.NewReplicationService(replRepo, assetRepo, localBlob, cfg.Auth.JWTSecret, cfg.Auth.EncryptionKeyBytes(), log)
+	// Read each asset from its own physical store, so replication keeps working
+	// once a repository is pointed at S3 or a second local store.
+	replSvc.WithResolver(blobRepo, blobRegistry)
 	go replSvc.StartCronScheduler(ctx)
 
 	promotionSvc, err := service.NewPromotionService(

--- a/internal/service/replication_service.go
+++ b/internal/service/replication_service.go
@@ -30,6 +30,8 @@ type ReplicationService struct {
 	repo       repository.ReplicationRepo
 	assets     repository.AssetRepo
 	blobStore  storage.BlobStore
+	blobs      repository.BlobStoreRepo
+	resolver   StoreResolver
 	primaryKey []byte // seals all new ciphertexts
 	legacyKey  []byte // sha256(jwt_secret) fallback; nil when no dedicated key is set
 	log        logger.Logger
@@ -72,6 +74,34 @@ func NewReplicationService(
 		s.primaryKey = legacy
 	}
 	return s
+}
+
+// WithResolver sets the blob-store repo and resolver so an asset is read from
+// the physical store it actually lives on (S3, a second local store, ...)
+// rather than the injected default. Without it the service falls back to
+// blobStore, which is only correct while every asset sits in the default store.
+func (s *ReplicationService) WithResolver(blobs repository.BlobStoreRepo, r StoreResolver) *ReplicationService {
+	s.blobs = blobs
+	s.resolver = r
+	return s
+}
+
+// storeForAsset resolves the physical blob store an asset lives on, falling
+// back to the default store when no resolver is configured, the asset carries
+// no store id, or resolution fails.
+func (s *ReplicationService) storeForAsset(ctx context.Context, a domain.Asset) storage.BlobStore {
+	if s.resolver == nil || s.blobs == nil || a.BlobStoreID == "" {
+		return s.blobStore
+	}
+	bs, err := s.blobs.GetByID(ctx, a.BlobStoreID)
+	if err != nil || bs == nil {
+		return s.blobStore
+	}
+	store, err := s.resolver.Get(ctx, storage.BlobStoreDescriptor{ID: bs.ID, Type: bs.Type, Config: bs.Config})
+	if err != nil || store == nil {
+		return s.blobStore
+	}
+	return store
 }
 
 // WithHTTPClientFactory overrides how HTTP clients are built (by timeout).
@@ -427,7 +457,7 @@ func (s *ReplicationService) listTargetPaths(ctx context.Context, rule *domain.R
 
 // pushAsset streams one blob to the target. Returns (pushed, bytes, error).
 func (s *ReplicationService) pushAsset(ctx context.Context, client *http.Client, rule *domain.ReplicationRule, password string, asset domain.Asset) (bool, int64, error) {
-	rc, size, err := s.blobStore.Get(ctx, asset.BlobKey)
+	rc, size, err := s.storeForAsset(ctx, asset).Get(ctx, asset.BlobKey)
 	if err != nil {
 		return false, 0, fmt.Errorf("fetch blob %s: %w", asset.BlobKey, err)
 	}

--- a/internal/service/replication_service_internal_test.go
+++ b/internal/service/replication_service_internal_test.go
@@ -81,7 +81,7 @@ func TestReplicationService_PushAsset_ReadsAssetsOwnStore(t *testing.T) {
 }
 
 // No resolver configured (or an asset with no store id) keeps the old
-// behaviour: read from the injected default store.
+// behavior: read from the injected default store.
 func TestReplicationService_PushAsset_FallsBackToDefaultStore(t *testing.T) {
 	defaultStore := testutil.NewBlobStore()
 	require.NoError(t, defaultStore.Put(context.Background(), "k", testutil.MakeReader("default-bytes"), 13))

--- a/internal/service/replication_service_internal_test.go
+++ b/internal/service/replication_service_internal_test.go
@@ -2,12 +2,17 @@ package service
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
@@ -27,4 +32,75 @@ func TestReplicationService_RunRule_RefusesConcurrentRun(t *testing.T) {
 
 	err := svc.RunRule(context.Background(), rule.ID)
 	require.ErrorContains(t, err, "already running")
+}
+
+// idResolver hands out a different physical store per blob-store id, the way a
+// real registry does once an operator adds a second store.
+type idResolver map[string]storage.BlobStore
+
+func (r idResolver) Get(_ context.Context, d storage.BlobStoreDescriptor) (storage.BlobStore, error) {
+	s, ok := r[d.ID]
+	if !ok {
+		return nil, errors.New("no store for " + d.ID)
+	}
+	return s, nil
+}
+
+// An asset living outside the default store must be read from its own store:
+// replication used to always read the injected default one, so every asset on
+// a second store failed with "blob not found" — or pushed whatever unrelated
+// bytes happened to share the key in the default store (#299).
+func TestReplicationService_PushAsset_ReadsAssetsOwnStore(t *testing.T) {
+	defaultStore := testutil.NewBlobStore()
+	s3Store := testutil.NewBlobStore()
+	require.NoError(t, defaultStore.Put(context.Background(), "k", testutil.MakeReader("stale-default-bytes"), 19))
+	require.NoError(t, s3Store.Put(context.Background(), "k", testutil.MakeReader("real-bytes"), 10))
+
+	s3 := &domain.BlobStore{ID: "store-s3", Name: "s3", Type: "s3"}
+	blobs := testutil.NewBlobStoreRepo(s3)
+
+	svc := NewReplicationService(testutil.NewReplicationRepo(), testutil.NewAssetRepo(), defaultStore,
+		"test-secret", nil, zap.NewNop().Sugar())
+	svc.WithResolver(blobs, idResolver{"store-s3": s3Store})
+
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	rule := &domain.ReplicationRule{TargetURL: srv.URL, TargetRepo: "dst"}
+	asset := domain.Asset{Path: "/a.jar", BlobKey: "k", BlobStoreID: "store-s3", SizeBytes: 10}
+
+	pushed, n, err := svc.pushAsset(context.Background(), srv.Client(), rule, "", asset)
+	require.NoError(t, err)
+	require.True(t, pushed)
+	require.Equal(t, int64(10), n)
+	require.Equal(t, "real-bytes", string(got))
+}
+
+// No resolver configured (or an asset with no store id) keeps the old
+// behaviour: read from the injected default store.
+func TestReplicationService_PushAsset_FallsBackToDefaultStore(t *testing.T) {
+	defaultStore := testutil.NewBlobStore()
+	require.NoError(t, defaultStore.Put(context.Background(), "k", testutil.MakeReader("default-bytes"), 13))
+
+	svc := NewReplicationService(testutil.NewReplicationRepo(), testutil.NewAssetRepo(), defaultStore,
+		"test-secret", nil, zap.NewNop().Sugar())
+
+	var got []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	rule := &domain.ReplicationRule{TargetURL: srv.URL, TargetRepo: "dst"}
+	asset := domain.Asset{Path: "/a.jar", BlobKey: "k", SizeBytes: 13}
+
+	pushed, _, err := svc.pushAsset(context.Background(), srv.Client(), rule, "", asset)
+	require.NoError(t, err)
+	require.True(t, pushed)
+	require.Equal(t, "default-bytes", string(got))
 }


### PR DESCRIPTION
Closes #299.

`ReplicationService` held a single fixed `blobStore` and called `Get` on it for every asset, ignoring `asset.BlobStoreID`. It was the only blob-touching service not given the registry — `cleanup`, `gc`, `promotion` and `blobMigSvc` all receive `blobRegistry` in `router.go`. With a second blob store configured, replication of any asset on it fails with `blob not found`, or silently pushes unrelated bytes that happen to share the key in the default store.

## Change

- `ReplicationService.WithResolver(blobs, resolver)`, mirroring `CleanupService.WithResolver`.
- `storeForAsset` resolves the physical store from `asset.BlobStoreID`; `pushAsset` reads through it.
- `router.go` wires `blobRepo` + `blobRegistry` into the service.

Fallback is unchanged behaviour: no resolver, no store id, or a failed lookup all fall back to the injected default store, so single-store deployments are untouched.

## Tests

Two new internal tests: an asset on a second store is read from that store (fails on `main` — it reads the default store's stale bytes), and the no-resolver path still reads the default store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcrsCyNcvsEKp881db5JL