### PR TITLE
fix(migrations): stop stranding source bytes and repointing rows at stale copies

### DIFF
--- a/SECURITY-AUDIT-2026-08-03.md
+++ b/SECURITY-AUDIT-2026-08-03.md
@@ -1,0 +1,211 @@
+# Security audit — nexspence
+
+**Date:** 2026-08-03 · **Commit:** `v1.25.0` (main) · **Scope:** Go backend (31.6k LOC), React frontend (14k LOC), Dockerfiles, compose, CI
+
+---
+
+## How this was produced
+
+| Layer | Tool / method | Result |
+|---|---|---|
+| Go SAST | `gosec` (154 files, 31k lines) | 23 findings — **all pre-annotated with justified `//nolint`**. No new issues. |
+| Go deps | `govulncheck` | 0 reachable vulnerabilities. |
+| JS deps | `npm audit` | 3 high (see M-8). |
+| Secrets | `gitleaks` (192 commits, 8.15 MB) | 210 hits — **all documentation examples, test fixtures, or placeholders. No real secret ever committed.** |
+| IaC / containers | `trivy config` | 1 high (`website/Dockerfile` runs as root). |
+| Manual review | auth, RBAC, path handling, SSRF, crypto, archive handling, CORS, CSP, session, SQL | findings below |
+
+Automated tooling was effectively clean. **Everything meaningful below came from manual review** — which is the expected shape for a codebase that has already been through static analysis.
+
+---
+
+## Findings
+
+Severity reflects impact **in the deployment shape the project ships by default** (docker-compose quick start), not the best-case hardened config.
+
+### HIGH
+
+#### H-1 · `auth.anonymous_enabled` is a control that does nothing
+`internal/config/config.go:405` defaults it to `true`, and `cmd/server/main.go:69` is the **only** place it is read — to print a warning. It is never consulted in any authorization path.
+
+```
+internal/service/rbac_service.go:31
+    if repo.AllowAnonymous && isReadAction(action) { return true, nil }
+```
+
+Anonymous access is decided purely per-repository. An operator who sets `anonymous_enabled: false` to lock the instance down gets a config that silently changes nothing — the most dangerous class of security bug, because it converts a real control into a false sense of safety.
+
+**Fix:** gate the `repo.AllowAnonymous` branch on the global flag, or delete the setting so it cannot mislead.
+
+> Mitigating: the DB default for `allow_anonymous` is `FALSE` (`006_repo_allow_anonymous.sql`), so repositories are not public unless someone opts in.
+
+---
+
+#### H-2 · CORS defaults to `Access-Control-Allow-Origin: *`
+`internal/api/middleware.go:35` — when `cors_origins` is empty (the shipped default, `config.go:385` and `config.yaml.example:6`), every response gets a wildcard origin.
+
+No `Allow-Credentials`, so cookie-authenticated requests are safe. But this API authenticates by `Authorization` header **and** serves anonymous repositories. The combination is exploitable:
+
+> Employee visits `evil.com` → page issues `fetch('http://nexspence.internal:8081/repository/private-maven/…')` → browser sends it from inside the corporate network → wildcard CORS lets the page **read the response**.
+
+Any internal artifact in an anonymous-readable repository is exfiltratable from any website the user visits.
+
+**Fix:** default to no CORS header at all. A wildcard should require explicitly writing `cors_origins: ["*"]`.
+
+---
+
+#### H-3 · `SetTrustedProxies` is never called — `X-Forwarded-For` is trusted from anyone
+Verified absent across the whole tree. Gin's default trusts all proxies, so `c.ClientIP()` returns whatever the client puts in `X-Forwarded-For`. Two consequences:
+
+1. **Rate limiting is trivially bypassed** — `ratelimit_middleware.go:73` keys buckets on `ip:` + ClientIP. Rotate the header per request, get unlimited buckets.
+2. **The audit log is forgeable** — `audit_middleware.go:64` stores `RemoteIP: c.ClientIP()`, as do the login success/failure logs (`auth.go:80,86`) and OIDC/SAML logs. An attacker picks the IP that appears in the security record of their own actions.
+
+For a product whose audit trail is a compliance feature, (2) is the bigger problem.
+
+**Fix:** `r.SetTrustedProxies([...])` from config; default to trusting nothing.
+
+---
+
+### MEDIUM
+
+#### M-1 · Rate limiting is off by default
+`config.go:409` — `auth.rate_limit_enabled: false`. Out of the box there is no throttle on `/api/v1/login` or on Basic auth. With `bcrypt_cost: 12` (~250 ms CPU per attempt) this is both an unmetered credential-guessing surface and a cheap CPU exhaustion vector: a few hundred concurrent bad logins saturate the box.
+
+There is also no account lockout or failed-attempt backoff anywhere.
+
+**Fix:** default it on; add per-account failed-login backoff independent of the IP bucket (which H-3 shows cannot be trusted).
+
+---
+
+#### M-2 · Bad credentials silently degrade to anonymous, unlogged
+`internal/api/handlers/auth.go:414` — in `OptionalAuth`, a failed `users.Login` falls through to `c.Next()` with no identity and **no log line**. The `/repository/*` and `/v2/*` trees all use `OptionalAuth`.
+
+Password guessing against `/repository/…` therefore produces no failed-login record at all — it is invisible to the audit log and to any alerting built on it, while still costing a bcrypt per try.
+
+**Fix:** log the failure (as the `AuthMiddleware` path does) and feed it to the same backoff as M-1.
+
+---
+
+#### M-3 · OIDC `cookie_key` ships as a fixed value and is not covered by the insecure-default gate
+`cmd/server/main.go:74-86` fails closed on the shipped JWT secret and on `admin123` — good, and clearly deliberate. But `NEXSPENCE_OIDC_COOKIE_KEY` is hard-coded in `docker-compose.yml:124`, `docker-compose.ha.yml:135`, and `config.yaml.example:176` (`YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY=` = `abcdefghijklmnopqrstuvwxyz123456`) and is **not** in that check.
+
+That key seals the OIDC state cookie (`internal/auth/oidc_cookie.go`, AES-GCM). An attacker who knows it can forge a state cookie matching their own `state` parameter, defeating the CSRF protection on the login flow.
+
+The rest of the OIDC implementation is solid — crypto-random state and nonce, PKCE, sealed cookie with expiry, `state` compared against the cookie (`handlers/oidc.go:116`). This one gap undercuts it.
+
+**Fix:** extend the fail-closed check to the shipped cookie key.
+
+---
+
+#### M-4 · No SSRF guards on any outbound URL
+No allow/deny list, no link-local blocking, no `IsPrivate`/`IsLoopback` check exists anywhere in the tree. Three distinct paths:
+
+| Path | Who controls the URL |
+|---|---|
+| `proxy_config.remote_url` | admin |
+| Webhook target URL | admin |
+| Docker token `realm` (`docker_registry_token.go:85`) | **the upstream registry's `WWW-Authenticate` response** |
+
+The first two are admin-only, but "Nexspence admin" and "owner of the cloud account" are not the same principal — a proxy repo pointed at `http://169.254.169.254/latest/meta-data/iam/security-credentials/` turns repo-admin into IAM credential theft.
+
+The third is the interesting one: `realm` is taken from a *response header* of the upstream. A compromised or MITM'd upstream redirects the server's authenticated fetch to an arbitrary host. Exfiltration is limited (the response must parse as a token JSON), so this is blind SSRF.
+
+**Fix:** resolve and reject link-local/loopback/private ranges before any outbound fetch, with an explicit opt-out for on-prem upstreams.
+
+---
+
+#### M-5 · SAML assertions are not bound to the AuthnRequest
+`internal/auth/saml.go:109` — `s.sp.ParseResponse(r, nil)`. The `possibleRequestIDs` argument is `nil`, and no request-ID state is stored between `AuthnRequestURL` and the ACS endpoint.
+
+In `crewjam/saml`, `InResponseTo` is only checked when present; an assertion **without** it skips the check entirely. So a validly-signed assertion that the attacker obtained (e.g. their own) can be replayed into a victim's browser to force a login as the attacker's identity — the classic SAML login-CSRF.
+
+`RelayState` is HMAC-signed (`SignRelayState`), which protects the `return_to` value but does not bind the assertion to a session.
+
+> **Confidence: needs confirmation.** This is read from the code and the library's documented behaviour; I did not build an assertion to prove it end to end. Worth verifying before prioritising.
+
+**Fix:** persist issued request IDs and pass them to `ParseResponse`.
+
+---
+
+#### M-6 · No Content-Security-Policy, JWT in `localStorage`
+`internal/api/middleware.go:53` sets `nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy` — and explicitly documents CSP as out of scope. The SPA stores its JWT in `localStorage` (`frontend/src/api/client.ts:25`, `OIDCCallbackPage.tsx:26`).
+
+Neither is wrong on its own — `localStorage` is normal for a Bearer-token SPA, and no `dangerouslySetInnerHTML` or `innerHTML` sink exists in the frontend. But together they mean any future XSS is a full token theft with no defence in depth.
+
+**Fix:** ship a CSP. The SPA is self-hosted and bundled, so a strict policy is achievable.
+
+---
+
+#### M-7 · Health probes bypass every middleware
+`internal/api/router.go:278-279` registers `/healthz` and `/readyz` **before** `r.Use(...)`. Gin snapshots the middleware chain at registration time, so these two routes run with no `Recovery`, no rate limit, no body limit, no audit.
+
+`/readyz` (`handlers.ReadinessHandler(pool, rdb)`) queries Postgres and Redis on every hit. Unauthenticated, unthrottled, one DB round-trip per request.
+
+**Fix:** register them after `r.Use`, or exempt them explicitly inside the middlewares.
+
+---
+
+#### M-8 · Frontend dependencies: 3 high
+- `react-router` / `react-router-dom` — RSC-mode CSRF bypass. The app does not use RSC mode, so **not exploitable here**, but it should still be bumped.
+- `brace-expansion` — OOM DoS; dev-dependency only.
+
+---
+
+### LOW
+
+| ID | Finding |
+|---|---|
+| L-1 | **Backup import buffers up to 8 GiB in memory.** `backup_import.go:26` caps decompression (good — the gzip-bomb guard is deliberate), but every entry lands in an in-memory map. Admin-only, so it is a self-inflicted DoS at worst. Stream to disk instead. |
+| L-2 | **Archive parsers cap entry size, not entry count.** npm/conda/nuget limit each metadata read (`4 MiB`, `maxManifestBytes`) but iterate unbounded tar entries. A pathological upload from a user with write access burns CPU. |
+| L-3 | **`website/Dockerfile` runs as root** (trivy DS-0002). The main `Dockerfile` correctly uses `USER 1000`. |
+| L-4 | **Presign handlers exist but are not mounted.** `PresignGet`/`PresignPut`/`ConfigureLifecycle` (`blobstores.go:277-361`) take an arbitrary blob key and are unreachable via `router.go` today. If they are ever wired up outside the `admin` group they become a straight RBAC bypass — any blob, any repository. Add the admin gate now, before someone mounts them. |
+| L-5 | **Subdomain not character-validated.** `subdomain_rewriter.go:57` rejects dots and empties but not other characters before splicing the value into a URL path. RBAC still runs on the resulting repo name so there is no bypass — worth tightening to `[a-z0-9-]+` regardless. |
+| L-6 | **`gitleaks` noise.** 210 hits, all `curl -u admin:admin123` examples in docs and test fixtures. Consider a `.gitleaksignore` so a real leak is not lost in the noise. |
+
+---
+
+## What is solid
+
+Worth stating explicitly, because it is the majority of the code:
+
+- **SQL injection: none.** Every value goes through `$N` placeholders; `fmt.Sprintf` is used only to assemble static column lists and JOIN clauses. No dynamic `ORDER BY`.
+- **Path traversal: correctly defended.** `storage/local.go:27` cleans and then verifies containment under the blob root, with the reasoning in a comment.
+- **JWT: correctly verified.** `auth/auth.go:83` asserts `*jwt.SigningMethodHMAC` — `alg: none` and algorithm-confusion both rejected.
+- **Token storage:** SHA-256 over 32 bytes of `crypto/rand`, with a comment explaining why bcrypt is unnecessary here. Correct reasoning.
+- **Passwords:** bcrypt cost 12.
+- **MD5/SHA-1 usage** is confined to package-format checksums (Maven, npm, conda) where the protocols mandate them — never for security decisions.
+- **Gzip-bomb guard** on backup import is explicit and tested.
+- **RBAC** has a coherent shape: admin bypass, anonymous read-only, then per-privilege matching with path selectors.
+- **No secret was ever committed** across 192 commits.
+- **`/metrics` requires authentication** — a very common miss, handled here.
+
+---
+
+## Suggested order of work
+
+1. **H-1** — a security control that does nothing is worse than an absent one. Smallest fix, largest correctness gain.
+2. **H-3** — one line, and it restores the integrity of the audit log.
+3. **H-2** — change the default; keep wildcard available but opt-in.
+4. **M-1 + M-2** — brute-force surface; they are the same fix.
+5. **M-3** — extend the existing fail-closed check by one condition.
+6. **M-4**, **M-5** — larger; M-5 needs confirmation first.
+
+---
+
+## Tooling recommendation
+
+Of the security plugins available in the official marketplace, the ones that fit this repo (self-contained, no SaaS account, no data leaving the machine):
+
+| Plugin | Why |
+|---|---|
+| **`claude-security`** | Anthropic's own deep vulnerability scanner. Runs entirely inside the session at a chosen effort tier and adversarially challenges each finding before reporting — the closest thing to a repeat of this audit, on demand. Best single pick. |
+| **`semgrep`** | Rule-based SAST, catches issues as code is written rather than after. Complements the above rather than duplicating it. |
+| **`security-guidance`** | Preventive: warns on edits and reviews diffs at commit time. |
+
+The SaaS-backed options (Aikido, Endor Labs, SonarQube, StackHawk, 42Crunch, NightVision) are all credible but each needs an account and sends code or findings off-machine — a deliberate trade-off worth making only if you want continuous monitoring rather than point-in-time review.
+
+Already in CI and worth keeping: `govulncheck` (`.github/workflows/govulncheck.yml`), `golangci-lint`, `trivy`.
+
+---
+
+*No finding in this report was exploited — all are derived from reading the code and from tool output. M-5 in particular is marked as needing confirmation.*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -186,7 +186,7 @@ Pure business logic; no HTTP concerns; depend only on repository interfaces.
 | `RoutingRuleService` | Path allow/block rules applied to group-repository fan-out |
 | `PromotionService` | Staging → production promotion with a scan-pass gate and optional manual approval |
 | `ReplicationService` | Push-on-publish to a secondary instance via streaming blob copy; per-rule cron |
-| `BlobGCService` | `ListAllBlobKeys` vs `BlobStore.ListKeys` → delete orphan blobs; dry-run |
+| `BlobGCService` | `ListAllBlobRefs` (key + store) vs `BlobStore.ListKeys` → delete blobs no asset references *in that store*; dry-run |
 | `BlobStoreMigrationService` | Move a repository's blobs between stores, resumable after a restart |
 | `NexusMigrationService` | Import a live Nexus OSS instance over its REST API — repositories, artifacts, privileges, roles, users, routing rules — one goroutine per job, pausable, and re-attached on startup |
 | `DownloadCounter` | In-memory download aggregation, flushed to the DB every 10s |

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -607,6 +607,14 @@ type MigrationAssetRow struct {
 	SizeBytes         int64
 }
 
+// BlobRef is one asset reference to a blob: which key, in which blob store.
+// GC needs both — the same key can exist in several stores, and being
+// referenced in one says nothing about the copy sitting in another.
+type BlobRef struct {
+	BlobKey     string
+	BlobStoreID string // empty when the asset row carries no store id
+}
+
 // BlobStoreMigration tracks progress of a background blob store migration for one repository.
 //
 // Serialized directly by the blob-store-migration handlers, so the tags ARE

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -77,8 +77,11 @@ type AssetRepo interface {
 	// ListByComponentIDs returns assets for many components in one query,
 	// grouped by component ID (each slice ordered by path, like ListByComponentID).
 	ListByComponentIDs(ctx context.Context, componentIDs []string) (map[string][]domain.Asset, error)
-	// ListAllBlobKeys returns distinct blob_key values referenced by assets (for GC).
-	ListAllBlobKeys(ctx context.Context) ([]string, error)
+	// ListAllBlobRefs returns the distinct (blob_key, blob_store_id) pairs
+	// referenced by assets (for GC). The store id is part of the answer
+	// because a key referenced in one store says nothing about the copy of
+	// that key sitting in another.
+	ListAllBlobRefs(ctx context.Context) ([]domain.BlobRef, error)
 	// SumSizeByRepo returns total size_bytes of all assets in the repository.
 	SumSizeByRepo(ctx context.Context, repoName string) (int64, error)
 	// ListForBlobStoreMigration returns distinct (blob_key, source_blob_store_id, size_bytes)
@@ -101,6 +104,10 @@ type AssetRepo interface {
 	// CountByBlobKey returns the number of assets that reference blobKey, excluding the asset with excludeID.
 	// Used to decide whether the physical blob file can be deleted.
 	CountByBlobKey(ctx context.Context, blobKey, excludeID string) (int, error)
+	// CountByBlobKeyInStore returns the number of assets that reference blobKey
+	// and still live on blobStoreID. Used to decide whether a physical blob may
+	// be removed from one specific store.
+	CountByBlobKeyInStore(ctx context.Context, blobKey, blobStoreID string) (int, error)
 	// ListRawBrowseAssets returns all assets for the given raw-format repos with metadata for tree building.
 	ListRawBrowseAssets(ctx context.Context, repoNames []string) ([]domain.RawBrowseAsset, error)
 	// ListOCIImageNames returns the distinct image names held by the given OCI

--- a/internal/repository/postgres/asset_repo.go
+++ b/internal/repository/postgres/asset_repo.go
@@ -333,22 +333,23 @@ func (r *assetRepo) TouchLastModified(ctx context.Context, id string) error {
 	return err
 }
 
-func (r *assetRepo) ListAllBlobKeys(ctx context.Context) ([]string, error) {
+func (r *assetRepo) ListAllBlobRefs(ctx context.Context) ([]domain.BlobRef, error) {
 	rows, err := r.db.Query(ctx,
-		`SELECT DISTINCT blob_key FROM assets WHERE blob_key IS NOT NULL AND TRIM(blob_key) <> ''`)
+		`SELECT DISTINCT blob_key, COALESCE(blob_store_id::text, '')
+		 FROM assets WHERE blob_key IS NOT NULL AND TRIM(blob_key) <> ''`)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var keys []string
+	var refs []domain.BlobRef
 	for rows.Next() {
-		var k string
-		if err := rows.Scan(&k); err != nil {
+		var ref domain.BlobRef
+		if err := rows.Scan(&ref.BlobKey, &ref.BlobStoreID); err != nil {
 			return nil, err
 		}
-		keys = append(keys, k)
+		refs = append(refs, ref)
 	}
-	return keys, rows.Err()
+	return refs, rows.Err()
 }
 
 // SumSizeByRepo returns the bytes the repository occupies: one size per stored
@@ -672,6 +673,17 @@ func (r *assetRepo) CountByBlobKey(ctx context.Context, blobKey, excludeID strin
 	err := r.db.QueryRow(ctx,
 		`SELECT COUNT(*) FROM assets WHERE blob_key = $1 AND id != $2`,
 		blobKey, excludeID,
+	).Scan(&count)
+	return count, err
+}
+
+// CountByBlobKeyInStore reports how many assets still reference blobKey on
+// blobStoreID — the guard before deleting a physical blob from that one store.
+func (r *assetRepo) CountByBlobKeyInStore(ctx context.Context, blobKey, blobStoreID string) (int, error) {
+	var count int
+	err := r.db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM assets WHERE blob_key = $1 AND blob_store_id = $2::uuid`,
+		blobKey, blobStoreID,
 	).Scan(&count)
 	return count, err
 }

--- a/internal/repository/postgres/asset_repo_queries_integration_test.go
+++ b/internal/repository/postgres/asset_repo_queries_integration_test.go
@@ -263,9 +263,9 @@ func TestAssetRepoQueries_SearchAssets_EmptyResult(t *testing.T) {
 	}
 }
 
-// ── ListAllBlobKeys (GC) ──────────────────────────────────────────────────────
+// ── ListAllBlobRefs (GC) ──────────────────────────────────────────────────────
 
-func TestAssetRepoQueries_ListAllBlobKeys_ReturnsDistinctKeys(t *testing.T) {
+func TestAssetRepoQueries_ListAllBlobRefs_ReturnsDistinctKeys(t *testing.T) {
 	pool := pgtest.Pool(t)
 	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
 	ctx := context.Background()
@@ -283,9 +283,16 @@ func TestAssetRepoQueries_ListAllBlobKeys_ReturnsDistinctKeys(t *testing.T) {
 		}
 	}
 
-	keys, err := repo.ListAllBlobKeys(ctx)
+	refs, err := repo.ListAllBlobRefs(ctx)
 	if err != nil {
-		t.Fatalf("ListAllBlobKeys: %v", err)
+		t.Fatalf("ListAllBlobRefs: %v", err)
+	}
+	keys := make([]string, 0, len(refs))
+	for _, r := range refs {
+		if r.BlobStoreID != p.BlobStoreID {
+			t.Errorf("ref %q carries store %q; want %q", r.BlobKey, r.BlobStoreID, p.BlobStoreID)
+		}
+		keys = append(keys, r.BlobKey)
 	}
 	// DISTINCT should give us exactly 2 keys
 	if len(keys) != 2 {
@@ -303,7 +310,7 @@ func TestAssetRepoQueries_ListAllBlobKeys_ReturnsDistinctKeys(t *testing.T) {
 	}
 }
 
-func TestAssetRepoQueries_ListAllBlobKeys_SkipsEmptyAndNullKeys(t *testing.T) {
+func TestAssetRepoQueries_ListAllBlobRefs_SkipsEmptyAndNullKeys(t *testing.T) {
 	pool := pgtest.Pool(t)
 	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
 	ctx := context.Background()
@@ -325,9 +332,13 @@ func TestAssetRepoQueries_ListAllBlobKeys_SkipsEmptyAndNullKeys(t *testing.T) {
 		t.Fatalf("Create no-key: %v", err)
 	}
 
-	keys, err := repo.ListAllBlobKeys(ctx)
+	refs, err := repo.ListAllBlobRefs(ctx)
 	if err != nil {
-		t.Fatalf("ListAllBlobKeys: %v", err)
+		t.Fatalf("ListAllBlobRefs: %v", err)
+	}
+	keys := make([]string, 0, len(refs))
+	for _, r := range refs {
+		keys = append(keys, r.BlobKey)
 	}
 	// Only the real key should appear; empty string excluded by WHERE TRIM <> ''
 	for _, k := range keys {
@@ -337,6 +348,66 @@ func TestAssetRepoQueries_ListAllBlobKeys_SkipsEmptyAndNullKeys(t *testing.T) {
 	}
 	if len(keys) != 1 || keys[0] != "sha256:realkey" {
 		t.Errorf("expected [sha256:realkey], got %v", keys)
+	}
+}
+
+// GC decides per store, so the store id has to come back with the key: the
+// same key can be live in one store and an abandoned migration leftover in
+// another (#297).
+func TestAssetRepoQueries_CountByBlobKeyInStore_CountsOnlyThatStore(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "bk_scoped")
+	repo := NewAssetRepo(pool)
+
+	// A second store, standing in for a migration target.
+	other := &domain.BlobStore{Name: "asset_bs_bk_scoped_other", Type: "local", Config: map[string]any{"path": "/data/other"}}
+	if err := NewBlobStoreRepo(pool).Create(ctx, other); err != nil {
+		t.Fatalf("second blob store: %v", err)
+	}
+
+	const key = "sha256:scoped_key"
+	here := makeAsset(p, "/scoped/here.bin")
+	here.BlobKey = key
+	if err := repo.Create(ctx, here); err != nil {
+		t.Fatalf("Create here: %v", err)
+	}
+	there := makeAsset(p, "/scoped/there.bin")
+	there.BlobKey = key
+	there.BlobStoreID = other.ID
+	if err := repo.Create(ctx, there); err != nil {
+		t.Fatalf("Create there: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		storeID string
+		want    int
+	}{
+		{"source store", p.BlobStoreID, 1},
+		{"target store", other.ID, 1},
+	} {
+		got, err := repo.CountByBlobKeyInStore(ctx, key, tc.storeID)
+		if err != nil {
+			t.Fatalf("CountByBlobKeyInStore(%s): %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("CountByBlobKeyInStore(%s) = %d; want %d", tc.name, got, tc.want)
+		}
+	}
+
+	// Moving the last row off the source leaves nothing referencing it there.
+	if err := repo.UpdateBlobStoreForBlobKey(ctx, key, p.RepoName, other.ID); err != nil {
+		t.Fatalf("UpdateBlobStoreForBlobKey: %v", err)
+	}
+	got, err := repo.CountByBlobKeyInStore(ctx, key, p.BlobStoreID)
+	if err != nil {
+		t.Fatalf("CountByBlobKeyInStore after move: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("after migrating every row off the source, count = %d; want 0", got)
 	}
 }
 

--- a/internal/service/blob_store_migration_internal_test.go
+++ b/internal/service/blob_store_migration_internal_test.go
@@ -1,0 +1,81 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/storage"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// shiftingStore is a store whose blob is overwritten with a different size
+// between the read and the post-copy re-check — what a client upload does to
+// the source store during a migration, since the repository still points there
+// until the very last row is done.
+type shiftingStore struct {
+	storage.BlobStore
+	sizeAfter int64
+	sizeErr   error
+}
+
+func (s shiftingStore) Size(_ context.Context, _ string) (int64, error) {
+	if s.sizeErr != nil {
+		return 0, s.sizeErr
+	}
+	return s.sizeAfter, nil
+}
+
+// Losing the race must not repoint the asset: the row would name the target
+// while the target holds the bytes read before the upload landed (#298).
+func TestBlobStoreMigration_CopyBlob_AbortsWhenSourceChangesMidCopy(t *testing.T) {
+	ctx := context.Background()
+	source := testutil.NewBlobStore()
+	target := testutil.NewBlobStore()
+	require.NoError(t, source.Put(ctx, "k", strings.NewReader("original"), 8))
+
+	svc := &BlobStoreMigrationService{}
+	_, err := svc.copyBlob(ctx, shiftingStore{BlobStore: source, sizeAfter: 7}, target, "k")
+
+	require.ErrorContains(t, err, "changed during migration")
+	require.False(t, target.Has("k"), "the stale staged copy must not be left in the target")
+}
+
+// A source that cannot be re-measured is the same situation with less
+// information: refuse rather than repoint on an unverified copy.
+func TestBlobStoreMigration_CopyBlob_AbortsWhenSourceCannotBeReChecked(t *testing.T) {
+	ctx := context.Background()
+	source := testutil.NewBlobStore()
+	target := testutil.NewBlobStore()
+	require.NoError(t, source.Put(ctx, "k", strings.NewReader("original"), 8))
+
+	svc := &BlobStoreMigrationService{}
+	_, err := svc.copyBlob(ctx, shiftingStore{BlobStore: source, sizeErr: errors.New("boom")}, target, "k")
+
+	require.ErrorContains(t, err, "re-checking source blob")
+	require.False(t, target.Has("k"))
+}
+
+// The unchanged case still copies the bytes through.
+func TestBlobStoreMigration_CopyBlob_CopiesUnchangedBlob(t *testing.T) {
+	ctx := context.Background()
+	source := testutil.NewBlobStore()
+	target := testutil.NewBlobStore()
+	require.NoError(t, source.Put(ctx, "k", strings.NewReader("original"), 8))
+
+	svc := &BlobStoreMigrationService{}
+	n, err := svc.copyBlob(ctx, source, target, "k")
+	require.NoError(t, err)
+	require.Equal(t, int64(8), n)
+
+	rc, _, err := target.Get(ctx, "k")
+	require.NoError(t, err)
+	defer func() { _ = rc.Close() }()
+	got, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(got))
+}

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -275,20 +275,13 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 			return
 		}
 		if !exists {
-			rc, size, err := sourceStore.Get(bgCtx, row.BlobKey)
+			copied, err := s.copyBlob(bgCtx, sourceStore, targetStore, row.BlobKey)
 			if err != nil {
-				errMsg := fmt.Sprintf("reading blob %s: %v", row.BlobKey, err)
+				errMsg := err.Error()
 				_ = s.migrations.FinishMigration(bgCtx, m.ID, "failed", &errMsg)
 				return
 			}
-			putErr := targetStore.Put(bgCtx, row.BlobKey, rc, size)
-			_ = rc.Close()
-			if putErr != nil {
-				errMsg := fmt.Sprintf("writing blob %s: %v", row.BlobKey, putErr)
-				_ = s.migrations.FinishMigration(bgCtx, m.ID, "failed", &errMsg)
-				return
-			}
-			_ = s.blobs.UpdateUsedBytes(bgCtx, targetStoreMeta.Name, size)
+			_ = s.blobs.UpdateUsedBytes(bgCtx, targetStoreMeta.Name, copied)
 		}
 
 		if err := s.assets.UpdateBlobStoreForBlobKey(bgCtx, row.BlobKey, m.RepositoryName, m.TargetStoreID); err != nil {
@@ -296,6 +289,12 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 			_ = s.migrations.FinishMigration(bgCtx, m.ID, "failed", &errMsg)
 			return
 		}
+
+		// The bytes now live in the target and no row points at the source copy
+		// any more: drop it and give the space back. Without this the source
+		// keeps both the object and its used_bytes forever — GC cannot help,
+		// the key is still referenced, just in another store (#297).
+		s.dropSourceCopy(bgCtx, sourceStore, sourceMeta.Name, row)
 
 		doneAssets++
 		doneBytes += row.SizeBytes
@@ -310,4 +309,57 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 	}
 
 	_ = s.migrations.FinishMigration(bgCtx, m.ID, "done", nil)
+}
+
+// copyBlob streams one blob from source to target and returns the bytes written.
+//
+// The source is re-measured after the copy, because a client can overwrite the
+// blob in place while it streams: the repository is still pointed at the source
+// store for the whole migration, so ordinary uploads keep landing there. Writing
+// the bytes we read before that upload and then repointing the row would leave
+// the asset row (new size) disagreeing with the target's physical bytes (old
+// content) — silent corruption on every later read (#298). A changed size means
+// we lost the race, so the staged copy is dropped and the whole migration fails
+// loudly; a re-run copies the current bytes.
+func (s *BlobStoreMigrationService) copyBlob(ctx context.Context, sourceStore, targetStore storage.BlobStore, blobKey string) (int64, error) {
+	rc, size, err := sourceStore.Get(ctx, blobKey)
+	if err != nil {
+		return 0, fmt.Errorf("reading blob %s: %v", blobKey, err)
+	}
+	putErr := targetStore.Put(ctx, blobKey, rc, size)
+	_ = rc.Close()
+	if putErr != nil {
+		return 0, fmt.Errorf("writing blob %s: %v", blobKey, putErr)
+	}
+
+	after, sizeErr := sourceStore.Size(ctx, blobKey)
+	if sizeErr != nil || after != size {
+		_ = targetStore.Delete(ctx, blobKey)
+		if sizeErr != nil {
+			return 0, fmt.Errorf("re-checking source blob %s: %v", blobKey, sizeErr)
+		}
+		return 0, fmt.Errorf("blob %s changed during migration (%d -> %d bytes); re-run the migration", blobKey, size, after)
+	}
+	return size, nil
+}
+
+// dropSourceCopy removes the migrated blob from the source store and decrements
+// that store's used_bytes, but only once nothing on the source references the
+// key any more — the same key can legitimately still be in use there by another
+// repository's asset or an OCI digest alias.
+func (s *BlobStoreMigrationService) dropSourceCopy(ctx context.Context, sourceStore storage.BlobStore, sourceName string, row domain.MigrationAssetRow) {
+	remaining, err := s.assets.CountByBlobKeyInStore(ctx, row.BlobKey, row.SourceBlobStoreID)
+	if err != nil || remaining > 0 {
+		return
+	}
+	size, err := sourceStore.Size(ctx, row.BlobKey)
+	if err != nil || size <= 0 {
+		size = row.SizeBytes
+	}
+	if err := sourceStore.Delete(ctx, row.BlobKey); err != nil {
+		return
+	}
+	if size > 0 {
+		_ = s.blobs.UpdateUsedBytes(ctx, sourceName, -size)
+	}
 }

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -324,19 +324,19 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 func (s *BlobStoreMigrationService) copyBlob(ctx context.Context, sourceStore, targetStore storage.BlobStore, blobKey string) (int64, error) {
 	rc, size, err := sourceStore.Get(ctx, blobKey)
 	if err != nil {
-		return 0, fmt.Errorf("reading blob %s: %v", blobKey, err)
+		return 0, fmt.Errorf("reading blob %s: %w", blobKey, err)
 	}
 	putErr := targetStore.Put(ctx, blobKey, rc, size)
 	_ = rc.Close()
 	if putErr != nil {
-		return 0, fmt.Errorf("writing blob %s: %v", blobKey, putErr)
+		return 0, fmt.Errorf("writing blob %s: %w", blobKey, putErr)
 	}
 
 	after, sizeErr := sourceStore.Size(ctx, blobKey)
 	if sizeErr != nil || after != size {
 		_ = targetStore.Delete(ctx, blobKey)
 		if sizeErr != nil {
-			return 0, fmt.Errorf("re-checking source blob %s: %v", blobKey, sizeErr)
+			return 0, fmt.Errorf("re-checking source blob %s: %w", blobKey, sizeErr)
 		}
 		return 0, fmt.Errorf("blob %s changed during migration (%d -> %d bytes); re-run the migration", blobKey, size, after)
 	}

--- a/internal/service/blob_store_migration_service_extra_test.go
+++ b/internal/service/blob_store_migration_service_extra_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -242,4 +243,113 @@ func TestBlobStoreMigration_ResumeAll_ReleasesStaleLocks(t *testing.T) {
 		[]string{"nexspence:lock:blobmig:repo1", "nexspence:lock:blobmig:repo2"},
 		lk.forcedKeys(),
 		"every migration ResumeAll gives up gives its lock back")
+}
+
+// A finished migration must leave nothing behind in the source: the copy there
+// is unreferenced, and GC can no longer see it as an orphan by key alone. Before
+// #297 the bytes stayed on disk and in the source's used_bytes forever — so a
+// migration off a full store freed nothing.
+func TestBlobStoreMigration_DropsSourceCopyAndUsage(t *testing.T) {
+	ctx := context.Background()
+	sourceID, targetID := "store-src-001", "store-tgt-002"
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+
+	sourceMeta := &domain.BlobStore{ID: sourceID, Name: "source-store", Type: "local", Config: map[string]any{"path": srcDir}}
+	targetMeta := &domain.BlobStore{ID: targetID, Name: "target-store", Type: "local", Config: map[string]any{"path": dstDir}}
+
+	bsID := sourceID
+	repo := &domain.Repository{ID: "repo-001", Name: "my-repo", Format: domain.RepoFormat("raw"),
+		Type: domain.TypeHosted, Online: true, BlobStoreID: &bsID}
+
+	srcStore, err := storage.NewLocalBlobStore(srcDir)
+	require.NoError(t, err)
+	dstStore, err := storage.NewLocalBlobStore(dstDir)
+	require.NoError(t, err)
+	require.NoError(t, srcStore.Put(ctx, "blob-1", strings.NewReader("data"), 4))
+
+	blobRepo := testutil.NewBlobStoreRepo(sourceMeta, targetMeta)
+	require.NoError(t, blobRepo.UpdateUsedBytes(ctx, "source-store", 4))
+
+	assetRepo := testutil.NewAssetRepo()
+	require.NoError(t, assetRepo.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: repo.ID, Repository: "my-repo",
+		Path: "/data.bin", BlobKey: "blob-1", BlobStoreID: sourceID, SizeBytes: 4,
+	}))
+	assetRepo.MigrationRows = []domain.MigrationAssetRow{
+		{BlobKey: "blob-1", SourceBlobStoreID: sourceID, SizeBytes: 4},
+	}
+
+	svc := service.NewBlobStoreMigrationService(testutil.NewBlobStoreMigrationRepo(), assetRepo,
+		testutil.NewRepoRepo(repo), blobRepo, storage.NewRegistry(srcStore))
+
+	_, err = svc.Start(ctx, "my-repo", targetID)
+	require.NoError(t, err)
+	waitForMigration(t, svc, "my-repo", "done")
+
+	inTarget, err := dstStore.Exists(ctx, "blob-1")
+	require.NoError(t, err)
+	require.True(t, inTarget, "target must hold the migrated blob")
+
+	inSource, err := srcStore.Exists(ctx, "blob-1")
+	require.NoError(t, err)
+	require.False(t, inSource, "source copy must be deleted once nothing references it there")
+
+	src, err := blobRepo.Get(ctx, "source-store")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), src.UsedBytes, "source usage must drop by the migrated bytes")
+
+	dst, err := blobRepo.Get(ctx, "target-store")
+	require.NoError(t, err)
+	require.Equal(t, int64(4), dst.UsedBytes)
+}
+
+// The same key can still be in use on the source by another repository's asset
+// (or an OCI digest alias). Then the physical blob stays, and so does the usage.
+func TestBlobStoreMigration_KeepsSourceCopyStillReferencedThere(t *testing.T) {
+	ctx := context.Background()
+	sourceID, targetID := "store-src-001", "store-tgt-002"
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+
+	sourceMeta := &domain.BlobStore{ID: sourceID, Name: "source-store", Type: "local", Config: map[string]any{"path": srcDir}}
+	targetMeta := &domain.BlobStore{ID: targetID, Name: "target-store", Type: "local", Config: map[string]any{"path": dstDir}}
+
+	bsID := sourceID
+	repo := &domain.Repository{ID: "repo-001", Name: "my-repo", Format: domain.RepoFormat("raw"),
+		Type: domain.TypeHosted, Online: true, BlobStoreID: &bsID}
+
+	srcStore, err := storage.NewLocalBlobStore(srcDir)
+	require.NoError(t, err)
+	require.NoError(t, srcStore.Put(ctx, "blob-1", strings.NewReader("data"), 4))
+
+	blobRepo := testutil.NewBlobStoreRepo(sourceMeta, targetMeta)
+	require.NoError(t, blobRepo.UpdateUsedBytes(ctx, "source-store", 4))
+
+	assetRepo := testutil.NewAssetRepo()
+	require.NoError(t, assetRepo.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: repo.ID, Repository: "my-repo",
+		Path: "/data.bin", BlobKey: "blob-1", BlobStoreID: sourceID, SizeBytes: 4,
+	}))
+	// Another repository shares the key on the source store; it is not migrated.
+	require.NoError(t, assetRepo.Create(ctx, &domain.Asset{
+		ComponentID: "c2", RepositoryID: "repo-002", Repository: "other-repo",
+		Path: "/data.bin", BlobKey: "blob-1", BlobStoreID: sourceID, SizeBytes: 4,
+	}))
+	assetRepo.MigrationRows = []domain.MigrationAssetRow{
+		{BlobKey: "blob-1", SourceBlobStoreID: sourceID, SizeBytes: 4},
+	}
+
+	svc := service.NewBlobStoreMigrationService(testutil.NewBlobStoreMigrationRepo(), assetRepo,
+		testutil.NewRepoRepo(repo), blobRepo, storage.NewRegistry(srcStore))
+
+	_, err = svc.Start(ctx, "my-repo", targetID)
+	require.NoError(t, err)
+	waitForMigration(t, svc, "my-repo", "done")
+
+	inSource, err := srcStore.Exists(ctx, "blob-1")
+	require.NoError(t, err)
+	require.True(t, inSource, "a copy another asset still points at must survive")
+
+	src, err := blobRepo.Get(ctx, "source-store")
+	require.NoError(t, err)
+	require.Equal(t, int64(4), src.UsedBytes)
 }

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -59,17 +59,51 @@ func (s *BlobGCService) log() logger.Logger {
 	return zap.NewNop().Sugar()
 }
 
-// referencedSet returns the set of all blob keys referenced by any asset.
-func (s *BlobGCService) referencedSet(ctx context.Context) (map[string]struct{}, error) {
-	keys, err := s.Assets.ListAllBlobKeys(ctx)
+// refIndex answers "is this key referenced in this store?".
+//
+// Scoping by store is what lets GC collect a copy left behind in a store an
+// asset no longer lives on — a blob-store migration repoints the row without
+// changing the key, so a set keyed by key alone kept calling the abandoned
+// source copy "referenced" forever (#297). Rows carrying no store id (an
+// implicit default) are counted as referenced in every store: they name a key
+// but not a location, and guessing wrong here deletes live data.
+type refIndex struct {
+	byStore map[string]map[string]struct{}
+	anyPos  map[string]struct{}
+}
+
+func (i refIndex) has(storeID, key string) bool {
+	if _, ok := i.anyPos[key]; ok {
+		return true
+	}
+	keys, ok := i.byStore[storeID]
+	if !ok {
+		return false
+	}
+	_, ok = keys[key]
+	return ok
+}
+
+// referencedSet indexes every blob key referenced by an asset, by store.
+func (s *BlobGCService) referencedSet(ctx context.Context) (refIndex, error) {
+	refs, err := s.Assets.ListAllBlobRefs(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("list db blob keys: %w", err)
+		return refIndex{}, fmt.Errorf("list db blob keys: %w", err)
 	}
-	set := make(map[string]struct{}, len(keys))
-	for _, k := range keys {
-		set[k] = struct{}{}
+	idx := refIndex{byStore: make(map[string]map[string]struct{}), anyPos: make(map[string]struct{})}
+	for _, r := range refs {
+		if r.BlobStoreID == "" {
+			idx.anyPos[r.BlobKey] = struct{}{}
+			continue
+		}
+		keys, ok := idx.byStore[r.BlobStoreID]
+		if !ok {
+			keys = make(map[string]struct{})
+			idx.byStore[r.BlobStoreID] = keys
+		}
+		keys[r.BlobKey] = struct{}{}
 	}
-	return set, nil
+	return idx, nil
 }
 
 // CompactStore compacts a single blob store by name.
@@ -88,7 +122,7 @@ func (s *BlobGCService) CompactStore(ctx context.Context, name string, opts GCOp
 	if err != nil {
 		return nil, fmt.Errorf("resolve blob store %q: %w", name, err)
 	}
-	return s.compact(ctx, name, store, referenced, opts), nil
+	return s.compact(ctx, name, row.ID, store, referenced, opts), nil
 }
 
 // CompactAll compacts every blob store. It holds a distributed lock so only one
@@ -130,14 +164,14 @@ func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCRe
 			})
 			continue
 		}
-		results = append(results, s.compact(ctx, row.Name, store, referenced, opts))
+		results = append(results, s.compact(ctx, row.Name, row.ID, store, referenced, opts))
 	}
 	return results, nil
 }
 
 // compact runs the core scan/delete for a single resolved store.
-func (s *BlobGCService) compact(ctx context.Context, name string, store storage.BlobStore,
-	referenced map[string]struct{}, opts GCOptions) *GCResult {
+func (s *BlobGCService) compact(ctx context.Context, name, storeID string, store storage.BlobStore,
+	referenced refIndex, opts GCOptions) *GCResult {
 	minAge := opts.MinAge
 	if minAge <= 0 {
 		minAge = s.DefaultMinAge
@@ -154,8 +188,8 @@ func (s *BlobGCService) compact(ctx context.Context, name string, store storage.
 
 	var removed int64
 	for _, e := range entries {
-		if _, ok := referenced[e.Key]; ok {
-			continue // still referenced
+		if referenced.has(storeID, e.Key) {
+			continue // still referenced in this store
 		}
 		// Age gate: skip blobs younger than the grace period (may be an
 		// in-flight upload whose asset row is not committed yet).

--- a/internal/service/gc_service_test.go
+++ b/internal/service/gc_service_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
+// defaultStoreID is the id testutil.NewBlobStoreRepo seeds the "default" store
+// with. GC now asks "referenced in THIS store?", so a fixture asset has to sit
+// on the store under compaction to count as a reference.
+const defaultStoreID = "00000000-0000-0000-0000-000000000001"
+
 func buildGC(assets *testutil.AssetRepo, bs *testutil.BlobStore) *service.BlobGCService {
 	return &service.BlobGCService{
 		Assets:   assets,
@@ -40,7 +45,7 @@ func TestGC_AllReferenced(t *testing.T) {
 	require.NoError(t, bs.Put(ctx, "key1", bytes.NewReader([]byte("data")), 4))
 	require.NoError(t, assets.Create(ctx, &domain.Asset{
 		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
-		Path: "/file.txt", BlobKey: "key1", BlobStoreID: "bs1",
+		Path: "/file.txt", BlobKey: "key1", BlobStoreID: defaultStoreID,
 	}))
 
 	svc := buildGC(assets, bs)
@@ -206,7 +211,7 @@ func TestGC_ReferencedBlob_LeavesTheStoreUsageAlone(t *testing.T) {
 	require.NoError(t, bs.Put(ctx, "kept", bytes.NewReader([]byte("data")), 4))
 	require.NoError(t, assets.Create(ctx, &domain.Asset{
 		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
-		Path: "/file.txt", BlobKey: "kept", BlobStoreID: "bs1", SizeBytes: 4,
+		Path: "/file.txt", BlobKey: "kept", BlobStoreID: defaultStoreID, SizeBytes: 4,
 	}))
 
 	stores := testutil.NewBlobStoreRepo()
@@ -233,4 +238,45 @@ func TestGC_CompactAllSkipsWhenLockHeld(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, results, "must skip when another node holds the lock")
 	assert.True(t, bs.Has("junk"), "nothing collected when skipped")
+}
+
+// A copy left behind in a store no asset points at any more is an orphan, even
+// though the very same key is alive in another store — what a blob-store
+// migration leaves behind, and what the old key-only reference set protected
+// forever (#297).
+func TestGC_KeyReferencedInAnotherStore_IsCollectedHere(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	source := testutil.NewBlobStore()
+	ctx := context.Background()
+
+	require.NoError(t, source.Put(ctx, "key1", bytes.NewReader([]byte("data")), 4))
+	// The asset was migrated: same key, now living on another store.
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
+		Path: "/file.txt", BlobKey: "key1", BlobStoreID: "store-target", SizeBytes: 4,
+	}))
+
+	result, err := buildGC(assets, source).CompactStore(ctx, "default", service.GCOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Orphans)
+	assert.False(t, source.Has("key1"))
+}
+
+// An asset row with no store id names a key but not a location. Collecting on
+// that would delete live blobs, so it counts as referenced in every store.
+func TestGC_AssetWithoutStoreID_ProtectsEveryStore(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	bs := testutil.NewBlobStore()
+	ctx := context.Background()
+
+	require.NoError(t, bs.Put(ctx, "key1", bytes.NewReader([]byte("data")), 4))
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		ComponentID: "c1", RepositoryID: "r1", Repository: "repo",
+		Path: "/file.txt", BlobKey: "key1",
+	}))
+
+	result, err := buildGC(assets, bs).CompactStore(ctx, "default", service.GCOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Orphans)
+	assert.True(t, bs.Has("key1"))
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -826,20 +826,26 @@ func (a *AssetRepo) ListByComponentIDs(_ context.Context, componentIDs []string)
 	return out, nil
 }
 
-func (a *AssetRepo) ListAllBlobKeys(_ context.Context) ([]string, error) {
+func (a *AssetRepo) ListAllBlobRefs(_ context.Context) ([]domain.BlobRef, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	seen := make(map[string]struct{})
+	seen := make(map[domain.BlobRef]struct{})
 	for _, v := range a.byID {
 		if v.BlobKey != "" {
-			seen[v.BlobKey] = struct{}{}
+			seen[domain.BlobRef{BlobKey: v.BlobKey, BlobStoreID: v.BlobStoreID}] = struct{}{}
 		}
 	}
-	keys := make([]string, 0, len(seen))
-	for k := range seen {
-		keys = append(keys, k)
+	refs := make([]domain.BlobRef, 0, len(seen))
+	for r := range seen {
+		refs = append(refs, r)
 	}
-	return keys, nil
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].BlobKey != refs[j].BlobKey {
+			return refs[i].BlobKey < refs[j].BlobKey
+		}
+		return refs[i].BlobStoreID < refs[j].BlobStoreID
+	})
+	return refs, nil
 }
 
 func (a *AssetRepo) SumSizeByRepo(_ context.Context, repoName string) (int64, error) {
@@ -988,6 +994,24 @@ func (a *AssetRepo) CountByBlobKey(_ context.Context, blobKey, excludeID string)
 	return n, nil
 }
 
+// CountByBlobKeyInStore mirrors the postgres query: how many assets reference
+// blobKey and still live on blobStoreID. The blob-store migration reads it
+// before deleting the source copy, so a stub answer would make that untestable.
+func (a *AssetRepo) CountByBlobKeyInStore(_ context.Context, blobKey, blobStoreID string) (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.Err != nil {
+		return 0, a.Err
+	}
+	n := 0
+	for _, v := range a.byID {
+		if v.BlobKey == blobKey && v.BlobStoreID == blobStoreID {
+			n++
+		}
+	}
+	return n, nil
+}
+
 func (a *AssetRepo) ListRawAssetPaths(_ context.Context, repoName string) ([]string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -1012,7 +1036,21 @@ func (a *AssetRepo) ListForBlobStoreMigration(_ context.Context, _, _ string) ([
 	return a.MigrationRows, nil
 }
 
-func (a *AssetRepo) UpdateBlobStoreForBlobKey(_ context.Context, _, _, _ string) error {
+// UpdateBlobStoreForBlobKey mirrors the postgres UPDATE: every asset of that
+// repository sharing the key is repointed at the new store. The migration
+// decides whether the source copy may be deleted from what this leaves behind,
+// so the old no-op made that decision untestable.
+func (a *AssetRepo) UpdateBlobStoreForBlobKey(_ context.Context, blobKey, repoName, newBlobStoreID string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.Err != nil {
+		return a.Err
+	}
+	for _, v := range a.byID {
+		if v.BlobKey == blobKey && v.Repository == repoName {
+			v.BlobStoreID = newBlobStoreID
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #297. Closes #298.

Both issues live in the same per-row loop of `runMigration`, and the fix for one moves the code the other needs, so they ship together.

## #297 — bytes stranded in the source

The loop copied the blob, credited the target's `used_bytes` and repointed the rows, but never deleted the source object or decremented the source's usage. GC could not clean up after it either: `referencedSet` was keyed by `blob_key` alone, and a migration changes only `blob_store_id`, so the abandoned copy stayed "referenced" forever.

- `dropSourceCopy` deletes the source object and decrements that store's `used_bytes`, guarded by a new store-scoped `CountByBlobKeyInStore` — the same key can legitimately still be in use on the source by another repository's asset or an OCI digest alias.
- `ListAllBlobKeys` becomes `ListAllBlobRefs` (`blob_key`, `blob_store_id`), and GC's index answers "referenced *in this store*". Rows with no store id name a key but not a location, so they still protect every store — nothing predating `blob_store_id` can be collected by mistake.

## #298 — row repointed at a stale copy

The repository stays pointed at the source store until the last row is done, so a client upload lands in the source while the migration streams that same blob. `copyBlob` now re-measures the source after the copy: if the size moved (or cannot be read), the staged target copy is deleted and the migration fails with a message naming the blob, instead of repointing a row whose size and bytes disagree. A re-run copies the bytes that actually exist; already-migrated rows are skipped by the existing `Exists` resume check.

## Tests

- `copyBlob` aborts and leaves no staged copy when the source size shifts, and when it cannot be re-checked; unchanged blobs still copy through.
- End-to-end migration drops the source copy and its usage, and keeps both when another repository still references the key on that store.
- GC collects a copy whose key is referenced only in another store, and leaves keys from store-id-less rows alone. Two existing GC fixtures used a store id (`bs1`) that did not match the store under compaction; they now sit on the default store, which is what they were describing.
- Mock `UpdateBlobStoreForBlobKey` / `CountByBlobKeyInStore` now mirror the real queries — the former was a no-op, which is why none of this was observable in tests before.

Unrelated pre-existing failures on this branch: `TestWebhookHandler_Test_200` (sandbox blocks loopback dial) and a flaky `TestValidateToken_TamperedSignature` (passes on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcrsCyNcvsEKp881db5JL