### PR TITLE
fix(api): close the RBAC gaps around direct component reads, quota, and pagination

### DIFF
--- a/internal/api/handlers/components.go
+++ b/internal/api/handlers/components.go
@@ -50,6 +50,112 @@ func (h *ComponentHandler) allowAnonMap(ctx context.Context, repoNames []string)
 	return m
 }
 
+// maxFilterScanPages bounds how many DB pages one request may drain while
+// assembling a filtered page, so a caller who can see almost nothing cannot
+// make a single request walk an arbitrarily large table. On hitting the bound
+// the partial page is returned with a continuationToken, and the client
+// resumes exactly where the scan stopped.
+const maxFilterScanPages = 10
+
+// drainFilteredPage assembles one caller-visible page of up to limit items,
+// fetching as many DB pages as needed to refill what the RBAC filter removes.
+// Filtering used to happen after LIMIT/OFFSET, which handed clients short or
+// empty pages with a non-null continuationToken (#296). The returned token is
+// the DB offset just past the last row consumed — the same offset-in-disguise
+// the repos already emit — so pages stay full until the set is exhausted.
+func drainFilteredPage[T any](
+	limit, offset int,
+	fetch func(limit, offset int) ([]T, *string, error),
+	filter func([]T) []T,
+	id func(T) string,
+) ([]T, *string, error) {
+	out := make([]T, 0, limit)
+	cur := offset
+	for scanned := 0; scanned < maxFilterScanPages; scanned++ {
+		items, next, err := fetch(limit, cur)
+		if err != nil {
+			return nil, nil, err
+		}
+		kept := filter(items)
+		keptSet := make(map[string]struct{}, len(kept))
+		for _, k := range kept {
+			keptSet[id(k)] = struct{}{}
+		}
+		for i, it := range items {
+			if _, ok := keptSet[id(it)]; !ok {
+				continue
+			}
+			out = append(out, it)
+			if len(out) == limit {
+				cur += i + 1
+				if i+1 < len(items) || next != nil {
+					tok := strconv.Itoa(cur)
+					return out, &tok, nil
+				}
+				return out, nil, nil
+			}
+		}
+		cur += len(items)
+		if next == nil {
+			return out, nil, nil
+		}
+	}
+	tok := strconv.Itoa(cur)
+	return out, &tok, nil
+}
+
+// componentFilter returns the RBAC filter for a page of components, computing
+// the AllowAnonymous map from the repositories actually present in the page.
+// With no RBAC service attached it is the identity.
+func (h *ComponentHandler) componentFilter(c *gin.Context) func([]domain.Component) []domain.Component {
+	if h.rbacSvc == nil {
+		return func(items []domain.Component) []domain.Component { return items }
+	}
+	userID, _ := c.Get("userID")
+	roles, _ := c.Get("roles")
+	return func(items []domain.Component) []domain.Component {
+		if len(items) == 0 {
+			return items
+		}
+		repoSet := make(map[string]struct{}, 4)
+		for _, comp := range items {
+			repoSet[comp.Repository] = struct{}{}
+		}
+		repoList := make([]string, 0, len(repoSet))
+		for n := range repoSet {
+			repoList = append(repoList, n)
+		}
+		anonMap := h.allowAnonMap(c.Request.Context(), repoList)
+		return h.rbacSvc.FilterComponents(c.Request.Context(),
+			stringVal(userID), stringSliceVal(roles), items, anonMap)
+	}
+}
+
+// assetFilter is componentFilter's twin for asset pages.
+func (h *ComponentHandler) assetFilter(c *gin.Context) func([]domain.Asset) []domain.Asset {
+	if h.rbacSvc == nil {
+		return func(items []domain.Asset) []domain.Asset { return items }
+	}
+	userID, _ := c.Get("userID")
+	roles, _ := c.Get("roles")
+	return func(items []domain.Asset) []domain.Asset {
+		if len(items) == 0 {
+			return items
+		}
+		repoSet := make(map[string]struct{}, 4)
+		for _, a := range items {
+			repoSet[a.Repository] = struct{}{}
+		}
+		repoList := make([]string, 0, len(repoSet))
+		for n := range repoSet {
+			repoList = append(repoList, n)
+		}
+		anonMap := h.allowAnonMap(c.Request.Context(), repoList)
+		return h.rbacSvc.FilterAssets(c.Request.Context(),
+			stringVal(userID), stringSliceVal(roles), items, anonMap)
+	}
+}
+
 // List handles GET /service/rest/v1/components?repository=X
 func (h *ComponentHandler) List(c *gin.Context) {
 	repoName := c.Query("repository")
@@ -93,22 +199,19 @@ func (h *ComponentHandler) List(c *gin.Context) {
 		return
 	}
 
-	page, err := h.components.ListByRepoNames(c.Request.Context(), names, limit, offset)
+	items, token, err := drainFilteredPage(limit, offset,
+		func(l, o int) ([]domain.Component, *string, error) {
+			page, err := h.components.ListByRepoNames(c.Request.Context(), names, l, o)
+			if err != nil {
+				return nil, nil, err
+			}
+			return page.Items, page.ContinuationToken, nil
+		},
+		h.componentFilter(c),
+		func(comp domain.Component) string { return comp.ID })
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
-	}
-
-	items := page.Items
-	if items == nil {
-		items = []domain.Component{}
-	}
-	if h.rbacSvc != nil {
-		anonMap := h.allowAnonMap(c.Request.Context(), names)
-		userID, _ := c.Get("userID")
-		roles, _ := c.Get("roles")
-		items = h.rbacSvc.FilterComponents(c.Request.Context(),
-			stringVal(userID), stringSliceVal(roles), items, anonMap)
 	}
 	if err := h.attachAssets(c.Request.Context(), items); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
@@ -120,7 +223,7 @@ func (h *ComponentHandler) List(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"items":             items,
-		"continuationToken": page.ContinuationToken,
+		"continuationToken": token,
 	})
 }
 
@@ -171,6 +274,22 @@ func (h *ComponentHandler) Get(c *gin.Context) {
 		return
 	}
 	comp.Assets = assets
+	// The list and search endpoints filter what they return through RBAC; a
+	// direct GET by id must answer the same question the same way, or knowing a
+	// UUID becomes a key to metadata and scan results the caller has no
+	// privilege over (#291). Filtered-out is reported as 404, not 403 — the id
+	// should stay unguessable.
+	if h.rbacSvc != nil {
+		anonMap := h.allowAnonMap(c.Request.Context(), []string{comp.Repository})
+		userID, _ := c.Get("userID")
+		roles, _ := c.Get("roles")
+		visible := h.rbacSvc.FilterComponents(c.Request.Context(),
+			stringVal(userID), stringSliceVal(roles), []domain.Component{*comp}, anonMap)
+		if len(visible) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "component not found"})
+			return
+		}
+	}
 	h.enrichComponent(c, comp)
 	c.JSON(http.StatusOK, comp)
 }
@@ -252,31 +371,21 @@ func (h *ComponentHandler) Search(c *gin.Context) {
 		p.Repository = ""
 	}
 
-	page, err := h.components.Search(c.Request.Context(), p)
+	items, token, err := drainFilteredPage(p.Limit, p.Offset,
+		func(l, o int) ([]domain.Component, *string, error) {
+			q := p
+			q.Limit, q.Offset = l, o
+			page, err := h.components.Search(c.Request.Context(), q)
+			if err != nil {
+				return nil, nil, err
+			}
+			return page.Items, page.ContinuationToken, nil
+		},
+		h.componentFilter(c),
+		func(comp domain.Component) string { return comp.ID })
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
-	}
-
-	items := page.Items
-	if items == nil {
-		items = []domain.Component{}
-	}
-	if h.rbacSvc != nil && len(items) > 0 {
-		// Collect unique repo names from results (may span group members).
-		repoSet := make(map[string]struct{}, 4)
-		for _, comp := range items {
-			repoSet[comp.Repository] = struct{}{}
-		}
-		repoList := make([]string, 0, len(repoSet))
-		for n := range repoSet {
-			repoList = append(repoList, n)
-		}
-		anonMap := h.allowAnonMap(c.Request.Context(), repoList)
-		userID, _ := c.Get("userID")
-		roles, _ := c.Get("roles")
-		items = h.rbacSvc.FilterComponents(c.Request.Context(),
-			stringVal(userID), stringSliceVal(roles), items, anonMap)
 	}
 	// Preload assets in a single batched query instead of one query per component.
 	if err := h.attachAssets(c.Request.Context(), items); err != nil {
@@ -289,7 +398,7 @@ func (h *ComponentHandler) Search(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"items":             items,
-		"continuationToken": page.ContinuationToken,
+		"continuationToken": token,
 	})
 }
 
@@ -325,30 +434,21 @@ func (h *ComponentHandler) SearchAssets(c *gin.Context) {
 		p.Repository = ""
 	}
 
-	page, err := h.assets.SearchAssets(c.Request.Context(), p)
+	items, token, err := drainFilteredPage(p.Limit, p.Offset,
+		func(l, o int) ([]domain.Asset, *string, error) {
+			q := p
+			q.Limit, q.Offset = l, o
+			page, err := h.assets.SearchAssets(c.Request.Context(), q)
+			if err != nil {
+				return nil, nil, err
+			}
+			return page.Items, page.ContinuationToken, nil
+		},
+		h.assetFilter(c),
+		func(a domain.Asset) string { return a.ID })
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
-	}
-
-	items := page.Items
-	if items == nil {
-		items = []domain.Asset{}
-	}
-	if h.rbacSvc != nil && len(items) > 0 {
-		repoSet := make(map[string]struct{}, 4)
-		for _, a := range items {
-			repoSet[a.Repository] = struct{}{}
-		}
-		repoList := make([]string, 0, len(repoSet))
-		for n := range repoSet {
-			repoList = append(repoList, n)
-		}
-		anonMap := h.allowAnonMap(c.Request.Context(), repoList)
-		userID, _ := c.Get("userID")
-		roles, _ := c.Get("roles")
-		items = h.rbacSvc.FilterAssets(c.Request.Context(),
-			stringVal(userID), stringSliceVal(roles), items, anonMap)
 	}
 	for i := range items {
 		items[i].DownloadURL = h.baseURL + "/repository/" + items[i].Repository + items[i].Path
@@ -356,7 +456,7 @@ func (h *ComponentHandler) SearchAssets(c *gin.Context) {
 
 	c.JSON(http.StatusOK, gin.H{
 		"items":             items,
-		"continuationToken": page.ContinuationToken,
+		"continuationToken": token,
 	})
 }
 
@@ -446,6 +546,20 @@ func (h *ComponentHandler) GetQuota(c *gin.Context) {
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
+	}
+
+	// Quota is repository-wide capacity metadata, so the gate is the same
+	// repo-level check the repository listing uses — a caller who cannot see
+	// the repository in a listing should not learn its size either (#295).
+	if h.rbacSvc != nil {
+		userID, _ := c.Get("userID")
+		roles, _ := c.Get("roles")
+		visible := h.rbacSvc.FilterRepos(c.Request.Context(),
+			stringVal(userID), stringSliceVal(roles), []domain.Repository{*repo})
+		if len(visible) == 0 {
+			c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
+			return
+		}
 	}
 
 	used, err := h.assets.SumSizeByRepo(c.Request.Context(), name)

--- a/internal/api/handlers/components_test.go
+++ b/internal/api/handlers/components_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
@@ -687,4 +689,147 @@ func TestComponentHandler_SearchAssets_RBAC_AdminPassthrough(t *testing.T) {
 	var got assetsResp
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
 	require.Len(t, got.Items, 1)
+}
+
+// ── RBAC on Get / GetQuota / pagination (#291, #295, #296) ────
+
+// grantRBACRepo grants one privilege: browse/read on a single repository.
+type grantRBACRepo struct{ repo string }
+
+func (g grantRBACRepo) GetUserPrivilegesWithSelectors(_ context.Context, _ string) ([]repository.PrivilegeWithSelector, error) {
+	return []repository.PrivilegeWithSelector{
+		{Actions: []string{"read", "browse"}, Expression: `repository == "` + g.repo + `"`},
+	}, nil
+}
+
+// mountComponentsAs wires the handler with an RBAC service backed by rbacRepo
+// and a middleware injecting the given non-admin identity.
+func mountComponentsAs(t *testing.T, rbacRepo repository.RBACRepo, userID string) (*gin.Engine, *testutil.ComponentRepo, *testutil.AssetRepo, *testutil.RepoRepo) {
+	t.Helper()
+	comps := testutil.NewComponentRepo()
+	assets := testutil.NewAssetRepo()
+	repos := testutil.NewRepoRepo()
+	rbacSvc := service.NewRBACService(rbacRepo, repos, zap.NewNop().Sugar(), true)
+	h := handlers.NewComponentHandler(comps, assets, repos, "http://localhost").WithRBAC(rbacSvc)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("userID", userID)
+		c.Set("roles", []string{"nx-user"})
+		c.Next()
+	})
+	r.GET("/service/rest/v1/components", h.List)
+	r.GET("/service/rest/v1/components/:id", h.Get)
+	r.GET("/service/rest/v1/search", h.Search)
+	r.GET("/service/rest/v1/search/assets", h.SearchAssets)
+	r.GET("/api/v1/repositories/:name/quota", h.GetQuota)
+	return r, comps, assets, repos
+}
+
+// Knowing a component UUID must not bypass the filter List applies: a user
+// with no privilege over a non-anonymous repo gets 404, not the metadata and
+// scan results (#291).
+func TestComponentHandler_Get_RBAC_FilteredOut_404(t *testing.T) {
+	r, comps, _, repos := mountComponentsAs(t, emptyRBACRepo{}, "nobody")
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "private-repo", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	comp := &domain.Component{Repository: "private-repo", Name: "secret", Version: "1"}
+	require.NoError(t, comps.Create(testContext(), comp))
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components/"+comp.ID, nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// The same request with a privilege over the repo still answers in full.
+func TestComponentHandler_Get_RBAC_Privileged_OK(t *testing.T) {
+	r, comps, _, repos := mountComponentsAs(t, grantRBACRepo{repo: "private-repo"}, "reader")
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "private-repo", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	comp := &domain.Component{Repository: "private-repo", Name: "app", Version: "1"}
+	require.NoError(t, comps.Create(testContext(), comp))
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components/"+comp.ID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// An anonymous-allowed repo stays reachable without privileges.
+func TestComponentHandler_Get_RBAC_AnonymousRepo_OK(t *testing.T) {
+	r, comps, _, repos := mountComponentsAs(t, emptyRBACRepo{}, "nobody")
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "public-repo", Format: domain.FormatRaw, Type: domain.TypeHosted, AllowAnonymous: true})
+	comp := &domain.Component{Repository: "public-repo", Name: "app", Version: "1"}
+	require.NoError(t, comps.Create(testContext(), comp))
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components/"+comp.ID, nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// Capacity metadata is gated by the same repo-level check the listing uses (#295).
+func TestComponentHandler_GetQuota_RBAC_FilteredOut_404(t *testing.T) {
+	r, _, _, repos := mountComponentsAs(t, emptyRBACRepo{}, "nobody")
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "private-repo", Format: domain.FormatRaw, Type: domain.TypeHosted})
+
+	rec := do(t, r, http.MethodGet, "/api/v1/repositories/private-repo/quota", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestComponentHandler_GetQuota_RBAC_Privileged_OK(t *testing.T) {
+	r, _, _, repos := mountComponentsAs(t, grantRBACRepo{repo: "private-repo"}, "reader")
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "private-repo", Format: domain.FormatRaw, Type: domain.TypeHosted})
+
+	rec := do(t, r, http.MethodGet, "/api/v1/repositories/private-repo/quota", nil)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// A page must stay full while visible rows remain: the RBAC filter runs after
+// LIMIT/OFFSET at the DB, so the handler refills the page from later DB rows
+// instead of returning a short page with a dangling token (#296).
+func TestComponentHandler_List_RBAC_RefillsFilteredPage(t *testing.T) {
+	r, comps, _, repos := mountComponentsAs(t, grantRBACRepo{repo: "mine"}, "reader")
+	seedRepo(t, repos, &domain.Repository{
+		ID: "r1", Name: "grp", Format: domain.FormatRaw, Type: domain.TypeGroup,
+		FormatConfig: map[string]any{"member_names": []string{"mine", "theirs"}},
+	})
+	seedRepo(t, repos, &domain.Repository{ID: "r2", Name: "mine", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	seedRepo(t, repos, &domain.Repository{ID: "r3", Name: "theirs", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	// Interleave visible and invisible components. Mock lists sort by name.
+	for i := 0; i < 4; i++ {
+		require.NoError(t, comps.Create(testContext(), &domain.Component{Repository: "mine", Name: fmt.Sprintf("a%d-mine", i), Version: "1"}))
+		require.NoError(t, comps.Create(testContext(), &domain.Component{Repository: "theirs", Name: fmt.Sprintf("a%d-their", i), Version: "1"}))
+	}
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components?repository=grp&limit=3", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got componentsResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	// Page 1: full despite half the DB rows being filtered out.
+	require.Len(t, got.Items, 3)
+	for _, it := range got.Items {
+		assert.Equal(t, "mine", it.Repository)
+	}
+	require.NotNil(t, got.ContinuationToken)
+
+	// Page 2: the remaining visible component, then the set is exhausted.
+	rec = do(t, r, http.MethodGet, "/service/rest/v1/components?repository=grp&limit=3&continuationToken="+*got.ContinuationToken, nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Len(t, got.Items, 1)
+	assert.Equal(t, "mine", got.Items[0].Repository)
+	assert.Nil(t, got.ContinuationToken)
+}
+
+// A caller who can see nothing must not walk the whole table in one request:
+// the scan is bounded, and the partial (empty) page keeps a token to resume.
+func TestComponentHandler_List_RBAC_ScanBounded(t *testing.T) {
+	r, comps, _, repos := mountComponentsAs(t, emptyRBACRepo{}, "nobody")
+	seedRepo(t, repos, &domain.Repository{ID: "r1", Name: "private-repo", Format: domain.FormatRaw, Type: domain.TypeHosted})
+	for i := 0; i < 30; i++ {
+		require.NoError(t, comps.Create(testContext(), &domain.Component{Repository: "private-repo", Name: fmt.Sprintf("c%02d", i), Version: "1"}))
+	}
+
+	// limit=2 → the bound allows 10 DB pages = 20 rows; 10 rows remain.
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/components?repository=private-repo&limit=2", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got componentsResp
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Empty(t, got.Items)
+	require.NotNil(t, got.ContinuationToken)
+	assert.Equal(t, "20", *got.ContinuationToken)
 }


### PR DESCRIPTION
Closes #291. Closes #295. Closes #296.

## #291 — `ComponentHandler.Get` IDOR

`Get` returned any component by UUID in full (assets, `downloadUrl`, `extra.scan_result` with real CVEs) to any authenticated caller, while `List`/`Search` filtered the same component out. It now runs the loaded component through the same `FilterComponents` call `List` makes and answers **404** when the filter excludes it — not 403, so ids stay unguessable.

## #295 — `GetQuota` unauthenticated capacity leak

Now gated on `FilterRepos` — the repo-level check the repository listing already uses, the right granularity for a repository-wide aggregate. Filtered-out → 404, same shape as the listing.

## #296 — RBAC filter after DB pagination

`List`/`Search`/`SearchAssets` filtered after `LIMIT/OFFSET`, producing short or empty pages with a non-null `continuationToken`. A shared `drainFilteredPage` helper now refills the page from later DB rows until full or exhausted; the emitted token is the DB offset just past the last consumed row (the same offset-in-disguise the repos already emit), so existing tokens stay valid. The scan is bounded at 10 DB pages per request — a caller who can see nothing cannot walk an arbitrarily large table in one call; at the bound the partial page carries a token to resume.

## Tests

- Get: filtered-out → 404, privileged → 200, anonymous repo → 200.
- GetQuota: filtered-out → 404, privileged → 200.
- List: page stays full when half the DB rows are invisible (interleaved group members), second page drains the tail with a null token; empty-visibility scan stops at the bound with a resumable token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcrsCyNcvsEKp881db5JL