### PR TITLE
fix(auth): enforce API token scopes instead of storing them as decoration

### DIFF
--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -209,19 +209,70 @@ func authenticateBearer(c *gin.Context, users *service.UserService, tokens *serv
 		c.Set("username", claims.Username)
 		c.Set("userID", claims.UserID)
 		c.Set("roles", claims.Roles)
+		setTokenScopes(c, claims.Scopes)
 		return true, false
 	}
 	if tokens == nil {
 		return false, false
 	}
-	u, err := tokens.Authenticate(c.Request.Context(), raw)
+	u, scopes, err := tokens.Authenticate(c.Request.Context(), raw)
 	if err != nil || u == nil {
 		return false, false
 	}
 	c.Set("username", u.Username)
 	c.Set("userID", u.ID)
 	c.Set("roles", u.Roles)
+	setTokenScopes(c, scopes)
 	return true, false
+}
+
+// setTokenScopes stashes a non-empty scope list for the request's
+// authorization checkpoints (scopesAllow in AuthMiddleware and
+// RBACMiddleware). Nothing is set for an unscoped token, so the absence of
+// the key means "unrestricted" everywhere it is read.
+func setTokenScopes(c *gin.Context, scopes []string) {
+	if len(scopes) > 0 {
+		c.Set("tokenScopes", scopes)
+	}
+}
+
+// scopesAllow reports whether the request's API-token scopes (if any) permit
+// the given action. Scopes are hierarchical — delete ⊃ write ⊃ read — because
+// real write flows read on the way (a Docker push HEADs blobs before
+// uploading), so a write-only token that cannot read would not be usable for
+// the one thing it was scoped to. Unknown scope names grant nothing.
+func scopesAllow(c *gin.Context, action string) bool {
+	v, ok := c.Get("tokenScopes")
+	if !ok {
+		return true
+	}
+	scopes, _ := v.([]string)
+	if len(scopes) == 0 {
+		return true
+	}
+	rank := map[string]int{"read": 1, "write": 2, "delete": 3}
+	need := rank[action]
+	if need == 0 {
+		need = rank["read"]
+	}
+	for _, sc := range scopes {
+		if rank[strings.ToLower(strings.TrimSpace(sc))] >= need {
+			return true
+		}
+	}
+	return false
+}
+
+// enforceTokenScopes aborts with 403 when the request's API-token scopes do
+// not cover the action its HTTP method implies. Returns false when aborted.
+// This is the management-API checkpoint; artifact routes get the same check
+// with a path-aware action inside RBACMiddleware.
+func enforceTokenScopes(c *gin.Context) bool {
+	if scopesAllow(c, methodToAction(c.Request.Method)) {
+		return true
+	}
+	c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "token scope does not permit this action"})
+	return false
 }
 
 // jwtNotRevoked reports whether the JWT's claims pass the per-user
@@ -256,10 +307,14 @@ func AuthMiddleware(users *service.UserService, tokens *service.TokenService, gu
 				// An API token can also be supplied via Basic auth with any
 				// username (convention: username=<token-name-or-user>, password=token).
 				if tokens != nil && strings.HasPrefix(password, service.TokenPrefix) {
-					if u, err := tokens.Authenticate(c.Request.Context(), password); err == nil && u != nil {
+					if u, scopes, err := tokens.Authenticate(c.Request.Context(), password); err == nil && u != nil {
 						c.Set("username", u.Username)
 						c.Set("userID", u.ID)
 						c.Set("roles", u.Roles)
+						setTokenScopes(c, scopes)
+						if !enforceTokenScopes(c) {
+							return
+						}
 						c.Next()
 						return
 					}
@@ -298,6 +353,9 @@ func AuthMiddleware(users *service.UserService, tokens *service.TokenService, gu
 				msg = "token invalidated"
 			}
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": msg})
+			return
+		}
+		if !enforceTokenScopes(c) {
 			return
 		}
 		c.Next()
@@ -381,7 +439,7 @@ func DockerV2Auth(
 				return
 			}
 			if tokens != nil {
-				if _, err := tokens.Authenticate(c.Request.Context(), raw); err == nil {
+				if _, _, err := tokens.Authenticate(c.Request.Context(), raw); err == nil {
 					c.Status(http.StatusOK)
 					return
 				}
@@ -389,7 +447,7 @@ func DockerV2Auth(
 		} else if strings.HasPrefix(authHeader, "Basic ") {
 			if username, password, ok := c.Request.BasicAuth(); ok {
 				if tokens != nil && strings.HasPrefix(password, service.TokenPrefix) {
-					if u, err := tokens.Authenticate(c.Request.Context(), password); err == nil && u != nil {
+					if u, _, err := tokens.Authenticate(c.Request.Context(), password); err == nil && u != nil {
 						c.Set("username", u.Username)
 						c.Set("userID", u.ID)
 						c.Status(http.StatusOK)
@@ -463,10 +521,11 @@ func OptionalAuth(users *service.UserService, tokens *service.TokenService, guar
 		if username, password, ok := c.Request.BasicAuth(); ok && username != "" {
 			ctx := c.Request.Context()
 			if tokens != nil && strings.HasPrefix(password, service.TokenPrefix) {
-				if u, err := tokens.Authenticate(ctx, password); err == nil && u != nil {
+				if u, scopes, err := tokens.Authenticate(ctx, password); err == nil && u != nil {
 					c.Set("username", u.Username)
 					c.Set("userID", u.ID)
 					c.Set("roles", u.Roles)
+					setTokenScopes(c, scopes)
 					c.Next()
 					return
 				}

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -2,6 +2,7 @@ package handlers_test
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -403,4 +404,134 @@ func TestDockerV2Auth_WrongBasicPassword_Returns401(t *testing.T) {
 	challenges := w.Header().Values("WWW-Authenticate")
 	require.Len(t, challenges, 1)
 	assert.Contains(t, challenges[0], "Bearer realm=")
+}
+
+// ── API token scope enforcement (#292) ────────────────────────
+
+// scopedTokenSetup builds a user + token service pair and mints one API token
+// with the given scopes, returning the plaintext token.
+func scopedTokenSetup(t *testing.T, scopes []string) (*service.UserService, *service.TokenService, string) {
+	t.Helper()
+	u := activeUser("dev", "pw")
+	userRepo := testutil.NewUserRepo(u)
+	userSvc := newUserSvc(u)
+	tokenSvc := service.NewTokenService(testutil.NewUserTokenRepo(), userRepo)
+	tok, err := tokenSvc.Create(testContext(), u.ID, "ci", scopes, nil)
+	require.NoError(t, err)
+	return userSvc, tokenSvc, tok.Token
+}
+
+// scopedRouter mounts AuthMiddleware plus echo handlers for each method.
+func scopedRouter(userSvc *service.UserService, tokenSvc *service.TokenService) *gin.Engine {
+	r := gin.New()
+	r.Use(handlers.AuthMiddleware(userSvc, tokenSvc, nil, nil))
+	ok := func(c *gin.Context) { c.Status(http.StatusOK) }
+	r.GET("/x", ok)
+	r.PUT("/x", ok)
+	r.DELETE("/x", ok)
+	return r
+}
+
+// A token created with scopes: ["read"] promised a restricted session; writes
+// through it must be refused even though the owning user could write (#292).
+func TestAuthMiddleware_TokenScopes_ReadOnlyBlocksWrite(t *testing.T) {
+	userSvc, tokenSvc, raw := scopedTokenSetup(t, []string{"read"})
+	r := scopedRouter(userSvc, tokenSvc)
+
+	get := httptest.NewRequest(http.MethodGet, "/x", nil)
+	get.Header.Set("Authorization", "Bearer "+raw)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, get)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	put := httptest.NewRequest(http.MethodPut, "/x", nil)
+	put.Header.Set("Authorization", "Bearer "+raw)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, put)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	del := httptest.NewRequest(http.MethodDelete, "/x", nil)
+	del.Header.Set("Authorization", "Bearer "+raw)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, del)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// Scopes are hierarchical: write covers read (a push HEADs blobs on the way),
+// delete covers everything.
+func TestAuthMiddleware_TokenScopes_WriteImpliesRead(t *testing.T) {
+	userSvc, tokenSvc, raw := scopedTokenSetup(t, []string{"write"})
+	r := scopedRouter(userSvc, tokenSvc)
+
+	for method, want := range map[string]int{
+		http.MethodGet:    http.StatusOK,
+		http.MethodPut:    http.StatusOK,
+		http.MethodDelete: http.StatusForbidden,
+	} {
+		req := httptest.NewRequest(method, "/x", nil)
+		req.Header.Set("Authorization", "Bearer "+raw)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, want, w.Code, method)
+	}
+}
+
+// A token created without scopes stays fully unrestricted — the behavior of
+// every token issued before scopes were enforced.
+func TestAuthMiddleware_TokenScopes_NoScopesUnrestricted(t *testing.T) {
+	userSvc, tokenSvc, raw := scopedTokenSetup(t, nil)
+	r := scopedRouter(userSvc, tokenSvc)
+
+	for _, method := range []string{http.MethodGet, http.MethodPut, http.MethodDelete} {
+		req := httptest.NewRequest(method, "/x", nil)
+		req.Header.Set("Authorization", "Bearer "+raw)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, method)
+	}
+}
+
+// The same cap holds when the token arrives as a Basic password.
+func TestAuthMiddleware_TokenScopes_BasicAuthPath(t *testing.T) {
+	userSvc, tokenSvc, raw := scopedTokenSetup(t, []string{"read"})
+	r := scopedRouter(userSvc, tokenSvc)
+
+	req := httptest.NewRequest(http.MethodPut, "/x", nil)
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("dev:"+raw)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// Exchanging a scoped API token at /v2/token must not widen it: the issued
+// JWT carries the scopes, and a Bearer request through OptionalAuth+RBAC
+// obeys the same cap (#292).
+func TestDockerToken_ScopedExchange_JWTKeepsScopes(t *testing.T) {
+	userSvc, tokenSvc, raw := scopedTokenSetup(t, []string{"read"})
+	authSvc := auth.NewService(testSecret, 24, bcryptCostTest)
+
+	r := gin.New()
+	r.GET("/v2/token", handlers.DockerToken(authSvc, userSvc, tokenSvc, false, time.Hour, nil, nil))
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/token", nil)
+	req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("dev:"+raw)))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct {
+		Token string `json:"token"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	claims, err := authSvc.ValidateToken(body.Token)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"read"}, claims.Scopes)
+
+	// The scoped JWT is capped exactly like the API token it came from.
+	pr := scopedRouter(userSvc, tokenSvc)
+	put := httptest.NewRequest(http.MethodPut, "/x", nil)
+	put.Header.Set("Authorization", "Bearer "+body.Token)
+	w = httptest.NewRecorder()
+	pr.ServeHTTP(w, put)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }

--- a/internal/api/handlers/docker_token.go
+++ b/internal/api/handlers/docker_token.go
@@ -20,6 +20,15 @@ type TokenIssuer interface {
 	GenerateToken(userID, username string, roles []string) (string, error)
 }
 
+// ScopedTokenIssuer is implemented by issuers that can embed an API token's
+// scopes into the minted JWT (*auth.Service does). When a scoped API token is
+// exchanged at /v2/token, the JWT must carry the restriction forward —
+// otherwise the exchange would be a one-request laundering of a read-only
+// token into a full-power session (#292).
+type ScopedTokenIssuer interface {
+	GenerateScopedToken(userID, username string, roles, scopes []string) (string, error)
+}
+
 // DockerToken serves GET /v2/token — the docker token protocol endpoint the
 // /v2/ ping's Bearer challenge points at (#260).
 //
@@ -41,7 +50,10 @@ type TokenIssuer interface {
 //
 // The requested scope/service query parameters are deliberately ignored: the
 // token conveys identity, not capability — authorization happens per request
-// in RBACMiddleware, so tokens never need to encode what they may touch.
+// in RBACMiddleware, so tokens never need to encode what they may touch. The
+// one exception is an nxs_ API token created with scopes: its restriction is
+// its own, not the protocol's, and it is embedded into the issued JWT so the
+// exchange cannot widen it.
 //
 // Registered for GET and POST. containerd and BuildKit try the OAuth2 form
 // POST (grant_type=password) first and fall back to GET only on 404/405 —
@@ -60,8 +72,14 @@ func DockerToken(
 	log logger.Logger,
 ) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		issue := func(userID, username string, roles []string) {
-			token, err := issuer.GenerateToken(userID, username, roles)
+		issue := func(userID, username string, roles, scopes []string) {
+			var token string
+			var err error
+			if si, ok := issuer.(ScopedTokenIssuer); ok && len(scopes) > 0 {
+				token, err = si.GenerateScopedToken(userID, username, roles, scopes)
+			} else {
+				token, err = issuer.GenerateToken(userID, username, roles)
+			}
 			if err != nil {
 				// Not 401: the caller's credentials were fine, signing failed.
 				c.JSON(http.StatusServiceUnavailable, gin.H{"error": "could not issue token"})
@@ -89,8 +107,8 @@ func DockerToken(
 		if username != "" {
 			ctx := c.Request.Context()
 			if tokens != nil && strings.HasPrefix(password, service.TokenPrefix) {
-				if u, err := tokens.Authenticate(ctx, password); err == nil && u != nil {
-					issue(u.ID, u.Username, u.Roles)
+				if u, scopes, err := tokens.Authenticate(ctx, password); err == nil && u != nil {
+					issue(u.ID, u.Username, u.Roles, scopes)
 					return
 				}
 			}
@@ -103,7 +121,7 @@ func DockerToken(
 			_, user, err := users.Login(ctx, username, password)
 			if err == nil {
 				guard.RecordSuccess(ctx, username)
-				issue(user.ID, user.Username, user.Roles)
+				issue(user.ID, user.Username, user.Roles, nil)
 				return
 			}
 			guard.RecordFailure(ctx, username)
@@ -118,6 +136,6 @@ func DockerToken(
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
 			return
 		}
-		issue("", "", nil)
+		issue("", "", nil, nil)
 	}
 }

--- a/internal/api/handlers/rbac_middleware.go
+++ b/internal/api/handlers/rbac_middleware.go
@@ -28,6 +28,15 @@ func RBACMiddleware(rbacSvc *service.RBACService, repoRepo repository.Repository
 
 		action := methodToAction(c.Request.Method)
 
+		// An API token created with scopes promised a restricted session; the
+		// privilege check below judges the user, so without this the token
+		// silently carried the account's full power (#292). Scopes cap the
+		// action on top of — never instead of — the privilege check.
+		if !scopesAllow(c, action) {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "token scope does not permit this action"})
+			return
+		}
+
 		userID, _ := c.Get("userID")
 		roles, _ := c.Get("roles")
 		userIDStr, _ := userID.(string)

--- a/internal/api/handlers/rbac_middleware_test.go
+++ b/internal/api/handlers/rbac_middleware_test.go
@@ -104,3 +104,41 @@ func TestRBACMiddleware_UnauthenticatedNonDocker_UsesGenericBody(t *testing.T) {
 	_, hasErrors := body["errors"]
 	assert.False(t, hasErrors, "non-/v2/ path must not emit OCI errors[] body")
 }
+
+// A read-scoped API token caps the artifact routes on top of the privilege
+// check: the user may write, the token may not (#292).
+func TestRBACMiddleware_TokenScopes_CapArtifactWrites(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	repo := &domain.Repository{
+		ID: "r1", Name: "raw-host", Format: domain.FormatRaw,
+		Type: domain.TypeHosted, Online: true, AllowAnonymous: true,
+	}
+	repoRepo := testutil.NewRepoRepo(repo)
+	rbacSvc := service.NewRBACService(&noPrivilegesRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
+
+	r := gin.New()
+	// Simulate OptionalAuth having authenticated a read-scoped API token
+	// for an admin — the strongest user the scope still has to cap.
+	r.Use(func(c *gin.Context) {
+		c.Set("userID", "u1")
+		c.Set("roles", []string{"nx-admin"})
+		c.Set("tokenScopes", []string{"read"})
+		c.Next()
+	})
+	grp := r.Group("/repository/:repoName", handlers.RBACMiddleware(rbacSvc, repoRepo))
+	grp.Any("/*path", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	get := httptest.NewRequest(http.MethodGet, "/repository/raw-host/a.txt", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, get)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	put := httptest.NewRequest(http.MethodPut, "/repository/raw-host/a.txt", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, put)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Contains(t, body["error"], "token scope")
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -22,6 +22,11 @@ type Claims struct {
 	Username   string   `json:"sub"`
 	Roles      []string `json:"roles"`
 	AuthMethod string   `json:"auth_method,omitempty"`
+	// Scopes carries an API token's read/write/delete restriction into a JWT
+	// minted from it (the /v2/token exchange), so the restriction survives the
+	// exchange instead of silently widening to the full account (#292).
+	// Empty means unrestricted — every JWT issued before scopes existed.
+	Scopes []string `json:"scopes,omitempty"`
 	jwt.RegisteredClaims
 }
 
@@ -67,6 +72,26 @@ func (s *Service) GenerateTokenWithMethod(userID, username string, roles []strin
 		Username:   username,
 		Roles:      roles,
 		AuthMethod: method,
+		RegisteredClaims: jwt.RegisteredClaims{
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Duration(s.expiryHrs) * time.Hour)),
+			Issuer:    "nexspence",
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(s.secret)
+}
+
+// GenerateScopedToken is GenerateToken with the API token's scopes embedded,
+// used when a scoped token is exchanged for a registry JWT so the JWT is no
+// wider than the token it came from.
+func (s *Service) GenerateScopedToken(userID, username string, roles, scopes []string) (string, error) {
+	now := time.Now()
+	claims := Claims{
+		UserID:   userID,
+		Username: username,
+		Roles:    roles,
+		Scopes:   scopes,
 		RegisteredClaims: jwt.RegisteredClaims{
 			IssuedAt:  jwt.NewNumericDate(now),
 			ExpiresAt: jwt.NewNumericDate(now.Add(time.Duration(s.expiryHrs) * time.Hour)),

--- a/internal/service/token_service.go
+++ b/internal/service/token_service.go
@@ -53,6 +53,16 @@ func (s *TokenService) Create(ctx context.Context, userID, name string, scopes [
 	if strings.TrimSpace(name) == "" {
 		return nil, fmt.Errorf("%w: token name is required", ErrInvalidInput)
 	}
+	// Scopes are enforced now (#292): an unknown name would mint a token that
+	// can do nothing and fail every request with an unhelpful 403, so refuse
+	// it at creation where the mistake is visible.
+	for _, sc := range scopes {
+		switch strings.ToLower(strings.TrimSpace(sc)) {
+		case "read", "write", "delete":
+		default:
+			return nil, fmt.Errorf("%w: unknown scope %q (valid: read, write, delete)", ErrInvalidInput, sc)
+		}
+	}
 	u, err := s.users.GetByID(ctx, userID)
 	if err != nil {
 		return nil, err
@@ -92,32 +102,38 @@ func (s *TokenService) Get(ctx context.Context, id string) (*domain.UserToken, e
 	return s.tokens.Get(ctx, id)
 }
 
-// Authenticate validates a presented plaintext token, returns the owning user
-// or an error. TouchLastUsed is called on success best-effort.
-func (s *TokenService) Authenticate(ctx context.Context, raw string) (*domain.User, error) {
+// Authenticate validates a presented plaintext token, returning the owning
+// user and the token's scopes. TouchLastUsed is called on success best-effort.
+//
+// Scopes come back alongside the user because the caller — not this method —
+// is the authorization checkpoint: a token created with scopes promises a
+// restricted session, and returning only the user silently handed every
+// integration the account's full power instead (#292). Empty scopes mean an
+// unrestricted token, matching every token issued before scopes were enforced.
+func (s *TokenService) Authenticate(ctx context.Context, raw string) (*domain.User, []string, error) {
 	if !strings.HasPrefix(raw, TokenPrefix) {
-		return nil, fmt.Errorf("not an API token")
+		return nil, nil, fmt.Errorf("not an API token")
 	}
 	tok, err := s.tokens.GetByHash(ctx, hashToken(raw))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if tok == nil {
-		return nil, fmt.Errorf("unknown token")
+		return nil, nil, fmt.Errorf("unknown token")
 	}
 	if tok.ExpiresAt != nil && time.Now().After(*tok.ExpiresAt) {
-		return nil, fmt.Errorf("token expired")
+		return nil, nil, fmt.Errorf("token expired")
 	}
 	u, err := s.users.GetByID(ctx, tok.UserID)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if u == nil {
-		return nil, fmt.Errorf("token owner not found")
+		return nil, nil, fmt.Errorf("token owner not found")
 	}
 	if u.Status != domain.UserStatusActive {
-		return nil, fmt.Errorf("user account disabled")
+		return nil, nil, fmt.Errorf("user account disabled")
 	}
 	_ = s.tokens.TouchLastUsed(ctx, tok.ID)
-	return u, nil
+	return u, tok.Scopes, nil
 }

--- a/internal/service/token_service_test.go
+++ b/internal/service/token_service_test.go
@@ -72,7 +72,7 @@ func TestTokenService_Authenticate_RoundTrip(t *testing.T) {
 
 	tok, _ := svc.Create(context.Background(), "u1", "ci", nil, nil)
 
-	got, err := svc.Authenticate(context.Background(), tok.Token)
+	got, _, err := svc.Authenticate(context.Background(), tok.Token)
 	if err != nil {
 		t.Fatalf("Authenticate: %v", err)
 	}
@@ -83,14 +83,14 @@ func TestTokenService_Authenticate_RoundTrip(t *testing.T) {
 
 func TestTokenService_Authenticate_RejectsNonPrefix(t *testing.T) {
 	svc, _, _ := newTokenSvc(t)
-	if _, err := svc.Authenticate(context.Background(), "some-jwt-without-prefix"); err == nil {
+	if _, _, err := svc.Authenticate(context.Background(), "some-jwt-without-prefix"); err == nil {
 		t.Fatal("expected error for non-token string")
 	}
 }
 
 func TestTokenService_Authenticate_UnknownToken(t *testing.T) {
 	svc, _, _ := newTokenSvc(t)
-	if _, err := svc.Authenticate(context.Background(), service.TokenPrefix+"deadbeef"); err == nil {
+	if _, _, err := svc.Authenticate(context.Background(), service.TokenPrefix+"deadbeef"); err == nil {
 		t.Fatal("expected error for unknown token")
 	}
 }
@@ -102,7 +102,7 @@ func TestTokenService_Authenticate_ExpiredToken(t *testing.T) {
 	past := time.Now().Add(-time.Hour)
 	tok, _ := svc.Create(context.Background(), "u1", "expired", nil, &past)
 
-	if _, err := svc.Authenticate(context.Background(), tok.Token); err == nil {
+	if _, _, err := svc.Authenticate(context.Background(), tok.Token); err == nil {
 		t.Fatal("expected error for expired token")
 	}
 }
@@ -112,7 +112,7 @@ func TestTokenService_Authenticate_DisabledUser(t *testing.T) {
 	svc, _, _ := newTokenSvc(t, u)
 
 	tok, _ := svc.Create(context.Background(), "u1", "x", nil, nil)
-	if _, err := svc.Authenticate(context.Background(), tok.Token); err == nil {
+	if _, _, err := svc.Authenticate(context.Background(), tok.Token); err == nil {
 		t.Fatal("expected error for disabled user")
 	}
 }
@@ -125,7 +125,7 @@ func TestTokenService_Delete_RevokesToken(t *testing.T) {
 	if err := svc.Delete(context.Background(), tok.ID); err != nil {
 		t.Fatalf("Delete: %v", err)
 	}
-	if _, err := svc.Authenticate(context.Background(), tok.Token); err == nil {
+	if _, _, err := svc.Authenticate(context.Background(), tok.Token); err == nil {
 		t.Fatal("revoked token still authenticates")
 	}
 }


### PR DESCRIPTION
Closes #292.

Token `scopes` were accepted, stored, and returned in listings — and never read by any authorization decision, so a token created with `scopes: ["read"]` silently carried the owning account's full power, admin roles included.

## Change

- `TokenService.Authenticate` returns the token's scopes alongside the user; auth middlewares stash non-empty scopes in gin context.
- **Management API** (`AuthMiddleware`, Bearer and Basic-password forms): the request's method-implied action is checked against the scopes; not covered → `403 token scope does not permit this action`.
- **Artifact routes** (`RBACMiddleware`): the same cap with the path-aware action, on top of — never instead of — the privilege check.
- **`/v2/token` exchange**: a scoped API token now mints a JWT carrying `scopes` in its claims (`auth.Claims.Scopes`, `omitempty`), and the bearer path enforces them — closing the laundering gap the reporter flagged where a read-only token exchanged into an unscoped registry JWT.
- Scopes are hierarchical (`delete` ⊃ `write` ⊃ `read`) because real write flows read on the way — a Docker push HEADs blobs before uploading. Unknown scope names grant nothing at enforcement, and are refused at creation (`400`, naming the valid set) so a typo can't mint a token that fails everything with an unhelpful 403.
- A token with no scopes stays fully unrestricted — matching every token issued before enforcement.

## Tests

Read-only token: GET 200, PUT/DELETE 403 (Bearer and Basic paths); write implies read but not delete; scope-less token unrestricted; scoped `/v2/token` exchange embeds scopes in the JWT and the JWT is capped identically; read-scoped token caps an admin on artifact routes with the RBAC middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcrsCyNcvsEKp881db5JL