### PR TITLE
feat(proxy): upstream HTTP Basic auth for private registries

### DIFF
--- a/frontend/src/pages/RepositoriesPage.test.tsx
+++ b/frontend/src/pages/RepositoriesPage.test.tsx
@@ -742,12 +742,55 @@ describe('RepositoriesPage', () => {
     renderWithProviders(<RepositoriesPage />)
     await openSettingsFor('npm-proxy')
     await user.click(screen.getByText(/Outbound proxy/))
-    await user.type(screen.getByPlaceholderText('Leave blank to keep current'), 'n3w')
+    await user.type(screen.getAllByPlaceholderText('Leave blank to keep current')[1], 'n3w')
     const form = document.querySelector('form') as HTMLFormElement
     fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
     await waitFor(() => expect(put).toBeTruthy())
     const pc = (put! as { proxyConfig?: Record<string, unknown> }).proxyConfig
     expect(pc?.proxy_password).toBe('n3w')
+  })
+
+
+  it('sends remote_password on save when typed, and omits it when untouched (#281)', async () => {
+    const user = userEvent.setup()
+    seedRepos([proxyRepo])
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(proxyRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('npm-proxy')
+    await user.click(screen.getByText(/Upstream authentication/))
+    // The upstream-auth password is the first "Leave blank to keep current"
+    // input; the outbound-proxy password is the second.
+    await user.type(screen.getAllByPlaceholderText('Leave blank to keep current')[0], 'up5tream')
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const pc = (put! as { proxyConfig?: Record<string, unknown> }).proxyConfig
+    expect(pc?.remote_password).toBe('up5tream')
+    expect(pc).not.toHaveProperty('remote_password_set')
+  })
+
+  it('omits remote_password on save when the field is untouched (#281)', async () => {
+    seedRepos([proxyRepo])
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(proxyRepo)
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await openSettingsFor('npm-proxy')
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const pc = (put! as { proxyConfig?: Record<string, unknown> }).proxyConfig
+    expect(pc).not.toHaveProperty('remote_password')
   })
 
   it('rejects an empty remote URL when editing a proxy repository', async () => {

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -437,6 +437,7 @@ function CreateRepoModal({ onClose, onCreated }: {
     remoteUrl: PROXY_DEFAULTS['maven2'],
     httpProxy: '', httpsProxy: '', socks5Proxy: '', noProxy: '',
     proxyUsername: '', proxyPassword: '',
+    remoteUsername: '', remotePassword: '',
     memberNames: [] as string[],
     cleanupPolicyIds: [] as string[],
     quotaGB: '',
@@ -507,6 +508,8 @@ function CreateRepoModal({ onClose, onCreated }: {
         if (form.noProxy.trim()) proxyConfig.no_proxy = form.noProxy.trim()
         if (form.proxyUsername.trim()) proxyConfig.proxy_username = form.proxyUsername.trim()
         if (form.proxyPassword) proxyConfig.proxy_password = form.proxyPassword
+        if (form.remoteUsername.trim()) proxyConfig.remote_username = form.remoteUsername.trim()
+        if (form.remotePassword) proxyConfig.remote_password = form.remotePassword
         body.proxyConfig = proxyConfig
       }
       if (form.type === 'group') body.formatConfig = { member_names: form.memberNames }
@@ -587,6 +590,32 @@ function CreateRepoModal({ onClose, onCreated }: {
           />
           <span className={styles.hint}>URL of the upstream registry to proxy and cache</span>
         </div>
+      )}
+      {form.type === 'proxy' && (
+        <details className={styles.formRow}>
+          <summary style={{ cursor: 'pointer', ...LABEL_STYLE }}>Upstream authentication (optional)</summary>
+          <span className={styles.hint}>
+            HTTP Basic credentials sent to the remote registry itself, for private
+            upstreams that require authentication to download.
+          </span>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>Username</label>
+            <HoloInput
+              value={form.remoteUsername}
+              onChange={e => setField('remoteUsername', e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>Password</label>
+            <HoloInput
+              type="password"
+              value={form.remotePassword}
+              onChange={e => setField('remotePassword', e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+        </details>
       )}
       {form.type === 'proxy' && (
         <details className={styles.formRow}>
@@ -837,6 +866,10 @@ function EditRepoModal({
   const [proxyPassword, setProxyPassword] = useState('')
   const [clearProxyPassword, setClearProxyPassword] = useState(false)
   const hasStoredProxyPassword = repo.proxyConfig?.['proxy_password_set'] === true
+  const [remoteUsername, setRemoteUsername] = useState(cfgString(repo.proxyConfig, 'remote_username'))
+  const [remotePassword, setRemotePassword] = useState('')
+  const [clearRemotePassword, setClearRemotePassword] = useState(false)
+  const hasStoredRemotePassword = repo.proxyConfig?.['remote_password_set'] === true
   const [memberNames, setMemberNames] = useState<string[]>(groupMemberNames(repo))
   const memberCandidates = allRepos.filter(r => r.format === repo.format && r.type !== 'group')
   const originalStoreId = repo.blobStoreId ?? ''
@@ -955,7 +988,7 @@ function EditRepoModal({
       if (repo.type === 'proxy') {
         const proxyConfig: Record<string, unknown> = {}
         for (const [k, v] of Object.entries(repo.proxyConfig ?? {})) {
-          if (k !== 'proxy_password_set') proxyConfig[k] = v
+          if (k !== 'proxy_password_set' && k !== 'remote_password_set') proxyConfig[k] = v
         }
         proxyConfig.remote_url = remoteUrl.trim()
         assignOrDelete(proxyConfig, 'http_proxy', httpProxy)
@@ -966,6 +999,10 @@ function EditRepoModal({
         // Omitted proxy_password means "unchanged"; an explicit empty string clears it.
         if (proxyPassword) proxyConfig.proxy_password = proxyPassword
         else if (clearProxyPassword) proxyConfig.proxy_password = ''
+        assignOrDelete(proxyConfig, 'remote_username', remoteUsername)
+        // Same contract for the upstream registry password.
+        if (remotePassword) proxyConfig.remote_password = remotePassword
+        else if (clearRemotePassword) proxyConfig.remote_password = ''
         updateBody.proxyConfig = proxyConfig
       }
       await nexusApi.updateRepository(repo.format, repo.type, repo.name, updateBody)
@@ -1031,6 +1068,48 @@ function EditRepoModal({
               new fetches go to the new upstream.
             </span>
           </div>
+        )}
+        {repo.type === 'proxy' && (
+          <details className={styles.formRow}>
+            <summary style={{ cursor: 'pointer', ...LABEL_STYLE }}>Upstream authentication (optional)</summary>
+            <span className={styles.hint}>
+              HTTP Basic credentials sent to the remote registry itself, for private
+              upstreams that require authentication to download.
+            </span>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>Username</label>
+              <HoloInput
+                value={remoteUsername}
+                onChange={e => setRemoteUsername(e.target.value)}
+                placeholder="Optional"
+              />
+            </div>
+            <div className={styles.formRow}>
+              <label style={LABEL_STYLE}>Password</label>
+              <HoloInput
+                type="password"
+                value={remotePassword}
+                onChange={e => { setRemotePassword(e.target.value); setClearRemotePassword(false) }}
+                placeholder="Leave blank to keep current"
+              />
+              {hasStoredRemotePassword && (
+                <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--holo-text)', cursor: 'pointer', marginTop: 6 }}>
+                  <input
+                    type="checkbox"
+                    checked={clearRemotePassword}
+                    disabled={remotePassword !== ''}
+                    onChange={e => setClearRemotePassword(e.target.checked)}
+                  />
+                  Remove the stored password
+                </label>
+              )}
+              <span className={styles.hint}>
+                {hasStoredRemotePassword
+                  ? 'A password is stored. It is never sent to the browser — leave this blank to keep it.'
+                  : 'No upstream password stored for this repository.'}
+              </span>
+            </div>
+          </details>
         )}
         {repo.type === 'proxy' && (
           <details className={styles.formRow}>

--- a/internal/domain/redact.go
+++ b/internal/domain/redact.go
@@ -6,6 +6,12 @@ const (
 	// ProxyPasswordSetKey is a read-only proxyConfig marker the API adds in place of
 	// ProxyPasswordKey so clients can tell a password is stored without receiving it.
 	ProxyPasswordSetKey = "proxy_password_set"
+	// RemotePasswordKey is the proxyConfig entry holding the password sent to the
+	// upstream registry itself (HTTP Basic), as opposed to ProxyPasswordKey, which
+	// authenticates to an outbound forward proxy on the way there (#281).
+	RemotePasswordKey = "remote_password"
+	// RemotePasswordSetKey mirrors ProxyPasswordSetKey for RemotePasswordKey.
+	RemotePasswordSetKey = "remote_password_set"
 	// SecretKeyKey is the blob store config entry holding the S3 secret access key.
 	SecretKeyKey = "secret_key"
 	// SecretKeySetKey is the read-only blob store config marker the API adds in place
@@ -57,6 +63,7 @@ func RedactedBlobStores(list []BlobStore) []BlobStore {
 // is stored, ProxyPasswordSetKey is set to true in its place. The input is untouched.
 func RedactedRepository(r Repository) Repository {
 	r.ProxyConfig = redactedConfig(r.ProxyConfig, ProxyPasswordKey, ProxyPasswordSetKey)
+	r.ProxyConfig = redactedConfig(r.ProxyConfig, RemotePasswordKey, RemotePasswordSetKey)
 	return r
 }
 

--- a/internal/domain/redact_test.go
+++ b/internal/domain/redact_test.go
@@ -164,3 +164,22 @@ func TestRedactedBlobStores_Nil(t *testing.T) {
 	t.Parallel()
 	require.Nil(t, RedactedBlobStores(nil))
 }
+
+// remote_password (upstream Basic auth, #281) is redacted like proxy_password.
+func TestRedactedRepository_StripsRemotePassword(t *testing.T) {
+	r := Repository{ProxyConfig: map[string]any{
+		"remote_url":      "https://api.mapbox.com/",
+		"remote_username": "deploy",
+		"remote_password": "upstream-s3cret",
+	}}
+	got := RedactedRepository(r)
+	if _, ok := got.ProxyConfig[RemotePasswordKey]; ok {
+		t.Fatal("remote_password must be stripped")
+	}
+	if got.ProxyConfig[RemotePasswordSetKey] != true {
+		t.Fatal("remote_password_set marker expected")
+	}
+	if got.ProxyConfig["remote_username"] != "deploy" {
+		t.Fatal("remote_username must survive")
+	}
+}

--- a/internal/formats/conda/handler.go
+++ b/internal/formats/conda/handler.go
@@ -281,6 +281,7 @@ func (h *Handler) proxyIndex(c *gin.Context, repo *domain.Repository, repoName, 
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	repoproxy.SetUpstreamAuth(req, repo)
 	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch: " + err.Error()})

--- a/internal/formats/helm/handler.go
+++ b/internal/formats/helm/handler.go
@@ -246,6 +246,7 @@ func (h *Handler) fetchAndRewriteHelmIndex(c *gin.Context, repo *domain.Reposito
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid upstream URL: " + err.Error()})
 		return
 	}
+	repoproxy.SetUpstreamAuth(req, repo)
 	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch failed: " + err.Error()})

--- a/internal/formats/nuget/handler.go
+++ b/internal/formats/nuget/handler.go
@@ -352,6 +352,7 @@ func (h *Handler) fetchAndRewriteNuGetIndex(c *gin.Context, repo *domain.Reposit
 	}
 	req.Header.Set("Accept", "application/json")
 
+	repoproxy.SetUpstreamAuth(req, repo)
 	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch failed: " + err.Error()})

--- a/internal/formats/repoproxy/docker_registry_token.go
+++ b/internal/formats/repoproxy/docker_registry_token.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
 	"strings"
 )
 
@@ -143,10 +145,11 @@ func fetchDockerRegistryToken(ctx context.Context, client *http.Client, realm, s
 	return "", fmt.Errorf("empty token in response")
 }
 
-// fetchUpstreamWithDockerHubAuth performs the HTTP request; on 401 from Docker Hub it obtains
+// fetchUpstreamWithDockerHubAuth performs the HTTP request with the repo's
+// upstream credentials (SetUpstreamAuth); on 401 from Docker Hub it obtains
 // an anonymous Bearer token and retries once. This prevents the registry client from
 // following Hub's WWW-Authenticate challenge with Nexspence credentials (wrong host).
-func fetchUpstreamWithDockerHubAuth(ctx context.Context, client *http.Client, method, upstreamURL, baseRemote string, hdr http.Header) (*http.Response, error) {
+func fetchUpstreamWithDockerHubAuth(ctx context.Context, repo *domain.Repository, client *http.Client, method, upstreamURL, baseRemote string, hdr http.Header) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, upstreamURL, nil)
 	if err != nil {
 		return nil, err
@@ -157,6 +160,7 @@ func fetchUpstreamWithDockerHubAuth(ctx context.Context, client *http.Client, me
 	if req.Header.Get("User-Agent") == "" {
 		req.Header.Set("User-Agent", "Nexspence/1.0 (proxy)")
 	}
+	SetUpstreamAuth(req, repo)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/formats/repoproxy/docker_registry_token.go
+++ b/internal/formats/repoproxy/docker_registry_token.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
-	"strings"
 )
 
 // isDockerRegistryRemote reports whether remote_url points at Docker Hub registry

--- a/internal/formats/repoproxy/proxyclient.go
+++ b/internal/formats/repoproxy/proxyclient.go
@@ -268,3 +268,23 @@ func hostPort(raw string) (string, error) {
 	}
 	return raw, nil
 }
+
+// SetUpstreamAuth adds the repository's upstream HTTP Basic credentials
+// (proxy_config.remote_username / remote_password) to an outbound request, for
+// private upstreams that gate downloads behind Basic auth — a private Maven
+// registry, Mapbox, a corporate npm mirror (#281). Distinct from
+// proxy_username/proxy_password, which authenticate to the outbound forward
+// proxy on the way, not to the registry itself.
+//
+// A request that already carries an Authorization header keeps it — the Docker
+// Hub token flow, for one, sets its own Bearer and must win.
+func SetUpstreamAuth(req *http.Request, repo *domain.Repository) {
+	if req == nil || repo == nil || req.Header.Get("Authorization") != "" {
+		return
+	}
+	user := cfgString(repo.ProxyConfig, "remote_username")
+	if user == "" {
+		return
+	}
+	req.SetBasicAuth(user, cfgString(repo.ProxyConfig, domain.RemotePasswordKey))
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -260,7 +260,7 @@ func FetchUpstreamOnce(ctx context.Context, repo *domain.Repository, upstreamPat
 	if rawQuery != "" {
 		upstream += "?" + rawQuery
 	}
-	return fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), http.MethodGet, upstream, baseRemote, hdr)
+	return fetchUpstreamWithDockerHubAuth(ctx, repo, ClientFor(repo), http.MethodGet, upstream, baseRemote, hdr)
 }
 
 // ServeGET serves a cached asset or fetches upstream, streaming to the client
@@ -365,7 +365,7 @@ func fetchAndCache(c *gin.Context, d formats.Deps, repo *domain.Repository,
 		upstreamMethod = http.MethodGet
 	}
 
-	resp, err := fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), upstreamMethod, upstream, baseRemote, upHdr)
+	resp, err := fetchUpstreamWithDockerHubAuth(ctx, repo, ClientFor(repo), upstreamMethod, upstream, baseRemote, upHdr)
 	if err != nil {
 		DispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream fetch failed: " + err.Error()})
@@ -427,7 +427,7 @@ func revalidateAndServe(c *gin.Context, d formats.Deps, repo *domain.Repository,
 		upHdr.Set("If-Modified-Since", asset.LastModified.UTC().Format(http.TimeFormat))
 	}
 
-	resp, err := fetchUpstreamWithDockerHubAuth(ctx, ClientFor(repo), http.MethodGet, upstream, baseRemote, upHdr)
+	resp, err := fetchUpstreamWithDockerHubAuth(ctx, repo, ClientFor(repo), http.MethodGet, upstream, baseRemote, upHdr)
 	if err != nil {
 		// Upstream unreachable → serve stale cache so metadata consumers keep working.
 		DispatchProxyError(d, repo.Name, repoRelativePath, upstream, err)

--- a/internal/formats/repoproxy/repoproxy_extra_test.go
+++ b/internal/formats/repoproxy/repoproxy_extra_test.go
@@ -662,3 +662,57 @@ func TestServeGET_DockerHub_ScopeFromV2URL(t *testing.T) {
 	assert.True(t, tokenServerCalled, "token server should have been called with scope from URL")
 	assert.Equal(t, 2, calls)
 }
+
+// ── upstream Basic auth (#281) ────────────────────────────────
+
+// A proxy repo with remote_username/remote_password must present them to the
+// upstream itself (HTTP Basic) — private Maven registries answer 401 without.
+func TestServeGET_SendsUpstreamBasicAuth(t *testing.T) {
+	useUnguardedUpstream(t)
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if u, p, ok := r.BasicAuth(); !ok || u != "deploy" || p != "s3cret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_, _ = fmt.Fprint(w, "artifact-bytes")
+	}))
+	defer upstream.Close()
+
+	repo := proxyRepo("pauth", upstream.URL)
+	repo.ProxyConfig["remote_username"] = "deploy"
+	repo.ProxyConfig["remote_password"] = "s3cret"
+	d := makeDeps(repo)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/com/x/a.jar", nil)
+	err := repoproxy.ServeGET(c, d, repo, "/com/x/a.jar", "", base.Coords{}, "", 0)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "artifact-bytes", w.Body.String())
+	assert.Contains(t, gotAuth, "Basic ")
+}
+
+// Without credentials configured, no Authorization header is invented.
+func TestServeGET_NoUpstreamAuthByDefault(t *testing.T) {
+	useUnguardedUpstream(t)
+	var sawAuth bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization") != ""
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+
+	repo := proxyRepo("pnoauth", upstream.URL)
+	d := makeDeps(repo)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/com/x/b.jar", nil)
+	err := repoproxy.ServeGET(c, d, repo, "/com/x/b.jar", "", base.Coords{}, "", 0)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, sawAuth)
+}

--- a/internal/formats/terraform/handler.go
+++ b/internal/formats/terraform/handler.go
@@ -352,6 +352,7 @@ func (h *Handler) serveProxy(c *gin.Context, repo *domain.Repository, repoName, 
 	}
 	req.Header.Set("Accept", "application/json")
 
+	repoproxy.SetUpstreamAuth(req, repo)
 	resp, err := repoproxy.ClientFor(repo).Do(req)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "upstream: " + err.Error()})

--- a/internal/service/repository_service.go
+++ b/internal/service/repository_service.go
@@ -241,27 +241,34 @@ func (s *RepositoryService) Update(ctx context.Context, name string, updates *do
 }
 
 // mergeProxyConfig produces the proxyConfig to persist from the stored one and the
-// caller's replacement. The replacement wins wholesale, except for the password:
+// caller's replacement. The replacement wins wholesale, except for the secrets:
 // clients read a redacted config (see domain.RedactedRepository), so an omitted
-// proxy_password means "unchanged" rather than "clear it". Sending an explicit empty
-// proxy_password clears the credential. The read-only proxy_password_set marker a
-// client may echo back is always dropped.
+// proxy_password / remote_password means "unchanged" rather than "clear it".
+// Sending an explicit empty value clears the credential. The read-only *_set
+// markers a client may echo back are always dropped.
 func mergeProxyConfig(stored, updates map[string]any) map[string]any {
-	merged := make(map[string]any, len(updates)+1)
+	secrets := [][2]string{
+		{domain.ProxyPasswordKey, domain.ProxyPasswordSetKey},
+		{domain.RemotePasswordKey, domain.RemotePasswordSetKey},
+	}
+	merged := make(map[string]any, len(updates)+len(secrets))
 	for k, v := range updates {
-		if k == domain.ProxyPasswordSetKey {
+		if k == domain.ProxyPasswordSetKey || k == domain.RemotePasswordSetKey {
 			continue
 		}
 		merged[k] = v
 	}
-	if pw, sent := merged[domain.ProxyPasswordKey]; sent {
-		if s, _ := pw.(string); s == "" {
-			delete(merged, domain.ProxyPasswordKey)
+	for _, keys := range secrets {
+		secretKey := keys[0]
+		if pw, sent := merged[secretKey]; sent {
+			if s, _ := pw.(string); s == "" {
+				delete(merged, secretKey)
+			}
+			continue
 		}
-		return merged
-	}
-	if pw, ok := stored[domain.ProxyPasswordKey].(string); ok && pw != "" {
-		merged[domain.ProxyPasswordKey] = pw
+		if pw, ok := stored[secretKey].(string); ok && pw != "" {
+			merged[secretKey] = pw
+		}
 	}
 	return merged
 }

--- a/internal/service/repository_service_proxy_test.go
+++ b/internal/service/repository_service_proxy_test.go
@@ -128,3 +128,35 @@ func TestRepositoryService_Create_DropsProxyPasswordSetMarker(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotContains(t, stored.ProxyConfig, domain.ProxyPasswordSetKey)
 }
+
+// remote_password (upstream Basic auth, #281) follows the same redact/merge
+// contract as proxy_password: omitted means unchanged, empty clears.
+func TestRepositoryService_Update_RemotePassword_MergeContract(t *testing.T) {
+	seeded := seededProxy()
+	seeded.ProxyConfig["remote_username"] = "deploy"
+	seeded.ProxyConfig["remote_password"] = "upstream-s3cret"
+	repos := testutil.NewRepoRepo(seeded)
+	svc := newRepoSvcFull(repos, testutil.NewBlobStoreRepo(), testutil.NewCleanupPolicyRepo())
+
+	// Omitted → unchanged (and the echoed *_set marker is dropped).
+	got, err := svc.Update(context.Background(), "maven-proxy", &domain.Repository{
+		ProxyConfig: map[string]any{
+			"remote_url":          "https://api.mapbox.com/downloads/v2/releases/maven/",
+			"remote_username":     "deploy",
+			"remote_password_set": true,
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "upstream-s3cret", got.ProxyConfig["remote_password"], "omitted remote_password must survive the edit")
+	assert.NotContains(t, got.ProxyConfig, "remote_password_set")
+
+	// Explicit empty → cleared.
+	got, err = svc.Update(context.Background(), "maven-proxy", &domain.Repository{
+		ProxyConfig: map[string]any{
+			"remote_url":      "https://api.mapbox.com/downloads/v2/releases/maven/",
+			"remote_password": "",
+		},
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, got.ProxyConfig, "remote_password")
+}


### PR DESCRIPTION
Closes #281.

Proxy repos could name a private upstream but not authenticate to it — `proxy_username`/`proxy_password` authenticate to the outbound forward proxy, not the registry, so a private Maven upstream (e.g. Mapbox) answered every fetch 401.

## Change

- New `proxyConfig` keys `remote_username` / `remote_password`, sent as HTTP Basic on every outbound fetch: the shared `repoproxy` chokepoint (`fetchUpstreamWithDockerHubAuth`, covering `ServeGET`, revalidation, and `FetchUpstreamOnce`) plus the four format handlers building their own upstream requests (terraform, conda, nuget, helm) via a new `repoproxy.SetUpstreamAuth`. A request already carrying `Authorization` keeps it — the Docker Hub Bearer flow must win.
- `remote_password` follows the established secret contract (#135 pattern): redacted from every API response with a `remote_password_set` marker; omitted on write = unchanged; explicit empty = clear. `mergeProxyConfig` generalized to handle both secrets.
- UI: "Upstream authentication" section in the create wizard and repository settings, with the same keep/replace/clear semantics as the outbound proxy password.

## Tests

Go: upstream receives correct Basic credentials through the full ServeGET path; no header invented without config; merge contract (omitted keeps, empty clears, marker dropped); redaction. Frontend: typed password is sent, untouched field omits both key and marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcrsCyNcvsEKp881db5JL