### PR TITLE
feat(docker): hostname aliases decouple the client DNS name from the repository name

### DIFF
--- a/docs/docker-subdomain-connector.md
+++ b/docs/docker-subdomain-connector.md
@@ -27,6 +27,29 @@ docker:
     base_domain: "nexspence.example.com"
 ```
 
+### Hostname aliases (optional)
+
+By default the subdomain must equal the repository name. When migrating from
+Nexus — where connector ports and DNS names are chosen independently of repo
+names — that forces repo renames or Host-rewriting proxy rules. Aliases map any
+client-facing hostname to the repository that should answer it:
+
+```yaml
+docker:
+  subdomain_connector:
+    enabled: true
+    base_domain: "nexspence.example.com"   # optional when only aliases are used
+    aliases:
+      # legacy DNS name (any domain) → repository name
+      docker-hub-proxy.domain.example.com: dockerhub-proxy
+      # an alias under base_domain overrides the implicit subdomain repo
+      hub.nexspence.example.com: dockerhub-proxy
+```
+
+Alias hostnames are matched case-insensitively, ignoring any port. Point the
+DNS record (or Istio/Ingress route) at Nexspence and pass the original `Host`
+header through, exactly as below — no repository rename needed.
+
 ### 2. Wildcard DNS
 
 Add a wildcard DNS A record pointing to your Nexspence server:

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -771,8 +771,8 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		ui(c)
 	})
 
-	if cfg.Docker.SubdomainConnector.Enabled && cfg.Docker.SubdomainConnector.BaseDomain != "" {
-		return NewSubdomainRewriter(r, cfg.Docker.SubdomainConnector.BaseDomain)
+	if sc := cfg.Docker.SubdomainConnector; sc.Enabled && (sc.BaseDomain != "" || len(sc.Aliases) > 0) {
+		return NewSubdomainRewriter(r, sc.BaseDomain, sc.Aliases)
 	}
 	return r
 }

--- a/internal/api/subdomain_rewriter.go
+++ b/internal/api/subdomain_rewriter.go
@@ -14,16 +14,34 @@ import (
 //	/v2/alpine/manifests/latest  →  /v2/<repoName>/alpine/manifests/latest
 //	/v2/                         →  /v2/  (unchanged — OCI version check)
 //
+// An explicit hostname alias wins over the subdomain pattern, so a legacy DNS
+// name can keep serving a repository whose name does not match it (#282).
+//
 // This makes the existing /v2/:repoName/*dockerpath Gin routes work transparently.
 type SubdomainRewriter struct {
 	next       http.Handler
-	baseDomain string // lower-cased, e.g. "nexspence.example.com"
+	baseDomain string            // lower-cased, e.g. "nexspence.example.com"
+	aliases    map[string]string // lower-cased full hostname → repository name
 }
 
 // NewSubdomainRewriter wraps next with subdomain path rewriting.
 // baseDomain must NOT have a leading dot (e.g. "nexspence.example.com").
-func NewSubdomainRewriter(next http.Handler, baseDomain string) http.Handler {
-	return &SubdomainRewriter{next: next, baseDomain: strings.ToLower(baseDomain)}
+// aliases maps full client hostnames to repository names; alias hostnames do
+// not have to sit under baseDomain, and an alias for "<sub>.<baseDomain>"
+// overrides the implicit "<sub>" repository. Alias targets that are not valid
+// repository name labels are ignored — the value is spliced into a URL path,
+// and a config typo must not become a path injection.
+func NewSubdomainRewriter(next http.Handler, baseDomain string, aliases map[string]string) http.Handler {
+	m := make(map[string]string, len(aliases))
+	for host, repo := range aliases {
+		host = strings.ToLower(strings.TrimSpace(host))
+		repo = strings.TrimSpace(repo)
+		if host == "" || !isRepoNameLabel(repo) {
+			continue
+		}
+		m[host] = repo
+	}
+	return &SubdomainRewriter{next: next, baseDomain: strings.ToLower(baseDomain), aliases: m}
 }
 
 func (s *SubdomainRewriter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -44,14 +62,21 @@ func (s *SubdomainRewriter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.next.ServeHTTP(w, r)
 }
 
-// extractRepo returns the subdomain when Host matches "*.<baseDomain>".
-// Returns "" when the pattern doesn't match (passthrough).
+// extractRepo returns the repository name for the request's Host: an explicit
+// alias when one is configured for the full hostname, else the subdomain when
+// Host matches "*.<baseDomain>". Returns "" when neither applies (passthrough).
 func (s *SubdomainRewriter) extractRepo(host string) string {
 	// Strip port if present.
 	if idx := strings.LastIndex(host, ":"); idx != -1 {
 		host = host[:idx]
 	}
 	host = strings.ToLower(host)
+	if repo, ok := s.aliases[host]; ok {
+		return repo
+	}
+	if s.baseDomain == "" {
+		return ""
+	}
 	suffix := "." + s.baseDomain
 	if !strings.HasSuffix(host, suffix) {
 		return ""

--- a/internal/api/subdomain_rewriter_test.go
+++ b/internal/api/subdomain_rewriter_test.go
@@ -31,7 +31,7 @@ func TestSubdomainRewriter_RejectsNonRepoNameSubdomains(t *testing.T) {
 		"trailing-.nexspence.example.com",
 	} {
 		h, captured := capturePathHandler()
-		rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+		rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
 		req.Host = host
@@ -49,7 +49,7 @@ func TestSubdomainRewriter_AcceptsRepoNameSubdomains(t *testing.T) {
 		"MyRepo.nexspence.example.com", // host matching is case-insensitive
 	} {
 		h, captured := capturePathHandler()
-		rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+		rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 		req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
 		req.Host = host
@@ -62,7 +62,7 @@ func TestSubdomainRewriter_AcceptsRepoNameSubdomains(t *testing.T) {
 
 func TestSubdomainRewriter_NonDockerPath_Passthrough(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/repository/myrepo/some/file", nil)
 	req.Host = "myrepo.nexspence.example.com"
@@ -73,7 +73,7 @@ func TestSubdomainRewriter_NonDockerPath_Passthrough(t *testing.T) {
 
 func TestSubdomainRewriter_V2Root_Passthrough(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/", nil)
 	req.Host = "myrepo.nexspence.example.com"
@@ -86,7 +86,7 @@ func TestSubdomainRewriter_V2Root_Passthrough(t *testing.T) {
 // dispatch it would 404 and break docker login/pull on subdomain hosts.
 func TestSubdomainRewriter_V2Token_Passthrough(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/token", nil)
 	req.Host = "myrepo.nexspence.example.com"
@@ -97,7 +97,7 @@ func TestSubdomainRewriter_V2Token_Passthrough(t *testing.T) {
 
 func TestSubdomainRewriter_V2ManifestPath_RepoInjected(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
 	req.Host = "myrepo.nexspence.example.com"
@@ -108,7 +108,7 @@ func TestSubdomainRewriter_V2ManifestPath_RepoInjected(t *testing.T) {
 
 func TestSubdomainRewriter_V2BlobPath_RepoInjected(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/myimage/blobs/sha256:abc123", nil)
 	req.Host = "releases.nexspence.example.com"
@@ -119,7 +119,7 @@ func TestSubdomainRewriter_V2BlobPath_RepoInjected(t *testing.T) {
 
 func TestSubdomainRewriter_HostWithPort_RepoInjected(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/alpine/tags/list", nil)
 	req.Host = "myrepo.nexspence.example.com:443"
@@ -130,7 +130,7 @@ func TestSubdomainRewriter_HostWithPort_RepoInjected(t *testing.T) {
 
 func TestSubdomainRewriter_NonMatchingHost_Passthrough(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
 	req.Host = "other.example.com"
@@ -141,7 +141,7 @@ func TestSubdomainRewriter_NonMatchingHost_Passthrough(t *testing.T) {
 
 func TestSubdomainRewriter_BaseDomainDirectAccess_Passthrough(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/myrepo/alpine/manifests/latest", nil)
 	req.Host = "nexspence.example.com"
@@ -152,11 +152,91 @@ func TestSubdomainRewriter_BaseDomainDirectAccess_Passthrough(t *testing.T) {
 
 func TestSubdomainRewriter_DeepSubdomain_Passthrough(t *testing.T) {
 	h, captured := capturePathHandler()
-	rw := api.NewSubdomainRewriter(h, "nexspence.example.com")
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
 	req.Host = "a.b.nexspence.example.com"
 	rw.ServeHTTP(httptest.NewRecorder(), req)
 
 	assert.Equal(t, "/v2/alpine/manifests/latest", *captured)
+}
+
+// ── hostname → repository aliases (#282) ──────────────────────
+
+// An alias decouples the client hostname from the repository name: legacy DNS
+// names keep working without renaming repositories (#282).
+func TestSubdomainRewriter_AliasMapsForeignHostname(t *testing.T) {
+	var gotPath string
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { gotPath = r.URL.Path })
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", map[string]string{
+		// A hostname entirely outside base_domain, Nexus-migration style.
+		"docker-hub-proxy.legacy.example.org": "dockerhub-proxy",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/library/alpine/manifests/latest", nil)
+	req.Host = "docker-hub-proxy.legacy.example.org"
+	rw.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "/v2/dockerhub-proxy/library/alpine/manifests/latest", gotPath)
+}
+
+// An alias for a host under base_domain overrides the implicit subdomain repo.
+func TestSubdomainRewriter_AliasOverridesSubdomain(t *testing.T) {
+	var gotPath string
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { gotPath = r.URL.Path })
+	rw := api.NewSubdomainRewriter(h, "nexspence.example.com", map[string]string{
+		"hub.nexspence.example.com": "dockerhub-proxy",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
+	req.Host = "hub.nexspence.example.com"
+	rw.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "/v2/dockerhub-proxy/alpine/manifests/latest", gotPath)
+}
+
+// Alias matching is case-insensitive and ignores the port, like the
+// subdomain pattern.
+func TestSubdomainRewriter_AliasHostNormalization(t *testing.T) {
+	var gotPath string
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { gotPath = r.URL.Path })
+	rw := api.NewSubdomainRewriter(h, "", map[string]string{
+		"Docker.Example.ORG": "dockerhub-proxy",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/alpine/tags/list", nil)
+	req.Host = "docker.example.org:8443"
+	rw.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "/v2/dockerhub-proxy/alpine/tags/list", gotPath)
+}
+
+// The registry-level endpoints stay unrewritten on alias hosts too.
+func TestSubdomainRewriter_AliasKeepsPingAndToken(t *testing.T) {
+	var paths []string
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { paths = append(paths, r.URL.Path) })
+	rw := api.NewSubdomainRewriter(h, "", map[string]string{"d.example.org": "dockerhub-proxy"})
+
+	for _, p := range []string{"/v2/", "/v2/token"} {
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		req.Host = "d.example.org"
+		rw.ServeHTTP(httptest.NewRecorder(), req)
+	}
+	assert.Equal(t, []string{"/v2/", "/v2/token"}, paths)
+}
+
+// An alias whose target could inject path separators is dropped at
+// construction — a config typo must not rewrite into an arbitrary path.
+func TestSubdomainRewriter_AliasInvalidTargetIgnored(t *testing.T) {
+	var gotPath string
+	h := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) { gotPath = r.URL.Path })
+	rw := api.NewSubdomainRewriter(h, "", map[string]string{
+		"evil.example.org": "../../admin",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v2/alpine/manifests/latest", nil)
+	req.Host = "evil.example.org"
+	rw.ServeHTTP(httptest.NewRecorder(), req)
+
+	assert.Equal(t, "/v2/alpine/manifests/latest", gotPath, "invalid alias target must be a passthrough")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -453,9 +453,17 @@ type DockerConfig struct {
 }
 
 // SubdomainConnectorConfig configures per-repository Docker subdomain routing.
+//
+// Aliases decouple the client-facing hostname from the repository name (#282):
+// each entry maps a full hostname (any DNS name the operator wired up — it
+// does not have to sit under BaseDomain) to the repository that should answer
+// it, the way Nexus lets an arbitrary DNS name point at a connector port.
+// Without an alias, a "<sub>.<base_domain>" host still resolves to the
+// repository named "<sub>", exactly as before.
 type SubdomainConnectorConfig struct {
-	Enabled    bool   `mapstructure:"enabled"`
-	BaseDomain string `mapstructure:"base_domain"`
+	Enabled    bool              `mapstructure:"enabled"`
+	BaseDomain string            `mapstructure:"base_domain"`
+	Aliases    map[string]string `mapstructure:"aliases"`
 }
 
 // RedisConfig holds optional Redis connection settings.


### PR DESCRIPTION
Closes #282.

The subdomain connector required the client hostname to be `<repo>.<base_domain>` with the subdomain equal to the repository name — so Nexus-style setups, where DNS names and connector ports are chosen independently of repo names, could not be migrated without renaming repositories or adding Host-rewriting proxy rules.

## Change

`docker.subdomain_connector.aliases` — a config map of full client hostname → repository name:

```yaml
docker:
  subdomain_connector:
    enabled: true
    base_domain: "nexspence.example.com"   # optional when only aliases are used
    aliases:
      docker-hub-proxy.domain.example.com: dockerhub-proxy
      hub.nexspence.example.com: dockerhub-proxy
```

- Alias hosts don't have to sit under `base_domain` (any DNS name the operator wires through Istio/Ingress works), and an alias under `base_domain` overrides the implicit subdomain repo.
- Matching is case-insensitive and port-agnostic, like the existing pattern; `/v2/` ping and `/v2/token` stay unrewritten on alias hosts.
- Alias targets that are not valid repository name labels are dropped at construction — a config typo can't become a path injection.
- Without aliases everything behaves exactly as before.

Config-level (rather than per-repo UI) fits how these hostnames are provisioned — DNS and ingress routes live in infra config; if a UI/API surface for this is wanted, it can layer on top later.

Docs: `docs/docker-subdomain-connector.md` gained a "Hostname aliases" section with the migration example from the issue.

## Tests

Foreign-domain alias, alias overriding the subdomain repo, host normalization (case/port), ping/token passthrough, and invalid-target rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcrsCyNcvsEKp881db5JL