### PR TITLE
feat(observability): carry trace_id/span_id in structured logs

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -59,6 +59,16 @@ guarantee, configure [tail-based sampling](https://opentelemetry.io/docs/concept
 in your collector — it buffers the whole trace and decides once it is
 finished.
 
+## Log correlation
+
+Every structured log line produced inside a traced scope carries the trace's
+ids as `trace_id` / `span_id` fields: the per-request summary line
+(`requestLogger`) and the log statements inside the background jobs. An error
+log can be jumped to its full trace, and — since `sample_ratio` means most
+requests have no trace at all — the log line is also the place that tells you
+whether this particular request was one of the sampled ones worth looking up.
+With tracing disabled the fields are simply absent.
+
 ## What is never recorded
 
 Span attributes carry metadata only: routes, repository names, blob keys and

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/logger"
@@ -15,13 +16,42 @@ func requestLogger(log logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		start := time.Now()
 		c.Next()
-		log.Infow("request",
+		fields := []any{
 			"method", c.Request.Method,
 			"path", c.Request.URL.Path,
 			"status", c.Writer.Status(),
 			"latency", time.Since(start),
 			"ip", c.ClientIP(),
-		)
+		}
+		// Correlate the log line with the request's trace (#321). The ids come
+		// from gin's key store, not c.Request.Context(): otelgin restores the
+		// request context to its pre-span value when its own middleware
+		// returns, so by the time this post-Next line runs the span is gone
+		// from the context — see traceLogStash.
+		if tid, ok := c.Get("traceID"); ok {
+			fields = append(fields, "trace_id", tid)
+			if sid, ok := c.Get("spanID"); ok {
+				fields = append(fields, "span_id", sid)
+			}
+		}
+		log.Infow("request", fields...)
+	}
+}
+
+// traceLogStash copies the request span's ids into gin's per-request key
+// store. It must be registered AFTER otelgin: it reads the span from
+// c.Request.Context() inside otelgin's scope, and stashes it somewhere that —
+// unlike the request context, which otelgin deliberately unwinds on return —
+// survives until requestLogger's post-Next summary line. requestLogger itself
+// stays first in the chain, so it keeps timing the full chain and keeps
+// logging aborted CORS preflights (#321).
+func traceLogStash() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if sc := trace.SpanContextFromContext(c.Request.Context()); sc.IsValid() {
+			c.Set("traceID", sc.TraceID().String())
+			c.Set("spanID", sc.SpanID().String())
+		}
+		c.Next()
 	}
 }
 

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -6,6 +6,14 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestCORS_AllowlistReflectsKnownOrigin(t *testing.T) {
@@ -135,4 +143,63 @@ func TestSecurityHeaders(t *testing.T) {
 			t.Errorf("%s = %q, want %q", h, got, want)
 		}
 	}
+}
+
+// The per-request summary line and the request's trace must share ids (#321).
+// requestLogger stays FIRST in the chain (it times everything and still sees
+// aborted CORS preflights), so it cannot read the span from the request
+// context — otelgin restores that to the pre-span value on unwind. The stash
+// middleware inside otelgin's scope is what carries the ids across.
+func TestRequestLogger_CarriesTraceIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	prev := otel.GetTracerProvider()
+	defer otel.SetTracerProvider(prev)
+	exp := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp), sdktrace.WithSampler(sdktrace.AlwaysSample())))
+
+	core, logs := observer.New(zap.InfoLevel)
+	log := zap.New(core).Sugar()
+
+	r := gin.New()
+	r.Use(requestLogger(log))
+	r.Use(otelgin.Middleware("nexspence-test"))
+	r.Use(traceLogStash())
+	r.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Equal(t, 1, logs.Len())
+	fields := logs.All()[0].ContextMap()
+	spans := exp.GetSpans()
+	require.NotEmpty(t, spans)
+	assert.Equal(t, spans[0].SpanContext.TraceID().String(), fields["trace_id"],
+		"the log line and the exported span must agree on the trace id")
+	assert.Equal(t, spans[0].SpanContext.SpanID().String(), fields["span_id"])
+}
+
+// Without tracing middleware the summary line simply has no trace fields —
+// and, unchanged from before, requestLogger first in the chain still logs
+// requests that later middlewares abort.
+func TestRequestLogger_NoTracing_NoTraceFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	core, logs := observer.New(zap.InfoLevel)
+	log := zap.New(core).Sugar()
+
+	r := gin.New()
+	r.Use(requestLogger(log))
+	r.Use(corsMiddleware([]string{"https://app.example.com"}))
+	r.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	// An OPTIONS preflight aborts inside corsMiddleware; the summary line must
+	// still be written (the reason requestLogger was not moved after otelgin).
+	req := httptest.NewRequest(http.MethodOptions, "/ping", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	require.Equal(t, 1, logs.Len())
+	entry := logs.All()[0].ContextMap()
+	assert.NotContains(t, entry, "trace_id")
+	assert.Equal(t, int64(http.StatusNoContent), entry["status"])
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -381,6 +381,9 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 			svcName = "nexspence"
 		}
 		r.Use(otelgin.Middleware(svcName))
+		// Inside otelgin's scope: stash the span ids where requestLogger's
+		// post-Next summary can still see them (#321).
+		r.Use(traceLogStash())
 	}
 	r.Use(AuditMiddleware(auditRepo))
 	if cfg.Auth.RateLimitEnabled {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,6 +1,9 @@
 package logger
 
 import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -26,4 +29,18 @@ func New(level, format string) Logger {
 		panic(err)
 	}
 	return log.Sugar()
+}
+
+// WithTraceContext returns log with trace_id/span_id fields when ctx carries a
+// valid span, and log unchanged otherwise (tracing disabled, or no span in
+// context). This is the bridge between the two observability systems: an
+// error log line can be jumped to its full trace and back — which matters
+// most under sampling, where only some requests have a trace at all and the
+// log line is the only place that says whether this one did (#321).
+func WithTraceContext(ctx context.Context, log Logger) Logger {
+	sc := trace.SpanContextFromContext(ctx)
+	if !sc.IsValid() {
+		return log
+	}
+	return log.With("trace_id", sc.TraceID().String(), "span_id", sc.SpanID().String())
 }

--- a/internal/logger/logger_trace_test.go
+++ b/internal/logger/logger_trace_test.go
@@ -1,0 +1,47 @@
+package logger_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+
+	"github.com/nexspence-oss/nexspence/internal/logger"
+)
+
+// Without a span in context the logger comes back unchanged — no empty
+// trace_id fields polluting every line when tracing is off.
+func TestWithTraceContext_NoSpan_Unchanged(t *testing.T) {
+	core, logs := observer.New(zap.InfoLevel)
+	log := zap.New(core).Sugar()
+
+	got := logger.WithTraceContext(context.Background(), log)
+	got.Infow("hello")
+
+	require.Equal(t, 1, logs.Len())
+	assert.Empty(t, logs.All()[0].ContextMap()["trace_id"])
+}
+
+// With a live span the line carries the span's exact ids.
+func TestWithTraceContext_AttachesIDs(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	ctx, span := tp.Tracer("t").Start(context.Background(), "job")
+	defer span.End()
+
+	core, logs := observer.New(zap.InfoLevel)
+	log := zap.New(core).Sugar()
+
+	logger.WithTraceContext(ctx, log).Infow("working")
+
+	require.Equal(t, 1, logs.Len())
+	fields := logs.All()[0].ContextMap()
+	assert.Equal(t, span.SpanContext().TraceID().String(), fields["trace_id"])
+	assert.Equal(t, span.SpanContext().SpanID().String(), fields["span_id"])
+}

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -189,7 +189,7 @@ func (s *CleanupService) runPolicyLocked(ctx context.Context, p domain.CleanupPo
 	lock, err := s.locker.Acquire(ctx, cleanupPolicyLockPrefix+p.ID, cleanupLockTTL)
 	if errors.Is(err, distlock.ErrLockHeld) {
 		const reason = "another node is already running this policy"
-		s.log.Info("cleanup skipped: "+reason, "policy", p.Name)
+		logger.WithTraceContext(ctx, s.log).Info("cleanup skipped: "+reason, "policy", p.Name)
 		return &domain.CleanupRunResult{
 			PolicyID: p.ID, DryRun: p.DryRun, Skipped: true, SkippedReason: reason,
 		}, nil
@@ -223,7 +223,7 @@ func (s *CleanupService) RunAll(ctx context.Context) error {
 			if errors.Is(err, errAcquireLock) {
 				return err
 			}
-			s.log.Error("cleanup policy failed", "policy", p.Name, "err", err)
+			logger.WithTraceContext(ctx, s.log).Error("cleanup policy failed", "policy", p.Name, "err", err)
 		}
 	}
 	return nil
@@ -253,6 +253,10 @@ func (s *CleanupService) RunPolicyResult(ctx context.Context, id string) (*domai
 }
 
 func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) (*domain.CleanupRunResult, error) {
+	// Every line this run logs carries the run's trace_id, so a warning like
+	// "blob delete failed" can be jumped to the exact cleanup.run trace it
+	// happened in (#321). With tracing disabled this is s.log unchanged.
+	log := logger.WithTraceContext(ctx, s.log)
 	res := &domain.CleanupRunResult{PolicyID: p.ID, DryRun: p.DryRun}
 
 	lastDownloadedDays := intCriteria(p.Criteria, "lastDownloadedDays")
@@ -275,7 +279,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 	}
 	if len(repoNames) == 0 {
 		reason := "policy is not attached to any repository — attach it to a repository or set a scope"
-		s.log.Info("cleanup: "+reason, "policy", p.Name)
+		log.Info("cleanup: "+reason, "policy", p.Name)
 		res.Skipped = true
 		res.SkippedReason = reason
 		return res, nil
@@ -285,7 +289,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 	// (path/name filters and retainNVersions still apply). This is intentional
 	// for a clear-all policy; the repository targeting above is the safety gate.
 	if lastDownloadedDays == 0 && artifactAgeDays == 0 {
-		s.log.Info("cleanup: no age criteria — removing all artifacts matching scope",
+		log.Info("cleanup: no age criteria — removing all artifacts matching scope",
 			"policy", p.Name, "repos", repoNames, "path_prefix", pathPrefix,
 			"name_glob", nameGlob, "retain_versions", p.RetainNVersions, "dry_run", p.DryRun)
 	}
@@ -303,7 +307,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 		}
 		for _, a := range stale {
 			if p.DryRun {
-				s.log.Info("cleanup dry-run: would delete", "policy", p.Name,
+				log.Info("cleanup dry-run: would delete", "policy", p.Name,
 					"asset", a.Path, "repo", a.Repository, "size", a.SizeBytes)
 				freed += a.SizeBytes
 				deleted++
@@ -319,17 +323,17 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 			bytesFreed := false
 			others, cerr := s.assets.CountByBlobKey(ctx, a.BlobKey, a.ID)
 			if cerr != nil {
-				s.log.Warn("cleanup: blob reference count failed, keeping blob",
+				log.Warn("cleanup: blob reference count failed, keeping blob",
 					"key", a.BlobKey, "err", cerr)
 			} else if others == 0 {
 				if err := s.storeForAsset(ctx, &asset).Delete(ctx, a.BlobKey); err != nil {
-					s.log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
+					log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
 				} else {
 					bytesFreed = true
 				}
 			}
 			if err := s.assets.Delete(ctx, a.ID); err != nil {
-				s.log.Warn("cleanup: asset delete failed", "id", a.ID, "err", err)
+				log.Warn("cleanup: asset delete failed", "id", a.ID, "err", err)
 				continue
 			}
 			// used_bytes is how full the store is, so it only moves when bytes
@@ -345,7 +349,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 		// would return the same rows forever — report the first batch and stop.
 		if p.DryRun {
 			if len(stale) == batchLimit {
-				s.log.Info("cleanup dry-run: results capped at one batch — actual run would delete more",
+				log.Info("cleanup dry-run: results capped at one batch — actual run would delete more",
 					"policy", p.Name, "batch", batchLimit)
 			}
 			break
@@ -357,17 +361,17 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 	if s.components != nil && !p.DryRun && deleted > 0 {
 		for _, rn := range repoNames {
 			if err := s.components.DeleteOrphans(ctx, rn); err != nil {
-				s.log.Warn("cleanup: failed to prune orphan components", "repo", rn, "err", err)
+				log.Warn("cleanup: failed to prune orphan components", "repo", rn, "err", err)
 			}
 		}
 	}
 
 	now := time.Now()
 	if err := s.policies.RecordRun(ctx, p.ID, now, deleted, freed); err != nil {
-		s.log.Warn("cleanup: failed to record run stats", "policy", p.Name, "err", err)
+		log.Warn("cleanup: failed to record run stats", "policy", p.Name, "err", err)
 	}
 
-	s.log.Info("cleanup policy complete",
+	log.Info("cleanup policy complete",
 		"policy", p.Name,
 		"deleted", deleted,
 		"freed_bytes", freed,

--- a/internal/service/cleanup_service_trace_test.go
+++ b/internal/service/cleanup_service_trace_test.go
@@ -1,0 +1,59 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A cleanup run's log lines carry the run's own trace id (#321): the root span
+// RunAll opens is the same trace every line inside the run correlates to.
+func TestCleanupService_RunLogsCarryTraceID(t *testing.T) {
+	prev := otel.GetTracerProvider()
+	defer otel.SetTracerProvider(prev)
+	exp := tracetest.NewInMemoryExporter()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(
+		sdktrace.WithSyncer(exp), sdktrace.WithSampler(sdktrace.AlwaysSample())))
+
+	core, logs := observer.New(zap.InfoLevel)
+	log := zap.New(core).Sugar()
+
+	repos := testutil.NewRepoRepo(testutil.SimpleRepo("raw-host", "raw"))
+	policies := testutil.NewCleanupPolicyRepo()
+	require.NoError(t, policies.Create(context.Background(), &domain.CleanupPolicy{
+		Name: "dry", Enabled: true, DryRun: true, Format: "*",
+		Scope:    domain.CleanupScope{RepositoryName: "raw-host"},
+		Criteria: map[string]any{"artifactAgeDays": 1},
+	}))
+
+	svc := service.NewCleanupService(policies, repos, testutil.NewAssetRepo(),
+		testutil.NewBlobStoreRepo(), testutil.NewBlobStore(), log)
+
+	require.NoError(t, svc.RunAll(context.Background()))
+
+	spans := exp.GetSpans()
+	var rootTrace string
+	for _, sp := range spans {
+		if sp.Name == "cleanup.run_all" {
+			rootTrace = sp.SpanContext.TraceID().String()
+		}
+	}
+	require.NotEmpty(t, rootTrace, "RunAll must open its root span")
+
+	require.NotZero(t, logs.Len(), "the dry run should have logged")
+	for _, entry := range logs.All() {
+		assert.Equal(t, rootTrace, entry.ContextMap()["trace_id"],
+			"log %q must carry the run's trace id", entry.Message)
+	}
+}

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -135,7 +135,7 @@ func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCRe
 	if s.Locker != nil {
 		lock, err := s.Locker.Acquire(ctx, gcLockKey, gcLockTTL)
 		if errors.Is(err, distlock.ErrLockHeld) {
-			s.log().Info("blob gc skipped: another node is running gc")
+			logger.WithTraceContext(ctx, s.log()).Info("blob gc skipped: another node is running gc")
 			return nil, nil
 		}
 		if err != nil {
@@ -160,7 +160,7 @@ func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCRe
 			ID: row.ID, Type: row.Type, Config: row.Config,
 		})
 		if rerr != nil {
-			s.log().Error("blob gc: resolve store failed", "store", row.Name, "err", rerr)
+			logger.WithTraceContext(ctx, s.log()).Error("blob gc: resolve store failed", "store", row.Name, "err", rerr)
 			results = append(results, &GCResult{
 				Store:  row.Name,
 				DryRun: opts.DryRun,
@@ -216,7 +216,7 @@ func (s *BlobGCService) compact(ctx context.Context, name, storeID string, store
 	// given back: a blob whose delete failed is still on the disk.
 	if removed > 0 {
 		if err := s.Stores.UpdateUsedBytes(ctx, name, -removed); err != nil {
-			s.log().Error("blob gc: usage decrement failed", "store", name, "bytes", removed, "err", err)
+			logger.WithTraceContext(ctx, s.log()).Error("blob gc: usage decrement failed", "store", name, "bytes", removed, "err", err)
 			result.Errors = append(result.Errors, fmt.Sprintf("update used_bytes: %v", err))
 		}
 	}

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -371,7 +371,7 @@ func (s *NexusMigrationService) run(ctx context.Context, jobID string) {
 
 	job, err := s.jobs.Get(bg, jobID)
 	if err != nil {
-		s.logf("migration: cannot load job %s: %v", jobID, err)
+		s.logf(bg, "migration: cannot load job %s: %v", jobID, err)
 		return
 	}
 	password, err := s.OpenPassword(job.SourcePassword)
@@ -381,7 +381,7 @@ func (s *NexusMigrationService) run(ctx context.Context, jobID string) {
 		return
 	}
 	if err := s.jobs.SetStarted(bg, jobID, time.Now().UTC()); err != nil {
-		s.logf("migration: cannot mark job %s started: %v", jobID, err)
+		s.logf(bg, "migration: cannot mark job %s started: %v", jobID, err)
 		return
 	}
 
@@ -825,7 +825,7 @@ func (s *NexusMigrationService) registerManifestDigestAlias(ctx context.Context,
 		res.SHA256, res.SHA1, res.MD5, res.Size,
 		res.Asset.BlobStoreID, "",
 	); err != nil {
-		s.logf("migration: cannot register digest alias %s%s: %v", a.repo, aliasPath, err)
+		s.logf(ctx, "migration: cannot register digest alias %s%s: %v", a.repo, aliasPath, err)
 	}
 }
 
@@ -1235,8 +1235,10 @@ func isNotFound(err error) bool {
 	return errors.Is(err, repository.ErrNotFound) || errors.Is(err, ErrNotFound)
 }
 
-func (s *NexusMigrationService) logf(format string, args ...any) {
+func (s *NexusMigrationService) logf(ctx context.Context, format string, args ...any) {
 	if s.log != nil {
-		s.log.Warnf(format, args...)
+		// The run's trace_id rides along, so a warning can be tied to the
+		// exact nexus_migration.run trace it belongs to (#321).
+		logger.WithTraceContext(ctx, s.log).Warnf(format, args...)
 	}
 }

--- a/internal/service/replication_service.go
+++ b/internal/service/replication_service.go
@@ -400,7 +400,7 @@ func (s *ReplicationService) runRule(ctx context.Context, rule *domain.Replicati
 			if hist.Error == "" {
 				hist.Error = pushErr.Error()
 			}
-			s.log.Warn("replication: push failed", "rule", rule.Name, "path", asset.Path, "err", pushErr)
+			logger.WithTraceContext(ctx, s.log).Warn("replication: push failed", "rule", rule.Name, "path", asset.Path, "err", pushErr)
 			continue
 		}
 		if pushed {


### PR DESCRIPTION
Closes #321.

Point 5 of #302's design, now implemented: every log line produced inside a traced scope carries `trace_id`/`span_id`, so logs and traces stop being two disconnected systems — which matters most under sampling, where the log line is the only place that says whether this request even has a trace to look up.

## Change

- `logger.WithTraceContext(ctx, log)` — attaches the ids when `ctx` carries a valid span, returns the logger unchanged otherwise. Call sites never branch on whether tracing is enabled.
- **HTTP**: the per-request summary line carries the ids via a small `traceLogStash` middleware registered inside otelgin's scope — it copies the span ids into gin's per-request key store, which (unlike `c.Request`'s context, which otelgin deliberately restores on unwind — the exact trap the issue's verification hit) survives until `requestLogger`'s post-`Next` line. `requestLogger` stays **first** in the chain, so the issue's known trade-off is avoided rather than accepted: it still times the full chain and still logs aborted CORS preflights (pinned by test).
- **Background jobs**: log statements along the five root-span paths derive the trace-aware logger from the ctx that already carries the root span — cleanup's run logs (including the `blob delete failed` warning from the issue's forced-failure repro), GC's compaction errors, nexus import's `logf` (now ctx-aware), replication's `push failed`. Scheduler-level lines with no run behind them are unchanged.
- `docs/tracing.md` gains a "Log correlation" section.

## Tests

- `WithTraceContext`: no span → logger unchanged (no empty fields); live span → exact ids.
- HTTP end-to-end with real otelgin + SDK: the summary line's `trace_id`/`span_id` match the exported span byte-for-byte; and an aborted OPTIONS preflight is still logged with no trace fields.
- Cleanup: a real `RunAll` produces log lines that all carry the `cleanup.run_all` root trace's id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UXcrsCyNcvsEKp881db5JL