### PR TITLE
fix(scan): BulkScan silently capped at 50 components; Trivy argv injection via imageRef

### DIFF
--- a/internal/repository/postgres/component_repo.go
+++ b/internal/repository/postgres/component_repo.go
@@ -163,8 +163,11 @@ func (r *componentRepo) Search(ctx context.Context, p domain.SearchParams) (*dom
 	}
 
 	limit := p.Limit
-	if limit <= 0 || limit > 500 {
+	if limit <= 0 {
 		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
 	}
 	offset := p.Offset
 

--- a/internal/repository/postgres/component_repo_integration_test.go
+++ b/internal/repository/postgres/component_repo_integration_test.go
@@ -1195,6 +1195,42 @@ func TestComponentRepo_Search_DefaultLimit(t *testing.T) {
 	}
 }
 
+// A limit above the 500 cap must clamp down to 500, not collapse to the
+// 50-row default: callers asking for "everything" (BulkScan uses Limit 10000)
+// would otherwise silently get the smallest page the layer serves.
+func TestComponentRepo_Search_OversizedLimitClampsUpNotDown(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories")
+	ctx := context.Background()
+
+	p := makeCompParent(t, ctx, "srch_bigl")
+	repo := NewComponentRepo(pool)
+
+	const total = 60
+	for i := 0; i < total; i++ {
+		c := &domain.Component{
+			RepositoryID: p.RepositoryID,
+			Format:       "raw",
+			Name:         fmt.Sprintf("bigl-lib-%03d", i),
+			Version:      "1.0",
+		}
+		if err := repo.Create(ctx, c); err != nil {
+			t.Fatalf("Create bigl-lib-%03d: %v", i, err)
+		}
+	}
+
+	page, err := repo.Search(ctx, domain.SearchParams{
+		Repository: p.RepoName,
+		Limit:      10000,
+	})
+	if err != nil {
+		t.Fatalf("Search(limit=10000): %v", err)
+	}
+	if len(page.Items) != total {
+		t.Errorf("Search(limit=10000) returned %d items, want all %d — an oversized limit must clamp to 500, not reset to 50", len(page.Items), total)
+	}
+}
+
 // ── ListDockerBrowseRows ──────────────────────────────────────────────────────
 
 func TestComponentRepo_ListDockerBrowseRows_ReturnsDockerComponents(t *testing.T) {

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -358,6 +359,13 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 		}
 	}
 
+	// Defense in depth on top of the "--" separator in TrivyScanArgs: a
+	// flag-shaped reference is never a real image, so refuse it loudly instead
+	// of letting a misparse report "no vulnerabilities".
+	if strings.HasPrefix(ref, "-") {
+		return nil, fmt.Errorf("invalid imageRef %q: must not start with %q", ref, "-")
+	}
+
 	result := &domain.ScanResult{
 		ScannedAt: time.Now().UTC(),
 		ImageRef:  ref,
@@ -544,23 +552,37 @@ func isDigestAlias(version string) bool {
 // BulkScan scans every component in a repository (skipping SHA digest aliases),
 // returning the count of scanned and failed components.
 func (s *ScanService) BulkScan(ctx context.Context, repoName string) (scanned int, failed int, err error) {
-	page, err := s.Components.Search(ctx, domain.SearchParams{Repository: repoName, Limit: 10000})
-	if err != nil {
-		return 0, 0, err
-	}
-	for _, comp := range page.Items {
-		if isDigestAlias(comp.Version) {
-			continue
+	// 500 is the most the repository layer hands out per Search call, so the
+	// full set is only covered by walking the continuation token.
+	const pageLimit = 500
+	offset := 0
+	for {
+		page, err := s.Components.Search(ctx, domain.SearchParams{Repository: repoName, Limit: pageLimit, Offset: offset})
+		if err != nil {
+			return scanned, failed, err
 		}
-		if isImageFormat(comp.Format) && !s.Scanner(ctx).Ready() {
-			continue
+		for _, comp := range page.Items {
+			if isDigestAlias(comp.Version) {
+				continue
+			}
+			if isImageFormat(comp.Format) && !s.Scanner(ctx).Ready() {
+				continue
+			}
+			_, scanErr := s.Scan(ctx, comp.ID, "")
+			if scanErr != nil {
+				failed++
+			} else {
+				scanned++
+			}
 		}
-		_, scanErr := s.Scan(ctx, comp.ID, "")
-		if scanErr != nil {
-			failed++
-		} else {
-			scanned++
+		if page.ContinuationToken == nil {
+			break
 		}
+		next, convErr := strconv.Atoi(*page.ContinuationToken)
+		if convErr != nil || next <= offset {
+			break
+		}
+		offset = next
 	}
 	return scanned, failed, nil
 }

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -579,7 +579,10 @@ func (s *ScanService) BulkScan(ctx context.Context, repoName string) (scanned in
 			break
 		}
 		next, convErr := strconv.Atoi(*page.ContinuationToken)
-		if convErr != nil || next <= offset {
+		if convErr != nil {
+			return scanned, failed, fmt.Errorf("malformed continuation token %q: %w", *page.ContinuationToken, convErr)
+		}
+		if next <= offset {
 			break
 		}
 		offset = next

--- a/internal/service/scan_service_test.go
+++ b/internal/service/scan_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -92,6 +93,41 @@ func TestScanService_TrivyNotInstalled(t *testing.T) {
 	}
 	if unavailable.Status.State != service.ScannerMissing {
 		t.Fatalf("State = %q, want %q", unavailable.Status.State, service.ScannerMissing)
+	}
+}
+
+// A flag-shaped imageRef ("--format=table") must be rejected before Trivy is
+// ever invoked: passed through, Trivy would parse it as an option and report
+// "scanned, no vulnerabilities" for an image it never looked at.
+func TestScanService_Scan_RejectsFlagShapedImageRef(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "trivy")
+	callLog := filepath.Join(dir, "calls.log")
+	script := "#!/bin/sh\necho \"$@\" >> " + callLog + "\necho 'Version: 0.99.0'\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	comp := newDockerComp("dockerhosted", "alpine", "latest")
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	svc := service.NewScanService(comps, "http://localhost:8081").
+		WithTrivy(service.TrivyOptions{Enabled: true, Bin: bin})
+
+	_, err := svc.Scan(context.Background(), comp.ID, "--format=table")
+	if err == nil {
+		t.Fatal("a flag-shaped imageRef must be rejected, got a successful scan")
+	}
+	if !strings.Contains(err.Error(), `must not start with "-"`) {
+		t.Errorf("error = %q, want it to say the reference must not start with \"-\"", err)
+	}
+
+	calls, _ := os.ReadFile(callLog)
+	for _, line := range strings.Split(string(calls), "\n") {
+		if strings.HasPrefix(line, "image ") {
+			t.Errorf("trivy was invoked for the scan anyway: %q", line)
+		}
 	}
 }
 
@@ -374,6 +410,42 @@ func TestScanService_BulkScan(t *testing.T) {
 	}
 	if failed != 1 {
 		t.Errorf("expected failed=1, got %d", failed)
+	}
+}
+
+// BulkScan is the safety net for whatever the auto-scan queue drops, so it must
+// walk the whole repository. The repository layer hands out at most 500 rows per
+// Search call — a repository above that size is only covered if BulkScan pages
+// through with the continuation token instead of trusting one oversized Limit.
+func TestScanService_BulkScan_PagesThroughLargeRepository(t *testing.T) {
+	t.Parallel()
+	const total = 520
+	comps := testutil.NewComponentRepo()
+	for i := 0; i < total; i++ {
+		comps.Create(context.Background(), &domain.Component{
+			Repository: "npm-big", Format: "npm",
+			Name: fmt.Sprintf("pkg-%03d", i), Version: "1.0.0",
+		})
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"vulns": []any{}})
+	}))
+	defer srv.Close()
+
+	svc := service.NewScanService(comps, "")
+	svc.WithScanResults(testutil.NewScanResultRepo())
+	svc.OSVClient.BaseURL = srv.URL
+
+	scanned, failed, err := svc.BulkScan(context.Background(), "npm-big")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scanned != total {
+		t.Errorf("scanned = %d, want %d — components beyond the first page were never attempted", scanned, total)
+	}
+	if failed != 0 {
+		t.Errorf("failed = %d, want 0", failed)
 	}
 }
 

--- a/internal/service/trivy_args.go
+++ b/internal/service/trivy_args.go
@@ -63,7 +63,10 @@ func TrivyScanArgs(o TrivyOptions, imageRef string, insecureRegistry bool) []str
 	if o.CacheDir != "" {
 		args = append(args, "--cache-dir", o.CacheDir)
 	}
-	return append(args, imageRef)
+	// "--" pins the reference as positional: imageRef arrives from a request
+	// body, and without the separator a flag-shaped value would be parsed as
+	// an option instead of an image.
+	return append(args, "--", imageRef)
 }
 
 // TrivyEnv returns the child environment for a Trivy run: the parent

--- a/internal/service/trivy_args_test.go
+++ b/internal/service/trivy_args_test.go
@@ -54,6 +54,19 @@ func TestTrivyArgs_OmitsEveryUnsetFlag(t *testing.T) {
 	}
 }
 
+// The image reference is caller-controlled (it arrives in a request body), so
+// the argv must pin it as positional: without a "--" separator a flag-shaped
+// reference like "--format=table" would be parsed as an option and silently
+// change what Trivy does.
+func TestTrivyArgs_SeparatorPinsImageRefAsPositional(t *testing.T) {
+	for _, ref := range []string{"reg/img:1", "--format=table"} {
+		args := service.TrivyScanArgs(service.TrivyOptions{Enabled: true}, ref, false)
+		if len(args) < 2 || args[len(args)-2] != "--" || args[len(args)-1] != ref {
+			t.Errorf("argv %q must end with [-- %q]", strings.Join(args, " "), ref)
+		}
+	}
+}
+
 func TestTrivyArgs_PassesConfiguredDatabases(t *testing.T) {
 	args := service.TrivyScanArgs(service.TrivyOptions{
 		Enabled:          true,

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -424,7 +424,35 @@ func (c *ComponentRepo) Search(_ context.Context, params domain.SearchParams) (*
 		}
 		items = append(items, *v)
 	}
-	return &domain.Page[domain.Component]{Items: items}, nil
+	// Mirror the SQL layer's ordering, limit clamp and continuation token
+	// (component_repo.go Search): a mock that returns everything regardless of
+	// Limit hides exactly the class of bug where a caller asks for more rows
+	// than the repository layer will ever hand out.
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Name != items[j].Name {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].Version < items[j].Version
+	})
+	limit := params.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 500 {
+		limit = 500
+	}
+	offset := params.Offset
+	if offset >= len(items) {
+		return &domain.Page[domain.Component]{Items: []domain.Component{}}, nil
+	}
+	items = items[offset:]
+	var token *string
+	if len(items) > limit {
+		items = items[:limit]
+		next := strconv.Itoa(offset + limit)
+		token = &next
+	}
+	return &domain.Page[domain.Component]{Items: items, ContinuationToken: token}, nil
 }
 
 func (c *ComponentRepo) ListDockerBrowseRows(_ context.Context, names []string, _ int) ([]domain.DockerBrowseRow, error) {


### PR DESCRIPTION
Fixes both bugs from #329.

## 1. BulkScan never scanned more than 50 components

The repository-layer limit clamp in `Search` collapsed any requested limit above 500 down to the 50-row default, so `BulkScan`'s single `Limit: 10000` call silently covered only 50 components — breaking the safety-net contract for any repository above that size.

- `Search` now clamps oversized limits to 500 (mirroring `ListByRepoNames`) instead of resetting them to 50.
- `BulkScan` paginates with the continuation token in pages of 500 until the full set is exhausted.
- The `testutil.ComponentRepo` mock's `Search` now mirrors the SQL layer's ordering, limit clamp and continuation token, so callers that over-ask are caught by unit tests instead of only in production.

## 2. Argument injection into Trivy's argv via `imageRef`

`TrivyScanArgs` appended the caller-controlled `imageRef` as the last argument with no `--` separator, so a flag-shaped reference (`{"imageRef": "--format=table"}`) was parsed by Trivy as an option and returned `status: ok, total: 0` — indistinguishable from a clean scan, for an image never looked at.

- The argv now carries `--` immediately before the image reference, pinning it as positional regardless of shape.
- `Scan` additionally rejects any resolved reference starting with `-` with a clear error before Trivy is ever invoked.

## Tests

- `TestTrivyArgs_SeparatorPinsImageRefAsPositional` — argv always ends with `["--", imageRef]`.
- `TestScanService_Scan_RejectsFlagShapedImageRef` — flag-shaped refs error out and Trivy is never invoked for the scan (verified via a recording fake binary).
- `TestScanService_BulkScan_PagesThroughLargeRepository` — 520 components in one repository are all attempted.
- `TestComponentRepo_Search_OversizedLimitClampsUpNotDown` (integration) — `Limit: 10000` no longer collapses to 50 rows.

All four were written first and observed failing against the unfixed code. `go build` / `go vet` / unit suite green; postgres integration `Search` tests green.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma