### PR TITLE
fix(blobs): serialize read-then-act on a shared blob_key; cleanup re-checks staleness at delete time

### DIFF
--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -360,31 +360,58 @@ func DeleteArtifact(ctx context.Context, d formats.Deps, repoName, filePath stri
 	if delStore == nil {
 		delStore = d.BlobStore
 	}
-	// One blob can carry several assets: an OCI manifest push registers the tag
-	// path and the digest-alias path on the same blob key, and a client that
-	// deletes one still pulls the other. Deleting the bytes here would leave the
-	// survivor — and the referrers index built from it — advertising content that
-	// is gone. A count that cannot be read keeps the blob: an orphan is reclaimed
-	// by the blob GC, whereas bytes deleted under a live asset are lost.
-	others, cerr := d.Assets.CountByBlobKey(ctx, asset.BlobKey, asset.ID)
+	// The count-then-delete sequence holds the blob-key lock: two concurrent
+	// deletes of the last two assets sharing one key would otherwise each see
+	// the other's still-present row, both skip the physical delete, and orphan
+	// the bytes with the usage counter overstated until GC.
+	var rowDeleted, freed bool
+	if err := d.Assets.WithBlobKeyLock(ctx, asset.BlobKey, func(ctx context.Context) error {
+		// Re-read under the lock: a concurrent DeleteArtifact may have already
+		// removed this row (idempotent, nothing to do), or a re-upload replaced
+		// it — in which case the path now carries a different artifact this call
+		// was never asked to delete.
+		cur, gerr := d.Assets.GetByPath(ctx, repoName, filePath)
+		if errors.Is(gerr, repository.ErrNotFound) {
+			return nil
+		}
+		if gerr != nil {
+			return gerr
+		}
+		if cur == nil || cur.ID != asset.ID || cur.BlobKey != asset.BlobKey {
+			return nil
+		}
+		// One blob can carry several assets: an OCI manifest push registers the tag
+		// path and the digest-alias path on the same blob key, and a client that
+		// deletes one still pulls the other. Deleting the bytes here would leave the
+		// survivor — and the referrers index built from it — advertising content that
+		// is gone. A count that cannot be read keeps the blob: an orphan is reclaimed
+		// by the blob GC, whereas bytes deleted under a live asset are lost.
+		others, cerr := d.Assets.CountByBlobKey(ctx, asset.BlobKey, asset.ID)
 
-	// The row goes first, before the bytes. Whichever half fails, the leftover
-	// has to be one the system can recover from: a blob with no row is reclaimed
-	// by the blob GC, while a row whose bytes are already gone is not
-	// self-healing — every later fetch finds the row and then fails to read the
-	// blob instead of answering a clean 404, and the store keeps accounting for
-	// bytes that no longer exist, since the usage decrement below is never
-	// reached. Everything after this point reasons from the asset struct already
-	// in hand, not from a fresh read, so the order does not change what is
-	// counted or decremented.
-	if err := d.Assets.Delete(ctx, asset.ID); err != nil {
+		// The row goes first, before the bytes. Whichever half fails, the leftover
+		// has to be one the system can recover from: a blob with no row is reclaimed
+		// by the blob GC, while a row whose bytes are already gone is not
+		// self-healing — every later fetch finds the row and then fails to read the
+		// blob instead of answering a clean 404, and the store keeps accounting for
+		// bytes that no longer exist, since the usage decrement below is never
+		// reached. Everything after this point reasons from the asset struct already
+		// in hand, not from a fresh read, so the order does not change what is
+		// counted or decremented.
+		if err := d.Assets.Delete(ctx, asset.ID); err != nil {
+			return err
+		}
+		rowDeleted = true
+		if cerr == nil && others == 0 {
+			// Both blob store backends report a missing object as a successful
+			// delete, so a nil error means the bytes are not there any more.
+			freed = delStore.Delete(ctx, asset.BlobKey) == nil
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
-	freed := false
-	if cerr == nil && others == 0 {
-		// Both blob store backends report a missing object as a successful
-		// delete, so a nil error means the bytes are not there any more.
-		freed = delStore.Delete(ctx, asset.BlobKey) == nil
+	if !rowDeleted {
+		return nil // a concurrent caller already deleted or replaced it
 	}
 	metrics.ArtifactsDeleted.Add(1)
 	// Decremented only when the bytes actually left the store, mirroring the

--- a/internal/formats/base/store_test.go
+++ b/internal/formats/base/store_test.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -291,6 +293,74 @@ func TestDeleteArtifact_KeepsBlobWhileAnotherAssetReferencesIt(t *testing.T) {
 	// Delete the last asset on the blob: now the bytes go.
 	require.NoError(t, base.DeleteArtifact(ctx, d, "aliasrepo", digestPath))
 	assert.False(t, blobStore.Has(key), "no asset references the blob any more")
+}
+
+// Two concurrent DeleteArtifact calls on the last two assets sharing one blob
+// key can each see "the sibling still exists" and both skip the physical
+// delete — every row gone, bytes orphaned on disk. The count-then-delete
+// sequence must hold the blob-key lock so one caller is provably last.
+func TestDeleteArtifact_ConcurrentSiblingDeletes_FreeTheBlob(t *testing.T) {
+	repo := testutil.SimpleRepo("racerepo", "oci")
+	d, blobStore, _, assets := deps(repo)
+
+	ctx := context.Background()
+	content := `{"schemaVersion":2}`
+	tagPath := "/manifests/app/1.0"
+	res, err := base.StoreArtifact(ctx, d,
+		"racerepo", tagPath, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "1.0"},
+		strings.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+
+	digestPath := "/manifests/app/sha256:" + res.SHA256
+	_, err = base.RegisterStoredBlob(ctx, d, repo,
+		digestPath, "application/vnd.oci.image.manifest.v1+json",
+		base.Coords{Name: "app", Version: "sha256:" + res.SHA256},
+		res.Asset.BlobKey, res.SHA256, res.SHA1, res.MD5, res.Size, "", "")
+	require.NoError(t, err)
+
+	key := res.Asset.BlobKey
+	require.True(t, blobStore.Has(key))
+
+	// Barrier: hold each caller right after its reference count until both have
+	// counted (or, when the blob-key lock serializes them so both never arrive,
+	// a timeout lets the holder proceed). Interleaved counts are the bug window.
+	var barrierMu sync.Mutex
+	arrivals := 0
+	bothCounted := make(chan struct{})
+	assets.CountByBlobKeyHook = func(blobKey, excludeID string) {
+		barrierMu.Lock()
+		arrivals++
+		if arrivals == 2 {
+			close(bothCounted)
+		}
+		barrierMu.Unlock()
+		select {
+		case <-bothCounted:
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	var wg sync.WaitGroup
+	for _, p := range []string{tagPath, digestPath} {
+		wg.Add(1)
+		go func(path string) {
+			defer wg.Done()
+			if err := base.DeleteArtifact(ctx, d, "racerepo", path); err != nil {
+				t.Errorf("DeleteArtifact(%s): %v", path, err)
+			}
+		}(p)
+	}
+	wg.Wait()
+
+	if _, err := assets.GetByPath(ctx, "racerepo", tagPath); err == nil {
+		t.Error("tag asset row survived its delete")
+	}
+	if _, err := assets.GetByPath(ctx, "racerepo", digestPath); err == nil {
+		t.Error("digest asset row survived its delete")
+	}
+	assert.False(t, blobStore.Has(key),
+		"both rows are gone but the bytes were never freed — each deleter saw the other's row and skipped the physical delete")
 }
 
 func TestDeleteArtifact_Idempotent(t *testing.T) {

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -663,27 +663,41 @@ func (h *Handler) mountBlob(c *gin.Context, repoName, imageName, dgst, from stri
 		if !h.callerMayRead(c, repo, sourcePath) {
 			continue
 		}
-		// An asset row outlives its bytes: a manual blob delete or a GC pass can
-		// leave the record behind. Answering 201 off one of those would hand the
-		// client a layer that 404s on pull, and the client — told the registry
-		// already has it — would never upload the copy it still holds.
-		storeName, present := h.locateBlob(ctx, src)
-		if !present {
-			continue
-		}
-		blobStoreID := src.BlobStoreID
-		if storeName == "" {
-			// The store the source names could not be resolved, so let the
-			// registration fall back to the repository's own default, exactly as
-			// a fetch of that asset would.
-			blobStoreID = ""
-		}
-		if _, err := base.RegisterStoredBlob(ctx, h.deps, repo,
-			blobPath(imageName, dgst), "application/octet-stream",
-			base.Coords{Name: imageName, Version: dgst},
-			src.BlobKey, src.SHA256, src.SHA1, src.MD5, src.SizeBytes,
-			blobStoreID, storeName); err != nil {
+		// The existence check and the row insert hold the blob-key lock as one
+		// unit: a cleanup or DeleteArtifact freeing this key between the two
+		// would let the mount answer 201 with a row pointing at bytes that are
+		// gone — worse than a 404, because the client, told the registry has the
+		// layer, never uploads the copy it still holds.
+		var mounted bool
+		if lockErr := h.deps.Assets.WithBlobKeyLock(ctx, src.BlobKey, func(ctx context.Context) error {
+			// An asset row outlives its bytes: a manual blob delete or a GC pass
+			// can leave the record behind. Answering 201 off one of those would
+			// hand the client a layer that 404s on pull.
+			storeName, present := h.locateBlob(ctx, src)
+			if !present {
+				return nil
+			}
+			blobStoreID := src.BlobStoreID
+			if storeName == "" {
+				// The store the source names could not be resolved, so let the
+				// registration fall back to the repository's own default, exactly as
+				// a fetch of that asset would.
+				blobStoreID = ""
+			}
+			if _, err := base.RegisterStoredBlob(ctx, h.deps, repo,
+				blobPath(imageName, dgst), "application/octet-stream",
+				base.Coords{Name: imageName, Version: dgst},
+				src.BlobKey, src.SHA256, src.SHA1, src.MD5, src.SizeBytes,
+				blobStoreID, storeName); err != nil {
+				return err
+			}
+			mounted = true
+			return nil
+		}); lockErr != nil {
 			return false
+		}
+		if !mounted {
+			continue
 		}
 		c.Header("Docker-Content-Digest", dgst)
 		c.Header("Location", blobLocation(c, imageName, dgst))

--- a/internal/formats/oci/mount_test.go
+++ b/internal/formats/oci/mount_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http/httptest"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -163,6 +165,56 @@ func TestMount_MountedBlobIsPullableAndSharesTheSourceBlobKey(t *testing.T) {
 	assert.Equal(t, src.MD5, dst.MD5)
 	assert.Equal(t, src.BlobStoreID, dst.BlobStoreID,
 		"the alias has to name the store the bytes actually live in, or the pull looks in the wrong place")
+}
+
+// A mount racing the delete of its source's last reference must not answer 201
+// while the bytes are being freed: the client — told the registry has the
+// layer — never uploads its own copy, and the first pull 404s. The mount's
+// existence check and row insert must hold the blob-key lock the deleter holds.
+func TestMount_RacingLastReferenceDelete_NeverServesDanglingRow(t *testing.T) {
+	repo := testutil.SimpleRepo("mntrace", "docker")
+	r, _, d, store := mountDeps(repo)
+	ctx := context.Background()
+
+	const layer = "bytes about to vanish"
+	dgst := pushBlob(t, r, "mntrace", "library/alpine", layer)
+	assets := d.Assets.(*testutil.AssetRepo)
+
+	srcPath := "/blobs/library/alpine/" + dgst
+	src, err := assets.GetByPath(ctx, "mntrace", srcPath)
+	require.NoError(t, err)
+
+	// Pause the deleter right after its reference count — it has just decided
+	// "I am the last reference" — fire the mount during the pause, and let the
+	// delete finish afterwards. When the lock serializes the two, the mount
+	// blocks instead and the pause simply times out.
+	var once sync.Once
+	mountResult := make(chan *httptest.ResponseRecorder, 1)
+	mountDone := make(chan struct{})
+	assets.CountByBlobKeyHook = func(string, string) {
+		once.Do(func() {
+			go func() {
+				mountResult <- postMount(r, "/repository/mntrace/v2/library/ubuntu/blobs/uploads/", dgst, "library/alpine")
+				close(mountDone)
+			}()
+			select {
+			case <-mountDone:
+			case <-time.After(500 * time.Millisecond):
+			}
+		})
+	}
+
+	require.NoError(t, base.DeleteArtifact(ctx, d, "mntrace", srcPath))
+	w := <-mountResult
+
+	if w.Code == http.StatusCreated {
+		assert.True(t, store.Has(src.BlobKey),
+			"mount answered 201 but the bytes are gone — the client will never re-upload a layer it was told the registry has")
+	}
+	if dst, gerr := assets.GetByPath(ctx, "mntrace", "/blobs/library/ubuntu/"+dgst); gerr == nil && dst != nil {
+		assert.True(t, store.Has(dst.BlobKey),
+			"the mounted asset row points at bytes that no longer exist")
+	}
 }
 
 // ── The `from` spellings a real client sends ──────────────────

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -64,6 +64,18 @@ type AssetRepo interface {
 	ListStale(ctx context.Context, format string, repoNames []string, lastDownloadedDays, artifactAgeDays int, pathPrefix, nameGlob string, retainNVersions int, limit int) ([]domain.Asset, error)
 	Create(ctx context.Context, a *domain.Asset) error
 	Delete(ctx context.Context, id string) error
+	// DeleteIfUnchanged deletes the row only if it is still exactly what an
+	// earlier scan read — same blob key, same last_downloaded. It reports
+	// whether the row was deleted; a mismatch (the asset was downloaded or
+	// re-uploaded since the scan) leaves the row alone.
+	DeleteIfUnchanged(ctx context.Context, id, blobKey string, lastDownloaded *time.Time) (bool, error)
+	// WithBlobKeyLock serializes every caller that wants to read-then-act on a
+	// given blob key (count references, physically delete, register a new
+	// reference). Any other WithBlobKeyLock caller for the same key — same
+	// process or not — blocks until fn returns. fn's own reads and writes go
+	// through the repo's normal connections: the guarantee is mutual exclusion,
+	// not that fn's effects share one transaction.
+	WithBlobKeyLock(ctx context.Context, blobKey string, fn func(ctx context.Context) error) error
 	// TouchLastModified sets last_modified = NOW() for the asset. The proxy cache
 	// uses last_modified as the "last validated" timestamp for metadata freshness:
 	// on a successful upstream 304 revalidation the cached copy is confirmed current,

--- a/internal/repository/postgres/asset_repo.go
+++ b/internal/repository/postgres/asset_repo.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -324,6 +325,39 @@ func (r *assetRepo) Create(ctx context.Context, a *domain.Asset) error {
 func (r *assetRepo) Delete(ctx context.Context, id string) error {
 	_, err := r.db.Exec(ctx, `DELETE FROM assets WHERE id = $1`, id)
 	return err
+}
+
+// DeleteIfUnchanged deletes the row only if it is still exactly what an earlier
+// scan read — same blob key, same last_downloaded. IS NOT DISTINCT FROM makes
+// the NULL comparison work: most never-downloaded rows carry NULL, and NULL =
+// NULL would refuse every one of them.
+func (r *assetRepo) DeleteIfUnchanged(ctx context.Context, id, blobKey string, lastDownloaded *time.Time) (bool, error) {
+	tag, err := r.db.Exec(ctx,
+		`DELETE FROM assets WHERE id = $1 AND blob_key = $2 AND last_downloaded IS NOT DISTINCT FROM $3`,
+		id, blobKey, lastDownloaded)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// WithBlobKeyLock serializes callers read-then-acting on one blob key via a
+// transaction-scoped Postgres advisory lock, so mutual exclusion holds across
+// processes, not just this one. The transaction exists only to scope the lock;
+// fn's own statements run on the pool's normal connections.
+func (r *assetRepo) WithBlobKeyLock(ctx context.Context, blobKey string, fn func(ctx context.Context) error) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, blobKey); err != nil {
+		return err
+	}
+	if err := fn(ctx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 // TouchLastModified sets last_modified = NOW() for the asset, extending the

--- a/internal/repository/postgres/asset_repo_bloblock_integration_test.go
+++ b/internal/repository/postgres/asset_repo_bloblock_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
+)
+
+// ── DeleteIfUnchanged ─────────────────────────────────────────────────────────
+
+func TestAssetRepo_DeleteIfUnchanged_DeletesMatchingSnapshot(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "diu_ok")
+	repo := NewAssetRepo(pool)
+
+	a := makeAsset(p, "/diu/ok.bin")
+	if err := repo.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, nil)
+	if err != nil {
+		t.Fatalf("DeleteIfUnchanged: %v", err)
+	}
+	if !deleted {
+		t.Fatal("DeleteIfUnchanged = false for an unchanged row, want true")
+	}
+	if got, _ := repo.Get(ctx, a.ID); got != nil {
+		t.Error("row still present after DeleteIfUnchanged reported deletion")
+	}
+}
+
+// A download between the staleness scan and the delete bumps last_downloaded;
+// the delete keyed to the scan's snapshot must then refuse, or cleanup erases
+// an artifact a client just fetched.
+func TestAssetRepo_DeleteIfUnchanged_RefusesWhenDownloadedSinceScan(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "diu_dl")
+	repo := NewAssetRepo(pool)
+
+	a := makeAsset(p, "/diu/downloaded.bin")
+	if err := repo.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// The scan saw last_downloaded = NULL; a client download then bumps it.
+	if err := repo.IncrementDownloads(ctx, map[string]int64{a.ID: 1}); err != nil {
+		t.Fatalf("IncrementDownloads: %v", err)
+	}
+
+	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, nil)
+	if err != nil {
+		t.Fatalf("DeleteIfUnchanged: %v", err)
+	}
+	if deleted {
+		t.Fatal("DeleteIfUnchanged deleted a row whose last_downloaded moved after the scan")
+	}
+	if got, _ := repo.Get(ctx, a.ID); got == nil {
+		t.Error("row vanished even though DeleteIfUnchanged reported no deletion")
+	}
+}
+
+// A re-upload to the same path reuses the row (upsert) but may swap blob_key;
+// deleting by the scan's stale snapshot would erase the fresh content.
+func TestAssetRepo_DeleteIfUnchanged_RefusesWhenBlobKeyChanged(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "diu_bk")
+	repo := NewAssetRepo(pool)
+
+	a := makeAsset(p, "/diu/reuploaded.bin")
+	if err := repo.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	oldKey := a.BlobKey
+
+	fresh := makeAsset(p, "/diu/reuploaded.bin")
+	fresh.BlobKey = "blobkey_fresh_content"
+	if err := repo.Create(ctx, fresh); err != nil {
+		t.Fatalf("Create (upsert): %v", err)
+	}
+	if fresh.ID != a.ID {
+		t.Fatalf("upsert changed the row ID (%s → %s); test setup assumption broken", a.ID, fresh.ID)
+	}
+
+	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, oldKey, nil)
+	if err != nil {
+		t.Fatalf("DeleteIfUnchanged: %v", err)
+	}
+	if deleted {
+		t.Fatal("DeleteIfUnchanged deleted a row whose blob_key changed after the scan")
+	}
+	if got, _ := repo.Get(ctx, a.ID); got == nil {
+		t.Error("row vanished even though DeleteIfUnchanged reported no deletion")
+	}
+}
+
+// ── WithBlobKeyLock ───────────────────────────────────────────────────────────
+
+func TestAssetRepo_WithBlobKeyLock_MutuallyExcludes(t *testing.T) {
+	pool := pgtest.Pool(t)
+	ctx := context.Background()
+	repo := NewAssetRepo(pool)
+
+	const key = "lock_race_key"
+	var inside atomic.Int32
+	var overlapped atomic.Bool
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := repo.WithBlobKeyLock(ctx, key, func(ctx context.Context) error {
+				if inside.Add(1) > 1 {
+					overlapped.Store(true)
+				}
+				time.Sleep(50 * time.Millisecond)
+				inside.Add(-1)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("WithBlobKeyLock: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if overlapped.Load() {
+		t.Fatal("two callers were inside WithBlobKeyLock for the same key at once")
+	}
+}
+
+func TestAssetRepo_WithBlobKeyLock_PropagatesFnError(t *testing.T) {
+	pool := pgtest.Pool(t)
+	ctx := context.Background()
+	repo := NewAssetRepo(pool)
+
+	wantErr := context.Canceled
+	err := repo.WithBlobKeyLock(ctx, "lock_err_key", func(ctx context.Context) error {
+		return wantErr
+	})
+	if err == nil || err != wantErr {
+		t.Fatalf("WithBlobKeyLock error = %v, want %v", err, wantErr)
+	}
+}

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -295,8 +295,14 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 	}
 
 	const batchLimit = 500
+	// A pass can legitimately delete nothing: every row it scanned changed under
+	// it, or every delete failed. The next scan re-reads fresh snapshots and
+	// usually succeeds — but a row perturbed on every pass would otherwise keep
+	// the loop spinning forever, so a few fruitless passes end the run.
+	const maxNoProgressPasses = 3
 	var freed int64
 	var deleted int
+	noProgress := 0
 	for {
 		stale, err := s.assets.ListStale(ctx, p.Format, repoNames, lastDownloadedDays, artifactAgeDays, pathPrefix, nameGlob, p.RetainNVersions, batchLimit)
 		if err != nil {
@@ -305,6 +311,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 		if len(stale) == 0 {
 			break
 		}
+		deletedBefore := deleted
 		for _, a := range stale {
 			if p.DryRun {
 				log.Info("cleanup dry-run: would delete", "policy", p.Name,
@@ -314,35 +321,62 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 				continue
 			}
 			asset := a
-			// One object can carry several assets — an OCI manifest's tag and its
-			// digest alias, a mounted layer — and expiring one of them says
-			// nothing about the others. Deleting the bytes under a surviving
-			// asset would leave it advertising content that is gone (#144); an
-			// unreadable count keeps them, since an orphan is reclaimed by the
-			// blob GC while bytes deleted under a live asset are lost.
-			bytesFreed := false
-			others, cerr := s.assets.CountByBlobKey(ctx, a.BlobKey, a.ID)
-			if cerr != nil {
-				log.Warn("cleanup: blob reference count failed, keeping blob",
-					"key", a.BlobKey, "err", cerr)
-			} else if others == 0 {
-				if err := s.storeForAsset(ctx, &asset).Delete(ctx, a.BlobKey); err != nil {
-					log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
-				} else {
-					bytesFreed = true
+			// The lock serializes this delete against every other reader-then-actor
+			// on the same blob key — a concurrent mount, a DeleteArtifact call,
+			// another cleanup — and the conditional delete refuses a row that was
+			// downloaded or re-uploaded after the staleness scan: deleting by the
+			// captured ID would erase a live artifact and the next pull would 404.
+			lockErr := s.assets.WithBlobKeyLock(ctx, a.BlobKey, func(ctx context.Context) error {
+				rowDeleted, derr := s.assets.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, a.LastDownloaded)
+				if derr != nil {
+					log.Warn("cleanup: asset delete failed", "id", a.ID, "err", derr)
+					return nil
 				}
+				if !rowDeleted {
+					log.Info("cleanup: skipped — asset changed after the staleness scan",
+						"id", a.ID, "path", a.Path, "repo", a.Repository)
+					return nil
+				}
+				freed += a.SizeBytes
+				deleted++
+				// One object can carry several assets — an OCI manifest's tag and its
+				// digest alias, a mounted layer — and expiring one of them says
+				// nothing about the others. Deleting the bytes under a surviving
+				// asset would leave it advertising content that is gone (#144); an
+				// unreadable count keeps them, since an orphan is reclaimed by the
+				// blob GC while bytes deleted under a live asset are lost.
+				others, cerr := s.assets.CountByBlobKey(ctx, a.BlobKey, a.ID)
+				if cerr != nil {
+					log.Warn("cleanup: blob reference count failed, keeping blob",
+						"key", a.BlobKey, "err", cerr)
+					return nil
+				}
+				if others == 0 {
+					if err := s.storeForAsset(ctx, &asset).Delete(ctx, a.BlobKey); err != nil {
+						log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
+					} else {
+						// used_bytes is how full the store is, so it only moves when
+						// bytes actually left it (#146).
+						_ = base.DecrementBlobStoreUsage(ctx, s.blobs, &asset)
+					}
+				}
+				return nil
+			})
+			if lockErr != nil {
+				log.Warn("cleanup: blob key lock failed", "key", a.BlobKey, "err", lockErr)
 			}
-			if err := s.assets.Delete(ctx, a.ID); err != nil {
-				log.Warn("cleanup: asset delete failed", "id", a.ID, "err", err)
-				continue
+		}
+		if !p.DryRun {
+			if deleted == deletedBefore {
+				noProgress++
+				if noProgress >= maxNoProgressPasses {
+					log.Warn("cleanup: no progress after repeated passes — stopping this run",
+						"policy", p.Name, "passes", noProgress)
+					break
+				}
+			} else {
+				noProgress = 0
 			}
-			// used_bytes is how full the store is, so it only moves when bytes
-			// actually left it (#146).
-			if bytesFreed {
-				_ = base.DecrementBlobStoreUsage(ctx, s.blobs, &asset)
-			}
-			freed += a.SizeBytes
-			deleted++
 		}
 		// A real run advances the cursor by deleting the batch, so the next query
 		// returns the following rows. A dry run deletes nothing, so re-querying

--- a/internal/service/cleanup_service_test.go
+++ b/internal/service/cleanup_service_test.go
@@ -56,6 +56,89 @@ func TestRunAll_SkipsNoCriteriaPolicies(t *testing.T) {
 	assert.Empty(t, policies.Updates)
 }
 
+// Between the staleness scan and a given row's turn in the delete loop, a
+// client can download or re-upload that exact asset. The delete keyed to the
+// scan's snapshot must then skip it — deleting by captured ID erases a live
+// artifact and the next pull 404s.
+func TestRunAll_SkipsAssetChangedAfterScan(t *testing.T) {
+	now := time.Now()
+	assets := testutil.NewAssetRepo()
+	// The scan's snapshot: never downloaded, so it matched lastDownloadedDays.
+	assets.Stale = []domain.Asset{
+		{ID: "a-race", Repository: "maven-hosted", BlobKey: "bk-race", SizeBytes: 100, Path: "/rel.jar"},
+	}
+	// The live row a moment later: a client just downloaded it.
+	assets.SeedAsset(&domain.Asset{
+		ID: "a-race", Repository: "maven-hosted", BlobKey: "bk-race",
+		SizeBytes: 100, Path: "/rel.jar", LastDownloaded: &now,
+	})
+
+	policies := testutil.NewCleanupPolicyRepo(
+		&domain.CleanupPolicy{
+			ID: "p-race", Name: "race-policy", Enabled: true, Format: "maven2",
+			Criteria: map[string]any{"lastDownloadedDays": float64(30)},
+		},
+	)
+	blobs := testutil.NewBlobStore()
+	_ = blobs.Put(context.Background(), "bk-race", testutil.MakeReader("bytes"), 5)
+	blobRepo := testutil.NewBlobStoreRepo()
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "maven-hosted", ID: "r1", Format: domain.FormatMaven2,
+		CleanupPolicyIDs: []string{"p-race"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, nopLog())
+	require.NoError(t, svc.RunAll(context.Background()))
+
+	if got, _ := assets.Get(context.Background(), "a-race"); got == nil {
+		t.Fatal("cleanup deleted an asset that was downloaded after the staleness scan")
+	}
+	assert.NotContains(t, blobs.Deleted, "bk-race",
+		"cleanup freed the bytes of an asset that was downloaded after the staleness scan")
+}
+
+// When every scanned row keeps changing under the loop (each pass skips
+// everything), the run must end after a few fruitless passes instead of
+// re-scanning the same rows forever.
+func TestRunAll_TerminatesWhenEveryPassSkips(t *testing.T) {
+	now := time.Now()
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{
+		{ID: "a-spin", Repository: "maven-hosted", BlobKey: "bk-spin", SizeBytes: 10, Path: "/spin.jar"},
+	}
+	// Non-consuming mode: ListStale keeps returning the row, as SQL would for a
+	// row that never gets deleted.
+	assets.StaleRepeat = true
+	assets.SeedAsset(&domain.Asset{
+		ID: "a-spin", Repository: "maven-hosted", BlobKey: "bk-spin",
+		SizeBytes: 10, Path: "/spin.jar", LastDownloaded: &now,
+	})
+
+	policies := testutil.NewCleanupPolicyRepo(
+		&domain.CleanupPolicy{
+			ID: "p-spin", Name: "spin-policy", Enabled: true, Format: "maven2",
+			Criteria: map[string]any{"lastDownloadedDays": float64(30)},
+		},
+	)
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "maven-hosted", ID: "r1", Format: domain.FormatMaven2,
+		CleanupPolicyIDs: []string{"p-spin"},
+	})
+
+	svc := service.NewCleanupService(policies, repos, assets, testutil.NewBlobStoreRepo(), testutil.NewBlobStore(), nopLog())
+	done := make(chan error, 1)
+	go func() { done <- svc.RunAll(context.Background()) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("cleanup run never terminated: every pass skipped the same changed row and the loop kept re-scanning it")
+	}
+	if got, _ := assets.Get(context.Background(), "a-spin"); got == nil {
+		t.Error("the changed asset must not be deleted")
+	}
+}
+
 func TestRunAll_DeletesStaleAssets(t *testing.T) {
 	staleAssets := []domain.Asset{
 		{ID: "a1", BlobKey: "bk1", SizeBytes: 100, Path: "/foo.jar"},

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -622,6 +622,17 @@ type AssetRepo struct {
 	DownloadIncrements map[string]int64
 	// createdPaths records the order Create was called in; read via CreatedPaths.
 	createdPaths []string
+	// blobKeyLocks holds one mutex per blob key, mirroring the postgres advisory
+	// lock: WithBlobKeyLock callers for the same key serialize, different keys
+	// run concurrently.
+	blobKeyLocks map[string]*sync.Mutex
+	// BlobKeyLockKeys records the keys WithBlobKeyLock was called with, in
+	// acquisition order, so tests can assert a call site takes the lock at all.
+	BlobKeyLockKeys []string
+	// CountByBlobKeyHook, when set, runs during CountByBlobKey after the count is
+	// taken but before it is returned (outside the repo's own mutex) — the seam
+	// race tests use to pause a caller exactly between its read and its act.
+	CountByBlobKeyHook func(blobKey, excludeID string)
 }
 
 func NewAssetRepo() *AssetRepo {
@@ -712,6 +723,18 @@ func (a *AssetRepo) ListStale(_ context.Context, _ string, _ []string, _, _ int,
 	if len(a.Stale) == 0 {
 		return nil, nil
 	}
+	// A row the SQL scan returns exists in the table at scan time. Tests populate
+	// Stale directly, so register each returned row as a live asset too — unless
+	// the test already seeded a (possibly diverged) live row under that ID, which
+	// is exactly how a changed-since-scan race is modeled.
+	for i := range a.Stale {
+		row := a.Stale[i]
+		if _, ok := a.byID[row.ID]; !ok && row.ID != "" {
+			live := row
+			a.byID[row.ID] = &live
+			a.assets[live.Repository+":"+live.Path] = &live
+		}
+	}
 	// Non-consuming mode: return the same rows each call (dry-run has no deletes).
 	if a.StaleRepeat {
 		n := limit
@@ -760,6 +783,16 @@ func (a *AssetRepo) Create(_ context.Context, asset *domain.Asset) error {
 	a.byID[asset.ID] = asset
 	a.createdPaths = append(a.createdPaths, asset.Path)
 	return nil
+}
+
+// SeedAsset inserts an asset preserving the ID the test chose — unlike Create,
+// which mirrors the postgres upsert and always assigns its own. Tests use it to
+// stage a live row that diverges from a scan snapshot carrying the same ID.
+func (a *AssetRepo) SeedAsset(asset *domain.Asset) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.byID[asset.ID] = asset
+	a.assets[asset.Repository+":"+asset.Path] = asset
 }
 
 // CreatedPaths returns the asset paths passed to Create, in call order. Tests
@@ -1009,8 +1042,8 @@ func (a *AssetRepo) ListOCIImageNames(_ context.Context, repoNames []string) ([]
 // untestable.
 func (a *AssetRepo) CountByBlobKey(_ context.Context, blobKey, excludeID string) (int, error) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	if a.Err != nil {
+		a.mu.Unlock()
 		return 0, a.Err
 	}
 	n := 0
@@ -1019,7 +1052,59 @@ func (a *AssetRepo) CountByBlobKey(_ context.Context, blobKey, excludeID string)
 			n++
 		}
 	}
+	// The hook runs outside the repo mutex: it exists to block a caller between
+	// its count and its next act, and holding the mutex there would wedge every
+	// other repo call instead of just this caller.
+	hook := a.CountByBlobKeyHook
+	a.mu.Unlock()
+	if hook != nil {
+		hook(blobKey, excludeID)
+	}
 	return n, nil
+}
+
+// DeleteIfUnchanged mirrors the postgres conditional delete: the row goes only
+// if it still carries the scanned blob key and last_downloaded (NULL-safe).
+func (a *AssetRepo) DeleteIfUnchanged(_ context.Context, id, blobKey string, lastDownloaded *time.Time) (bool, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.DeleteErr != nil {
+		return false, a.DeleteErr
+	}
+	v, ok := a.byID[id]
+	if !ok || v.BlobKey != blobKey {
+		return false, nil
+	}
+	switch {
+	case v.LastDownloaded == nil && lastDownloaded == nil:
+	case v.LastDownloaded != nil && lastDownloaded != nil && v.LastDownloaded.Equal(*lastDownloaded):
+	default:
+		return false, nil
+	}
+	delete(a.byID, id)
+	delete(a.assets, v.Repository+":"+v.Path)
+	return true, nil
+}
+
+// WithBlobKeyLock mirrors the postgres advisory lock with one in-process mutex
+// per key: same-key callers serialize, different keys do not block each other.
+func (a *AssetRepo) WithBlobKeyLock(ctx context.Context, blobKey string, fn func(ctx context.Context) error) error {
+	a.mu.Lock()
+	if a.blobKeyLocks == nil {
+		a.blobKeyLocks = make(map[string]*sync.Mutex)
+	}
+	l, ok := a.blobKeyLocks[blobKey]
+	if !ok {
+		l = &sync.Mutex{}
+		a.blobKeyLocks[blobKey] = l
+	}
+	a.mu.Unlock()
+	l.Lock()
+	defer l.Unlock()
+	a.mu.Lock()
+	a.BlobKeyLockKeys = append(a.BlobKeyLockKeys, blobKey)
+	a.mu.Unlock()
+	return fn(ctx)
 }
 
 // CountByBlobKeyInStore mirrors the postgres query: how many assets reference


### PR DESCRIPTION
Fixes gaps A, B and C of #325 (three TOCTOU windows sharing one root cause: cleanup, `DeleteArtifact` and the OCI blob mount all read-then-act on a shared `blob_key` with no mutual exclusion).

## New AssetRepo primitives

- **`WithBlobKeyLock`** — serializes every caller that read-then-acts on one blob key via a transaction-scoped Postgres advisory lock (`pg_advisory_xact_lock(hashtextextended(key, 0))`), so mutual exclusion holds across processes, not just in-memory.
- **`DeleteIfUnchanged`** — deletes a row only if it still carries the `blob_key` and `last_downloaded` an earlier scan read (`IS NOT DISTINCT FROM` for the NULL case).

## Applied at the three sites

- **A — cleanup (`runPolicy`)**: the conditional delete runs first, under the lock; only a row actually deleted proceeds to the reference count and physical delete. A row downloaded or re-uploaded after the staleness scan is skipped (previously: silent loss of a live artifact — the next pull 404s) and swept up by a later pass. A few fruitless passes now end the run instead of re-scanning the same changed rows forever.
- **B — OCI `mountBlob`**: the existence check and the row insert hold the lock as one unit, so a mount racing the delete of its source's last reference falls back to a normal upload session instead of answering 201 with a row pointing at freed bytes.
- **C — `DeleteArtifact`**: the count-then-delete sequence holds the lock, with an idempotency re-read inside it. Two concurrent deletes of the last two sibling assets (an OCI tag manifest and its digest alias) can no longer both see the other's row and both skip the physical delete, orphaning the bytes with `used_bytes` overstated until GC.

Gap D (promotion orphan blob) lands with the #330 fix, which subsumes it.

## Tests

All written first and observed failing against the unfixed code:

- `TestRunAll_SkipsAssetChangedAfterScan` — a row downloaded after the scan survives the cleanup pass.
- `TestRunAll_TerminatesWhenEveryPassSkips` — a run where every pass skips ends instead of spinning.
- `TestDeleteArtifact_ConcurrentSiblingDeletes_FreeTheBlob` — deterministic interleave via a count-barrier hook; the bytes are freed by whichever deleter is provably last.
- `TestMount_RacingLastReferenceDelete_NeverServesDanglingRow` — a mount racing the last-reference delete never 201s a dangling row.
- Integration: `DeleteIfUnchanged` (match/download-moved/blob-key-changed) and `WithBlobKeyLock` (mutual exclusion, error propagation) against real Postgres.

The testutil `AssetRepo` mirrors both primitives (per-key mutexes, NULL-safe conditional delete) and `ListStale` now registers scanned rows as live table rows, keeping mock and SQL semantics aligned.

`go build` / `go vet` / unit suite green; full postgres integration suite green.

Part of #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma