### PR TITLE
fix(promotion): request-row lock ends double-approve; failed copy compensates; batch re-reads the rule

### DIFF
--- a/internal/repository/errors.go
+++ b/internal/repository/errors.go
@@ -24,3 +24,14 @@ func (e *UniqueViolationError) Error() string { return e.Field + " already exist
 // Is makes every UniqueViolationError match ErrAlreadyExists, so callers that
 // only care that the row exists can test for the sentinel.
 func (e *UniqueViolationError) Is(target error) bool { return target == ErrAlreadyExists }
+
+// RequestNotPendingError is returned by WithPendingRequestLock when the locked
+// promotion request already left the pending state — typically because a
+// concurrent reviewer got there first. It carries the status that reviewer set.
+type RequestNotPendingError struct {
+	Status string
+}
+
+func (e *RequestNotPendingError) Error() string {
+	return "request is not pending (status: " + e.Status + ")"
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -372,4 +372,25 @@ type PromotionRepo interface {
 	// UpdateRequestStatus sets status and optional review/completion metadata.
 	UpdateRequestStatus(ctx context.Context, id string, status domain.PromotionStatus,
 		reviewedBy *string, reviewedAt, completedAt *time.Time, errMsg string) error
+	// WithPendingRequestLock locks the request row, verifies it is still
+	// pending, runs fn with the row held, and persists fn's outcome in the same
+	// transaction. A concurrent caller for the same request blocks until this
+	// one commits, then sees the non-pending status — so fn (the copy) can never
+	// run twice for one request. Returns ErrNotFound for an unknown id and
+	// *RequestNotPendingError when the row already left pending, in both cases
+	// without calling fn. An outcome whose Status is still PromotionPending
+	// leaves the row untouched.
+	WithPendingRequestLock(ctx context.Context, id string,
+		fn func(ctx context.Context, req *domain.PromotionRequest) PromotionOutcome) error
+}
+
+// PromotionOutcome is what a WithPendingRequestLock callback decides about the
+// locked request: the final status plus the review/completion metadata that
+// UpdateRequestStatus would take.
+type PromotionOutcome struct {
+	Status      domain.PromotionStatus
+	ReviewedBy  *string
+	ReviewedAt  *time.Time
+	CompletedAt *time.Time
+	Error       string
 }

--- a/internal/repository/postgres/promotion_repo.go
+++ b/internal/repository/postgres/promotion_repo.go
@@ -186,6 +186,51 @@ func (r *promotionRepo) ListRequests(ctx context.Context, status string) ([]doma
 	return out, rows.Err()
 }
 
+// WithPendingRequestLock serializes reviewers of one request with SELECT ...
+// FOR UPDATE: the second concurrent approver blocks on the row lock until the
+// first commits, then sees the non-pending status and never runs fn — so the
+// copy fn performs cannot execute twice for one request.
+func (r *promotionRepo) WithPendingRequestLock(ctx context.Context, id string,
+	fn func(ctx context.Context, req *domain.PromotionRequest) repository.PromotionOutcome,
+) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	row := tx.QueryRow(ctx,
+		`SELECT `+promotionReqFields+` FROM promotion_requests WHERE id=$1 FOR UPDATE`, id)
+	req, err := scanPromotionRequest(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return repository.ErrNotFound
+	}
+	if err != nil {
+		return err
+	}
+	if req.Status != domain.PromotionPending {
+		return &repository.RequestNotPendingError{Status: string(req.Status)}
+	}
+
+	outcome := fn(ctx, req)
+	if outcome.Status == domain.PromotionPending {
+		return tx.Commit(ctx)
+	}
+	var em *string
+	if outcome.Error != "" {
+		em = &outcome.Error
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE promotion_requests
+		 SET status=$1, reviewed_by=$2, reviewed_at=$3, completed_at=$4, error=$5
+		 WHERE id=$6`,
+		string(outcome.Status), outcome.ReviewedBy, outcome.ReviewedAt, outcome.CompletedAt, em, id,
+	); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 func (r *promotionRepo) UpdateRequestStatus(
 	ctx context.Context, id string, status domain.PromotionStatus,
 	reviewedBy *string, reviewedAt, completedAt *time.Time, errMsg string,

--- a/internal/repository/postgres/promotion_repo_integration_test.go
+++ b/internal/repository/postgres/promotion_repo_integration_test.go
@@ -5,6 +5,8 @@ package postgres
 import (
 	"context"
 	"errors"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -899,5 +901,133 @@ func TestPromotionRepo_UpdateRequestStatus_NonexistentIsNoOp(t *testing.T) {
 	}
 	if got != nil {
 		t.Errorf("GetRequest(missing): got %+v, want nil", got)
+	}
+}
+
+// ── WithPendingRequestLock ────────────────────────────────────────────────────
+
+// Concurrent reviewers of one pending request: exactly one callback runs; every
+// other caller blocks on the row lock, then sees non-pending and gets
+// RequestNotPendingError without its callback ever executing.
+func TestPromotionRepo_WithPendingRequestLock_OneCallbackWins(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, promoTables...)
+	ctx := context.Background()
+	repo := NewPromotionRepo(pool)
+
+	p := makePromotionParents(t, ctx, "lock_race")
+	rule := makePromotionRule("rule_lock_race", p)
+	if err := repo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+	compID := makePromotionComponent(t, ctx, p.FromRepoID, "1.0.0")
+	req := &domain.PromotionRequest{
+		RuleID: rule.ID, ComponentID: compID,
+		Status: domain.PromotionPending, RequestedBy: p.UserID,
+	}
+	if err := repo.CreateRequest(ctx, req); err != nil {
+		t.Fatalf("CreateRequest: %v", err)
+	}
+
+	const callers = 6
+	var ran atomic.Int32
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- repo.WithPendingRequestLock(ctx, req.ID,
+				func(ctx context.Context, r *domain.PromotionRequest) repository.PromotionOutcome {
+					ran.Add(1)
+					time.Sleep(30 * time.Millisecond) // widen the window the row lock must cover
+					now := time.Now()
+					return repository.PromotionOutcome{Status: domain.PromotionCompleted, CompletedAt: &now}
+				})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	succeeded, notPending := 0, 0
+	for err := range errs {
+		var npe *repository.RequestNotPendingError
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.As(err, &npe):
+			notPending++
+		default:
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	if succeeded != 1 || int(ran.Load()) != 1 {
+		t.Errorf("succeeded=%d callbacks=%d, want exactly 1 of each", succeeded, ran.Load())
+	}
+	if notPending != callers-1 {
+		t.Errorf("RequestNotPendingError count = %d, want %d", notPending, callers-1)
+	}
+
+	got, err := repo.GetRequest(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("GetRequest: %v", err)
+	}
+	if got.Status != domain.PromotionCompleted {
+		t.Errorf("final status = %q, want completed", got.Status)
+	}
+}
+
+// A pending outcome leaves the row untouched — the caller decided not to settle
+// the request (e.g. a validation error it will surface without consuming the
+// review).
+func TestPromotionRepo_WithPendingRequestLock_PendingOutcomeLeavesRow(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, promoTables...)
+	ctx := context.Background()
+	repo := NewPromotionRepo(pool)
+
+	p := makePromotionParents(t, ctx, "lock_keep")
+	rule := makePromotionRule("rule_lock_keep", p)
+	if err := repo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+	compID := makePromotionComponent(t, ctx, p.FromRepoID, "1.0.0")
+	req := &domain.PromotionRequest{
+		RuleID: rule.ID, ComponentID: compID,
+		Status: domain.PromotionPending, RequestedBy: p.UserID,
+	}
+	if err := repo.CreateRequest(ctx, req); err != nil {
+		t.Fatalf("CreateRequest: %v", err)
+	}
+
+	if err := repo.WithPendingRequestLock(ctx, req.ID,
+		func(ctx context.Context, r *domain.PromotionRequest) repository.PromotionOutcome {
+			return repository.PromotionOutcome{Status: domain.PromotionPending}
+		}); err != nil {
+		t.Fatalf("WithPendingRequestLock: %v", err)
+	}
+	got, err := repo.GetRequest(ctx, req.ID)
+	if err != nil {
+		t.Fatalf("GetRequest: %v", err)
+	}
+	if got.Status != domain.PromotionPending {
+		t.Errorf("status = %q, want still pending", got.Status)
+	}
+}
+
+// An unknown id answers ErrNotFound without running the callback.
+func TestPromotionRepo_WithPendingRequestLock_NotFound(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, promoTables...)
+	ctx := context.Background()
+	repo := NewPromotionRepo(pool)
+
+	err := repo.WithPendingRequestLock(ctx, "00000000-0000-0000-0000-000000000000",
+		func(ctx context.Context, r *domain.PromotionRequest) repository.PromotionOutcome {
+			t.Error("callback ran for a request that does not exist")
+			return repository.PromotionOutcome{Status: domain.PromotionCompleted}
+		})
+	if !errors.Is(err, repository.ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
 }

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -274,18 +274,39 @@ func (s *PromotionService) Promote(ctx context.Context, ruleID string, component
 		}
 
 		if !rule.RequireManualApproval {
-			if copyErr := s.executeCopy(ctx, req, rule); copyErr != nil {
-				now := time.Now()
-				_ = s.promotionRepo.UpdateRequestStatus(ctx, req.ID, domain.PromotionFailed,
-					nil, nil, &now, copyErr.Error())
-				req.Status = domain.PromotionFailed
-				req.Error = copyErr.Error()
-			} else {
-				now := time.Now()
-				_ = s.promotionRepo.UpdateRequestStatus(ctx, req.ID, domain.PromotionCompleted,
-					nil, nil, &now, "")
-				req.Status = domain.PromotionCompleted
-				req.CompletedAt = &now
+			// The same row lock Approve takes: the freshly created pending request
+			// is already visible, and a concurrent manual approval racing this
+			// auto-approve would otherwise copy twice.
+			lockErr := s.promotionRepo.WithPendingRequestLock(ctx, req.ID,
+				func(ctx context.Context, lockedReq *domain.PromotionRequest) repository.PromotionOutcome {
+					now := time.Now()
+					// Re-read the rule for every component: an administrator editing
+					// it mid-batch (disabling a gate, narrowing the filter) must
+					// govern the components still to be processed, exactly as it
+					// would if each were approved individually.
+					freshRule, rerr := s.promotionRepo.GetRule(ctx, ruleID)
+					if rerr != nil || freshRule == nil {
+						req.Status = domain.PromotionFailed
+						req.Error = fmt.Sprintf("promotion rule not found: %s", ruleID)
+						return repository.PromotionOutcome{Status: domain.PromotionFailed,
+							CompletedAt: &now, Error: req.Error}
+					}
+					if copyErr := s.executeCopy(ctx, lockedReq, freshRule); copyErr != nil {
+						req.Status = domain.PromotionFailed
+						req.Error = copyErr.Error()
+						return repository.PromotionOutcome{Status: domain.PromotionFailed,
+							CompletedAt: &now, Error: copyErr.Error()}
+					}
+					req.Status = domain.PromotionCompleted
+					req.CompletedAt = &now
+					return repository.PromotionOutcome{Status: domain.PromotionCompleted, CompletedAt: &now}
+				})
+			if lockErr != nil {
+				// A concurrent reviewer settled this request first; report what the
+				// row says now rather than inventing an outcome.
+				if settled, gerr := s.promotionRepo.GetRequest(ctx, req.ID); gerr == nil && settled != nil {
+					req = settled
+				}
 			}
 		}
 
@@ -294,45 +315,67 @@ func (s *PromotionService) Promote(ctx context.Context, ruleID string, component
 	return results, nil
 }
 
-// Approve approves a pending promotion request and copies the artifact.
+// Approve approves a pending promotion request and copies the artifact. The
+// pending check, the copy and the status write happen under the request row's
+// lock: two concurrent approvals would otherwise both pass the check and both
+// copy — double blob writes and a double-fired publish webhook.
 func (s *PromotionService) Approve(ctx context.Context, requestID, reviewerID string) error {
-	req, err := s.promotionRepo.GetRequest(ctx, requestID)
-	if err != nil || req == nil {
+	var copyErr error
+	err := s.promotionRepo.WithPendingRequestLock(ctx, requestID,
+		func(ctx context.Context, req *domain.PromotionRequest) repository.PromotionOutcome {
+			now := time.Now()
+			rule, rerr := s.promotionRepo.GetRule(ctx, req.RuleID)
+			if rerr != nil || rule == nil {
+				copyErr = fmt.Errorf("promotion rule not found: %s", req.RuleID)
+				return repository.PromotionOutcome{Status: domain.PromotionFailed,
+					ReviewedBy: &reviewerID, ReviewedAt: &now, CompletedAt: &now, Error: copyErr.Error()}
+			}
+			if cerr := s.executeCopy(ctx, req, rule); cerr != nil {
+				copyErr = cerr
+				return repository.PromotionOutcome{Status: domain.PromotionFailed,
+					ReviewedBy: &reviewerID, ReviewedAt: &now, CompletedAt: &now, Error: cerr.Error()}
+			}
+			return repository.PromotionOutcome{Status: domain.PromotionCompleted,
+				ReviewedBy: &reviewerID, ReviewedAt: &now, CompletedAt: &now}
+		})
+	if errors.Is(err, repository.ErrNotFound) {
 		return fmt.Errorf("promotion request not found: %s", requestID)
 	}
-	if req.Status != domain.PromotionPending {
-		return fmt.Errorf("request is not pending (status: %s)", req.Status)
+	if err != nil {
+		return err
 	}
-	rule, err := s.promotionRepo.GetRule(ctx, req.RuleID)
-	if err != nil || rule == nil {
-		return fmt.Errorf("promotion rule not found: %s", req.RuleID)
-	}
-	now := time.Now()
-	if copyErr := s.executeCopy(ctx, req, rule); copyErr != nil {
-		_ = s.promotionRepo.UpdateRequestStatus(ctx, req.ID, domain.PromotionFailed,
-			&reviewerID, &now, &now, copyErr.Error())
-		return copyErr
-	}
-	return s.promotionRepo.UpdateRequestStatus(ctx, req.ID, domain.PromotionCompleted,
-		&reviewerID, &now, &now, "")
+	return copyErr
 }
 
-// Reject rejects a pending promotion request.
+// Reject rejects a pending promotion request, under the same row lock Approve
+// takes — a rejection racing an approval must lose to whichever committed
+// first, not silently overwrite it.
 func (s *PromotionService) Reject(ctx context.Context, requestID, reviewerID, reason string) error {
-	req, err := s.promotionRepo.GetRequest(ctx, requestID)
-	if err != nil || req == nil {
+	err := s.promotionRepo.WithPendingRequestLock(ctx, requestID,
+		func(ctx context.Context, req *domain.PromotionRequest) repository.PromotionOutcome {
+			now := time.Now()
+			return repository.PromotionOutcome{Status: domain.PromotionRejected,
+				ReviewedBy: &reviewerID, ReviewedAt: &now, Error: reason}
+		})
+	if errors.Is(err, repository.ErrNotFound) {
 		return fmt.Errorf("promotion request not found: %s", requestID)
 	}
-	if req.Status != domain.PromotionPending {
-		return fmt.Errorf("request is not pending (status: %s)", req.Status)
-	}
-	now := time.Now()
-	return s.promotionRepo.UpdateRequestStatus(ctx, req.ID, domain.PromotionRejected,
-		&reviewerID, &now, nil, reason)
+	return err
 }
 
 // executeCopy copies a component's blobs and metadata from from_repo to to_repo.
-func (s *PromotionService) executeCopy(ctx context.Context, req *domain.PromotionRequest, rule *domain.PromotionRule) error {
+//
+// The copy is not transactional — the rows and blobs go one at a time — so a
+// mid-copy failure compensates explicitly: every asset row and blob THIS call
+// created fresh is removed, and the target component goes too once nothing
+// references it. Only fresh creations roll back: both ComponentRepo.Create and
+// AssetRepo.Create upsert on conflict, and blindly deleting "what I touched"
+// after an upsert would destroy a legitimate pre-existing component from an
+// earlier successful promotion of the same version. The one acknowledged
+// residual: a pre-existing asset overwritten in place by this call's own upsert
+// keeps the new content — point-in-time rollback of in-place updates is out of
+// scope; what this prevents is the DB-visible half-populated component.
+func (s *PromotionService) executeCopy(ctx context.Context, req *domain.PromotionRequest, rule *domain.PromotionRule) (err error) {
 	comp, err := s.componentRepo.Get(ctx, req.ComponentID)
 	if err != nil || comp == nil {
 		return fmt.Errorf("source component not found: %s", req.ComponentID)
@@ -376,6 +419,27 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 		return fmt.Errorf("upsert component in target: %w", err)
 	}
 
+	// Compensation state for the deferred rollback: only rows and blobs this
+	// call created fresh (rows go before their bytes — a row whose blob is
+	// already gone is not self-healing, an orphan blob is GC'd).
+	var freshAssetIDs []string
+	var freshBlobKeys []string
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, id := range freshAssetIDs {
+			_ = s.assetRepo.Delete(ctx, id)
+		}
+		for _, key := range freshBlobKeys {
+			_ = toStore.Delete(ctx, key)
+		}
+		remaining, lerr := s.assetRepo.ListByComponentID(ctx, newComp.ID)
+		if lerr == nil && len(remaining) == 0 {
+			_ = s.componentRepo.Delete(ctx, newComp.ID)
+		}
+	}()
+
 	for _, asset := range assets {
 		blobStoreID := asset.BlobStoreID
 		fromStore, _, err := s.resolveStore(ctx, &blobStoreID)
@@ -384,6 +448,15 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 		}
 
 		newBlobKey := base.BlobKey(toRepo.Name, asset.Path)
+
+		// Fresh or pre-existing decides what the rollback may touch: a fresh
+		// path's blob and row are this call's to delete; a pre-existing one was
+		// only overwritten in place and must survive the compensation.
+		_, preErr := s.assetRepo.GetByPath(ctx, toRepo.Name, asset.Path)
+		fresh := errors.Is(preErr, repository.ErrNotFound)
+		if preErr != nil && !fresh {
+			return fmt.Errorf("check target asset %s: %w", asset.Path, preErr)
+		}
 
 		rc, size, err := fromStore.Get(ctx, asset.BlobKey)
 		if err != nil {
@@ -394,6 +467,9 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 			return fmt.Errorf("write blob %s: %w", newBlobKey, putErr)
 		}
 		_ = rc.Close()
+		if fresh {
+			freshBlobKeys = append(freshBlobKeys, newBlobKey)
+		}
 
 		newAsset := &domain.Asset{
 			ComponentID:  newComp.ID,
@@ -410,6 +486,9 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 		}
 		if err := s.assetRepo.Create(ctx, newAsset); err != nil {
 			return fmt.Errorf("create asset record: %w", err)
+		}
+		if fresh {
+			freshAssetIDs = append(freshAssetIDs, newAsset.ID)
 		}
 	}
 

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -352,7 +352,7 @@ func (s *PromotionService) Approve(ctx context.Context, requestID, reviewerID st
 // first, not silently overwrite it.
 func (s *PromotionService) Reject(ctx context.Context, requestID, reviewerID, reason string) error {
 	err := s.promotionRepo.WithPendingRequestLock(ctx, requestID,
-		func(ctx context.Context, req *domain.PromotionRequest) repository.PromotionOutcome {
+		func(_ context.Context, _ *domain.PromotionRequest) repository.PromotionOutcome {
 			now := time.Now()
 			return repository.PromotionOutcome{Status: domain.PromotionRejected,
 				ReviewedBy: &reviewerID, ReviewedAt: &now, Error: reason}

--- a/internal/service/promotion_service_atomicity_test.go
+++ b/internal/service/promotion_service_atomicity_test.go
@@ -1,0 +1,326 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// dispatchFunc adapts a func to domain.WebhookDispatcher for tests.
+type dispatchFunc func(domain.WebhookPayload)
+
+func (f dispatchFunc) Dispatch(p domain.WebhookPayload) { f(p) }
+
+// promoFixture seeds source/target repos and a two-asset component (jar + pom)
+// the atomicity tests promote.
+type promoFixture struct {
+	rule       *domain.PromotionRule
+	comp       *domain.Component
+	jarKey     string
+	pomKey     string
+	blobStore  *testutil.BlobStore
+	promoRepo  *testutil.PromotionRepo
+	compRepo   *testutil.ComponentRepo
+	assetRepo  *testutil.AssetRepo
+	beforeKeys []string
+}
+
+func seedTwoAssetPromotion(t *testing.T, svcDeps func() (
+	*testutil.PromotionRepo, *testutil.ComponentRepo, *testutil.AssetRepo,
+	*testutil.BlobStore, *testutil.RepoRepo), manualApproval bool,
+) *promoFixture {
+	t.Helper()
+	ctx := context.Background()
+	promoRepo, compRepo, assetRepo, blobStore, repoRepo := svcDeps()
+
+	fromRepo := testutil.SimpleRepo("staging", "raw")
+	toRepo := testutil.SimpleRepo("production", "raw")
+	repoRepo.Create(ctx, fromRepo)
+	repoRepo.Create(ctx, toRepo)
+
+	comp := &domain.Component{
+		ID:           "comp-atomic-1",
+		RepositoryID: fromRepo.ID,
+		Repository:   fromRepo.Name,
+		Format:       "raw",
+		Group:        "com/example",
+		Name:         "mylib",
+		Version:      "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	jarKey := "staging:mylib-1.0.0.jar"
+	pomKey := "staging:mylib-1.0.0.pom"
+	if err := blobStore.PutBytes(ctx, jarKey, []byte("jar bytes")); err != nil {
+		t.Fatal(err)
+	}
+	if err := blobStore.PutBytes(ctx, pomKey, []byte("pom bytes")); err != nil {
+		t.Fatal(err)
+	}
+	for path, key := range map[string]string{"mylib-1.0.0.jar": jarKey, "mylib-1.0.0.pom": pomKey} {
+		assetRepo.Create(ctx, &domain.Asset{
+			ComponentID: comp.ID, RepositoryID: fromRepo.ID, Repository: fromRepo.Name,
+			Path: path, BlobKey: key, SizeBytes: 9, ContentType: "application/octet-stream",
+		})
+	}
+
+	rule := &domain.PromotionRule{
+		Name: "to-prod", FromRepo: "staging", ToRepo: "production",
+		RequireManualApproval: manualApproval,
+	}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatal(err)
+	}
+
+	keys, err := blobStore.ListKeys(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(keys)
+	return &promoFixture{
+		rule: rule, comp: comp, jarKey: jarKey, pomKey: pomKey,
+		blobStore: blobStore, promoRepo: promoRepo, compRepo: compRepo,
+		assetRepo: assetRepo, beforeKeys: keys,
+	}
+}
+
+func targetState(t *testing.T, f *promoFixture) (comps int, assets int, keys []string) {
+	t.Helper()
+	ctx := context.Background()
+	page, err := f.compRepo.ListByRepoNames(ctx, []string{"production"}, 100, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows, err := f.assetRepo.ListByRepoAndPath(ctx, "production", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, err = f.blobStore.ListKeys(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(keys)
+	return len(page.Items), len(rows), keys
+}
+
+// A promotion that fails halfway must not leave a half-populated component in
+// the target repo: the jar copied, the pom's source blob unreadable — before
+// compensation, every consumer of the target saw a component missing half its
+// files, silently.
+func TestPromotion_ExecuteCopy_PartialFailureLeavesNoHalfComponent(t *testing.T) {
+	svc, promoRepo, compRepo, assetRepo, blobStore, repoRepo, _, _ := newTestPromotionSvc(t)
+	f := seedTwoAssetPromotion(t, func() (*testutil.PromotionRepo, *testutil.ComponentRepo, *testutil.AssetRepo, *testutil.BlobStore, *testutil.RepoRepo) {
+		return promoRepo, compRepo, assetRepo, blobStore, repoRepo
+	}, false)
+	ctx := context.Background()
+
+	// The pom's source blob vanishes before the copy reaches it (a corrupted or
+	// GC'd source blob). ListByComponentID orders by path: jar copies first.
+	if err := blobStore.Delete(ctx, f.pomKey); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := svc.Promote(ctx, f.rule.ID, []string{f.comp.ID}, "user-1")
+	if err != nil {
+		t.Fatalf("Promote (batch validation) failed outright: %v", err)
+	}
+	if results[0].Status != domain.PromotionFailed {
+		t.Fatalf("status = %s, want failed", results[0].Status)
+	}
+
+	comps, assets, keys := targetState(t, f)
+	if comps != 0 {
+		t.Errorf("target repo holds %d component(s) after a failed promotion — a half-populated component is visible to every consumer", comps)
+	}
+	if assets != 0 {
+		t.Errorf("target repo holds %d asset row(s) after a failed promotion", assets)
+	}
+	// The source pom blob was deleted by the test itself, so "no orphans" means:
+	// nothing NEW beyond the pre-promotion keys minus the deleted pom.
+	want := make([]string, 0, len(f.beforeKeys))
+	for _, k := range f.beforeKeys {
+		if k != f.pomKey {
+			want = append(want, k)
+		}
+	}
+	if strings.Join(keys, ",") != strings.Join(want, ",") {
+		t.Errorf("blob keys after failed promotion = %v, want %v (no orphaned copies)", keys, want)
+	}
+}
+
+// The row insert failing right after the blob bytes were written must not
+// leave the bytes behind with no row referencing them.
+func TestPromotion_ExecuteCopy_CreateFailureLeavesNoOrphanBlob(t *testing.T) {
+	svc, promoRepo, compRepo, assetRepo, blobStore, repoRepo, _, _ := newTestPromotionSvc(t)
+	f := seedTwoAssetPromotion(t, func() (*testutil.PromotionRepo, *testutil.ComponentRepo, *testutil.AssetRepo, *testutil.BlobStore, *testutil.RepoRepo) {
+		return promoRepo, compRepo, assetRepo, blobStore, repoRepo
+	}, false)
+	ctx := context.Background()
+
+	assetRepo.CreateErr = errors.New("simulated DB insert failure after blob write")
+
+	results, err := svc.Promote(ctx, f.rule.ID, []string{f.comp.ID}, "user-1")
+	if err != nil {
+		t.Fatalf("Promote (batch validation) failed outright: %v", err)
+	}
+	if results[0].Status != domain.PromotionFailed {
+		t.Fatalf("status = %s, want failed", results[0].Status)
+	}
+	assetRepo.CreateErr = nil
+
+	_, _, keys := targetState(t, f)
+	if strings.Join(keys, ",") != strings.Join(f.beforeKeys, ",") {
+		t.Errorf("blob keys after failed promotion = %v, want unchanged %v — the written blob has no row referencing it", keys, f.beforeKeys)
+	}
+}
+
+// Concurrent approvals of one pending request must execute the copy exactly
+// once: both passing the pending check means double blob writes and a
+// double-fired EventArtifactPublished webhook to external systems.
+func TestPromotion_Approve_ConcurrentApprovalsCopyOnce(t *testing.T) {
+	svc, promoRepo, compRepo, assetRepo, blobStore, repoRepo, _, _ := newTestPromotionSvc(t)
+	f := seedTwoAssetPromotion(t, func() (*testutil.PromotionRepo, *testutil.ComponentRepo, *testutil.AssetRepo, *testutil.BlobStore, *testutil.RepoRepo) {
+		return promoRepo, compRepo, assetRepo, blobStore, repoRepo
+	}, true)
+	ctx := context.Background()
+
+	var published atomic32
+	svc.WithWebhooks(dispatchFunc(func(p domain.WebhookPayload) {
+		if p.Event == domain.EventArtifactPublished {
+			published.Add(1)
+		}
+	}))
+
+	results, err := svc.Promote(ctx, f.rule.ID, []string{f.comp.ID}, "user-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	reqID := results[0].ID
+
+	// Line every approver up on the same pending snapshot: each reads the
+	// request, then waits until all have read it (or a timeout, for the fixed
+	// path where the lock serializes them and the barrier can never fill).
+	const approvers = 8
+	var barrierMu sync.Mutex
+	arrived := 0
+	allArrived := make(chan struct{})
+	promoRepo.GetRequestHook = func(string) {
+		barrierMu.Lock()
+		arrived++
+		if arrived == approvers {
+			close(allArrived)
+		}
+		barrierMu.Unlock()
+		select {
+		case <-allArrived:
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, approvers)
+	for i := 0; i < approvers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- svc.Approve(ctx, reqID, "reviewer-1")
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	succeeded := 0
+	for err := range errs {
+		if err == nil {
+			succeeded++
+		} else if !strings.Contains(err.Error(), "not pending") {
+			t.Errorf("unexpected approve error: %v", err)
+		}
+	}
+	if succeeded != 1 {
+		t.Errorf("%d of %d concurrent approvals succeeded, want exactly 1", succeeded, approvers)
+	}
+	if got := published.Load(); got != 1 {
+		t.Errorf("EventArtifactPublished fired %d times, want exactly 1 — external systems see every duplicate", got)
+	}
+}
+
+// An administrator editing the rule mid-batch must affect the components still
+// to be processed: Approve re-reads the rule on every call, and the
+// auto-approve batch loop must do the same instead of reusing one snapshot.
+func TestPromotion_Promote_BatchRereadsRulePerComponent(t *testing.T) {
+	svc, promoRepo, compRepo, assetRepo, blobStore, repoRepo, _, _ := newTestPromotionSvc(t)
+	f := seedTwoAssetPromotion(t, func() (*testutil.PromotionRepo, *testutil.ComponentRepo, *testutil.AssetRepo, *testutil.BlobStore, *testutil.RepoRepo) {
+		return promoRepo, compRepo, assetRepo, blobStore, repoRepo
+	}, false)
+	ctx := context.Background()
+
+	comp2 := &domain.Component{
+		ID:           "comp-atomic-2",
+		RepositoryID: f.comp.RepositoryID,
+		Repository:   "staging",
+		Format:       "raw",
+		Group:        "com/example",
+		Name:         "otherlib",
+		Version:      "2.0.0",
+	}
+	compRepo.AddComponent(comp2)
+	otherKey := "staging:otherlib-2.0.0.jar"
+	if err := blobStore.PutBytes(ctx, otherKey, []byte("other bytes")); err != nil {
+		t.Fatal(err)
+	}
+	assetRepo.Create(ctx, &domain.Asset{
+		ComponentID: comp2.ID, RepositoryID: f.comp.RepositoryID, Repository: "staging",
+		Path: "otherlib-2.0.0.jar", BlobKey: otherKey, SizeBytes: 11,
+	})
+
+	// The first component's copy fires the published webhook; the "operator"
+	// edits the rule right there — mid-batch — to exclude everything.
+	svc.WithWebhooks(dispatchFunc(func(p domain.WebhookPayload) {
+		if p.Event != domain.EventArtifactPublished {
+			return
+		}
+		edited := *f.rule
+		edited.PathFilter = `path.startsWith("/nothing-matches-this/")`
+		if err := promoRepo.UpdateRule(ctx, &edited); err != nil {
+			t.Errorf("UpdateRule: %v", err)
+		}
+	}))
+
+	results, err := svc.Promote(ctx, f.rule.ID, []string{f.comp.ID, comp2.ID}, "user-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0].Status != domain.PromotionCompleted {
+		t.Fatalf("first component: status = %s, want completed (rule was intact when it ran)", results[0].Status)
+	}
+	if results[1].Status != domain.PromotionFailed {
+		t.Errorf("second component: status = %s, want failed — the rule edited mid-batch must apply to it", results[1].Status)
+	}
+}
+
+// atomic32 is a minimal atomic counter (avoids importing sync/atomic's Int32
+// under a name that collides with the test helpers).
+type atomic32 struct {
+	mu sync.Mutex
+	n  int32
+}
+
+func (a *atomic32) Add(d int32) {
+	a.mu.Lock()
+	a.n += d
+	a.mu.Unlock()
+}
+
+func (a *atomic32) Load() int32 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.n
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -605,6 +605,9 @@ type AssetRepo struct {
 	// DeleteErr, when non-nil, makes Delete fail while leaving the row in place —
 	// the seam for "the DB write failed after the bytes were already touched".
 	DeleteErr error
+	// CreateErr, when non-nil, makes Create fail without writing — the seam for
+	// "the row insert failed after the blob bytes were already stored".
+	CreateErr error
 	// ListByComponentIDsCalls counts how many times ListByComponentIDs has been called.
 	ListByComponentIDsCalls int
 	// ListByComponentIDCalls counts how many times the singular ListByComponentID has been called.
@@ -759,6 +762,9 @@ func (a *AssetRepo) ListStale(_ context.Context, _ string, _ []string, _, _ int,
 func (a *AssetRepo) Create(_ context.Context, asset *domain.Asset) error {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.CreateErr != nil {
+		return a.CreateErr
+	}
 	// Mirror the postgres upsert: an existing (repo,path) keeps its ID and refreshes
 	// last_modified, rather than creating a duplicate row.
 	key := asset.Repository + ":" + asset.Path
@@ -2559,6 +2565,13 @@ type PromotionRepo struct {
 	Rules    map[string]*domain.PromotionRule
 	Requests map[string]*domain.PromotionRequest
 	nextID   int
+	// GetRequestHook, when set, runs during GetRequest after the row is read but
+	// before it is returned (outside the repo mutex) — the seam race tests use to
+	// line up several callers on the same pending snapshot.
+	GetRequestHook func(id string)
+	// requestLocks holds one mutex per request id, mirroring the postgres
+	// SELECT ... FOR UPDATE row lock in WithPendingRequestLock.
+	requestLocks map[string]*sync.Mutex
 }
 
 func NewPromotionRepo() *PromotionRepo {
@@ -2648,12 +2661,23 @@ func (r *PromotionRepo) CreateRequest(_ context.Context, req *domain.PromotionRe
 
 func (r *PromotionRepo) GetRequest(_ context.Context, id string) (*domain.PromotionRequest, error) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
+	var req *domain.PromotionRequest
 	if v, ok := r.Requests[id]; ok {
 		cp := *v
-		return &cp, nil
+		req = &cp
 	}
-	return nil, repository.ErrNotFound
+	// The hook runs outside the repo mutex; it exists to hold callers between
+	// their status read and their next act, and holding the mutex there would
+	// wedge every other repo call.
+	hook := r.GetRequestHook
+	r.mu.Unlock()
+	if hook != nil {
+		hook(id)
+	}
+	if req == nil {
+		return nil, repository.ErrNotFound
+	}
+	return req, nil
 }
 
 func (r *PromotionRepo) ListRequests(_ context.Context, status string) ([]domain.PromotionRequest, error) {
@@ -2682,6 +2706,58 @@ func (r *PromotionRepo) UpdateRequestStatus(_ context.Context, id string, status
 	req.ReviewedAt = reviewedAt
 	req.CompletedAt = completedAt
 	req.Error = errMsg
+	return nil
+}
+
+// WithPendingRequestLock mirrors the postgres SELECT ... FOR UPDATE flow: one
+// mutex per request id serializes reviewers; the second caller enters only
+// after the first's outcome is applied and so sees the non-pending status.
+func (r *PromotionRepo) WithPendingRequestLock(ctx context.Context, id string,
+	fn func(ctx context.Context, req *domain.PromotionRequest) repository.PromotionOutcome,
+) error {
+	r.mu.Lock()
+	if r.requestLocks == nil {
+		r.requestLocks = make(map[string]*sync.Mutex)
+	}
+	l, ok := r.requestLocks[id]
+	if !ok {
+		l = &sync.Mutex{}
+		r.requestLocks[id] = l
+	}
+	r.mu.Unlock()
+	l.Lock()
+	defer l.Unlock()
+
+	r.mu.Lock()
+	stored, ok := r.Requests[id]
+	if !ok {
+		r.mu.Unlock()
+		return repository.ErrNotFound
+	}
+	if stored.Status != domain.PromotionPending {
+		status := string(stored.Status)
+		r.mu.Unlock()
+		return &repository.RequestNotPendingError{Status: status}
+	}
+	cp := *stored
+	r.mu.Unlock()
+
+	outcome := fn(ctx, &cp)
+	if outcome.Status == domain.PromotionPending {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	req, ok := r.Requests[id]
+	if !ok {
+		return repository.ErrNotFound
+	}
+	req.Status = outcome.Status
+	req.ReviewedBy = outcome.ReviewedBy
+	req.ReviewedAt = outcome.ReviewedAt
+	req.CompletedAt = outcome.CompletedAt
+	req.Error = outcome.Error
 	return nil
 }
 


### PR DESCRIPTION
Fixes the three atomicity/consistency gaps of #330, and gap D of #325.

## 1. Double-approve TOCTOU

`Approve` did `GetRequest` → status check → `executeCopy` → `UpdateRequestStatus` as separate statements: two concurrent approvals both passed the pending check and both executed the copy — double blob writes and a double-fired `EventArtifactPublished` webhook to external systems.

New `PromotionRepo.WithPendingRequestLock` (`SELECT ... FOR UPDATE`) runs the pending check, the copy callback and the status write in one transaction holding the row lock. The concurrent loser blocks until the winner commits, then sees the settled status and gets `request is not pending (status: …)` without re-executing. `Reject` and the auto-approve path in `Promote` take the same lock.

## 2. Half-populated component on mid-copy failure (+ #325 gap D)

`executeCopy` created the target component first, then copied assets one at a time with no rollback: a failure between assets left a permanently half-populated component visible to every consumer of the target repo. It now compensates explicitly — asset rows and blobs created fresh by the failing call are removed (rows before bytes), and the target component is deleted once nothing references it.

Only fresh creations roll back: both `Create` paths upsert on conflict, and blindly deleting "what I touched" would destroy a legitimate pre-existing component from an earlier successful promotion of the same version. Acknowledged residual (as scoped in the issue): a pre-existing asset overwritten in place keeps the new content.

This also closes #325's gap D — a blob written right before a failed asset insert is deleted by the same compensation instead of being orphaned.

## 3. Stale rule snapshot across an auto-approve batch

`Promote` fetched the rule once and reused it for the whole batch; an administrator's mid-batch edit (disabling a gate, narrowing a filter) had no effect on the components still to be processed. The rule is now re-read per component, matching `Approve`'s per-call fresh read.

## Tests

All written first and observed failing against the unfixed code:

- `TestPromotion_Approve_ConcurrentApprovalsCopyOnce` — 8 barrier-aligned concurrent approvals: exactly 1 succeeds, webhook fires once.
- `TestPromotion_ExecuteCopy_PartialFailureLeavesNoHalfComponent` — jar copies, pom's source blob is gone: target ends with zero components, zero rows, zero orphaned blobs.
- `TestPromotion_ExecuteCopy_CreateFailureLeavesNoOrphanBlob` — row insert fails after the blob write: blob-store keys are unchanged.
- `TestPromotion_Promote_BatchRereadsRulePerComponent` — rule edited between two components of one batch: first completes, second fails under the edited rule.
- Integration (real Postgres): `WithPendingRequestLock` — 6 concurrent callers, exactly 1 callback runs; a pending outcome leaves the row untouched; unknown id → `ErrNotFound` without running the callback.

`go build` / `go vet` / unit suite green; postgres integration suite green.

Closes #330. Together with #332, closes #325.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma