### PR TITLE
fix(quota): enforce atomically at the registration waist; fail closed on check errors; meter chunked sessions

### DIFF
--- a/internal/formats/base/quota_atomic_test.go
+++ b/internal/formats/base/quota_atomic_test.go
@@ -1,0 +1,181 @@
+package base_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// Quota enforcement must be atomic with the registration, not a separate
+// check-then-write: two concurrent uploads each individually within quota at
+// check time could otherwise both pass and jointly exceed the limit.
+
+// quotaAtomicDeps is deps() plus a "default" blob store row (resolveBlobStoreObj
+// falls back to it when the repo pins no store).
+func quotaAtomicDeps(repo *domain.Repository, defaultStore *domain.BlobStore) (formats.Deps, *testutil.BlobStore, *testutil.AssetRepo, *testutil.BlobStoreRepo) {
+	d, blobStore, _, assets := deps(repo)
+	blobs := testutil.NewBlobStoreRepo(defaultStore)
+	d.Blobs = blobs
+	return d, blobStore, assets, blobs
+}
+
+// Two concurrent uploads, 10 bytes each, into a repository with a 15-byte
+// quota, both aligned on the same usage snapshot: exactly one may land.
+func TestStoreArtifact_ConcurrentUploads_CannotJointlyExceedRepoQuota(t *testing.T) {
+	repo := testutil.SimpleRepo("cqrepo", "raw")
+	quota := int64(15)
+	repo.QuotaBytes = &quota
+	d, blobStore, assets, _ := quotaAtomicDeps(repo, &domain.BlobStore{
+		ID: "00000000-0000-0000-0000-000000000001", Name: "default", Type: "local",
+	})
+	ctx := context.Background()
+
+	// Barrier: hold each caller right after its usage read until both have read
+	// (or a timeout, for the fixed path where the enforcement read is serialized
+	// and both can never be inside it at once).
+	var barrierMu sync.Mutex
+	arrived := 0
+	bothRead := make(chan struct{})
+	assets.SumSizeByRepoHook = func(string) {
+		barrierMu.Lock()
+		arrived++
+		if arrived == 2 {
+			close(bothRead)
+		}
+		barrierMu.Unlock()
+		select {
+		case <-bothRead:
+		case <-time.After(300 * time.Millisecond):
+		}
+	}
+
+	body := "ten-bytes!" // 10 bytes
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	paths := []string{"/a.bin", "/b.bin"}
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = base.StoreArtifact(ctx, d, "cqrepo", paths[i],
+				"application/octet-stream", base.Coords{Name: "f" + paths[i]},
+				strings.NewReader(body), int64(len(body)))
+		}(i)
+	}
+	wg.Wait()
+
+	quotaErrs := 0
+	for _, err := range errs {
+		if errors.Is(err, base.ErrQuotaExceeded) {
+			quotaErrs++
+		} else if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+	if quotaErrs != 1 {
+		t.Errorf("%d of 2 uploads rejected, want exactly 1 — both passed an unserialized quota check and jointly exceeded the limit", quotaErrs)
+	}
+
+	rows, err := assets.ListByRepoAndPath(ctx, "cqrepo", "")
+	require.NoError(t, err)
+	if len(rows) != 1 {
+		t.Errorf("repository holds %d assets (%d bytes each) against a %d-byte quota, want 1", len(rows), len(body), quota)
+	}
+	// The rejected upload's bytes must not linger in the store.
+	for i, err := range errs {
+		if errors.Is(err, base.ErrQuotaExceeded) {
+			assert.False(t, blobStore.Has(base.BlobKey("cqrepo", paths[i])),
+				"the rejected upload's blob was left behind")
+		}
+	}
+}
+
+// RegisterStoredBlob is the narrow waist every write path funnels through
+// (StoreArtifact, the proxy cache fill, the OCI mount), so the quota has to
+// hold there — a caller that skipped its own pre-check must still be stopped.
+func TestRegisterStoredBlob_EnforcesBlobStoreQuota(t *testing.T) {
+	repo := testutil.SimpleRepo("bsqrepo", "raw")
+	quota := int64(10)
+	d, _, assets, blobs := quotaAtomicDeps(repo, &domain.BlobStore{
+		ID: "00000000-0000-0000-0000-000000000001", Name: "default", Type: "local",
+		QuotaBytes: &quota, UsedBytes: 8,
+	})
+	ctx := context.Background()
+
+	_, err := base.RegisterStoredBlob(ctx, d, repo, "/big.bin", "application/octet-stream",
+		base.Coords{Name: "big.bin"}, base.BlobKey("bsqrepo", "/big.bin"),
+		"aa", "bb", "cc", 5, "", "")
+	if !errors.Is(err, base.ErrQuotaExceeded) {
+		t.Fatalf("err = %v, want ErrQuotaExceeded — registration must not push used_bytes past the quota", err)
+	}
+	if _, gerr := assets.GetByPath(ctx, "bsqrepo", "/big.bin"); gerr == nil {
+		t.Error("the over-quota asset row was registered anyway")
+	}
+	bs, _ := blobs.Get(ctx, "default")
+	if bs.UsedBytes != 8 {
+		t.Errorf("used_bytes = %d, want unchanged 8", bs.UsedBytes)
+	}
+}
+
+func TestRegisterStoredBlob_EnforcesRepoQuota(t *testing.T) {
+	repo := testutil.SimpleRepo("rqrepo", "raw")
+	quota := int64(10)
+	repo.QuotaBytes = &quota
+	d, _, assets, _ := quotaAtomicDeps(repo, &domain.BlobStore{
+		ID: "00000000-0000-0000-0000-000000000001", Name: "default", Type: "local",
+	})
+	ctx := context.Background()
+
+	// 8 of the 10 bytes are already used.
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		Repository: "rqrepo", RepositoryID: repo.ID, Path: "/old.bin",
+		BlobKey: "k-old", SizeBytes: 8,
+	}))
+
+	_, err := base.RegisterStoredBlob(ctx, d, repo, "/new.bin", "application/octet-stream",
+		base.Coords{Name: "new.bin"}, base.BlobKey("rqrepo", "/new.bin"),
+		"aa", "bb", "cc", 5, "", "")
+	if !errors.Is(err, base.ErrQuotaExceeded) {
+		t.Fatalf("err = %v, want ErrQuotaExceeded", err)
+	}
+	if _, gerr := assets.GetByPath(ctx, "rqrepo", "/new.bin"); gerr == nil {
+		t.Error("the over-quota asset row was registered anyway")
+	}
+}
+
+// A registration that adds no bytes — an OCI digest alias, a cross-repo mount
+// sharing an already-stored blob — must pass even at full quota: the store
+// gains nothing, and rejecting it would break mounts exactly when the store
+// is fullest.
+func TestRegisterStoredBlob_SharedBlobKeyAtFullQuota_StillRegisters(t *testing.T) {
+	repo := testutil.SimpleRepo("fullrepo", "raw")
+	quota := int64(10)
+	d, _, assets, _ := quotaAtomicDeps(repo, &domain.BlobStore{
+		ID: "00000000-0000-0000-0000-000000000001", Name: "default", Type: "local",
+		QuotaBytes: &quota, UsedBytes: 10,
+	})
+	ctx := context.Background()
+
+	require.NoError(t, assets.Create(ctx, &domain.Asset{
+		Repository: "fullrepo", RepositoryID: repo.ID, Path: "/orig.bin",
+		BlobKey: "shared-key", SizeBytes: 10,
+	}))
+
+	_, err := base.RegisterStoredBlob(ctx, d, repo, "/alias.bin", "application/octet-stream",
+		base.Coords{Name: "alias.bin"}, "shared-key",
+		"aa", "bb", "cc", 10, "", "")
+	if err != nil {
+		t.Fatalf("aliasing an already-stored blob at full quota must succeed (it adds no bytes), got: %v", err)
+	}
+}

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -144,6 +144,13 @@ func StoreArtifact(ctx context.Context, d formats.Deps,
 
 	asset, err := RegisterStoredBlob(ctx, d, repo, filePath, contentType, coords, blobKey, sha256sum, sha1sum, md5sum, size, resolvedBlobStoreID, resolvedBlobStoreName)
 	if err != nil {
+		// A registration the quota refused leaves bytes nothing references; drop
+		// them unless another asset legitimately shares the key.
+		if errors.Is(err, ErrQuotaExceeded) {
+			if others, cerr := d.Assets.CountByBlobKey(ctx, blobKey, ""); cerr == nil && others == 0 {
+				_ = physStore.Delete(ctx, blobKey)
+			}
+		}
 		return nil, err
 	}
 
@@ -227,9 +234,6 @@ func RegisterStoredBlob(ctx context.Context, d formats.Deps, repo *domain.Reposi
 		Name:         name,
 		Version:      version,
 	}
-	if err := d.Components.Create(ctx, comp); err != nil {
-		return nil, fmt.Errorf("upsert component: %w", err)
-	}
 
 	asset := &domain.Asset{
 		ComponentID:  comp.ID,
@@ -247,16 +251,113 @@ func RegisterStoredBlob(ctx context.Context, d formats.Deps, repo *domain.Reposi
 	if uid := requestctx.UserID(ctx); uid != "" {
 		asset.UploaderID = uid
 	}
-	if err := d.Assets.Create(ctx, asset); err != nil {
-		return nil, fmt.Errorf("upsert asset: %w", err)
+
+	// This is the narrow waist every write path funnels through, so the quota is
+	// ENFORCED here — the callers' own checkQuota calls are fast pre-checks, not
+	// the guarantee. The check, the upserts and the counter update run under
+	// per-quota advisory locks (store first, then repo — a fixed order, so two
+	// registrations can never deadlock): without the serialization, two
+	// concurrent writers each read a usage snapshot that ignores the other and
+	// jointly exceed the limit (#328). No quota configured → no locks, no cost.
+	register := func(ctx context.Context) error {
+		// The real increment, not the raw size: an alias or mount of an
+		// already-stored blob adds no bytes and must pass even at full quota.
+		probe := *asset
+		if prev != nil {
+			probe.ID = prev.ID
+		}
+		delta := usageDelta(ctx, d, &probe, prev)
+		if delta > 0 {
+			// Fresh reads inside the lock — the counters are exactly what a
+			// concurrent registration just changed.
+			if qErr := quotaHeadroom(ctx, d, repo, blobStoreID, delta); qErr != nil {
+				return qErr
+			}
+		}
+		if err := d.Components.Create(ctx, comp); err != nil {
+			return fmt.Errorf("upsert component: %w", err)
+		}
+		asset.ComponentID = comp.ID
+		if err := d.Assets.Create(ctx, asset); err != nil {
+			return fmt.Errorf("upsert asset: %w", err)
+		}
+		if delta != 0 {
+			_ = d.Blobs.UpdateUsedBytes(ctx, blobStoreName, delta)
+		}
+		return nil
 	}
 
-	if delta := usageDelta(ctx, d, asset, prev); delta != 0 {
-		_ = d.Blobs.UpdateUsedBytes(ctx, blobStoreName, delta)
+	run := register
+	if repo.QuotaBytes != nil {
+		inner := run
+		run = func(ctx context.Context) error {
+			return d.Assets.WithBlobKeyLock(ctx, "quota:repo:"+repo.Name, inner)
+		}
+	}
+	if storeQuotaConfigured(ctx, d, repo, blobStoreID) {
+		inner := run
+		lockName := blobStoreName
+		if lockName == "" {
+			lockName = "default"
+		}
+		run = func(ctx context.Context) error {
+			return d.Assets.WithBlobKeyLock(ctx, "quota:store:"+lockName, inner)
+		}
+	}
+	if err := run(ctx); err != nil {
+		return nil, err
 	}
 
 	queueForScanning(d, comp)
 	return asset, nil
+}
+
+// storeQuotaConfigured reports whether the store this registration lands in has
+// a byte quota — the signal that the registration must serialize with its
+// peers. An unreadable store reads as unconfigured: the enforcement read inside
+// the lock decides, and it fails closed.
+func storeQuotaConfigured(ctx context.Context, d formats.Deps, repo *domain.Repository, blobStoreID string) bool {
+	bs := storeForQuota(ctx, d, repo, blobStoreID)
+	return bs != nil && bs.Type != "group" && bs.QuotaBytes != nil
+}
+
+// storeForQuota resolves the blob-store row whose quota governs this
+// registration: the pinned store when the caller pinned one, the repository's
+// own store otherwise. nil when no row can be read.
+func storeForQuota(ctx context.Context, d formats.Deps, repo *domain.Repository, blobStoreID string) *domain.BlobStore {
+	if blobStoreID != "" {
+		if bs, err := d.Blobs.GetByID(ctx, blobStoreID); err == nil {
+			return bs
+		}
+		return nil
+	}
+	bs, err := resolveBlobStoreObj(ctx, d, repo)
+	if err != nil {
+		return nil
+	}
+	return bs
+}
+
+// quotaHeadroom answers whether the store and the repository can absorb delta
+// more bytes, reading both counters fresh. Callers hold the corresponding
+// advisory locks, which is what makes the answer still true at commit time.
+func quotaHeadroom(ctx context.Context, d formats.Deps, repo *domain.Repository, blobStoreID string, delta int64) error {
+	if bs := storeForQuota(ctx, d, repo, blobStoreID); bs != nil &&
+		bs.Type != "group" && bs.QuotaBytes != nil && bs.UsedBytes+delta > *bs.QuotaBytes {
+		return fmt.Errorf("%w: blob store %q usage %d + %d > limit %d",
+			ErrQuotaExceeded, bs.Name, bs.UsedBytes, delta, *bs.QuotaBytes)
+	}
+	if repo.QuotaBytes != nil {
+		used, err := d.Assets.SumSizeByRepo(ctx, repo.Name)
+		if err != nil {
+			return fmt.Errorf("quota check: %w", err)
+		}
+		if used+delta > *repo.QuotaBytes {
+			return fmt.Errorf("%w: repository %q usage %d + %d > limit %d",
+				ErrQuotaExceeded, repo.Name, used, delta, *repo.QuotaBytes)
+		}
+	}
+	return nil
 }
 
 // queueForScanning asks for a background scan of a component that has just been

--- a/internal/formats/oci/handler.go
+++ b/internal/formats/oci/handler.go
@@ -793,8 +793,31 @@ func blobLocation(c *gin.Context, imageName, digest string) string {
 	return "/v2/" + imageName + "/blobs/" + digest
 }
 
-func (h *Handler) patchUpload(c *gin.Context, _, _, uuid string) {
-	offset, ok, err := h.uploads.append(c.Request.Context(), uuid, c.Request.Body)
+func (h *Handler) patchUpload(c *gin.Context, repoName, _, uuid string) {
+	ctx := c.Request.Context()
+	// Quota sees the session at every chunk, not only at the finalizing PUT: a
+	// session opened and fed chunks but never finalized would otherwise hold an
+	// arbitrary amount of data invisibly (#328). The check is against bytes
+	// already staged plus this chunk's declared length; an evaluation failure
+	// fails closed, like every other quota-checked write path.
+	if declared := c.Request.ContentLength; declared > 0 {
+		if repo, rerr := h.deps.Repos.Get(ctx, repoName); rerr == nil && repo != nil {
+			stored, known := h.uploads.size(ctx, uuid)
+			if !known {
+				dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
+				return
+			}
+			if qErr := base.CheckQuota(ctx, h.deps, repo, stored+declared); qErr != nil {
+				status := http.StatusInternalServerError
+				if errors.Is(qErr, base.ErrQuotaExceeded) {
+					status = http.StatusRequestEntityTooLarge
+				}
+				dockerError(c, status, "BLOB_UPLOAD_INVALID", qErr.Error())
+				return
+			}
+		}
+	}
+	offset, ok, err := h.uploads.append(ctx, uuid, c.Request.Body)
 	if !ok {
 		dockerError(c, http.StatusNotFound, "BLOB_UPLOAD_UNKNOWN", "upload unknown")
 		return

--- a/internal/formats/oci/upload_quota_test.go
+++ b/internal/formats/oci/upload_quota_test.go
@@ -1,0 +1,83 @@
+package oci_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/oci"
+	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// An in-flight upload session must be visible to quota at every PATCH, not
+// only at the finalizing PUT: a session opened and fed chunks but never
+// finalized can otherwise hold an arbitrary amount of data with the quota
+// system never seeing it.
+
+func setupQuotaUploadRouter(repoQuota int64) *gin.Engine {
+	repo := &domain.Repository{
+		ID: "repo-quota-upload", Name: "docker-quota",
+		Format: domain.FormatDocker, Type: domain.TypeHosted, Online: true,
+		QuotaBytes: &repoQuota,
+	}
+	d := formats.Deps{
+		Repos: testutil.NewRepoRepo(repo),
+		Blobs: testutil.NewBlobStoreRepo(&domain.BlobStore{
+			ID: "00000000-0000-0000-0000-000000000001", Name: "default", Type: "local",
+		}),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := oci.New(d)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		ctx := requestctx.WithUser(c.Request.Context(), "test-user-id", "testuser")
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	})
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+func startQuotaUpload(t *testing.T, r *gin.Engine) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost,
+		"/repository/docker-quota/v2/lib/app/blobs/uploads/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code, w.Body.String())
+	loc := w.Header().Get("Location")
+	require.NotEmpty(t, loc)
+	return loc
+}
+
+func TestPatchUpload_SessionBytesCountAgainstQuota(t *testing.T) {
+	r := setupQuotaUploadRouter(5)
+	loc := startQuotaUpload(t, r)
+
+	// First chunk: 4 bytes into a 5-byte quota — accepted.
+	req := httptest.NewRequest(http.MethodPatch, loc, strings.NewReader("aaaa"))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusAccepted, w.Code, w.Body.String())
+
+	// Second chunk: session 4 + declared 4 = 8 > 5 — must be refused before the
+	// bytes are staged, not silently accepted until a finalize that never comes.
+	req = httptest.NewRequest(http.MethodPatch, loc, strings.NewReader("bbbb"))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code,
+		"an unfinalized session grew past the quota invisibly: %d %s", w.Code, w.Body.String())
+}

--- a/internal/formats/repoproxy/quota_test.go
+++ b/internal/formats/repoproxy/quota_test.go
@@ -180,3 +180,84 @@ func TestServeGET_CacheFill_WithinQuota_StillCaches(t *testing.T) {
 	assert.Equal(t, overQuotaBody, w2.Body.String())
 	assert.Equal(t, 1, fu.count())
 }
+
+// ── Quota check failing OUTRIGHT (not "exceeded") must also skip the cache ────
+//
+// A DB timeout or blob-store lookup failure during the quota check is not a
+// license to cache: with the check unevaluated, caching proceeds with no quota
+// applied at all for the whole failure window. The client is still served from
+// upstream — a transient blip never blocks a download — but nothing is cached.
+
+// Streaming path, declared length: the pre-write gate.
+func TestServeGET_CacheFill_QuotaCheckError_ServesWithoutCaching(t *testing.T) {
+	useUnguardedUpstream(t)
+	_, srv := newFakeUpstream(overQuotaBody)
+	defer srv.Close()
+
+	repo := proxyRepo("quotaerrproxy", srv.URL)
+	quota := int64(1000) // roomy — only the check's own failure is under test
+	repo.QuotaBytes = &quota
+	d, assets, blobStore := quotaDeps(repo)
+	assets.Err = errors.New("db timeout during quota check")
+
+	w := quotaGET(d, repo, "/pkg/1.0/a.jar")
+	assert.Equal(t, http.StatusOK, w.Code, "client must still get the artifact")
+	assert.Equal(t, overQuotaBody, w.Body.String())
+
+	assets.Err = nil
+	requireNotCached(t, assets, blobStore, "quotaerrproxy", "/pkg/1.0/a.jar")
+}
+
+// Streaming path, unknown length: the post-write gate.
+func TestServeGET_CacheFill_UnknownLength_QuotaCheckError_DropsCache(t *testing.T) {
+	useUnguardedUpstream(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		// Flush between writes so the response goes out chunked, without Content-Length.
+		fl := w.(http.Flusher)
+		_, _ = w.Write([]byte(overQuotaBody[:10]))
+		fl.Flush()
+		_, _ = w.Write([]byte(overQuotaBody[10:]))
+	}))
+	defer srv.Close()
+
+	repo := proxyRepo("quotaerrnolen", srv.URL)
+	quota := int64(1000)
+	repo.QuotaBytes = &quota
+	d, assets, blobStore := quotaDeps(repo)
+	assets.Err = errors.New("db timeout during quota check")
+
+	w := quotaGET(d, repo, "/pkg/1.0/a.jar")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, overQuotaBody, w.Body.String())
+
+	assets.Err = nil
+	requireNotCached(t, assets, blobStore, "quotaerrnolen", "/pkg/1.0/a.jar")
+}
+
+// Buffered/rewritten path.
+func TestServeGETRewritten_CacheFill_QuotaCheckError_ServesWithoutCaching(t *testing.T) {
+	useUnguardedUpstream(t)
+	_, srv := newFakeUpstream(overQuotaBody)
+	defer srv.Close()
+
+	repo := proxyRepo("rwquotaerr", srv.URL)
+	quota := int64(1000)
+	repo.QuotaBytes = &quota
+	d, assets, blobStore := quotaDeps(repo)
+	assets.Err = errors.New("db timeout during quota check")
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/meta.json", nil)
+	rewrite := func(b []byte) []byte { return append([]byte("rw:"), b...) }
+	err := repoproxy.ServeGETRewritten(c, d, repo, "/meta.json", "", base.Coords{Name: "meta"}, "text/plain", 0, rewrite)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "rw:"+overQuotaBody, w.Body.String())
+
+	assets.Err = nil
+	requireNotCached(t, assets, blobStore, "rwquotaerr", "/meta.json")
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -562,10 +562,12 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 
 	// Post-write quota gate for upstreams that don't declare Content-Length: the
 	// client already has the bytes, so just drop the over-quota blob unregistered.
+	// A check that failed to evaluate drops the blob the same way — fail closed,
+	// but the client keeps its stream (#328).
 	if resp.ContentLength <= 0 && size > 0 {
 		if qErr := base.CheckQuota(ctx, d, repo, size); qErr != nil {
 			dropUnreferencedBlob(ctx, d, repo, repoRelativePath, physStore, blobKey)
-			return nil
+			return nil //nolint:nilerr // deliberate: skip the cache, never fail the served download
 		}
 	}
 
@@ -608,9 +610,10 @@ func dropUnreferencedBlob(ctx context.Context, d formats.Deps, repo *domain.Repo
 func storeOriginal(ctx context.Context, c *gin.Context, d formats.Deps, repo *domain.Repository,
 	repoRelativePath, ct string, coords base.Coords, body []byte,
 ) error {
-	// Quota gate (#189): over-quota metadata is served (rewritten) but not cached.
+	// Quota gate (#189): over-quota metadata is served (rewritten) but not
+	// cached; a check that failed to evaluate skips the cache the same way (#328).
 	if qErr := base.CheckQuota(ctx, d, repo, int64(len(body))); qErr != nil {
-		return nil
+		return nil //nolint:nilerr // deliberate: skip the cache, never fail the served response
 	}
 
 	blobKey := base.BlobKey(repo.Name, repoRelativePath)

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -500,9 +500,11 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 
 	// Quota gate (#189): when caching this artifact would exceed the repository
 	// or blob-store quota, serve it straight from upstream and skip the cache —
-	// clients keep working, the cache stops growing.
+	// clients keep working, the cache stops growing. Any check failure skips the
+	// cache the same way: a DB blip during the check is not a license to cache
+	// with no quota applied (#328).
 	if resp.ContentLength > 0 {
-		if qErr := base.CheckQuota(ctx, d, repo, resp.ContentLength); errors.Is(qErr, base.ErrQuotaExceeded) {
+		if qErr := base.CheckQuota(ctx, d, repo, resp.ContentLength); qErr != nil {
 			if c.Request.Method != http.MethodHead {
 				_, _ = io.Copy(c.Writer, resp.Body)
 			}
@@ -561,7 +563,7 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 	// Post-write quota gate for upstreams that don't declare Content-Length: the
 	// client already has the bytes, so just drop the over-quota blob unregistered.
 	if resp.ContentLength <= 0 && size > 0 {
-		if qErr := base.CheckQuota(ctx, d, repo, size); errors.Is(qErr, base.ErrQuotaExceeded) {
+		if qErr := base.CheckQuota(ctx, d, repo, size); qErr != nil {
 			dropUnreferencedBlob(ctx, d, repo, repoRelativePath, physStore, blobKey)
 			return nil
 		}
@@ -607,7 +609,7 @@ func storeOriginal(ctx context.Context, c *gin.Context, d formats.Deps, repo *do
 	repoRelativePath, ct string, coords base.Coords, body []byte,
 ) error {
 	// Quota gate (#189): over-quota metadata is served (rewritten) but not cached.
-	if qErr := base.CheckQuota(ctx, d, repo, int64(len(body))); errors.Is(qErr, base.ErrQuotaExceeded) {
+	if qErr := base.CheckQuota(ctx, d, repo, int64(len(body))); qErr != nil {
 		return nil
 	}
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -636,6 +636,10 @@ type AssetRepo struct {
 	// taken but before it is returned (outside the repo's own mutex) — the seam
 	// race tests use to pause a caller exactly between its read and its act.
 	CountByBlobKeyHook func(blobKey, excludeID string)
+	// SumSizeByRepoHook, when set, runs during SumSizeByRepo after the sum is
+	// taken but before it is returned (outside the repo's own mutex) — the seam
+	// quota race tests use to line up concurrent uploads on one usage snapshot.
+	SumSizeByRepoHook func(repoName string)
 }
 
 func NewAssetRepo() *AssetRepo {
@@ -917,8 +921,8 @@ func (a *AssetRepo) ListAllBlobRefs(_ context.Context) ([]domain.BlobRef, error)
 
 func (a *AssetRepo) SumSizeByRepo(_ context.Context, repoName string) (int64, error) {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	if a.Err != nil {
+		a.mu.Unlock()
 		return 0, a.Err
 	}
 	// Mirrors the SQL: one size per distinct blob key, largest wins. Several
@@ -935,6 +939,14 @@ func (a *AssetRepo) SumSizeByRepo(_ context.Context, repoName string) (int64, er
 	var total int64
 	for _, size := range perKey {
 		total += size
+	}
+	// The hook runs outside the repo mutex — it exists to hold a caller between
+	// its usage read and its next act, and holding the mutex there would wedge
+	// every other repo call instead of just this caller.
+	hook := a.SumSizeByRepoHook
+	a.mu.Unlock()
+	if hook != nil {
+		hook(repoName)
 	}
 	return total, nil
 }


### PR DESCRIPTION
Fixes all three gaps of #328 — `checkQuota` was a check-then-write model applied inconsistently.

## 1. Check-then-write TOCTOU on uploads

Two concurrent uploads each individually within quota at check time could both pass and jointly exceed the limit (reproduced in the issue: 15MB quota, two 10MB uploads, both 201).

Enforcement now lives in `RegisterStoredBlob` — the narrow waist every write path funnels through (`StoreArtifact`, the proxy cache fill, the OCI mount). The quota check, the component/asset upserts and the `used_bytes` update run under per-quota advisory locks (store first, then repo — a fixed order, so registrations can never deadlock; no quota configured → no locks, no cost). The second concurrent writer serializes behind the first and sees the counters the first just committed.

The check uses the real usage **delta**, not the raw size: an OCI digest alias or cross-repo mount of an already-stored blob adds no bytes, and still registers at full quota. The callers' existing `checkQuota` calls remain as fast pre-checks (reject before streaming). A quota-refused registration in `StoreArtifact` also deletes the now-unreferenced bytes.

## 2. Proxy cache fill failed open on quota-check errors

Three call sites used `errors.Is(qErr, base.ErrQuotaExceeded)` instead of `qErr != nil`: a blob-store lookup failure or DB timeout during the check was silently discarded and the fill cached the artifact with no quota applied at all. All three now fail closed — skip the cache, still serve the client from upstream (a transient blip never blocks a download).

## 3. Chunked OCI upload sessions invisible to quota until finalize

The PATCH path staged chunks with no quota check; a session fed chunks but never finalized could hold arbitrary data unseen (reproduced: 5MB quota, 20MB staged via 5 PATCHes, all 202). Every PATCH now checks staged-bytes + the chunk's declared length and refuses with 413 before staging; a check that cannot be evaluated fails closed.

## Tests

All written first and observed failing against the unfixed code:

- `TestStoreArtifact_ConcurrentUploads_CannotJointlyExceedRepoQuota` — two barrier-aligned 10-byte uploads into a 15-byte quota: exactly one lands, the loser's bytes are dropped.
- `TestRegisterStoredBlob_EnforcesBlobStoreQuota` / `_EnforcesRepoQuota` — the waist stops a caller that skipped its own pre-check.
- `TestRegisterStoredBlob_SharedBlobKeyAtFullQuota_StillRegisters` — regression guard: aliasing at full quota keeps working (delta = 0).
- `TestServeGET_CacheFill_QuotaCheckError_ServesWithoutCaching`, `…_UnknownLength_QuotaCheckError_DropsCache`, `TestServeGETRewritten_CacheFill_QuotaCheckError_ServesWithoutCaching` — all three proxy sites fail closed.
- `TestPatchUpload_SessionBytesCountAgainstQuota` — second chunk that crosses the quota gets 413 instead of 202.

`go build` / `go vet` / full unit suite green.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma