### PR TITLE
fix(handlers): four small robustness gaps in audit/cleanup/replication

### DIFF
--- a/internal/api/handlers/audit.go
+++ b/internal/api/handlers/audit.go
@@ -58,8 +58,12 @@ func parseAuditQuery(c *gin.Context) (repository.AuditQuery, error) {
 	// where the caller sent bad input and deserves a 400. AuditRepo.List clamps
 	// the page size itself, but a non-numeric limit would otherwise be read as
 	// "use the default" without the caller ever hearing about it.
+	//
+	// An absent limit stays 0 — "not specified". List applies its own 100-row
+	// default internally; the NDJSON export deliberately streams everything
+	// (bounded only by streamRowCap), and a default here would silently cap it.
 	var err error
-	if q.Limit, err = parseNonNegative(c, "limit", 100); err != nil {
+	if q.Limit, err = parseNonNegative(c, "limit", 0); err != nil {
 		return q, err
 	}
 	if q.Offset, err = parseNonNegative(c, "offset", 0); err != nil {

--- a/internal/api/handlers/audit_test.go
+++ b/internal/api/handlers/audit_test.go
@@ -190,6 +190,50 @@ func TestAuditList_NDJSON_Export(t *testing.T) {
 	assert.Equal(t, 2, n)
 }
 
+// ndjsonLines counts the JSON lines of an NDJSON response body.
+func ndjsonLines(t *testing.T, body string) int {
+	t.Helper()
+	sc := bufio.NewScanner(strings.NewReader(body))
+	n := 0
+	for sc.Scan() {
+		var e domain.AuditEvent
+		require.NoError(t, json.Unmarshal(sc.Bytes(), &e), "each line must be JSON")
+		n++
+	}
+	return n
+}
+
+// The doc lists limit/offset for both modes; the NDJSON export must honor them
+// rather than returning the full dump.
+func TestAuditList_NDJSON_HonorsLimit(t *testing.T) {
+	r, repo := mountAudit(t)
+	seed(t, repo, []domain.AuditEvent{
+		{EventTime: time.Now(), Username: "a", Domain: "REPOSITORY", Action: "CREATE", Result: "success"},
+		{EventTime: time.Now(), Username: "b", Domain: "REPOSITORY", Action: "DELETE", Result: "success"},
+		{EventTime: time.Now(), Username: "c", Domain: "REPOSITORY", Action: "CREATE", Result: "success"},
+	})
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/audit?format=ndjson&limit=1", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 1, ndjsonLines(t, rec.Body.String()), "limit=1 must return one row, not the full dump")
+}
+
+// A bulk export that omits ?limit is intentionally unbounded (streamRowCap is
+// the only ceiling): the JSON mode's 100-row default must not leak into it.
+func TestAuditList_NDJSON_NoLimit_NotCappedAtJSONDefault(t *testing.T) {
+	r, repo := mountAudit(t)
+	events := make([]domain.AuditEvent, 120)
+	for i := range events {
+		events[i] = domain.AuditEvent{EventTime: time.Now(), Username: "u", Domain: "REPOSITORY", Action: "CREATE", Result: "success"}
+	}
+	seed(t, repo, events)
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/audit?format=ndjson", nil)
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 120, ndjsonLines(t, rec.Body.String()),
+		"an export without ?limit must stream everything, not the JSON mode's default page")
+}
+
 func TestAuditList_BadFromValue_400(t *testing.T) {
 	r, _ := mountAudit(t)
 

--- a/internal/api/handlers/cleanup.go
+++ b/internal/api/handlers/cleanup.go
@@ -2,12 +2,14 @@ package handlers
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/robfig/cron/v3"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 )
 
@@ -25,6 +27,7 @@ type CleanupHandler struct {
 	policies repository.CleanupPolicyRepo
 	repos    repository.RepositoryRepo
 	runner   cleanupRunner
+	log      logger.Logger
 }
 
 // NewCleanupHandler constructs a CleanupHandler from the policy/repository repos and the cleanup runner.
@@ -32,8 +35,9 @@ func NewCleanupHandler(
 	policies repository.CleanupPolicyRepo,
 	repos repository.RepositoryRepo,
 	runner cleanupRunner,
+	log logger.Logger,
 ) *CleanupHandler {
-	return &CleanupHandler{policies: policies, repos: repos, runner: runner}
+	return &CleanupHandler{policies: policies, repos: repos, runner: runner, log: log}
 }
 
 // List GET /service/rest/v1/cleanup-policies
@@ -129,7 +133,15 @@ func (h *CleanupHandler) Delete(c *gin.Context) {
 		return
 	}
 	if err := h.policies.Delete(c.Request.Context(), id); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		// The first half already ran: repositories no longer reference the
+		// policy, but its row survives. A generic 500 reads as "nothing
+		// happened"; say what state the operation left behind and that a retry
+		// finishes it (DetachCleanupPolicyID is idempotent).
+		h.log.Errorw("cleanup policy delete failed after repositories were detached",
+			"policy", id, "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("repositories were detached from policy %s, but deleting the policy failed: %v — retry the delete to finish", id, err),
+		})
 		return
 	}
 	// Policy is deleted; ReloadPolicy sees it's gone and removes the cron entry.
@@ -144,7 +156,14 @@ func (h *CleanupHandler) Delete(c *gin.Context) {
 func (h *CleanupHandler) Run(c *gin.Context) {
 	id := c.Param("id")
 	if id == "_all" {
-		go func() { _ = h.runner.RunAll(context.Background()) }()
+		// The client already has its 202; the log is the only place a
+		// background failure (an unreachable lock backend, a dead DB) can
+		// surface.
+		go func() {
+			if err := h.runner.RunAll(context.Background()); err != nil {
+				h.log.Errorw("cleanup: background run of all policies failed", "err", err)
+			}
+		}()
 		c.JSON(http.StatusAccepted, gin.H{"status": "running all policies"})
 		return
 	}

--- a/internal/api/handlers/cleanup_test.go
+++ b/internal/api/handlers/cleanup_test.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
@@ -22,6 +24,12 @@ func cleanupNopLog() *zap.SugaredLogger { return zap.NewNop().Sugar() }
 // mountCleanup wires the real CleanupService (over mocks) as the runner so Preview / Run
 // exercise the actual service path, mirroring router.go.
 func mountCleanup(t *testing.T) (*gin.Engine, *testutil.CleanupPolicyRepo, *testutil.RepoRepo, *testutil.AssetRepo) {
+	return mountCleanupWithLog(t, cleanupNopLog())
+}
+
+// mountCleanupWithLog is mountCleanup with a caller-chosen handler logger, so
+// tests can observe what the handler logs.
+func mountCleanupWithLog(t *testing.T, log *zap.SugaredLogger) (*gin.Engine, *testutil.CleanupPolicyRepo, *testutil.RepoRepo, *testutil.AssetRepo) {
 	t.Helper()
 	policies := testutil.NewCleanupPolicyRepo()
 	repos := testutil.NewRepoRepo()
@@ -29,7 +37,7 @@ func mountCleanup(t *testing.T) (*gin.Engine, *testutil.CleanupPolicyRepo, *test
 	blobRepo := testutil.NewBlobStoreRepo()
 	blobs := testutil.NewBlobStore()
 	svc := service.NewCleanupService(policies, repos, assets, blobRepo, blobs, cleanupNopLog())
-	h := handlers.NewCleanupHandler(policies, repos, svc)
+	h := handlers.NewCleanupHandler(policies, repos, svc, log)
 
 	r := gin.New()
 	r.GET("/service/rest/v1/cleanup-policies", h.List)
@@ -180,6 +188,21 @@ func TestCleanupHandler_Delete_DeleteError_500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// A failure in the second half of the two-step delete leaves repositories
+// already detached while the policy row survives; the response has to say so —
+// a generic 500 reads as "nothing happened" and hides that a retry finishes
+// the job.
+func TestCleanupHandler_Delete_DeleteError_SaysReposWereDetached(t *testing.T) {
+	r, policies, _, _ := mountCleanup(t)
+	policies.Err = errors.New("db connection lost")
+	rec := do(t, r, http.MethodDelete, "/service/rest/v1/cleanup-policies/p1", nil)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Contains(t, rec.Body.String(), "detached",
+		"the client must learn the repositories are already detached")
+	assert.Contains(t, rec.Body.String(), "retry",
+		"the client must learn a retry completes the deletion")
+}
+
 // ── Run ───────────────────────────────────────────────────────────────────────
 
 // A single-policy run is synchronous and returns the run summary. A policy not
@@ -228,6 +251,25 @@ func TestCleanupHandler_Run_All_202(t *testing.T) {
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, "running all policies", body["status"])
+}
+
+// The client already got its 202, so a background RunAll failure (an
+// unreachable lock backend, a dead DB) is invisible unless it is logged.
+func TestCleanupHandler_Run_All_BackgroundFailureIsLogged(t *testing.T) {
+	core, logs := observer.New(zap.ErrorLevel)
+	r, policies, _, _ := mountCleanupWithLog(t, zap.New(core).Sugar())
+	policies.Err = errors.New("lock backend unreachable")
+
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/cleanup-policies/_all/run", nil)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for logs.Len() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NotZero(t, logs.Len(), "a failed background run-all must be logged, not discarded")
+	assert.Contains(t, logs.All()[0].Message, "run",
+		"the log entry names the failed operation")
 }
 
 // ── Preview ───────────────────────────────────────────────────────────────────

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -160,7 +160,10 @@ func (h *ReplicationHandler) TestConnection(c *gin.Context) {
 func (h *ReplicationHandler) ListHistory(c *gin.Context) {
 	limit := 20
 	if v := c.Query("limit"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
+		// The n > 0 guard every sibling paginated handler applies: a
+		// non-positive value falls back to the default instead of being
+		// passed through.
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			limit = n
 		}
 	}

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -208,6 +208,17 @@ func TestReplicationHandler_ListHistory_WithLimit_OK(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 }
 
+// A non-positive limit falls back to the default instead of being passed
+// through — the guard every sibling paginated handler already applies.
+func TestReplicationHandler_ListHistory_NonPositiveLimit_FallsBack(t *testing.T) {
+	r := mountReplication(t)
+	id := replicationCreate(t, r, "neg-history")
+	for _, qs := range []string{"limit=-1", "limit=0"} {
+		rec := do(t, r, http.MethodGet, "/api/v1/replication/rules/"+id+"/history?"+qs, nil)
+		assert.Equal(t, http.StatusOK, rec.Code, qs)
+	}
+}
+
 // ── Request-context detachment (#254) ───────────────────────────────────────
 
 // ctxCapturingReplRepo records the context each GetRule call arrives with.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -299,7 +299,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	// artifacts a registry delete does, from the same stores, with the same
 	// webhook.
 	browseH := handlers.NewBrowseHandler(formatDeps, rbacSvc)
-	cleanupH := handlers.NewCleanupHandler(cleanupRepo, repoRepo, cleanupSvc)
+	cleanupH := handlers.NewCleanupHandler(cleanupRepo, repoRepo, cleanupSvc, log)
 	auditH := handlers.NewAuditHandler(auditRepo)
 	scanH := handlers.NewScanHandler(scanSvc)
 	tokenH := handlers.NewTokenHandler(tokenSvc, userSvc, cfg.Auth.TokenMaxDays)

--- a/internal/repository/postgres/audit_repo.go
+++ b/internal/repository/postgres/audit_repo.go
@@ -143,6 +143,17 @@ func (r *AuditRepo) Stream(ctx context.Context, q repository.AuditQuery, fn func
 		       context, result
 		FROM audit_events ` + where + `
 		ORDER BY event_time DESC`
+	// limit/offset apply only when the caller set them: Limit 0 means "not
+	// specified" and streams everything up to streamRowCap — the documented
+	// bulk-export contract.
+	if q.Limit > 0 {
+		args = append(args, q.Limit)
+		sql += fmt.Sprintf(" LIMIT $%d", len(args))
+	}
+	if q.Offset > 0 {
+		args = append(args, q.Offset)
+		sql += fmt.Sprintf(" OFFSET $%d", len(args))
+	}
 	rows, err := r.pool.Query(ctx, sql, args...)
 	if err != nil {
 		return err

--- a/internal/repository/postgres/audit_repo_integration_test.go
+++ b/internal/repository/postgres/audit_repo_integration_test.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -821,5 +822,41 @@ func TestAuditRepo_Write_WithValidUserID(t *testing.T) {
 	}
 	if *items[0].UserID != u.ID {
 		t.Errorf("UserID: got %q, want %q", *items[0].UserID, u.ID)
+	}
+}
+
+// The NDJSON export documents limit/offset; Stream must apply them when the
+// caller sets them, and stream everything when it does not (Limit 0).
+func TestAuditRepo_Stream_AppliesLimitAndOffset(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "audit_events")
+	ctx := context.Background()
+	repo := NewAuditRepo(pool)
+
+	for i := 0; i < 5; i++ {
+		if err := repo.Write(ctx, &domain.AuditEvent{
+			Username: fmt.Sprintf("u%d", i), Domain: "REPOSITORY", Action: "CREATE", Result: "success",
+		}); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+	}
+
+	count := func(q repository.AuditQuery) int {
+		t.Helper()
+		n := 0
+		if err := repo.Stream(ctx, q, func(domain.AuditEvent) error { n++; return nil }); err != nil {
+			t.Fatalf("Stream: %v", err)
+		}
+		return n
+	}
+
+	if got := count(repository.AuditQuery{Limit: 2}); got != 2 {
+		t.Errorf("Stream(limit=2) yielded %d rows, want 2", got)
+	}
+	if got := count(repository.AuditQuery{Limit: 2, Offset: 4}); got != 1 {
+		t.Errorf("Stream(limit=2, offset=4) yielded %d rows, want the 1 remaining", got)
+	}
+	if got := count(repository.AuditQuery{}); got != 5 {
+		t.Errorf("Stream with no limit yielded %d rows, want all 5", got)
 	}
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -1498,13 +1498,24 @@ func (a *AuditRepo) Stream(_ context.Context, q repository.AuditQuery, fn func(d
 	a.mu.Lock()
 	snapshot := append([]domain.AuditEvent(nil), a.Events...)
 	a.mu.Unlock()
+	// Mirror the SQL: limit/offset apply when the caller set them; Limit 0
+	// means "not specified" and streams everything.
+	skipped, sent := 0, 0
 	for _, e := range snapshot {
 		if !a.match(e, q) {
 			continue
 		}
+		if skipped < q.Offset {
+			skipped++
+			continue
+		}
+		if q.Limit > 0 && sent >= q.Limit {
+			break
+		}
 		if err := fn(e); err != nil {
 			return err
 		}
+		sent++
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes the four gaps of #327, bundled the same way #273–#279 were.

## 1. Audit NDJSON export ignores `limit`/`offset`

`AuditRepo.Stream` never applied them — `GET /service/rest/v1/audit?format=ndjson&limit=1` returned the full dump. `Stream` now applies `LIMIT`/`OFFSET` when the caller sets them, and the query-parsing layer uses `0` as the "not specified" sentinel (per the issue's suggestion) so a bulk export without `?limit` still streams everything, bounded only by `streamRowCap`; `List` keeps its own internal 100-row default, unaffected.

## 2. `CleanupHandler.Delete` swallows which half failed

When `policies.Delete` fails after `DetachCleanupPolicyID` succeeded, the client got a generic 500 indistinguishable from "nothing happened" — while repositories were already detached. The failure is now logged and the response says what state was left behind and that a retry finishes the job (detach is idempotent).

## 3. `Run("_all")` discards RunAll's error

The background goroutine now logs the failure — previously an unreachable lock backend failed with no trace anywhere. The handler takes the logger the router already holds.

## 4. `ListHistory` limit lower bound

Handler-level `n > 0` guard, matching the sibling paginated handlers. Note: the service layer has clamped non-positive values to the default since v1.13.0, so on current main this is edge-consistency rather than the user-visible 500 the issue describes.

## Tests

Written first, observed failing (except the two pass-through guards):

- `TestAuditList_NDJSON_HonorsLimit`, `TestAuditList_NDJSON_NoLimit_NotCappedAtJSONDefault` (the latter RED: default capped exports at 100)
- Integration `TestAuditRepo_Stream_AppliesLimitAndOffset` (RED: limit/offset ignored by SQL)
- `TestCleanupHandler_Delete_DeleteError_SaysReposWereDetached` (RED)
- `TestCleanupHandler_Run_All_BackgroundFailureIsLogged` (RED, via a zap observer)
- `TestReplicationHandler_ListHistory_NonPositiveLimit_FallsBack` (guard)

The testutil `AuditRepo.Stream` now mirrors the SQL limit/offset semantics.

`go build` / `go vet` / unit suite green; audit integration tests green.

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma