### PR TITLE
fix(cargo): register proxied crates under their real name and version

### DIFF
--- a/internal/formats/cargo/handler.go
+++ b/internal/formats/cargo/handler.go
@@ -62,7 +62,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		if strings.HasPrefix(p, "/index/") {
 			maxAge = repoproxy.MetadataMaxAge(repo)
 		}
-		coords := base.Coords{}
+		coords := proxyCoords(p)
 		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
@@ -262,6 +262,30 @@ func (h *Handler) handleYank(c *gin.Context, repoName, p string) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+// proxyCoords derives component coordinates for a proxied path. A cached crate
+// must carry its real name and version — the OSV scan queries by them, so the
+// generic path-fallback name and placeholder version made every crate pulled
+// through a Cargo proxy invisible to vulnerability scanning (#336). Index
+// entries are versionless metadata and follow the npm proxy's convention
+// (Version "metadata"). Anything else keeps the generic fallback.
+func proxyCoords(p string) base.Coords {
+	if rest, ok := strings.CutPrefix(p, "/api/v1/crates/"); ok {
+		if nv, isDownload := strings.CutSuffix(rest, "/download"); isDownload {
+			if name, version, ok := strings.Cut(nv, "/"); ok &&
+				name != "" && version != "" && !strings.Contains(version, "/") {
+				return base.Coords{Name: strings.ToLower(name), Version: version}
+			}
+		}
+	}
+	if rest, ok := strings.CutPrefix(p, "/index/"); ok && rest != "config.json" {
+		parts := strings.Split(rest, "/")
+		if name := parts[len(parts)-1]; name != "" {
+			return base.Coords{Name: strings.ToLower(name), Version: "metadata"}
+		}
+	}
+	return base.Coords{}
 }
 
 func normPath(p string) string {

--- a/internal/formats/cargo/proxy_coords_test.go
+++ b/internal/formats/cargo/proxy_coords_test.go
@@ -1,0 +1,92 @@
+package cargo_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/cargo"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A proxied crate must be registered under its real name and version: the OSV
+// scan queries by comp.Name/comp.Version, so a path-fallback name
+// ("api/v1/crates/…/download") and placeholder version ("1") make every crate
+// pulled through a Cargo proxy invisible to vulnerability scanning (#336).
+
+func setupCargoProxy(t *testing.T, upstreamBody string) (*gin.Engine, *testutil.ComponentRepo) {
+	t.Helper()
+	orig := repoproxy.UpstreamClient
+	repoproxy.UpstreamClient = &http.Client{}
+	t.Cleanup(func() { repoproxy.UpstreamClient = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	repo := &domain.Repository{
+		ID: "repo-cargo-proxy", Name: "cargo-proxy", Format: domain.RepoFormat("cargo"),
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": srv.URL},
+	}
+	comps := testutil.NewComponentRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := cargo.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps
+}
+
+func TestCargo_ProxyDownload_RegistersRealCrateCoords(t *testing.T) {
+	r, comps := setupCargoProxy(t, "crate-bytes")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/cargo-proxy/api/v1/crates/smallvec/1.6.1/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{Repository: "cargo-proxy", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1, "the cached crate must be registered as one component")
+	assert.Equal(t, "smallvec", page.Items[0].Name,
+		"the component carries the crate's real name — the OSV query is built from it")
+	assert.Equal(t, "1.6.1", page.Items[0].Version,
+		"the component carries the crate's real version — a placeholder never matches an advisory range")
+}
+
+// Index entries are versionless metadata; they follow the same convention the
+// npm proxy uses (Version "metadata") instead of a path-mangled name.
+func TestCargo_ProxyIndexEntry_RegistersMetadataCoords(t *testing.T) {
+	r, comps := setupCargoProxy(t, `{"name":"smallvec","vers":"1.6.1"}`)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/cargo-proxy/index/sm/al/smallvec", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{Repository: "cargo-proxy", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "smallvec", page.Items[0].Name,
+		"the index entry is registered under the crate's name, not the sharded path")
+	assert.Equal(t, "metadata", page.Items[0].Version)
+}


### PR DESCRIPTION
Fixes #336.

The Cargo proxy branch passed empty `Coords{}` into `ServeGET`, so every cached file fell back to the generic registration: name = asset path, version = `"1"`. The OSV scan builds its query from `comp.Name`/`comp.Version`, so a crate pulled through a Cargo proxy could never match an advisory — `status: ok, total: 0` for known-vulnerable crates, exactly as reported.

- `/api/v1/crates/<name>/<version>/download` now registers `Coords{name, version}` (name lowercased, matching the hosted publish path).
- `/index/<p1>/<p2>/<name>` sparse-index entries register as `Coords{name, "metadata"}` — the same convention the npm proxy uses for versionless metadata — instead of the sharded-path name (`"sm/al/smallvec"`).
- Anything else keeps the generic fallback.

Notes:

- Components already cached with mangled coordinates are not rewritten by this fix; they age out via cleanup, and a re-fetch after cache expiry registers the correct component. If you want a one-off migration for existing rows, that's a separate small task.
- The same empty-`Coords{}` pattern exists in the gomod/yum/nuget/conan proxy branches, but none of those formats are OSV-scannable today, so there it's cosmetic (search shows path-like names) rather than a scan blindspot. Left out of scope here.

## Tests

Written first and observed failing (name was `"api/v1/crates/smallvec/1.6.1/download"` / `"index/sm/al/smallvec"`):

- `TestCargo_ProxyDownload_RegistersRealCrateCoords` — proxied download registers `smallvec` / `1.6.1`.
- `TestCargo_ProxyIndexEntry_RegistersMetadataCoords` — index entry registers `smallvec` / `metadata`.

`go build` / `go vet` / full unit suite green.

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma