### PR TITLE
fix(frontend): four stale-state guards in BrowsePage and SecurityPage

### DIFF
--- a/frontend/src/pages/BrowsePage.staleState.test.tsx
+++ b/frontend/src/pages/BrowsePage.staleState.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { screen, waitFor, fireEvent, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import BrowsePage from './BrowsePage'
+import { renderWithProviders, seedAuthAsAdmin } from '@/test/renderUtils'
+import { server } from '@/test/msw/server'
+import { fixtures } from '@/test/fixtures'
+
+/**
+ * Stale-state guards (#337): component state crossing an async boundary — a
+ * fetch, a race, an unmount — must not act on the value from before that
+ * boundary.
+ */
+
+const repos = [
+  fixtures.repository({ id: 'r1', name: 'maven-hosted', format: 'maven2', type: 'hosted' }),
+  fixtures.repository({ id: 'r3', name: 'raw-hosted', format: 'raw', type: 'hosted' }),
+]
+
+function renderBrowse(search = '') {
+  return renderWithProviders(<BrowsePage />, {
+    routerProps: { initialEntries: [`/browse${search}`] },
+  })
+}
+
+beforeEach(() => {
+  seedAuthAsAdmin()
+  server.use(http.get('/service/rest/v1/repositories', () => HttpResponse.json(repos)))
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('BrowsePage — single-item Promote seeds the rule from the fresh fetch', () => {
+  const twoFileTree = {
+    root: {
+      kind: 'folder', label: '', path: '', children: [
+        {
+          kind: 'folder', label: 'releases', path: '/releases', children: [
+            { kind: 'file', label: 'app.tar.gz', path: '/releases/app.tar.gz', size: 4096, sha256: 'abc123', contentType: 'application/gzip', updatedAt: new Date().toISOString(), componentId: 'comp-raw-1' },
+            { kind: 'file', label: 'lib.tar.gz', path: '/releases/lib.tar.gz', size: 2048, sha256: 'def456', contentType: 'application/gzip', updatedAt: new Date().toISOString(), componentId: 'comp-raw-2' },
+          ],
+        },
+      ],
+    },
+  }
+
+  // The security-relevant scenario from #337: rules already fetched for one
+  // component must never leak into the Promote dialog of another — the operator
+  // sees an apparently empty selection while a rule from an unrelated pair is
+  // silently armed for submission.
+  it('promoting a second component submits its own rule, not the previous component\'s', async () => {
+    const user = userEvent.setup()
+    const promoted: string[] = []
+    server.use(
+      http.get('/api/v1/browse/repositories/:name/raw-tree', () => HttpResponse.json(twoFileTree)),
+      http.get('/service/rest/v1/components/:id', () => HttpResponse.json({ tags: [] })),
+      http.get('/api/v1/components/:id/promotion-rules', ({ params }) =>
+        HttpResponse.json(params.id === 'comp-raw-1'
+          ? [{ id: 'rule-a', name: 'ruleA', from_repo: 'raw-hosted', to_repo: 'staging', require_scan_pass: false, require_manual_approval: false }]
+          : [{ id: 'rule-b', name: 'ruleB', from_repo: 'raw-hosted', to_repo: 'prod', require_scan_pass: false, require_manual_approval: false }]),
+      ),
+      http.post('/api/v1/promotion/promote', async ({ request }) => {
+        const body = await request.json() as { rule_id: string }
+        promoted.push(body.rule_id)
+        return HttpResponse.json({ requests: [{ status: 'completed' }] })
+      }),
+    )
+
+    renderBrowse('?repo=raw-hosted')
+    await user.click(await screen.findByText('releases'))
+
+    // First component: open Promote (its rule becomes the live selection),
+    // then cancel without submitting.
+    await user.click(await screen.findByText('app.tar.gz'))
+    await screen.findByText('File details')
+    await user.click(screen.getByRole('button', { name: 'Promote' }))
+    await screen.findByText(/Promote 1 component/)
+    expect(await screen.findByText('ruleA (raw-hosted → staging)')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    await waitFor(() => expect(screen.queryByText(/Promote 1 component/)).not.toBeInTheDocument())
+
+    // Second component: the dialog must be seeded from ITS freshly-fetched
+    // rule list, not the closure's previous one.
+    await user.click(await screen.findByText('lib.tar.gz'))
+    await screen.findByText('File details')
+    await user.click(screen.getByRole('button', { name: 'Promote' }))
+    const dialog = (await screen.findByText(/Promote 1 component/)).closest('.holo-modal') as HTMLElement
+    expect(await within(dialog).findByText('ruleB (raw-hosted → prod)')).toBeInTheDocument()
+
+    await user.click(within(dialog).getByRole('button', { name: 'Promote' }))
+    await waitFor(() => expect(promoted).toHaveLength(1))
+    expect(promoted[0]).toBe('rule-b')
+  })
+})
+
+describe('BrowsePage — bulk delete invalidates on partial failure', () => {
+  it('refreshes the component list when a later delete in the batch fails', async () => {
+    const user = userEvent.setup()
+    let componentsFetches = 0
+    server.use(
+      http.get('/service/rest/v1/components', () => {
+        componentsFetches++
+        return HttpResponse.json({
+          items: [{
+            id: 'c1', name: 'pkg-a', group: '', version: '1', format: 'maven2',
+            assets: [
+              { id: 'a1', path: 'p/pkg.jar', fileSize: 1, contentType: 't' },
+              { id: 'a2', path: 'p/pkg.pom', fileSize: 1, contentType: 't' },
+            ],
+          }],
+          continuationToken: null,
+        })
+      }),
+      http.delete('/api/v1/browse/repositories/:name/path', ({ request }) => {
+        const path = new URL(request.url).searchParams.get('path') ?? ''
+        if (path.endsWith('.jar')) return new HttpResponse(null, { status: 204 })
+        // The second asset was already removed elsewhere: the first delete
+        // genuinely succeeded server-side, the view must not pretend otherwise.
+        return HttpResponse.json({ error: 'not found' }, { status: 404 })
+      }),
+    )
+
+    renderBrowse('?repo=maven-hosted')
+    await screen.findByText('pkg-a')
+    const fetchesBefore = componentsFetches
+    await user.click(screen.getByTitle('Delete'))
+    await screen.findByText('Delete component?')
+    const delBtns = screen.getAllByRole('button', { name: /^Delete/ })
+    await user.click(delBtns[delBtns.length - 1])
+
+    // The failure is reported…
+    expect(await screen.findByText(/not found/)).toBeInTheDocument()
+    // …and the list is refreshed anyway: the jar IS gone server-side, and a
+    // view that still shows the untouched component would mislead a retry.
+    await waitFor(() => expect(componentsFetches).toBeGreaterThan(fetchesBefore))
+  })
+})
+
+describe('BrowsePage — upload aborts when the modal goes away', () => {
+  const rawTree = {
+    root: {
+      kind: 'folder', label: '', path: '', children: [
+        { kind: 'file', label: 'existing.bin', path: '/existing.bin', size: 1, sha256: 'aa', contentType: 't', updatedAt: new Date().toISOString(), componentId: 'comp-raw-1' },
+      ],
+    },
+  }
+
+  it('aborts the in-flight XHR when the modal is dismissed via the backdrop', async () => {
+    const user = userEvent.setup()
+    const abortSpy = vi.spyOn(XMLHttpRequest.prototype, 'abort')
+    server.use(
+      http.get('/api/v1/browse/repositories/:name/raw-tree', () => HttpResponse.json(rawTree)),
+      // The PUT never resolves within the test: the upload stays in flight.
+      http.put('/repository/:name/*', () => new Promise<never>(() => {})),
+    )
+
+    renderBrowse('?repo=raw-hosted')
+    await screen.findByText('existing.bin')
+    await user.click(screen.getByRole('button', { name: /Upload/ }))
+    await screen.findByText('Upload file')
+
+    const dropZone = screen.getByText('Click or drag a file here')
+    fireEvent.drop(dropZone, {
+      dataTransfer: { files: [new File(['payload'], 'new-file.bin', { type: 'application/octet-stream' })] },
+    })
+    await screen.findByText('new-file.bin')
+    const dialog = screen.getByRole('dialog')
+    await user.click(within(dialog).getByRole('button', { name: 'Upload' }))
+    await screen.findAllByText(/Uploading/)
+
+    // Dismissing via the backdrop closes the modal exactly like switching
+    // repositories does — neither path is the Cancel button.
+    fireEvent.click(document.querySelector('.holo-overlay')!)
+    await waitFor(() => expect(screen.queryByText('Upload file')).not.toBeInTheDocument())
+
+    await waitFor(() => expect(abortSpy).toHaveBeenCalled(),
+      { timeout: 2000 })
+  })
+})

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -1185,6 +1185,15 @@ export default function BrowsePage() {
 
   async function confirmDelete() {
     if (!deleteTarget) return
+    const repo = deleteTarget.repo
+    // Invalidation must not depend on full success: a batch that fails partway
+    // has already deleted assets server-side, and a view still showing them
+    // would mislead the retry (#337).
+    const invalidate = () => {
+      void queryClient.invalidateQueries({ queryKey: ['components', repo] })
+      void queryClient.invalidateQueries({ queryKey: ['dockerBrowseTree', repo] })
+      void queryClient.invalidateQueries({ queryKey: ['rawBrowseTree', repo] })
+    }
     setDeleting(true)
     setDeleteError(null)
     try {
@@ -1203,16 +1212,14 @@ export default function BrowsePage() {
           await nexspenceApi.deleteByPath(deleteTarget.repo, p)
         }
       }
-      const repo = deleteTarget.repo
       setDeleteTarget(null)
-      void queryClient.invalidateQueries({ queryKey: ['components', repo] })
-      void queryClient.invalidateQueries({ queryKey: ['dockerBrowseTree', repo] })
-      void queryClient.invalidateQueries({ queryKey: ['rawBrowseTree', repo] })
+      invalidate()
     } catch (err: unknown) {
       const msg = axios.isAxiosError(err)
         ? err.response?.data?.message ?? err.response?.data?.error ?? err.message
         : err instanceof Error ? err.message : String(err)
       setDeleteError(msg)
+      invalidate()
     } finally {
       setDeleting(false)
     }
@@ -1486,10 +1493,15 @@ export default function BrowsePage() {
                       try {
                         const res = await apiClient.get(`/api/v1/components/${dockerSelection.componentId}/promotion-rules`)
                         if (res.data.length === 0) { alert('No promotion rules defined for this repository.'); return }
+                        // Seed the selection from the response, not from state:
+                        // `promotionRules` here is still the PREVIOUS component's
+                        // list (React state updates are async), and a rule id left
+                        // over from it would arm an unrelated rule behind an
+                        // apparently-empty dropdown (#337).
                         setPromotionRules(res.data)
-                      } catch { setPromotionRules([]) }
+                        setSelectedRuleID(res.data[0]?.id ?? '')
+                      } catch { setPromotionRules([]); setSelectedRuleID('') }
                       setPromoteComponentIDs([dockerSelection.componentId])
-                      setSelectedRuleID(promotionRules[0]?.id ?? '')
                       setPromotionResult(null)
                       setPromoteModalOpen(true)
                     }}>
@@ -1610,10 +1622,12 @@ export default function BrowsePage() {
                           try {
                             const res = await apiClient.get(`/api/v1/components/${node.componentId}/promotion-rules`)
                             if (res.data.length === 0) { alert('No promotion rules defined for this repository.'); return }
+                            // Same stale-closure hazard as the Docker handler
+                            // above: seed from the response, not from state (#337).
                             setPromotionRules(res.data)
-                          } catch { setPromotionRules([]) }
+                            setSelectedRuleID(res.data[0]?.id ?? '')
+                          } catch { setPromotionRules([]); setSelectedRuleID('') }
                           setPromoteComponentIDs([node.componentId!])
-                          setSelectedRuleID(promotionRules[0]?.id ?? '')
                           setPromotionResult(null)
                           setPromoteModalOpen(true)
                         }}>
@@ -1941,7 +1955,13 @@ function RawUploadModal({
   const [progress, setProgress] = useState(0)
   const [uploadError, setUploadError] = useState<string | null>(null)
   const [dragOver, setDragOver] = useState(false)
-  const xhrRef = useState<XMLHttpRequest | null>(null)
+  const xhrRef = useRef<XMLHttpRequest | null>(null)
+
+  // The modal can go away without its Cancel button — the backdrop click, a
+  // repository switch — and the in-flight PUT would otherwise keep running
+  // headless, landing a file in a repository the user is no longer looking at,
+  // with no notification either way (#337). Aborting a finished XHR is a no-op.
+  useEffect(() => () => { xhrRef.current?.abort() }, [])
 
   function handleFileChange(f: File) {
     setFile(f)
@@ -1955,7 +1975,7 @@ function RawUploadModal({
   function doUpload() {
     if (!file) return
     const xhr = new XMLHttpRequest()
-    xhrRef[0] = xhr
+    xhrRef.current = xhr
     const path = destPath.replace(/^\//, '')
     xhr.open('PUT', `/repository/${repoName}/${path}`)
     xhr.setRequestHeader('Content-Type', file.type || 'application/octet-stream')
@@ -2083,8 +2103,8 @@ function RawUploadModal({
         <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
           <HoloButton
             onClick={() => {
-              if (uploadState === 'uploading' && xhrRef[0]) {
-                xhrRef[0].abort()
+              if (uploadState === 'uploading' && xhrRef.current) {
+                xhrRef.current.abort()
                 setUploadState('idle')
               } else {
                 onClose()

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect, useMemo, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { Shield, RefreshCw, Webhook, AlertTriangle, CheckCircle, Loader, Trash2, Plus, Bug, Zap, Pencil, Download } from 'lucide-react'
@@ -738,6 +738,10 @@ function VulnDashTab() {
   const [error, setError] = useState('')
 
   const LIMIT = 50
+  // Responses are applied in resolution order, not request order: a broader,
+  // earlier query resolving late must not overwrite the current one — the
+  // table would show rows for a filter the input no longer contains (#337).
+  const vulnReqSeq = useRef(0)
 
   async function loadSummary() {
     try {
@@ -747,6 +751,7 @@ function VulnDashTab() {
   }
 
   async function loadVulns(reset = false, explicitOffset?: number) {
+    const seq = ++vulnReqSeq.current
     const newOffset = reset ? 0 : (explicitOffset ?? offset)
     if (reset) setOffset(0)
     setLoading(true)
@@ -755,12 +760,14 @@ function VulnDashTab() {
       if (repoFilter) params.repo = repoFilter
       if (severityFilter) params.severity = severityFilter
       const res = await apiClient.get<{ items: VulnRow[]; total: number }>('/api/v1/security/vulnerabilities', { params })
+      if (seq !== vulnReqSeq.current) return // superseded by a newer request
       setItems(reset ? res.data.items : [...items, ...res.data.items])
       setTotal(res.data.total)
     } catch (e: unknown) {
+      if (seq !== vulnReqSeq.current) return
       if (axios.isAxiosError(e)) setError(e.response?.data?.error ?? e.message)
     } finally {
-      setLoading(false)
+      if (seq === vulnReqSeq.current) setLoading(false)
     }
   }
 

--- a/frontend/src/pages/SecurityPageVulnRace.test.tsx
+++ b/frontend/src/pages/SecurityPageVulnRace.test.tsx
@@ -1,0 +1,85 @@
+import { it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { screen, waitFor, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import SecurityPage from './SecurityPage'
+import { renderWithProviders, seedAuthAsAdmin } from '@/test/renderUtils'
+import { server } from '@/test/msw/server'
+import { fixtures } from '@/test/fixtures'
+
+/**
+ * #337 gap 2: the vulnerability table applies responses in resolution order,
+ * not request order. A broader, earlier query that resolves late must not
+ * overwrite the narrower, current one — the table would show rows for a filter
+ * the input no longer contains.
+ */
+
+function seedBaseline() {
+  server.use(
+    http.get('/service/rest/v1/security/roles', () => HttpResponse.json([
+      { id: 'role-1', name: 'nx-admin', description: 'Admin role', privileges: [], roles: [], readOnly: true },
+    ])),
+    http.get('/service/rest/v1/security/privileges', () => HttpResponse.json([])),
+    http.get('/service/rest/v1/security/content-selectors', () => HttpResponse.json([])),
+    http.get('/api/v1/security/privilege-role-map', () => HttpResponse.json({})),
+    http.get('/service/rest/v1/repositories', () => HttpResponse.json([fixtures.repository()])),
+    http.get('/service/rest/v1/security/users', () => HttpResponse.json([fixtures.user()])),
+    http.get('/api/v1/webhooks', () => HttpResponse.json([])),
+    http.get('/api/v1/security/summary', () =>
+      HttpResponse.json({ malicious: 0, critical: 0, high: 0, medium: 0, low: 0, unknown: 0, scanned_total: 1 }),
+    ),
+  )
+}
+
+beforeEach(() => {
+  seedAuthAsAdmin()
+  seedBaseline()
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function vulnRow(repoName: string) {
+  return {
+    repoName, format: 'npm', componentId: 'c-' + repoName, name: 'pkg-for-' + repoName, version: '1.0.0',
+    malicious: 0, critical: 1, high: 0, medium: 0, low: 0, unknown: 0,
+    scannedAt: '2026-08-26T00:00:00Z',
+  }
+}
+
+it('a superseded filter response resolving late does not overwrite the current one', async () => {
+  const user = userEvent.setup()
+  // Each request parks until the test releases it, keyed by its repo filter.
+  const release = new Map<string, () => void>()
+  server.use(
+    http.get('/api/v1/security/vulnerabilities', async ({ request }) => {
+      const repo = new URL(request.url).searchParams.get('repo') ?? ''
+      await new Promise<void>(res => { release.set(repo, res) })
+      return HttpResponse.json({ total: 1, items: [vulnRow(repo || 'all')] })
+    }),
+  )
+
+  renderWithProviders(<SecurityPage />)
+  await user.click(await screen.findByRole('button', { name: 'Vulnerability Dashboard' }))
+
+  // Initial unfiltered load.
+  await waitFor(() => expect(release.has('')).toBe(true))
+  release.get('')!()
+  expect(await screen.findByText('pkg-for-all')).toBeInTheDocument()
+
+  const filter = screen.getByPlaceholderText('Filter by repo')
+  fireEvent.change(filter, { target: { value: 'n' } })
+  await waitFor(() => expect(release.has('n')).toBe(true))
+  fireEvent.change(filter, { target: { value: 'npm' } })
+  await waitFor(() => expect(release.has('npm')).toBe(true))
+
+  // The narrower, CURRENT request resolves first…
+  release.get('npm')!()
+  expect(await screen.findByText('pkg-for-npm')).toBeInTheDocument()
+
+  // …then the superseded broader one trickles in late. It must be discarded.
+  release.get('n')!()
+  await new Promise(r => setTimeout(r, 100))
+  expect(screen.queryByText('pkg-for-n')).not.toBeInTheDocument()
+  expect(screen.getByText('pkg-for-npm')).toBeInTheDocument()
+})


### PR DESCRIPTION
Fixes all four gaps of #337, in the reporter's severity order.

## 1. Single-item Promote could silently arm the wrong rule (security-relevant)

Both single-item handlers read `promotionRules[0]` from the closure — the PREVIOUS component's list — after fetching the new one. Cancelling a Promote on component A and opening it on component B left A's rule id as the live selection: the dropdown showed the placeholder (no visible match) while the submit button stayed enabled, submitting a rule from an unrelated repo pair. The selection now seeds from the freshly fetched response (`res.data[0]`), and the fetch-failure path clears it — matching the bulk handler, per the issue's suggested fix.

## 2. Vulnerability dashboard applied stale filter responses

`loadVulns` had no request-generation guard: whichever response resolved last won, so a broader earlier query resolving late (ordinary network jitter) overwrote the narrower current one — table rows for "n" under a search box reading "npm". A generation counter now discards superseded responses (including their error and loading-state effects).

## 3. Partial bulk-delete failure left the view stale

The sequential delete loop only invalidated queries on the fully-successful path. When a later delete 404s after earlier ones succeeded, the assets already deleted server-side stayed on screen. Invalidation now also runs on the failure path (the error message still shows).

## 4. Upload not aborted when the modal goes away

`xhrRef` was a misused `useState` tuple, and only the Cancel button called `abort()`. The backdrop click — and a repository switch — closed the modal the same way, leaving the PUT running headless with no notification either way. The XHR now lives in a `useRef` with a cleanup effect that aborts on unmount (a no-op for a finished request).

## Tests

All four written first and observed failing against the unfixed code:

- `BrowsePage.staleState.test.tsx` — promote seeds/submits the second component's own rule (asserts the POSTed `rule_id`); partial delete failure still refetches the list; backdrop dismissal aborts the in-flight XHR (spy on `XMLHttpRequest.prototype.abort`).
- `SecurityPageVulnRace.test.tsx` — deterministic two-request race via per-filter response gates: the superseded response resolving late is discarded.

Full frontend suite: 535 passed, 0 failed; eslint and `tsc --noEmit` clean.

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma