### PR TITLE
feat: optional minimum package age policy for npm/PyPI proxy repositories

### DIFF
--- a/frontend/src/pages/RepositoriesPage.test.tsx
+++ b/frontend/src/pages/RepositoriesPage.test.tsx
@@ -419,6 +419,37 @@ describe('RepositoriesPage', () => {
     expect((put! as { description: string }).description).toBe('updated desc')
   })
 
+  // #323: an npm/pypi proxy exposes the minimum-package-age policy in its
+  // settings; the field round-trips as proxy_config.minimum_package_age in
+  // seconds while the operator types days.
+  it('edits minimum package age on an npm proxy', async () => {
+    const user = userEvent.setup()
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/repositories/:format/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(fixtures.repository())
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    await screen.findByText('npm-proxy')
+    fireEvent.click(screen.getAllByTitle('Settings')[1])
+    await screen.findByText('Repository settings')
+
+    const url = screen.getByPlaceholderText('https://registry.example.com/')
+    await user.clear(url)
+    await user.type(url, 'https://registry.npmjs.org/')
+    const age = screen.getByPlaceholderText('e.g. 7')
+    await user.clear(age)
+    await user.type(age, '7')
+
+    const form = document.querySelector('form') as HTMLFormElement
+    fireEvent.click(within(form).getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const cfg = (put! as { proxyConfig: Record<string, unknown> }).proxyConfig
+    expect(cfg.minimum_package_age).toBe(7 * 24 * 3600)
+  })
+
   it('shows an error when edit save fails', async () => {
     const user = userEvent.setup()
     server.use(

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -438,6 +438,7 @@ function CreateRepoModal({ onClose, onCreated }: {
     httpProxy: '', httpsProxy: '', socks5Proxy: '', noProxy: '',
     proxyUsername: '', proxyPassword: '',
     remoteUsername: '', remotePassword: '',
+    minPackageAgeDays: '',
     memberNames: [] as string[],
     cleanupPolicyIds: [] as string[],
     quotaGB: '',
@@ -501,7 +502,9 @@ function CreateRepoModal({ onClose, onCreated }: {
       }
       if (effectiveStoreId) body.blobStoreId = effectiveStoreId
       if (form.type === 'proxy') {
-        const proxyConfig: Record<string, string> = { remote_url: form.remoteUrl.trim() }
+        const proxyConfig: Record<string, string | number> = { remote_url: form.remoteUrl.trim() }
+        const ageDays = parseFloat(form.minPackageAgeDays)
+        if (!isNaN(ageDays) && ageDays > 0) proxyConfig.minimum_package_age = Math.round(ageDays * 86400)
         if (form.httpProxy.trim()) proxyConfig.http_proxy = form.httpProxy.trim()
         if (form.httpsProxy.trim()) proxyConfig.https_proxy = form.httpsProxy.trim()
         if (form.socks5Proxy.trim()) proxyConfig.socks5_proxy = form.socks5Proxy.trim()
@@ -589,6 +592,23 @@ function CreateRepoModal({ onClose, onCreated }: {
             placeholder="https://registry.example.com/"
           />
           <span className={styles.hint}>URL of the upstream registry to proxy and cache</span>
+        </div>
+      )}
+      {form.type === 'proxy' && ['npm', 'pypi'].includes(form.format) && (
+        <div className={styles.formRow}>
+          <label style={LABEL_STYLE}>Minimum package age (days)</label>
+          <HoloInput
+            type="number"
+            min="0"
+            step="any"
+            value={form.minPackageAgeDays}
+            onChange={e => setField('minPackageAgeDays', e.target.value)}
+            placeholder="e.g. 7"
+          />
+          <span className={styles.hint}>
+            Supply-chain quarantine: upstream versions published more recently than this
+            are hidden until they reach the configured age. Leave blank to disable.
+          </span>
         </div>
       )}
       {form.type === 'proxy' && (
@@ -856,6 +876,13 @@ function EditRepoModal({
   const [blobStoreId, setBlobStoreId] = useState<string>(repo.blobStoreId ?? '')
   const [routingRuleId, setRoutingRuleId] = useState<string>(repo.routingRuleId ?? '')
   const [remoteUrl, setRemoteUrl] = useState(cfgString(repo.proxyConfig, 'remote_url'))
+  // Stored in seconds (proxy_config.minimum_package_age); the operator thinks
+  // in days. Empty = policy disabled.
+  const [minAgeDays, setMinAgeDays] = useState(() => {
+    const raw = repo.proxyConfig?.['minimum_package_age']
+    const secs = typeof raw === 'number' ? raw : typeof raw === 'string' ? parseFloat(raw) : NaN
+    return !isNaN(secs) && secs > 0 ? String(secs / 86400) : ''
+  })
   const [httpProxy, setHttpProxy] = useState(cfgString(repo.proxyConfig, 'http_proxy'))
   const [httpsProxy, setHttpsProxy] = useState(cfgString(repo.proxyConfig, 'https_proxy'))
   const [socks5Proxy, setSocks5Proxy] = useState(cfgString(repo.proxyConfig, 'socks5_proxy'))
@@ -1003,6 +1030,9 @@ function EditRepoModal({
         // Same contract for the upstream registry password.
         if (remotePassword) proxyConfig.remote_password = remotePassword
         else if (clearRemotePassword) proxyConfig.remote_password = ''
+        const ageDays = parseFloat(minAgeDays)
+        if (!isNaN(ageDays) && ageDays > 0) proxyConfig.minimum_package_age = Math.round(ageDays * 86400)
+        else delete proxyConfig.minimum_package_age
         updateBody.proxyConfig = proxyConfig
       }
       await nexusApi.updateRepository(repo.format, repo.type, repo.name, updateBody)
@@ -1066,6 +1096,24 @@ function EditRepoModal({
             <span className={styles.hint}>
               URL of the upstream registry to proxy and cache. Already-cached artifacts are kept;
               new fetches go to the new upstream.
+            </span>
+          </div>
+        )}
+        {repo.type === 'proxy' && ['npm', 'pypi'].includes(repo.format) && (
+          <div className={styles.formRow}>
+            <label style={LABEL_STYLE}>Minimum package age (days)</label>
+            <HoloInput
+              type="number"
+              min="0"
+              step="any"
+              value={minAgeDays}
+              onChange={e => setMinAgeDays(e.target.value)}
+              placeholder="e.g. 7"
+            />
+            <span className={styles.hint}>
+              Supply-chain quarantine: upstream versions published more recently than this
+              are hidden from metadata and refused on download until they reach the
+              configured age. Leave blank to disable.
             </span>
           </div>
         )}

--- a/internal/formats/npm/age_filter.go
+++ b/internal/formats/npm/age_filter.go
@@ -1,0 +1,206 @@
+package npm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// FilterPackumentByAge removes from a packument every version published after
+// cutoff, so a proxy with a minimum-package-age policy (#323) never shows a
+// client a version younger than the operator allows. The returned applied flag
+// reports whether the policy could be evaluated at all: a document carrying no
+// usable dates is returned unchanged with applied=false — hiding the whole
+// package would be worse than no policy — and the caller logs the gap.
+//
+// Within a dated document the filter fails closed: a version missing from the
+// time map has an unknowable age and is hidden. Dist-tags pointing at a hidden
+// version fall back to the newest surviving version (by publish time) — a
+// "latest" left dangling would break `npm install pkg` outright, which is
+// quarantine of the wrong thing. Malformed input is returned unchanged.
+func FilterPackumentByAge(body []byte, cutoff time.Time) (out []byte, applied bool) {
+	var doc map[string]any
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return body, false
+	}
+	versions, ok := doc["versions"].(map[string]any)
+	if !ok {
+		return body, false
+	}
+	times, ok := doc["time"].(map[string]any)
+	if !ok {
+		return body, false
+	}
+
+	// Parse every per-version date once. "created"/"modified" describe the
+	// package, not a version.
+	published := make(map[string]time.Time, len(times))
+	for v, raw := range times {
+		if v == "created" || v == "modified" {
+			continue
+		}
+		s, ok := raw.(string)
+		if !ok {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			published[v] = t
+		}
+	}
+	if len(published) == 0 {
+		return body, false
+	}
+
+	changed := false
+	var newestSurviving string
+	for v := range versions {
+		t, dated := published[v]
+		if !dated || t.After(cutoff) {
+			delete(versions, v)
+			delete(times, v)
+			changed = true
+			continue
+		}
+		if newestSurviving == "" || t.After(published[newestSurviving]) {
+			newestSurviving = v
+		}
+	}
+
+	if tags, ok := doc["dist-tags"].(map[string]any); ok {
+		for tag, target := range tags {
+			name, _ := target.(string)
+			if _, alive := versions[name]; alive {
+				continue
+			}
+			if newestSurviving != "" {
+				tags[tag] = newestSurviving
+			} else {
+				delete(tags, tag)
+			}
+			changed = true
+		}
+	}
+
+	if !changed {
+		return body, true
+	}
+	filtered, err := json.Marshal(doc)
+	if err != nil {
+		return body, true
+	}
+	return filtered, true
+}
+
+// maxPackumentBytes bounds how much upstream metadata the download gate will
+// read while deciding a version's age. Real packuments run to a few MB.
+const maxPackumentBytes = 32 << 20
+
+// PackumentPublishTimes extracts the version→publish-time map from a raw
+// packument. "created"/"modified" describe the package, not a version. An
+// empty map means the document carries no usable dates.
+func PackumentPublishTimes(body []byte) map[string]time.Time {
+	var doc struct {
+		Time map[string]string `json:"time"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil
+	}
+	out := make(map[string]time.Time, len(doc.Time))
+	for v, s := range doc.Time {
+		if v == "created" || v == "modified" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, s); err == nil {
+			out[v] = t
+		}
+	}
+	return out
+}
+
+// tarballAgeAllowed is the download half of the minimum-package-age policy: a
+// direct tarball URL must not bypass the metadata filter. It answers whether
+// the request may proceed; on refusal it has already written the 403.
+//
+// Within a dated publish history the gate fails closed — a version the history
+// does not name (including one published after the cached copy was taken) is
+// refused. When no dates are available at all, the gate opens and logs the
+// gap, mirroring the metadata filter's hybrid failure mode.
+func (h *Handler) tarballAgeAllowed(c *gin.Context, repo *domain.Repository, pkg, version string, minAge time.Duration) bool {
+	times := h.packumentTimesFor(c.Request.Context(), repo, pkg)
+	if len(times) == 0 {
+		log.Printf("nexspence: minimum_package_age not enforceable for %s/%s — no publish dates available", repo.Name, pkg)
+		return true
+	}
+	published, ok := times[version]
+	if !ok {
+		c.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf(
+			"version %q of %q is not in the package's known publish history; this repository enforces a minimum package age", version, pkg)})
+		return false
+	}
+	if age := time.Since(published); age < minAge {
+		c.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf(
+			"%s@%s was published %s ago; this repository enforces a minimum package age of %s",
+			pkg, version, age.Round(time.Minute), minAge)})
+		return false
+	}
+	return true
+}
+
+// packumentTimesFor returns the publish history for pkg: the proxy's own
+// cached packument when present (no upstream round-trip per download — clients
+// fetch metadata before tarballs, so the cache is fresh within the metadata
+// TTL), the upstream document otherwise.
+func (h *Handler) packumentTimesFor(ctx context.Context, repo *domain.Repository, pkg string) map[string]time.Time {
+	if asset, err := h.deps.Assets.GetByPath(ctx, repo.Name, "/"+pkg); err == nil && asset != nil {
+		if body := h.readCachedBlob(ctx, asset); body != nil {
+			if times := PackumentPublishTimes(body); len(times) > 0 {
+				return times
+			}
+		}
+	}
+	resp, err := repoproxy.FetchUpstreamOnce(ctx, repo, "/"+repoproxy.NPMMetadataPath(pkg), "", nil)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPackumentBytes))
+	if err != nil {
+		return nil
+	}
+	return PackumentPublishTimes(body)
+}
+
+// readCachedBlob reads a cached asset's bytes from the store that holds them.
+// Deliberately not base.FetchArtifact: that path counts a download, and an
+// internal policy read must not inflate the packument's statistics.
+func (h *Handler) readCachedBlob(ctx context.Context, asset *domain.Asset) []byte {
+	store := h.deps.BlobStore
+	if asset.BlobStoreID != "" {
+		if meta, err := h.deps.Blobs.GetByID(ctx, asset.BlobStoreID); err == nil && meta != nil {
+			store = base.PhysicalStore(ctx, h.deps, meta)
+		}
+	}
+	rc, _, err := store.Get(ctx, asset.BlobKey)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rc.Close() }()
+	b, err := io.ReadAll(io.LimitReader(rc, maxPackumentBytes))
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/internal/formats/npm/age_filter.go
+++ b/internal/formats/npm/age_filter.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -203,4 +204,22 @@ func (h *Handler) readCachedBlob(ctx context.Context, asset *domain.Asset) []byt
 		return nil
 	}
 	return b
+}
+
+// tarballVersion cuts "<base>-<version>.tgz" at the package's base-name
+// prefix, so prerelease hyphens survive ("pkg-1.0.0-beta.1.tgz" →
+// "1.0.0-beta.1"; a last-hyphen split would yield "beta.1" and fail closed on
+// a perfectly aged artifact). npm requests scoped tarballs as
+// /@scope/name/-/name-ver.tgz — the filename carries the unscoped base name.
+// An unrecognizable filename yields "", which the gate fails closed on.
+func tarballVersion(pkg, baseName string) string {
+	base := pkg
+	if i := strings.LastIndex(pkg, "/"); i >= 0 {
+		base = pkg[i+1:]
+	}
+	name := strings.TrimSuffix(baseName, ".tgz")
+	if v, ok := strings.CutPrefix(name, base+"-"); ok {
+		return v
+	}
+	return ""
 }

--- a/internal/formats/npm/age_filter_test.go
+++ b/internal/formats/npm/age_filter_test.go
@@ -1,0 +1,138 @@
+package npm_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/npm"
+)
+
+// Minimum-package-age filtering of an npm packument (#323): versions published
+// after the cutoff disappear from the document a client resolves against.
+
+var ageCutoff = time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC)
+
+func packument(t *testing.T, distTags map[string]string, times map[string]string) []byte {
+	t.Helper()
+	versions := map[string]any{}
+	for v := range times {
+		if v == "created" || v == "modified" {
+			continue
+		}
+		versions[v] = map[string]any{"name": "pkg", "version": v, "dist": map[string]any{"tarball": "https://reg/pkg/-/pkg-" + v + ".tgz"}}
+	}
+	doc := map[string]any{"name": "pkg", "dist-tags": distTags, "versions": versions, "time": times}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return b
+}
+
+func parse(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(b, &doc))
+	return doc
+}
+
+func TestFilterPackumentByAge_HidesYoungVersions(t *testing.T) {
+	body := packument(t,
+		map[string]string{"latest": "2.0.0"},
+		map[string]string{
+			"created":  "2026-01-01T00:00:00Z",
+			"modified": "2026-08-25T00:00:00Z",
+			"1.0.0":    "2026-01-01T00:00:00Z",
+			"1.5.0":    "2026-06-01T00:00:00Z",
+			"2.0.0":    "2026-08-25T00:00:00Z", // after the cutoff — too young
+		})
+
+	out, applied := npm.FilterPackumentByAge(body, ageCutoff)
+	require.True(t, applied, "a dated packument must have the policy applied")
+	doc := parse(t, out)
+
+	versions := doc["versions"].(map[string]any)
+	assert.Contains(t, versions, "1.0.0")
+	assert.Contains(t, versions, "1.5.0")
+	assert.NotContains(t, versions, "2.0.0", "a version younger than the cutoff must disappear")
+
+	times := doc["time"].(map[string]any)
+	assert.NotContains(t, times, "2.0.0", "the time entry goes with the version")
+	assert.Contains(t, times, "created")
+
+	// The latest tag pointed at the hidden version: it must fall back to the
+	// newest surviving one, or `npm install pkg` breaks entirely.
+	tags := doc["dist-tags"].(map[string]any)
+	assert.Equal(t, "1.5.0", tags["latest"])
+}
+
+func TestFilterPackumentByAge_KeepsIntactWhenNothingIsYoung(t *testing.T) {
+	body := packument(t,
+		map[string]string{"latest": "1.5.0"},
+		map[string]string{"1.0.0": "2026-01-01T00:00:00Z", "1.5.0": "2026-06-01T00:00:00Z"})
+
+	out, applied := npm.FilterPackumentByAge(body, ageCutoff)
+	require.True(t, applied)
+	doc := parse(t, out)
+	assert.Len(t, doc["versions"].(map[string]any), 2)
+	assert.Equal(t, "1.5.0", doc["dist-tags"].(map[string]any)["latest"])
+}
+
+// Hybrid failure mode: a version listed in a DATED document but absent from
+// its time map has an unknowable age — fail closed and hide it.
+func TestFilterPackumentByAge_UndatedVersionInDatedDocIsHidden(t *testing.T) {
+	body := packument(t,
+		map[string]string{"latest": "1.0.0"},
+		map[string]string{"1.0.0": "2026-01-01T00:00:00Z"})
+	// Splice in a version with no time entry.
+	doc := parse(t, body)
+	doc["versions"].(map[string]any)["9.9.9"] = map[string]any{"name": "pkg", "version": "9.9.9"}
+	spliced, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	out, applied := npm.FilterPackumentByAge(spliced, ageCutoff)
+	require.True(t, applied)
+	got := parse(t, out)
+	assert.NotContains(t, got["versions"].(map[string]any), "9.9.9",
+		"an undated version in a dated document fails closed")
+}
+
+// Hybrid failure mode: a document with no usable dates at all is served
+// unchanged — hiding the whole package would be worse than no policy — and the
+// caller is told the policy was NOT applied so it can log the gap.
+func TestFilterPackumentByAge_NoDatesAtAll_SkipsPolicy(t *testing.T) {
+	doc := map[string]any{
+		"name":      "pkg",
+		"dist-tags": map[string]string{"latest": "1.0.0"},
+		"versions":  map[string]any{"1.0.0": map[string]any{"name": "pkg", "version": "1.0.0"}},
+	}
+	body, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	out, applied := npm.FilterPackumentByAge(body, ageCutoff)
+	assert.False(t, applied, "no dates → policy skipped, caller logs the gap")
+	assert.JSONEq(t, string(body), string(out))
+}
+
+func TestFilterPackumentByAge_MalformedBodyUnchanged(t *testing.T) {
+	body := []byte("not json at all")
+	out, applied := npm.FilterPackumentByAge(body, ageCutoff)
+	assert.False(t, applied)
+	assert.Equal(t, body, out)
+}
+
+// Every version young: versions empty, tags dropped — the package looks not
+// yet published, which is exactly the quarantine semantic.
+func TestFilterPackumentByAge_AllVersionsYoung(t *testing.T) {
+	body := packument(t,
+		map[string]string{"latest": "2.0.0"},
+		map[string]string{"2.0.0": "2026-08-25T00:00:00Z"})
+
+	out, applied := npm.FilterPackumentByAge(body, ageCutoff)
+	require.True(t, applied)
+	doc := parse(t, out)
+	assert.Empty(t, doc["versions"].(map[string]any))
+	assert.Empty(t, doc["dist-tags"].(map[string]any))
+}

--- a/internal/formats/npm/age_policy_test.go
+++ b/internal/formats/npm/age_policy_test.go
@@ -1,0 +1,160 @@
+package npm_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/npm"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// Minimum-package-age policy on an npm proxy (#323): versions younger than the
+// configured age are invisible in metadata AND blocked on direct download.
+
+// agePolicyUpstream serves a two-version packument (1.0.0 old, 2.0.0 published
+// an hour ago) and both tarballs, counting tarball hits.
+func agePolicyUpstream(t *testing.T, withDates bool) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var tarballHits atomic.Int32
+	now := time.Now().UTC()
+	doc := map[string]any{
+		"name":      "pkg",
+		"dist-tags": map[string]any{"latest": "2.0.0"},
+		"versions": map[string]any{
+			"1.0.0": map[string]any{"name": "pkg", "version": "1.0.0", "dist": map[string]any{"tarball": "https://up/pkg/-/pkg-1.0.0.tgz"}},
+			"2.0.0": map[string]any{"name": "pkg", "version": "2.0.0", "dist": map[string]any{"tarball": "https://up/pkg/-/pkg-2.0.0.tgz"}},
+		},
+	}
+	if withDates {
+		doc["time"] = map[string]any{
+			"created": now.Add(-90 * 24 * time.Hour).Format(time.RFC3339),
+			"1.0.0":   now.Add(-90 * 24 * time.Hour).Format(time.RFC3339),
+			"2.0.0":   now.Add(-1 * time.Hour).Format(time.RFC3339),
+		}
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/-/") {
+			tarballHits.Add(1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write([]byte("tarball-bytes"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &tarballHits
+}
+
+// agedProxySetup is proxySetup with a 7-day minimum package age.
+func agedProxySetup(upstream *httptest.Server) *gin.Engine {
+	repo := &domain.Repository{
+		ID: "npm-aged", Name: "npm-aged", Format: "npm",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{
+			"remote_url":          upstream.URL,
+			"minimum_package_age": 7 * 24 * 3600,
+		},
+	}
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := npm.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+func TestNPM_AgePolicy_MetadataHidesYoungVersion(t *testing.T) {
+	upstream, _ := agePolicyUpstream(t, true)
+	r := agedProxySetup(upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/npm-aged/pkg", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+	versions := doc["versions"].(map[string]any)
+	assert.Contains(t, versions, "1.0.0")
+	assert.NotContains(t, versions, "2.0.0", "an hour-old version must be invisible behind a 7-day policy")
+	assert.Equal(t, "1.0.0", doc["dist-tags"].(map[string]any)["latest"],
+		"latest falls back to the newest version old enough to serve")
+}
+
+func TestNPM_AgePolicy_TarballOfYoungVersionIs403(t *testing.T) {
+	upstream, tarballHits := agePolicyUpstream(t, true)
+	r := agedProxySetup(upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/npm-aged/pkg/-/pkg-2.0.0.tgz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"a direct URL must not bypass the metadata filter: %d %s", w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "minimum package age")
+	assert.Zero(t, tarballHits.Load(), "the young tarball must never be fetched upstream")
+}
+
+func TestNPM_AgePolicy_TarballOfOldVersionServes(t *testing.T) {
+	upstream, _ := agePolicyUpstream(t, true)
+	r := agedProxySetup(upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/npm-aged/pkg/-/pkg-1.0.0.tgz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "tarball-bytes", w.Body.String())
+}
+
+// Hybrid failure mode: an upstream that publishes no dates at all cannot be
+// policed — the package is served rather than hidden wholesale.
+func TestNPM_AgePolicy_UpstreamWithoutDates_SkipsPolicy(t *testing.T) {
+	upstream, _ := agePolicyUpstream(t, false)
+	r := agedProxySetup(upstream)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/npm-aged/pkg", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+	assert.Contains(t, doc["versions"].(map[string]any), "2.0.0",
+		"no dates → policy skipped, the document is served as-is")
+
+	req = httptest.NewRequest(http.MethodGet, "/repository/npm-aged/pkg/-/pkg-2.0.0.tgz", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "no dates → the download gate opens too")
+}
+
+// A proxy without the option keeps today's behavior byte for byte.
+func TestNPM_AgePolicy_DisabledByDefault(t *testing.T) {
+	upstream, _ := agePolicyUpstream(t, true)
+	r, _ := proxySetup(upstream)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/repository/%s/pkg", "npm-proxy"), nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
+	assert.Contains(t, doc["versions"].(map[string]any), "2.0.0")
+}

--- a/internal/formats/npm/age_policy_test.go
+++ b/internal/formats/npm/age_policy_test.go
@@ -158,3 +158,37 @@ func TestNPM_AgePolicy_DisabledByDefault(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &doc))
 	assert.Contains(t, doc["versions"].(map[string]any), "2.0.0")
 }
+
+// Prerelease versions carry hyphens ("1.0.0-beta.1"): the version must be cut
+// at the package-name prefix, not at the last hyphen, or an OLD prerelease
+// fails closed as "not in the publish history" — a false positive that blocks
+// a perfectly aged artifact.
+func TestNPM_AgePolicy_OldPrereleaseTarballServes(t *testing.T) {
+	now := time.Now().UTC()
+	doc := map[string]any{
+		"name":      "pkg",
+		"dist-tags": map[string]any{"latest": "1.0.0-beta.1"},
+		"versions": map[string]any{
+			"1.0.0-beta.1": map[string]any{"name": "pkg", "version": "1.0.0-beta.1", "dist": map[string]any{"tarball": "https://up/pkg/-/pkg-1.0.0-beta.1.tgz"}},
+		},
+		"time": map[string]any{
+			"1.0.0-beta.1": now.Add(-90 * 24 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/-/") {
+			_, _ = w.Write([]byte("tarball-bytes"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	}))
+	t.Cleanup(srv.Close)
+	r := agedProxySetup(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/npm-aged/pkg/-/pkg-1.0.0-beta.1.tgz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code,
+		"a 90-day-old prerelease must serve: %d %s", w.Code, w.Body.String())
+}

--- a/internal/formats/npm/handler.go
+++ b/internal/formats/npm/handler.go
@@ -13,9 +13,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -108,6 +110,11 @@ func (h *Handler) serveTarball(c *gin.Context, repoName, filePath string) {
 			}
 		}
 		pkg := strings.TrimPrefix(strings.Split(filePath, "/-/")[0], "/")
+		if minAge := repoproxy.MinimumPackageAge(repo); minAge > 0 {
+			if !h.tarballAgeAllowed(c, repo, pkg, ver, minAge) {
+				return
+			}
+		}
 		coords := base.Coords{Name: pkg, Version: ver}
 		if coords.Version == "" {
 			coords.Version = "1"
@@ -154,6 +161,17 @@ func (h *Handler) serveMetadata(c *gin.Context, repoName, pkgPath string) {
 		// upstream original.
 		localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repo.Name
 		rewrite := func(b []byte) []byte { return RewritePackument(b, localBase) }
+		if minAge := repoproxy.MinimumPackageAge(repo); minAge > 0 {
+			cutoff := time.Now().Add(-minAge)
+			inner := rewrite
+			rewrite = func(b []byte) []byte {
+				filtered, applied := FilterPackumentByAge(b, cutoff)
+				if !applied {
+					log.Printf("nexspence: minimum_package_age not applied for %s%s — upstream metadata carries no publish dates", repo.Name, pkgPath)
+				}
+				return inner(filtered)
+			}
+		}
 		if err := repoproxy.ServeGETRewritten(c, h.deps, repo, pkgPath, up, coords, "application/json", repoproxy.MetadataMaxAge(repo), rewrite); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		}

--- a/internal/formats/npm/handler.go
+++ b/internal/formats/npm/handler.go
@@ -111,7 +111,7 @@ func (h *Handler) serveTarball(c *gin.Context, repoName, filePath string) {
 		}
 		pkg := strings.TrimPrefix(strings.Split(filePath, "/-/")[0], "/")
 		if minAge := repoproxy.MinimumPackageAge(repo); minAge > 0 {
-			if !h.tarballAgeAllowed(c, repo, pkg, ver, minAge) {
+			if !h.tarballAgeAllowed(c, repo, pkg, tarballVersion(pkg, path.Base(filePath)), minAge) {
 				return
 			}
 		}

--- a/internal/formats/pypi/age_filter.go
+++ b/internal/formats/pypi/age_filter.go
@@ -1,0 +1,163 @@
+package pypi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// The minimum-package-age policy (#323) needs per-file upload dates, and the
+// PEP 503 HTML page the proxy pipeline serves carries none. Dates come from a
+// separate upstream request for the PEP 691 JSON page (upload-time is PEP 700);
+// an upstream that only speaks HTML, or omits upload-time, cannot be policed —
+// hybrid failure mode: the policy is skipped and the gap logged.
+
+// pep691JSONAccept asks upstream for the JSON simple page. This request is
+// internal to the date lookup; the page pipeline itself keeps forcing HTML
+// upstream (#191), which TestPyPI_AgePolicy_ServedPageStaysHTML pins.
+const pep691JSONAccept = "application/vnd.pypi.simple.v1+json"
+
+// maxSimpleJSONBytes bounds the date-lookup response read.
+const maxSimpleJSONBytes = 16 << 20
+
+// fileAnchorRe matches one file anchor (with its trailing <br>, if any) on a
+// PEP 503 per-package page — a machine-generated list of
+// <a href=...>filename</a> elements. anchorRe in groupindex.go extracts pairs;
+// this one has to swallow the whole element so a filtered file leaves no
+// dangling markup behind.
+var fileAnchorRe = regexp.MustCompile(`(?s)<a\b[^>]*>(.*?)</a>(\s*<br\s*/?>)?`)
+
+// uploadTimesEntry caches one package's filename→upload-time map. A nil map is
+// cached too: an upstream without dates should not be re-asked on every
+// request within the TTL.
+type uploadTimesEntry struct {
+	fetched time.Time
+	dates   map[string]time.Time
+}
+
+// FilterSimpleHTMLByAge removes from a per-package simple page every file
+// anchor whose upload time is after cutoff — and, failing closed within a
+// dated map, every anchor the map does not name at all (a file uploaded after
+// the dates were fetched has an unknowable age). dates must be non-empty; the
+// caller handles the no-dates hybrid case.
+func FilterSimpleHTMLByAge(body []byte, dates map[string]time.Time, cutoff time.Time) []byte {
+	return fileAnchorRe.ReplaceAllFunc(body, func(m []byte) []byte {
+		sub := fileAnchorRe.FindSubmatch(m)
+		filename := strings.TrimSpace(string(sub[1]))
+		t, ok := dates[filename]
+		if !ok || t.After(cutoff) {
+			return nil
+		}
+		return m
+	})
+}
+
+// simpleUploadTimes returns the filename→upload-time map for pkg from the
+// upstream PEP 691 JSON page, cached per (repo, pkg) for the repository's
+// metadata TTL. A nil map means no dates are available.
+func (h *Handler) simpleUploadTimes(ctx context.Context, repo *domain.Repository, pkg string) map[string]time.Time {
+	key := repo.Name + "/" + pkg
+	ttl := repoproxy.MetadataMaxAge(repo)
+
+	h.ageMu.Lock()
+	if e, ok := h.ageDates[key]; ok && time.Since(e.fetched) < ttl {
+		h.ageMu.Unlock()
+		return e.dates
+	}
+	h.ageMu.Unlock()
+
+	dates := fetchSimpleUploadTimes(ctx, repo, pkg)
+
+	h.ageMu.Lock()
+	if h.ageDates == nil {
+		h.ageDates = make(map[string]uploadTimesEntry)
+	}
+	h.ageDates[key] = uploadTimesEntry{fetched: time.Now(), dates: dates}
+	h.ageMu.Unlock()
+	return dates
+}
+
+func fetchSimpleUploadTimes(ctx context.Context, repo *domain.Repository, pkg string) map[string]time.Time {
+	hdr := http.Header{}
+	hdr.Set("Accept", pep691JSONAccept)
+	resp, err := repoproxy.FetchUpstreamOnce(ctx, repo, "/simple/"+pkg+"/", "", hdr)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK ||
+		!strings.Contains(resp.Header.Get("Content-Type"), "json") {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxSimpleJSONBytes))
+	if err != nil {
+		return nil
+	}
+	var doc struct {
+		Files []struct {
+			Filename   string `json:"filename"`
+			UploadTime string `json:"upload-time"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil
+	}
+	out := make(map[string]time.Time, len(doc.Files))
+	for _, f := range doc.Files {
+		if f.Filename == "" || f.UploadTime == "" {
+			continue
+		}
+		if t, err := time.Parse(time.RFC3339, f.UploadTime); err == nil {
+			out[f.Filename] = t
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// fileAgeAllowed is the download half of the policy: a direct /packages/ URL
+// must not bypass the simple-page filter. On refusal the 403 is already
+// written. The package name is the distribution segment of the filename
+// (everything before the first "-", per wheel/sdist naming), normalized the
+// way the simple index is.
+func (h *Handler) fileAgeAllowed(c *gin.Context, repo *domain.Repository, filePath string, minAge time.Duration) bool {
+	filename := path.Base(filePath)
+	dist, _, ok := strings.Cut(filename, "-")
+	if !ok || dist == "" {
+		c.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf(
+			"cannot derive a package name from %q; this repository enforces a minimum package age", filename)})
+		return false
+	}
+	dates := h.simpleUploadTimes(c.Request.Context(), repo, normalizePackageName(dist))
+	if len(dates) == 0 {
+		log.Printf("nexspence: minimum_package_age not enforceable for %s/%s — no upload dates available", repo.Name, dist)
+		return true
+	}
+	uploaded, ok := dates[filename]
+	if !ok {
+		c.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf(
+			"%q is not in the package's known upload history; this repository enforces a minimum package age", filename)})
+		return false
+	}
+	if age := time.Since(uploaded); age < minAge {
+		c.JSON(http.StatusForbidden, gin.H{"error": fmt.Sprintf(
+			"%s was uploaded %s ago; this repository enforces a minimum package age of %s",
+			filename, age.Round(time.Minute), minAge)})
+		return false
+	}
+	return true
+}

--- a/internal/formats/pypi/age_policy_test.go
+++ b/internal/formats/pypi/age_policy_test.go
@@ -1,0 +1,157 @@
+package pypi_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// Minimum-package-age policy on a PyPI proxy (#323): files uploaded more
+// recently than the configured age disappear from the simple page and are
+// refused on direct download. Dates come from the upstream PEP 691 JSON page
+// (the HTML page pip is served carries none); an upstream that cannot provide
+// them leaves the policy unapplied (hybrid failure mode).
+
+const (
+	oldWhl   = "requests-2.31.0-py3-none-any.whl"
+	youngWhl = "requests-2.32.0-py3-none-any.whl"
+)
+
+// agedPyPIUpstream negotiates like pypi.org: PEP 691 JSON (with upload-time)
+// when asked for it, PEP 503 HTML otherwise. jsonCapable=false models an index
+// that only speaks HTML. fileHits counts /packages/ downloads.
+func agedPyPIUpstream(t *testing.T, jsonCapable bool) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var fileHits atomic.Int32
+	now := time.Now().UTC()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/packages/") {
+			fileHits.Add(1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write([]byte("wheel-bytes"))
+			return
+		}
+		if jsonCapable && strings.Contains(r.Header.Get("Accept"), "application/vnd.pypi.simple.v1+json") {
+			w.Header().Set("Content-Type", "application/vnd.pypi.simple.v1+json")
+			fmt.Fprintf(w, `{"name":"requests","files":[
+				{"filename":%q,"url":"https://files.pythonhosted.org/packages/ab/cd/%s","upload-time":%q},
+				{"filename":%q,"url":"https://files.pythonhosted.org/packages/ab/ce/%s","upload-time":%q}
+			]}`,
+				oldWhl, oldWhl, now.Add(-90*24*time.Hour).Format(time.RFC3339),
+				youngWhl, youngWhl, now.Add(-1*time.Hour).Format(time.RFC3339))
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<!DOCTYPE html><html><body>
+<a href="https://files.pythonhosted.org/packages/ab/cd/%s#sha256=aa">%s</a><br/>
+<a href="https://files.pythonhosted.org/packages/ab/ce/%s#sha256=bb">%s</a><br/>
+</body></html>`, oldWhl, oldWhl, youngWhl, youngWhl)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &fileHits
+}
+
+func agedPyPIProxy(upstreamURL string) *gin.Engine {
+	repo := proxyRepo("pypi-aged", upstreamURL)
+	repo.ProxyConfig["minimum_package_age"] = 7 * 24 * 3600
+	return setupExtra(repo)
+}
+
+func TestPyPI_AgePolicy_SimplePageHidesYoungFile(t *testing.T) {
+	upstream, _ := agedPyPIUpstream(t, true)
+	r := agedPyPIProxy(upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-aged/simple/requests/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	body := w.Body.String()
+	assert.Contains(t, body, oldWhl)
+	assert.NotContains(t, body, youngWhl,
+		"an hour-old upload must be invisible behind a 7-day policy")
+}
+
+func TestPyPI_AgePolicy_YoungFileDownloadIs403(t *testing.T) {
+	upstream, fileHits := agedPyPIUpstream(t, true)
+	r := agedPyPIProxy(upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-aged/packages/ab/ce/"+youngWhl, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code,
+		"a direct URL must not bypass the simple-page filter: %d %s", w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), "minimum package age")
+	assert.Zero(t, fileHits.Load(), "the young file must never be fetched upstream")
+}
+
+func TestPyPI_AgePolicy_OldFileDownloadServes(t *testing.T) {
+	upstream, _ := agedPyPIUpstream(t, true)
+	r := agedPyPIProxy(upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-aged/packages/ab/cd/"+oldWhl, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	assert.Equal(t, "wheel-bytes", w.Body.String())
+}
+
+// Hybrid failure mode: an upstream that only speaks HTML carries no upload
+// dates — the policy is skipped rather than hiding the whole package.
+func TestPyPI_AgePolicy_HTMLOnlyUpstream_SkipsPolicy(t *testing.T) {
+	upstream, _ := agedPyPIUpstream(t, false)
+	r := agedPyPIProxy(upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-aged/simple/requests/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), youngWhl,
+		"no dates available → the page is served as-is")
+
+	req = httptest.NewRequest(http.MethodGet, "/repository/pypi-aged/packages/ab/ce/"+youngWhl, nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "no dates → the download gate opens too")
+}
+
+// The pipeline invariant from #191 must survive the policy: the SERVED page
+// stays the rewritten HTML representation even while dates are fetched as JSON.
+func TestPyPI_AgePolicy_ServedPageStaysHTML(t *testing.T) {
+	upstream, _ := agedPyPIUpstream(t, true)
+	r := agedPyPIProxy(upstream.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-aged/simple/requests/", nil)
+	req.Header.Set("Accept", pipAccept)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	assert.NotContains(t, body, `"files"`, "client must get HTML, not the PEP 691 JSON page")
+	assert.Contains(t, body, `href="http://localhost:8080/repository/pypi-aged/packages/ab/cd/`+oldWhl,
+		"file links must still be rewritten to the proxy")
+}
+
+// A proxy without the option keeps today's behavior.
+func TestPyPI_AgePolicy_DisabledByDefault(t *testing.T) {
+	upstream, _ := agedPyPIUpstream(t, true)
+	r := setupExtra(proxyRepo("pypi-noage", upstream.URL))
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/pypi-noage/simple/requests/", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), youngWhl)
+}
+
+var _ = domain.TypeProxy // keep the import when helpers move

--- a/internal/formats/pypi/handler.go
+++ b/internal/formats/pypi/handler.go
@@ -9,9 +9,12 @@ package pypi
 import (
 	"fmt"
 	"html"
+	"log"
 	"net/http"
 	"path"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -22,7 +25,14 @@ import (
 )
 
 // Handler serves the PyPI repository protocol.
-type Handler struct{ deps formats.Deps }
+type Handler struct {
+	deps formats.Deps
+
+	// ageMu/ageDates cache per-package upload-time maps for the
+	// minimum-package-age policy (#323); see age_filter.go.
+	ageMu    sync.Mutex
+	ageDates map[string]uploadTimesEntry
+}
 
 // New creates a PyPI format Handler with the given dependencies.
 func New(deps formats.Deps) *Handler { return &Handler{deps: deps} }
@@ -73,6 +83,15 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			// this proxy instead of upstream (#98); the cache keeps the original.
 			localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repo.Name
 			rewrite := func(b []byte) []byte { return RewriteSimplePage(b, localBase) }
+			if minAge := repoproxy.MinimumPackageAge(repo); minAge > 0 {
+				if dates := h.simpleUploadTimes(c.Request.Context(), repo, normalized); len(dates) > 0 {
+					cutoff := time.Now().Add(-minAge)
+					inner := rewrite
+					rewrite = func(b []byte) []byte { return inner(FilterSimpleHTMLByAge(b, dates, cutoff)) }
+				} else {
+					log.Printf("nexspence: minimum_package_age not applied for %s/%s — upstream provides no upload dates", repo.Name, normalized)
+				}
+			}
 			if err := repoproxy.ServeGETRewritten(c, h.deps, repo, p, "", coords, "text/html; charset=utf-8", repoproxy.MetadataMaxAge(repo), rewrite); err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			}
@@ -206,6 +225,11 @@ func (h *Handler) serveFile(c *gin.Context, repoName, filePath string) {
 		return
 	}
 	if repo != nil && repo.Type == domain.TypeProxy {
+		if minAge := repoproxy.MinimumPackageAge(repo); minAge > 0 {
+			if !h.fileAgeAllowed(c, repo, filePath, minAge) {
+				return
+			}
+		}
 		pkgGuess := path.Base(path.Dir(filePath))
 		coords := base.Coords{Name: normalizePackageName(pkgGuess), Version: "wheel"}
 		ct := pypiContentType(path.Base(filePath))

--- a/internal/formats/repoproxy/coverage_extra_test.go
+++ b/internal/formats/repoproxy/coverage_extra_test.go
@@ -131,3 +131,32 @@ func TestScopeFromRegistryV2URL_Endpoints(t *testing.T) {
 		}
 	}
 }
+
+// MinimumPackageAge: absent/zero/invalid means DISABLED (0) — the policy is
+// opt-in, unlike MetadataMaxAge which falls back to a positive default.
+func TestMinimumPackageAge_Parsing(t *testing.T) {
+	cases := []struct {
+		name string
+		repo *domain.Repository
+		want time.Duration
+	}{
+		{"nil repo", nil, 0},
+		{"nil config", &domain.Repository{}, 0},
+		{"missing key", proxyRepoWith(map[string]any{"remote_url": "x"}), 0},
+		{"seconds float64", proxyRepoWith(map[string]any{"minimum_package_age": float64(604800)}), 7 * 24 * time.Hour},
+		{"seconds int", proxyRepoWith(map[string]any{"minimum_package_age": 86400}), 24 * time.Hour},
+		{"seconds string", proxyRepoWith(map[string]any{"minimum_package_age": "3600"}), time.Hour},
+		{"json.Number", proxyRepoWith(map[string]any{"minimum_package_age": json.Number("60")}), time.Minute},
+		{"zero disables", proxyRepoWith(map[string]any{"minimum_package_age": 0}), 0},
+		{"negative disables", proxyRepoWith(map[string]any{"minimum_package_age": -5}), 0},
+		{"bad string disables", proxyRepoWith(map[string]any{"minimum_package_age": "week"}), 0},
+		{"wrong type disables", proxyRepoWith(map[string]any{"minimum_package_age": true}), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := MinimumPackageAge(tc.repo); got != tc.want {
+				t.Fatalf("MinimumPackageAge = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -197,6 +197,52 @@ func MetadataMaxAge(repo *domain.Repository) time.Duration {
 	return time.Duration(secs * float64(time.Second))
 }
 
+// MinimumPackageAge returns the minimum age an upstream package version must
+// have before this proxy repository serves it (#323) — a supply-chain gate: a
+// freshly published malicious version stays invisible until it has had time to
+// be detected and reported. Read from proxy_config["minimum_package_age"] in
+// seconds (the metadata_max_age convention). Absent, zero, negative or invalid
+// means DISABLED (0) — the policy is opt-in, so unlike MetadataMaxAge there is
+// no positive default to fall back to.
+func MinimumPackageAge(repo *domain.Repository) time.Duration {
+	if repo == nil || repo.ProxyConfig == nil {
+		return 0
+	}
+	raw, ok := repo.ProxyConfig["minimum_package_age"]
+	if !ok {
+		return 0
+	}
+	var secs float64
+	switch v := raw.(type) {
+	case float64:
+		secs = v
+	case float32:
+		secs = float64(v)
+	case int:
+		secs = float64(v)
+	case int64:
+		secs = float64(v)
+	case json.Number:
+		f, err := v.Float64()
+		if err != nil {
+			return 0
+		}
+		secs = f
+	case string:
+		f, err := strconv.ParseFloat(strings.TrimSpace(v), 64)
+		if err != nil {
+			return 0
+		}
+		secs = f
+	default:
+		return 0
+	}
+	if secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs * float64(time.Second))
+}
+
 // cacheFetchStore resolves the physical blob store that holds a cached asset.
 func cacheFetchStore(ctx context.Context, d formats.Deps, asset *domain.Asset) storage.BlobStore {
 	if asset.BlobStoreID != "" {


### PR DESCRIPTION
Implements #323 for the first wave of formats: **npm** and **PyPI** — the two ecosystems where a freshly published malicious version is most likely to reach developers before detection. The same protection exists in Nexus Repository + Firewall (age-based quarantine) and Artifactory Curation (immature-package policy).

## Behavior

`proxy_config["minimum_package_age"]` (seconds, same convention as `metadata_max_age`; absent/0 = disabled — existing proxies are untouched). With `604800` (7 days) configured and an upstream holding `foo@2.0.0` published 2 hours ago, that version is invisible until it turns 7 days old, while older versions serve normally.

Enforced at **both** layers, so a direct URL can't bypass the metadata filter:

- **npm**: the packument filter removes young versions from `versions`/`time` and remaps `dist-tags` to the newest surviving version (a dangling `latest` would break `npm install` outright). The tarball path answers 403 for a young version, using the proxy's own cached packument for the date (no extra upstream round-trip per download) and falling back to an upstream fetch.
- **PyPI**: file anchors younger than the cutoff are filtered from the simple page, and direct `/packages/` downloads answer 403. Dates come from a separate upstream **PEP 691 JSON** request (`upload-time`, PEP 700) — the PEP 503 HTML page the pipeline serves carries none; #191's force-HTML invariant is preserved and pinned by a dedicated test. Per-package date maps are cached for the repository's metadata TTL.

**Hybrid failure mode** (as agreed): a version/file without a date inside a *dated* document fails closed (hidden/refused — this also covers a version published after the cached metadata was taken); an upstream that provides **no dates at all** (e.g. an HTML-only PyPI index) leaves the policy unapplied, with the gap logged — hiding the entire repository would be worse than no policy.

## UI

The create wizard and the repository settings modal expose "Minimum package age (days)" for npm/PyPI proxies; the operator types days, the config stores seconds. Blank disables.

## Out of scope (as discussed)

Maven Central and Cargo publish no dates in their metadata — supporting them needs per-artifact `Last-Modified` probing and a date cache; a later wave if wanted.

## Tests

All written first and observed failing:

- `MinimumPackageAge` config parsing (disabled-by-default semantics vs `MetadataMaxAge`'s positive fallback).
- npm: packument filter unit tests (young hidden, dist-tag remap, undated-version fail-closed, no-dates skip, all-young → empty) + handler-level policy tests (metadata filtered, young tarball 403 with zero upstream tarball fetches, old tarball serves, no-dates hybrid, disabled default).
- PyPI: handler-level policy tests (simple page filtered, young file 403 with zero upstream file fetches, old file serves, HTML-only upstream skips policy, served page stays HTML per #191, disabled default).
- UI: the settings modal round-trips the field as seconds.

Backend suite green (the one webhook-handler failure is the known sandbox network restriction), frontend 536/536, eslint/tsc clean.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma