### PR TITLE
fix(npm): scoped packages through a proxy — stop double-escaping the upstream path

### DIFF
--- a/internal/formats/npm/age_policy_test.go
+++ b/internal/formats/npm/age_policy_test.go
@@ -192,3 +192,31 @@ func TestNPM_AgePolicy_OldPrereleaseTarballServes(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code,
 		"a 90-day-old prerelease must serve: %d %s", w.Code, w.Body.String())
 }
+
+// Scoped packages reach upstream as "@scope%2Fname" (one escape). Found live:
+// JoinURL re-escaped the "%" into "%252F" and registry.npmjs.org answered 405
+// for every scoped package pulled through a proxy.
+func TestNPM_Proxy_ScopedMetadata_SingleEscapeUpstream(t *testing.T) {
+	var gotURI string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURI = r.RequestURI
+		if r.RequestURI != "/@types%2Fnode" {
+			// Mimic registry.npmjs.org: anything else (double-escaped included)
+			// is not a package route.
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"name":"@types/node","dist-tags":{"latest":"1.0.0"},"versions":{"1.0.0":{"name":"@types/node","version":"1.0.0"}}}`))
+	}))
+	t.Cleanup(srv.Close)
+	r, _ := proxySetup(srv)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/npm-proxy/@types/node", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code,
+		"scoped metadata failed (upstream saw %q): %d %s", gotURI, w.Code, w.Body.String())
+	assert.Equal(t, "/@types%2Fnode", gotURI)
+	assert.Contains(t, w.Body.String(), `"@types/node"`)
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -117,6 +117,17 @@ func JoinURL(remoteBase, repoRelativePath string) (string, error) {
 	suffix := strings.Trim(repoRelativePath, "/")
 	merged := path.Join(strings.TrimSuffix(u.Path, "/"), suffix)
 	u.Path = "/" + strings.TrimPrefix(merged, "/")
+	// A caller may hand over a pre-escaped segment — NPMMetadataPath encodes a
+	// scoped package as "@scope%2Fname". Serializing that from Path alone would
+	// escape the "%" again ("%252F"), a URL registry.npmjs.org answers with 405.
+	// When the merged path IS a valid encoding, record it as the raw form and
+	// keep the decoded form in Path, so String() emits it exactly once-escaped.
+	// A stray "%" that is not a valid escape fails PathUnescape and keeps
+	// today's escape-once behavior.
+	if unescaped, uerr := url.PathUnescape(u.Path); uerr == nil && unescaped != u.Path {
+		u.RawPath = u.Path
+		u.Path = unescaped
+	}
 	return u.String(), nil
 }
 

--- a/internal/formats/repoproxy/repoproxy_extra_test.go
+++ b/internal/formats/repoproxy/repoproxy_extra_test.go
@@ -373,8 +373,14 @@ func TestServeGET_UpstreamPathOverride(t *testing.T) {
 	// When upstreamPath is set, that path should be fetched but cache key uses repoRelativePath.
 	const body = "scoped npm meta"
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Should be called with the upstream path, not the repo-relative path.
-		assert.Equal(t, "/@babel%2Fcore", r.URL.Path)
+		// Should be called with the upstream path, not the repo-relative path —
+		// and escaped exactly once on the wire. The old assertion checked
+		// r.URL.Path (the DECODED path) against "/@babel%2Fcore", which only
+		// held while the wire carried the double-escaped "/@babel%252Fcore" —
+		// the very bug that made registry.npmjs.org answer 405 for every
+		// scoped package.
+		assert.Equal(t, "/@babel%2Fcore", r.RequestURI)
+		assert.Equal(t, "/@babel/core", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprint(w, body)

--- a/internal/formats/repoproxy/repoproxy_test.go
+++ b/internal/formats/repoproxy/repoproxy_test.go
@@ -58,6 +58,22 @@ func TestJoinURL(t *testing.T) {
 	}
 }
 
+// A pre-escaped segment must survive serialization intact: NPMMetadataPath
+// hands over "@scope%2Fname", and re-escaping the "%" turns it into
+// "@scope%252Fname" — a URL registry.npmjs.org answers with 405, which broke
+// every scoped package through an npm proxy.
+func TestJoinURL_PreservesPreEscapedSegments(t *testing.T) {
+	got, err := repoproxy.JoinURL("https://registry.npmjs.org/", "@types%2Fnode")
+	require.NoError(t, err)
+	assert.Equal(t, "https://registry.npmjs.org/@types%2Fnode", got)
+
+	// A literal "%" that is NOT a valid escape keeps today's behavior: it is
+	// escaped once so the URL stays parseable.
+	got, err = repoproxy.JoinURL("https://repo.example.com", "/odd%file.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "https://repo.example.com/odd%25file.txt", got)
+}
+
 // ── RejectMutation ───────────────────────────────────────────────
 
 func TestRejectMutation_ProxyPUT(t *testing.T) {


### PR DESCRIPTION
Found live while verifying #323 against registry.npmjs.org: **every scoped-package request through an npm proxy answered 405** — `GET /repository/<proxy>/@types/node` never worked.

## Cause

`NPMMetadataPath` encodes a scoped package as `@scope%2Fname`, and `JoinURL` put that into `url.URL.Path`. `URL.String()` escapes the path from scratch, so the `%` was escaped again and the wire carried `@scope%252Fname` — a URL registry.npmjs.org rejects with 405.

The bug was invisible to the test suite because `TestServeGET_UpstreamPathOverride` asserted on `r.URL.Path` — the **decoded** path — which equals `/@babel%2Fcore` precisely when the wire is double-escaped. The test pinned the bug as the expected behavior; it now asserts the `RequestURI` on the wire (`/@babel%2Fcore`) and the decoded path (`/@babel/core`) separately.

## Fix

When the merged path is a valid encoding, `JoinURL` records it as `RawPath` and keeps the decoded form in `Path`, so serialization emits it exactly once-escaped. A stray `%` that is not a valid escape fails `PathUnescape` and keeps today's escape-once behavior (covered by a test).

## Tests

- `TestJoinURL_PreservesPreEscapedSegments` (RED first: produced `%252F`) — including the stray-`%` behavior guard.
- `TestNPM_Proxy_ScopedMetadata_SingleEscapeUpstream` (RED first: upstream saw `/@types%252Fnode`, got 405) — a fake upstream that, like the real registry, only answers the once-escaped route.
- `TestServeGET_UpstreamPathOverride` updated as described.

Live-verified against registry.npmjs.org: `@types/node` metadata through a proxy answers 200 with 2,356 versions (was 405), and the #323 minimum-package-age policy correctly hides its two <7-day versions and remaps `latest`.

Full suite green (the webhook-handler failure is the known sandbox network restriction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma