### PR TITLE
fix(migration): translate the Nexus action vocabulary; migrate content selectors

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -320,6 +320,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		Roles:         roleRepo,
 		Privileges:    privilegeRepo,
 		RoutingRules:  rrRepo,
+		Selectors:     selectorSvc,
 		Deps:          formatDeps,
 		JWTSecret:     cfg.Auth.JWTSecret,
 		EncryptionKey: cfg.Auth.EncryptionKeyBytes(),

--- a/internal/nexusclient/client.go
+++ b/internal/nexusclient/client.go
@@ -87,6 +87,14 @@ type Privilege struct {
 	Attrs       map[string]any
 }
 
+// ContentSelector is a CSEL content selector: a named expression that scopes
+// repository-content-selector privileges to a subset of a repository's paths.
+type ContentSelector struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Expression  string `json:"expression"`
+}
+
 // RoutingRule is a request routing rule (ALLOW or BLOCK plus regex matchers).
 type RoutingRule struct {
 	Name        string
@@ -425,6 +433,17 @@ func (c *Client) ListRoles(ctx context.Context) ([]Role, error) {
 // Nexus returns is type-specific and kept in Attrs.
 var privilegeIdentityFields = map[string]bool{
 	"name": true, "description": true, "type": true, "readOnly": true,
+}
+
+// ListContentSelectors returns every content selector on the source. A
+// repository-content-selector privilege is unusable without the selector it
+// names, so the migration re-creates these first.
+func (c *Client) ListContentSelectors(ctx context.Context) ([]ContentSelector, error) {
+	var out []ContentSelector
+	if err := c.getJSON(ctx, "/service/rest/v1/security/content-selectors", &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // ListPrivileges returns every security privilege with its type-specific

--- a/internal/service/nexus_migration_internal_test.go
+++ b/internal/service/nexus_migration_internal_test.go
@@ -1,0 +1,34 @@
+package service
+
+import "testing"
+
+// translateNexusSelectorExpression: Nexus's CSEL dialect → the CEL dialect
+// selectors are evaluated under here (#342).
+func TestTranslateNexusSelectorExpression(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain CEL untouched",
+			`format == "maven2" && path.startsWith("/org/")`,
+			`format == "maven2" && path.startsWith("/org/")`},
+		{"=~ becomes matches()",
+			`path =~ ".*-SNAPSHOT.*"`,
+			`path.matches(".*-SNAPSHOT.*")`},
+		{"backslash doubled into a valid CEL literal",
+			`format == "maven2" && path =~ ".*maven-metadata\.xml.*"`,
+			`format == "maven2" && path.matches(".*maven-metadata\\.xml.*")`},
+		{"multiple occurrences",
+			`path =~ "a\d+" || path =~ "b"`,
+			`path.matches("a\\d+") || path.matches("b")`},
+		{"no spaces around operator",
+			`path=~"x"`,
+			`path.matches("x")`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := translateNexusSelectorExpression(tc.in); got != tc.want {
+				t.Fatalf("translate(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -87,6 +87,10 @@ type NexusMigrationConfig struct {
 	Roles        repository.RoleRepo
 	Privileges   repository.PrivilegeRepo
 	RoutingRules repository.RoutingRuleRepo
+	// Selectors re-creates the source's content selectors (and validates their
+	// translated CEL), so repository-content-selector privileges can resolve
+	// the selector they name instead of failing the DB constraint.
+	Selectors *ContentSelectorService
 	// Deps is the storage waist every format handler writes through; the
 	// migration ingests assets the same way an upload does.
 	Deps formats.Deps
@@ -114,6 +118,7 @@ type NexusMigrationService struct {
 	roles        repository.RoleRepo
 	privileges   repository.PrivilegeRepo
 	routingRules repository.RoutingRuleRepo
+	selectors    *ContentSelectorService
 	deps         formats.Deps
 	log          logger.Logger
 
@@ -135,6 +140,7 @@ func NewNexusMigrationService(cfg NexusMigrationConfig) *NexusMigrationService {
 		roles:        cfg.Roles,
 		privileges:   cfg.Privileges,
 		routingRules: cfg.RoutingRules,
+		selectors:    cfg.Selectors,
 		deps:         cfg.Deps,
 		log:          cfg.Log,
 		newClient:    cfg.HTTPClientFor,
@@ -873,6 +879,14 @@ func ociManifestPath(raw string) (ociPath, bool) {
 func (s *NexusMigrationService) migratePrivileges(ctx context.Context, client *nexusclient.Client, p *progress) error {
 	bg := context.Background()
 
+	// Content selectors first: a repository-content-selector privilege is
+	// rejected by the DB outright unless it names its selector, so without
+	// this every such privilege fails with a raw constraint violation (#342).
+	selectorIDs, err := s.migrateContentSelectors(ctx, client, p)
+	if err != nil {
+		return err
+	}
+
 	source, err := client.ListPrivileges(ctx)
 	if err != nil {
 		return fmt.Errorf("list privileges on the source Nexus: %w", err)
@@ -898,6 +912,15 @@ func (s *NexusMigrationService) migratePrivileges(ctx context.Context, client *n
 			Type:        privType,
 			Attrs:       normalizePrivilegeAttrs(src.Attrs),
 		}
+		if privType == domain.PrivilegeTypeRepositoryContentSelector {
+			selName, _ := src.Attrs["contentSelector"].(string)
+			id, ok := selectorIDs[selName]
+			if !ok {
+				p.fail(bg, "privilege %q: content selector %q was not migrated (missing on the source, or its expression could not be translated)", src.Name, selName)
+				continue
+			}
+			priv.ContentSelectorID = &id
+		}
 		if err := s.privileges.Create(ctx, priv); err != nil {
 			p.fail(bg, "privilege %q: %v", src.Name, err)
 		}
@@ -905,8 +928,95 @@ func (s *NexusMigrationService) migratePrivileges(ctx context.Context, client *n
 	return nil
 }
 
-// normalizePrivilegeAttrs lowercases the action names. Nexus reports them
-// uppercase ("READ"); every check here compares against lowercase.
+// migrateContentSelectors re-creates the source's content selectors and
+// returns a name→ID map for resolving privileges. A selector whose expression
+// cannot be translated or validated is a per-item failure, not fatal.
+func (s *NexusMigrationService) migrateContentSelectors(ctx context.Context, client *nexusclient.Client, p *progress) (map[string]string, error) {
+	bg := context.Background()
+	ids := make(map[string]string)
+	if s.selectors == nil {
+		return ids, nil
+	}
+	source, err := client.ListContentSelectors(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list content selectors on the source Nexus: %w", err)
+	}
+	existing, err := s.selectors.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list local content selectors: %w", err)
+	}
+	byName := make(map[string]string, len(existing))
+	for _, sel := range existing {
+		byName[sel.Name] = sel.ID
+	}
+	for _, src := range source {
+		if err := checkPaused(ctx); err != nil {
+			return nil, err
+		}
+		if id, ok := byName[src.Name]; ok {
+			ids[src.Name] = id // idempotent re-run
+			continue
+		}
+		sel := &domain.ContentSelector{
+			Name:        src.Name,
+			Description: src.Description,
+			Expression:  translateNexusSelectorExpression(src.Expression),
+		}
+		// Create validates against the exact CEL environment selectors are
+		// evaluated under later, so a migrated selector is guaranteed to still
+		// compile when it matters.
+		if err := s.selectors.Create(ctx, sel); err != nil {
+			p.fail(bg, "content selector %q: %v", src.Name, err)
+			continue
+		}
+		ids[src.Name] = sel.ID
+	}
+	return ids, nil
+}
+
+// nexusSelectorRegexRe matches Nexus's "field =~ \"regex\"" — a Sonatype
+// extension to CEL for regex match, a hard syntax error in plain CEL.
+var nexusSelectorRegexRe = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_.]*)\s*=~\s*"([^"]*)"`)
+
+// translateNexusSelectorExpression rewrites a Nexus CSEL expression into the
+// CEL dialect selectors are evaluated under here. Two divergences matter on
+// real data (#342):
+//
+//   - `field =~ "regex"` becomes `field.matches("regex")`.
+//   - Nexus's grammar passes a backslash straight through as a regex escape
+//     (`\.` for a literal dot) — never an escape in its own string literal.
+//     CEL disagrees: `\.` is a hard syntax error, and `\\` is the only way to
+//     spell one literal backslash. Every backslash inside the captured
+//     literal is doubled, which decodes back to exactly the regex Nexus meant.
+//
+// Anything else passes through unchanged; validation happens at Create.
+func translateNexusSelectorExpression(expr string) string {
+	return nexusSelectorRegexRe.ReplaceAllStringFunc(expr, func(m string) string {
+		sub := nexusSelectorRegexRe.FindStringSubmatch(m)
+		pattern := strings.ReplaceAll(sub[2], `\`, `\\`)
+		return sub[1] + `.matches("` + pattern + `")`
+	})
+}
+
+// nexusActionVocabulary maps Nexus's action names onto the four actions this
+// RBAC engine understands (actionAllowed compares exact lowercase strings).
+// "add" and "edit" are both write; an untranslated one silently strips
+// push/delete rights from every migrated account (#342).
+var nexusActionVocabulary = map[string]string{
+	"read":   "read",
+	"browse": "browse",
+	"add":    "write",
+	"edit":   "write",
+	"delete": "delete",
+}
+
+// nexusActionAll is what Nexus's "all" expands to.
+var nexusActionAll = []string{"read", "browse", "write", "delete"}
+
+// normalizePrivilegeAttrs lowercases the action names and translates Nexus's
+// vocabulary (add/edit → write, all → every action). Nexus reports them
+// uppercase ("READ"); every check here compares against lowercase. An
+// unrecognized action is kept as-is rather than silently dropped.
 func normalizePrivilegeAttrs(attrs map[string]any) map[string]any {
 	out := make(map[string]any, len(attrs))
 	for k, v := range attrs {
@@ -919,11 +1029,31 @@ func normalizePrivilegeAttrs(attrs map[string]any) map[string]any {
 			out[k] = v
 			continue
 		}
+		seen := make(map[string]bool, len(raw))
 		actions := make([]string, 0, len(raw))
-		for _, item := range raw {
-			if s, ok := item.(string); ok {
-				actions = append(actions, strings.ToLower(s))
+		add := func(a string) {
+			if !seen[a] {
+				seen[a] = true
+				actions = append(actions, a)
 			}
+		}
+		for _, item := range raw {
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			lower := strings.ToLower(s)
+			if lower == "all" || lower == "*" {
+				for _, a := range nexusActionAll {
+					add(a)
+				}
+				continue
+			}
+			if translated, ok := nexusActionVocabulary[lower]; ok {
+				add(translated)
+				continue
+			}
+			add(lower)
 		}
 		out[k] = actions
 	}

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -28,11 +28,11 @@ import (
 // fakeNexus serves the slice of the Nexus OSS REST API the migration reads.
 // Every field is a raw JSON body; empty means "endpoint returns an empty list".
 type fakeNexus struct {
-	settings     string            // /service/rest/v1/repositorySettings
-	settingsCode int               // non-zero forces this status instead of settings
-	repositories string            // /service/rest/v1/repositories
-	components   map[string]string // repository name → one full component page
-	files        map[string]string // /repository/... path → body
+	settings         string            // /service/rest/v1/repositorySettings
+	settingsCode     int               // non-zero forces this status instead of settings
+	repositories     string            // /service/rest/v1/repositories
+	components       map[string]string // repository name → one full component page
+	files            map[string]string // /repository/... path → body
 	users            string
 	roles            string
 	privileges       string

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -33,10 +33,11 @@ type fakeNexus struct {
 	repositories string            // /service/rest/v1/repositories
 	components   map[string]string // repository name → one full component page
 	files        map[string]string // /repository/... path → body
-	users        string
-	roles        string
-	privileges   string
-	routingRules string
+	users            string
+	roles            string
+	privileges       string
+	routingRules     string
+	contentSelectors string
 	// onFile, when set, runs before an artifact byte is served. It lets a test
 	// hold the run inside a download and act while it is demonstrably in flight.
 	onFile func()
@@ -86,6 +87,8 @@ func (f *fakeNexus) start(t *testing.T) *httptest.Server {
 			_, _ = io.WriteString(w, orEmptyList(f.roles))
 		case r.URL.Path == "/service/rest/v1/security/privileges":
 			_, _ = io.WriteString(w, orEmptyList(f.privileges))
+		case r.URL.Path == "/service/rest/v1/security/content-selectors":
+			_, _ = io.WriteString(w, orEmptyList(f.contentSelectors))
 		case r.URL.Path == "/service/rest/v1/routing-rules":
 			_, _ = io.WriteString(w, orEmptyList(f.routingRules))
 		case strings.HasPrefix(r.URL.Path, "/repository/"):
@@ -179,6 +182,7 @@ type migHarness struct {
 	roles      *testutil.RoleRepo
 	privileges *testutil.PrivilegeRepo
 	rules      *testutil.RoutingRuleRepo
+	csRepo     *testutil.ContentSelectorRepo
 	nexus      *httptest.Server
 }
 
@@ -213,8 +217,11 @@ func newMigHarness(t *testing.T, fake *fakeNexus, existingUsers ...*domain.User)
 		roles:      testutil.NewRoleRepo(),
 		privileges: testutil.NewPrivilegeRepo(),
 		rules:      testutil.NewRoutingRuleRepo(),
+		csRepo:     testutil.NewContentSelectorRepo(),
 		nexus:      srv,
 	}
+	selectorSvc, err := service.NewContentSelectorService(h.csRepo)
+	require.NoError(t, err)
 
 	h.svc = service.NewNexusMigrationService(service.NexusMigrationConfig{
 		Jobs:          h.jobs,
@@ -223,6 +230,7 @@ func newMigHarness(t *testing.T, fake *fakeNexus, existingUsers ...*domain.User)
 		Roles:         h.roles,
 		Privileges:    h.privileges,
 		RoutingRules:  h.rules,
+		Selectors:     selectorSvc,
 		Deps:          deps,
 		JWTSecret:     "unit-test-secret",
 		Log:           zap.NewNop().Sugar(),
@@ -639,6 +647,87 @@ func TestNexusMigration_MigratesPrivilegesSkippingBuiltins(t *testing.T) {
 
 	_, err = h.privileges.GetByName(ctx, "nx-all")
 	assert.Error(t, err, "Nexus built-in privileges are not copied")
+}
+
+// #342/2: Nexus's action vocabulary (add/edit/all) must translate into the
+// four actions this RBAC engine understands, or migrated accounts silently
+// lose their push/delete/admin rights.
+func TestNexusMigration_TranslatesPrivilegeActionVocabulary(t *testing.T) {
+	fake := &fakeNexus{
+		privileges: `[
+			{"type":"repository-view","name":"push-maven","description":"","readOnly":false,
+			 "format":"maven2","repository":"r","actions":["ADD","EDIT"]},
+			{"type":"repository-admin","name":"admin-maven","description":"","readOnly":false,
+			 "format":"maven2","repository":"r","actions":["ALL","READ"]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	ctx := context.Background()
+	push, err := h.privileges.GetByName(ctx, "push-maven")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"write"}, push.Attrs["actions"],
+		"add and edit both mean write — translated and deduplicated")
+
+	admin, err := h.privileges.GetByName(ctx, "admin-maven")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"read", "browse", "write", "delete"}, admin.Attrs["actions"],
+		"all expands to every action, without doubling the explicit read")
+}
+
+// #342/6: repository-content-selector privileges are unusable without the
+// selector they name — the selectors must be re-created first (with Nexus's
+// "=~" regex operator and its raw-backslash literals translated to CEL), and
+// each privilege's ContentSelectorID resolved, or every one of them fails the
+// DB constraint with an opaque error.
+func TestNexusMigration_MigratesContentSelectorsAndResolvesPrivileges(t *testing.T) {
+	fake := &fakeNexus{
+		contentSelectors: `[
+			{"name":"meta-files","type":"csel","description":"metadata only",
+			 "expression":"format == \"maven2\" && path =~ \".*maven-metadata\\.xml.*\""}
+		]`,
+		privileges: `[
+			{"type":"repository-content-selector","name":"cs-priv","description":"","readOnly":false,
+			 "contentSelector":"meta-files","repository":"*","actions":["READ"]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount, "nothing may fail: %v", done.LastError)
+
+	ctx := context.Background()
+	sel, err := h.csRepo.GetByName(ctx, "meta-files")
+	require.NoError(t, err, "the source's content selector must be re-created here")
+	assert.Equal(t, `format == "maven2" && path.matches(".*maven-metadata\\.xml.*")`, sel.Expression,
+		"Nexus's =~ becomes CEL matches(), and the raw backslash is doubled into a valid CEL literal")
+
+	priv, err := h.privileges.GetByName(ctx, "cs-priv")
+	require.NoError(t, err, "the privilege must migrate now that its selector exists")
+	require.NotNil(t, priv.ContentSelectorID)
+	assert.Equal(t, sel.ID, *priv.ContentSelectorID)
+}
+
+// A privilege naming a selector the source does not define fails as that one
+// item, with an error that names the selector — not a raw DB constraint.
+func TestNexusMigration_ContentSelectorPrivilegeWithUnknownSelectorFailsClearly(t *testing.T) {
+	fake := &fakeNexus{
+		privileges: `[
+			{"type":"repository-content-selector","name":"orphan-priv","description":"","readOnly":false,
+			 "contentSelector":"no-such-selector","repository":"*","actions":["READ"]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	_, err := h.privileges.GetByName(context.Background(), "orphan-priv")
+	assert.Error(t, err, "a privilege with no resolvable selector cannot be created")
+	require.NotNil(t, done.LastError)
+	assert.Contains(t, *done.LastError, "no-such-selector",
+		"the failure must name the missing selector, not a database constraint")
 }
 
 func TestNexusMigration_MigratesRolesInDependencyOrderAndFlattensNesting(t *testing.T) {

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -2206,6 +2206,12 @@ func (r *PrivilegeRepo) Create(_ context.Context, p *domain.Privilege) error {
 	if r.Err != nil {
 		return r.Err
 	}
+	// Mirror migration 007's check constraint: a repository-content-selector
+	// privilege must name its selector. A mock that accepts the row hides
+	// exactly the failure every such privilege hits against real Postgres.
+	if p.Type == domain.PrivilegeTypeRepositoryContentSelector && (p.ContentSelectorID == nil || *p.ContentSelectorID == "") {
+		return fmt.Errorf(`new row for relation "privileges" violates check constraint "privileges_selector_required"`)
+	}
 	if p.ID == "" {
 		p.ID = fmt.Sprintf("priv-%d", len(r.data)+1)
 	}


### PR DESCRIPTION
Items **2** and **6** of #342 — the two silent RBAC regressions, implemented per the issue's verified designs.

## Item 2 — action-vocabulary mismatch

`normalizePrivilegeAttrs` only lowercased; `actionAllowed` compares the exact strings `read`/`browse`/`write`/`delete`. A migrated `add`/`edit` (push) or `all` (admin) privilege granted nothing — `mvn deploy` got 403 with the migration reporting success. Now: `add`/`edit` → `write`, `all` (and `*`) expands to all four actions, everything deduplicated (`["ALL","READ"]` doesn't double `read`), unrecognized actions kept as-is rather than silently dropped.

## Item 6 — content selectors never migrated

Nothing listed the source's selectors, so every `repository-content-selector` privilege failed the `privileges_selector_required` check constraint with raw Postgres text (68/73 on the reporter's real instance). The privileges stage now:

- lists the source's `/security/content-selectors` (new `nexusclient.ListContentSelectors`),
- translates each expression from the Nexus CSEL dialect: `field =~ "regex"` → `field.matches("regex")`, with every raw backslash inside the literal doubled — Nexus's grammar passes `\.` straight through as a regex escape, while CEL rejects it and demands `\\` (the reporter's real `.*maven-metadata\.xml.*` selector is a test case),
- creates each through `ContentSelectorService.Create`, which validates against the exact CEL environment selectors are evaluated under later,
- resolves each privilege's `ContentSelectorID` by name; an unresolvable selector fails that one privilege with an error naming the selector, not a constraint dump.

Idempotent re-runs reuse existing selectors by name. The migration service takes the selector service as a dependency (wired in the router); a nil dependency degrades to the old behavior.

## Why the suite never saw this

The testutil `PrivilegeRepo` accepted any row; real Postgres refuses a selector-typed privilege without its selector. The mock now mirrors the constraint (the same mock-vs-SQL divergence lesson as #250), which is what made an honest failing test possible.

## Tests

Written first and observed failing:

- `TestNexusMigration_TranslatesPrivilegeActionVocabulary` (was `["add","edit"]` verbatim)
- `TestNexusMigration_MigratesContentSelectorsAndResolvesPrivileges` (selector absent, privilege failed the mirrored constraint)
- `TestNexusMigration_ContentSelectorPrivilegeWithUnknownSelectorFailsClearly` (error named the constraint, not the selector)
- `TestTranslateNexusSelectorExpression` unit cases: plain CEL untouched, `=~` rewrite, backslash doubling, multiple occurrences, no-space operator

Full suite green (the webhook-handler failure is the known sandbox network restriction).

Part of #342 (items 1, 3–5, 7–10 follow in separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma