### PR TITLE
fix(migration): independent stages, blocking Pause, guarded Resume, sealed-credential errors

### DIFF
--- a/internal/domain/migration.go
+++ b/internal/domain/migration.go
@@ -57,3 +57,10 @@ type MigrationJob struct {
 func (j MigrationJob) IsActive() bool {
 	return j.Status == MigrationPending || j.Status == MigrationRunning
 }
+
+// IsResumable reports whether Resume may relaunch the job: parked by an
+// operator, or failed and worth retrying after the cause is fixed. A finished
+// job is not — relaunching it would relist the entire source for nothing.
+func (j MigrationJob) IsResumable() bool {
+	return j.Status == MigrationPaused || j.Status == MigrationError
+}

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -129,6 +129,12 @@ type NexusMigrationService struct {
 
 	mu      sync.Mutex
 	cancels map[string]context.CancelFunc
+	// dones lets Pause block until the runner has actually unwound: the channel
+	// is created in launch and closed in run's deferred cleanup, AFTER the final
+	// status is written. Returning from Pause on cancel() alone raced Resume
+	// (a second overlapping run) and DeleteJob (deleting the row under a
+	// still-writing goroutine) — #342.
+	dones map[string]chan struct{}
 }
 
 // NewNexusMigrationService constructs the migration runner.
@@ -145,6 +151,7 @@ func NewNexusMigrationService(cfg NexusMigrationConfig) *NexusMigrationService {
 		log:          cfg.Log,
 		newClient:    cfg.HTTPClientFor,
 		cancels:      make(map[string]context.CancelFunc),
+		dones:        make(map[string]chan struct{}),
 	}
 	if s.newClient == nil {
 		s.newClient = netguard.Client
@@ -159,16 +166,19 @@ func NewNexusMigrationService(cfg NexusMigrationConfig) *NexusMigrationService {
 	return s
 }
 
-// SealPassword encrypts a Nexus password for storage on the job row.
-func (s *NexusMigrationService) SealPassword(plain string) string {
+// SealPassword encrypts a Nexus password for storage on the job row. The
+// error is real: swallowing it used to return "", indistinguishable from "no
+// password provided", and the job then authenticated with an empty credential
+// forever, failing every item with a misleading per-item error (#342).
+func (s *NexusMigrationService) SealPassword(plain string) (string, error) {
 	if plain == "" {
-		return ""
+		return "", nil
 	}
 	sealed, err := sealWithKey(s.primaryKey, plain)
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("seal the source credential: %w", err)
 	}
-	return sealed
+	return sealed, nil
 }
 
 // OpenPassword decrypts a stored source credential, falling back to the legacy
@@ -200,7 +210,11 @@ func (s *NexusMigrationService) Create(ctx context.Context, job *domain.Migratio
 	}
 	job.SourceURL = strings.TrimRight(strings.TrimSpace(job.SourceURL), "/")
 	job.Status = domain.MigrationPending
-	job.SourcePassword = s.SealPassword(password)
+	sealed, err := s.SealPassword(password)
+	if err != nil {
+		return err
+	}
+	job.SourcePassword = sealed
 
 	if err := s.jobs.Create(ctx, job); err != nil {
 		return err
@@ -209,8 +223,19 @@ func (s *NexusMigrationService) Create(ctx context.Context, job *domain.Migratio
 	return nil
 }
 
+// pauseUnwindCeiling caps how long Pause waits for the runner to unwind. The
+// runner reacts to cancellation within one aborted request in practice; the
+// ceiling only guards against a pathological source that ignores the closed
+// connection.
+const pauseUnwindCeiling = 30 * time.Second
+
 // Pause stops the run and parks the job. A job that is not running is parked
 // where it stands, so an operator can stop one before it ever starts.
+//
+// Pause returns only after the runner has actually unwound and written the
+// final state (#342): returning on cancel() alone let an immediate Resume
+// no-op against the still-registered run (or start a second overlapping one),
+// and let DeleteJob remove the row under a goroutine still writing progress.
 func (s *NexusMigrationService) Pause(ctx context.Context, id string) error {
 	job, err := s.jobs.Get(ctx, id)
 	if err != nil {
@@ -218,11 +243,20 @@ func (s *NexusMigrationService) Pause(ctx context.Context, id string) error {
 	}
 	s.mu.Lock()
 	cancel, running := s.cancels[id]
+	done := s.dones[id]
 	s.mu.Unlock()
 	if running {
 		// The runner writes the paused status when it unwinds, so progress
 		// recorded between here and there is not lost.
 		cancel()
+		if done != nil {
+			select {
+			case <-done:
+			case <-time.After(pauseUnwindCeiling):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 		return nil
 	}
 	if !job.IsActive() {
@@ -232,10 +266,16 @@ func (s *NexusMigrationService) Pause(ctx context.Context, id string) error {
 }
 
 // Resume starts a fresh pass over the job. Everything already migrated is
-// skipped, so resuming costs only the work that is left.
+// skipped, so resuming costs only the work that is left. Only a paused or
+// errored job is resumable (#342): a finished one would relist the entire
+// source for nothing, and Pause's status guard deserves a symmetric sibling.
 func (s *NexusMigrationService) Resume(ctx context.Context, id string) error {
-	if _, err := s.jobs.Get(ctx, id); err != nil {
+	job, err := s.jobs.Get(ctx, id)
+	if err != nil {
 		return err
+	}
+	if !job.IsResumable() {
+		return fmt.Errorf("%w: migration job is %s, not resumable", ErrInvalidInput, job.Status)
 	}
 	s.launch(id)
 	return nil
@@ -265,6 +305,7 @@ func (s *NexusMigrationService) launch(id string) {
 	//nolint:gosec // the run must outlive the request; cancel is stored below and always invoked in run's defer
 	ctx, cancel := context.WithCancel(context.Background())
 	s.cancels[id] = cancel
+	s.dones[id] = make(chan struct{})
 	s.mu.Unlock()
 
 	go s.run(ctx, id)
@@ -364,6 +405,12 @@ func (s *NexusMigrationService) run(ctx context.Context, jobID string) {
 			cancel()
 			delete(s.cancels, jobID)
 		}
+		// Closed AFTER the final status write below (this defer runs last):
+		// whoever unblocks from Pause reads the already-settled job.
+		if done, ok := s.dones[jobID]; ok {
+			close(done)
+			delete(s.dones, jobID)
+		}
 		s.mu.Unlock()
 	}()
 
@@ -410,20 +457,46 @@ func (s *NexusMigrationService) finish(ctx context.Context, jobID string, status
 }
 
 // runStages walks the fixed sequence. Each stage is gated by its own scope
-// flag, and each returns an error only when it cannot proceed at all —
-// per-item problems are counted on the job instead.
+// flag, tolerates per-item problems internally (counted on the job), and
+// returns a hard error only when it cannot proceed at all. A hard error in one
+// stage must not rob the independent stages after it of their chance to run —
+// on a real source, one broken LDAP record 500'd the users listing and
+// routing rules never even started (#342). Every stage failure is named and
+// collected; only a pause aborts the walk outright, because a pause must not
+// leave later stages half-done behind the operator's back.
 func (s *NexusMigrationService) runStages(ctx context.Context, client *nexusclient.Client,
 	job *domain.MigrationJob, p *progress,
 ) error {
 	bg := context.Background()
 
-	if job.MigrateRepos {
-		hosted, err := s.migrateRepositories(ctx, client, p)
-		if err != nil {
+	var stageErrs []error
+	runStage := func(name string, fn func() error) error {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, errMigrationPaused) {
 			return err
 		}
-		if job.MigrateBlobs {
-			if err := s.migrateAssets(ctx, client, hosted, p); err != nil {
+		stageErrs = append(stageErrs, fmt.Errorf("%s: %w", name, err))
+		return nil
+	}
+
+	if job.MigrateRepos {
+		var hosted []nexusclient.Repository
+		if err := runStage("repositories", func() error {
+			var e error
+			hosted, e = s.migrateRepositories(ctx, client, p)
+			return e
+		}); err != nil {
+			return err
+		}
+		// Blobs genuinely depend on the repository listing — hosted is empty
+		// when that stage failed hard, so there is nothing to transfer.
+		if job.MigrateBlobs && len(hosted) > 0 {
+			if err := runStage("blobs", func() error {
+				return s.migrateAssets(ctx, client, hosted, p)
+			}); err != nil {
 				return err
 			}
 		}
@@ -432,27 +505,30 @@ func (s *NexusMigrationService) runStages(ctx context.Context, client *nexusclie
 	// Privileges first: a role references them by name, so they must exist
 	// before the roles that name them are wired up.
 	if job.MigratePrivileges {
-		if err := s.migratePrivileges(ctx, client, p); err != nil {
+		if err := runStage("privileges", func() error { return s.migratePrivileges(ctx, client, p) }); err != nil {
 			return err
 		}
 	}
 	if job.MigrateRoles {
-		if err := s.migrateRoles(ctx, client, p); err != nil {
+		if err := runStage("roles", func() error { return s.migrateRoles(ctx, client, p) }); err != nil {
 			return err
 		}
 	}
 	if job.MigrateUsers {
-		if err := s.migrateUsers(ctx, client, p); err != nil {
+		if err := runStage("users", func() error { return s.migrateUsers(ctx, client, p) }); err != nil {
 			return err
 		}
 	}
 	if job.MigrateRoutingRules {
-		if err := s.migrateRoutingRules(ctx, client, p); err != nil {
+		if err := runStage("routing rules", func() error { return s.migrateRoutingRules(ctx, client, p) }); err != nil {
 			return err
 		}
 	}
 	p.flush(bg)
-	return checkPaused(ctx)
+	if err := checkPaused(ctx); err != nil {
+		return err
+	}
+	return errors.Join(stageErrs...)
 }
 
 func checkPaused(ctx context.Context) error {

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -34,6 +34,7 @@ type fakeNexus struct {
 	components       map[string]string // repository name → one full component page
 	files            map[string]string // /repository/... path → body
 	users            string
+	usersCode        int // non-zero forces this status on /security/users
 	roles            string
 	privileges       string
 	routingRules     string
@@ -82,6 +83,10 @@ func (f *fakeNexus) start(t *testing.T) *httptest.Server {
 			}
 			_, _ = io.WriteString(w, body)
 		case r.URL.Path == "/service/rest/v1/security/users":
+			if f.usersCode != 0 {
+				w.WriteHeader(f.usersCode)
+				return
+			}
 			_, _ = io.WriteString(w, orEmptyList(f.users))
 		case r.URL.Path == "/service/rest/v1/security/roles":
 			_, _ = io.WriteString(w, orEmptyList(f.roles))
@@ -836,6 +841,103 @@ func TestNexusMigration_ExistingUserIsSkipped(t *testing.T) {
 	assert.Equal(t, "old@example.com", h.users.get("jdoe").Email)
 }
 
+// #342/1: a hard failure in one stage must not abort the independent stages
+// after it. On the reporter's real instance a broken LDAP record 500'd the
+// whole /security/users listing — and routing rules, which depend on nothing
+// that failed, never even ran.
+func TestNexusMigration_StageFailureDoesNotAbortIndependentStages(t *testing.T) {
+	fake := &fakeNexus{
+		usersCode:    http.StatusInternalServerError,
+		privileges:   `[{"type":"application","name":"p-ok","description":"","readOnly":false,"domain":"d","actions":["read"]}]`,
+		routingRules: `[{"name":"block-x","description":"","mode":"BLOCK","matchers":["^/x/.*"]}]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	got := h.waitForStatus(t, job.ID, domain.MigrationError)
+
+	require.NotNil(t, got.LastError)
+	assert.Contains(t, *got.LastError, "users:",
+		"the stage failure is named, so an operator sees WHICH stage broke")
+
+	ctx := context.Background()
+	rule, err := h.rules.GetByName(ctx, "block-x")
+	require.NoError(t, err, "routing rules depend on nothing that failed — they must still run")
+	assert.Equal(t, "BLOCK", rule.Mode)
+	_, err = h.privileges.GetByName(ctx, "p-ok")
+	require.NoError(t, err, "the privileges stage before the failure keeps its result")
+}
+
+// #342/3: Pause must not return before the runner has actually unwound —
+// otherwise Pause→Resume can silently no-op or launch a second overlapping
+// run, and Pause→Delete can delete the row under a still-writing goroutine.
+func TestNexusMigration_PauseBlocksUntilTheRunUnwinds(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"raw-hosted": `{"items":[{"name":"a.txt","version":null,"group":"/","format":"raw","assets":[
+				{"path":"a.txt","downloadUrl":"%BASE%/repository/raw-hosted/a.txt",
+				 "contentType":"text/plain","fileSize":5}]}],"continuationToken":null}`,
+		},
+		files: map[string]string{"/repository/raw-hosted/a.txt": "hello"},
+		onFile: func() {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+		},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["raw-hosted"] = strings.ReplaceAll(fake.components["raw-hosted"], "%BASE%", h.nexus.URL)
+	defer close(release)
+
+	job := h.startJob(t)
+	<-entered // the run is demonstrably inside a download
+
+	require.NoError(t, h.svc.Pause(context.Background(), job.ID))
+
+	// No polling: by the time Pause returns, the runner must have unwound and
+	// written the final state.
+	got, err := h.jobs.Get(context.Background(), job.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.MigrationPaused, got.Status,
+		"Pause returned before the runner finished unwinding")
+}
+
+// #342/5: Resume relaunches only a paused or errored job. A done job must be
+// refused, not re-run through the whole pipeline.
+func TestNexusMigration_ResumeRefusesFinishedJobs(t *testing.T) {
+	fake := &fakeNexus{}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+	listings := fake.count("/service/rest/v1/repositorySettings")
+
+	err := h.svc.Resume(context.Background(), job.ID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not resumable")
+	assert.ErrorIs(t, err, service.ErrInvalidInput)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Equal(t, listings, fake.count("/service/rest/v1/repositorySettings"),
+		"a refused resume must not have relaunched the pipeline")
+}
+
+// The flip side: an errored job IS resumable — that is how an operator retries
+// after fixing the cause.
+func TestNexusMigration_ResumeRelaunchesErroredJobs(t *testing.T) {
+	fake := &fakeNexus{usersCode: http.StatusInternalServerError}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	h.waitForStatus(t, job.ID, domain.MigrationError)
+
+	fake.usersCode = 0 // the operator fixed the source
+	require.NoError(t, h.svc.Resume(context.Background(), job.ID))
+	h.waitForStatus(t, job.ID, domain.MigrationDone)
+}
+
 func TestNexusMigration_MigratesRoutingRules(t *testing.T) {
 	fake := &fakeNexus{
 		routingRules: `[
@@ -987,12 +1089,14 @@ func TestNexusMigration_ResumeAllRestartsInterruptedJobs(t *testing.T) {
 		MigrateRepos: true,
 	}
 	require.NoError(t, h.jobs.Create(ctx, job))
-	require.NoError(t, h.jobs.SetSourcePassword(ctx, job.ID, h.svc.SealPassword("s3cret")))
+	sealed, err := h.svc.SealPassword("s3cret")
+	require.NoError(t, err)
+	require.NoError(t, h.jobs.SetSourcePassword(ctx, job.ID, sealed))
 
 	require.NoError(t, h.svc.ResumeAll(ctx))
 	h.waitForStatus(t, job.ID, domain.MigrationDone)
 
-	_, err := h.repos.Get(ctx, "raw-hosted")
+	_, err = h.repos.Get(ctx, "raw-hosted")
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
Items **1, 3, 4 and 5** of #342 — the job-lifecycle group, implemented per the issue's verified designs.

## Item 1 — one failing stage aborted everything after it

The reporter's real instance reproduced this organically: a duplicate LDAP record 500'd `/security/users`, and routing rules — which depend on nothing that failed — never ran. `runStages` now runs each stage through a `runStage(name, fn)` helper that names the failure (`"users: …"`) and collects it instead of returning; `errors.Join` combines every stage failure into the job's final error (the job still ends in `error`). Only `errMigrationPaused` still aborts the walk immediately — a pause must not leave later stages half-done. Blobs remain nested under a successful repositories stage: that dependency is real. No schema change.

## Item 3 — Pause→Resume / Pause→Delete race

`Pause` returned right after `cancel()`, before the runner observed it: a near-simultaneous Resume no-op'ed against the still-registered run or launched a second overlapping one (the issue reproduced both live), and `DeleteJob` deleted the row under a goroutine still writing progress. `Pause` now blocks on a per-job `done` channel created in `launch` and closed in `run`'s deferred cleanup — **after** the final status write, so whoever unblocks reads the settled job. A 30s ceiling guards the pathological source that ignores a closed connection. `DeleteJob` (Pause-then-delete) is covered with no change of its own.

## Item 5 — Resume lacked Pause's status guard

`Resume` relaunched the entire pipeline on a `done` job. `MigrationJob.IsResumable()` (paused or error) now gates it with the same `ErrInvalidInput` shape `Pause` uses; an errored job stays resumable — that's the retry path after the operator fixes the cause (covered by a test that flips the source back to healthy and resumes to done).

## Item 4 — SealPassword swallowed encryption errors

A seal failure returned `""`, indistinguishable from "no password", and the job then authenticated with an empty credential forever — every item failing with a misleading per-item error. `SealPassword` returns `(string, error)`; `Create` propagates it. As in the issue, the underlying `crypto/rand` failure isn't externally forceable, so this one carries the signature-level guarantee plus the surrounding chain exercised by every other test.

## Tests

Written first; three observed failing, one as the explicit flip-side guard:

- `TestNexusMigration_StageFailureDoesNotAbortIndependentStages` (RED: routing rules never ran, error unnamed)
- `TestNexusMigration_PauseBlocksUntilTheRunUnwinds` (RED: status still `running` on the read right after Pause returned) — holds the run inside a real in-flight download via the fake source
- `TestNexusMigration_ResumeRefusesFinishedJobs` (RED: no error, pipeline relaunched)
- `TestNexusMigration_ResumeRelaunchesErroredJobs` (guard for the retry path)

Migration suite green under `-race`; full suite green (the webhook-handler failure is the known sandbox restriction).

Part of #342 (items 7–10 follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma