### PR TITLE
fix(migration): retry email collisions without the email; scope user migration to explicit realms

### DIFF
--- a/frontend/src/pages/MigrationPage.test.tsx
+++ b/frontend/src/pages/MigrationPage.test.tsx
@@ -300,6 +300,42 @@ describe('MigrationPage — test connection', () => {
       migratePrivileges: true,
       migrateRoles: true,
       migrateRoutingRules: false,
+      userRealms: ['default'],
     })
+  })
+
+  // #342/10: user migration is scoped to explicit realms, local by default;
+  // an opted-in external realm travels with the scope.
+  it('sends the user realms the operator opted into', async () => {
+    const user = userEvent.setup()
+    let posted: { scope?: { userRealms?: string[] } } | null = null
+    server.use(
+      http.post('/api/v1/migration/jobs', async ({ request }) => {
+        posted = (await request.json()) as { scope?: { userRealms?: string[] } }
+        return HttpResponse.json({ id: 'new-job' }, { status: 201 })
+      }),
+    )
+    await openModal(user)
+
+    await user.type(screen.getByPlaceholderText('https://nexus.example.com'), 'https://src.example.com')
+    const pwd = document.querySelector('input[type="password"]') as HTMLInputElement
+    await user.type(pwd, 'secret')
+
+    expect(screen.getByRole('checkbox', { name: 'Local' })).toBeChecked()
+    await user.click(screen.getByRole('checkbox', { name: 'LDAP' }))
+
+    const submit = pwd.closest('form')!.querySelector('button[type="submit"]') as HTMLButtonElement
+    await user.click(submit)
+
+    await waitFor(() => expect(posted).toBeTruthy())
+    expect(posted!.scope!.userRealms).toEqual(['default', 'LDAP'])
+  })
+
+  it('hides the realm picker when user migration is off', async () => {
+    const user = userEvent.setup()
+    await openModal(user)
+    expect(screen.getByText('User realms')).toBeInTheDocument()
+    await user.click(screen.getByRole('checkbox', { name: /Users/ }))
+    expect(screen.queryByText('User realms')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/pages/MigrationPage.tsx
+++ b/frontend/src/pages/MigrationPage.tsx
@@ -154,11 +154,22 @@ const SCOPES = [
 
 type ScopeKey = (typeof SCOPES)[number]['key']
 
+/** Source realms user migration can pull accounts from ("default" = local).
+ *  Local-only by default: an external account migrated onto a fresh target is
+ *  a permanently-unusable login unless its provider is already configured. */
+const USER_REALMS = [
+  { key: 'default', label: 'Local' },
+  { key: 'LDAP', label: 'LDAP' },
+  { key: 'OIDC', label: 'OIDC' },
+  { key: 'SAML', label: 'SAML' },
+] as const
+
 function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
   const [form, setForm] = useState({ sourceUrl: '', username: 'admin', password: '', concurrency: '4' })
   const [scope, setScope] = useState<Record<ScopeKey, boolean>>(
     () => Object.fromEntries(SCOPES.map(s => [s.key, true])) as Record<ScopeKey, boolean>,
   )
+  const [userRealms, setUserRealms] = useState<string[]>(['default'])
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [testing, setTesting] = useState(false)
@@ -174,6 +185,9 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
   }
 
   const toggleScope = (k: ScopeKey) => () => setScope(s => ({ ...s, [k]: !s[k] }))
+
+  const toggleRealm = (realm: string) => () =>
+    setUserRealms(r => (r.includes(realm) ? r.filter(x => x !== realm) : [...r, realm]))
 
   const handleTest = async () => {
     setPreview(null)
@@ -202,7 +216,7 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
         sourceUrl: form.sourceUrl,
         credentials: { username: form.username, password: form.password },
         options: { concurrency: parseInt(form.concurrency) || 4 },
-        scope,
+        scope: { ...scope, userRealms },
       })
       onCreated()
     } catch (err) {
@@ -270,6 +284,22 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
             ))}
           </div>
         </div>
+        {scope.migrateUsers && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>User realms</label>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '6px 12px' }}>
+              {USER_REALMS.map(r => (
+                <label key={r.key} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: 'var(--holo-text)', cursor: 'pointer' }}>
+                  <input type="checkbox" checked={userRealms.includes(r.key)} onChange={toggleRealm(r.key)} />
+                  {r.label}
+                </label>
+              ))}
+            </div>
+            <span style={{ fontSize: 11, color: 'var(--holo-text-faint)' }}>
+              An external realm (LDAP/OIDC/SAML) only makes sense when the matching provider is already configured here.
+            </span>
+          </div>
+        )}
         {error && <div style={{ background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.25)', borderRadius: 8, padding: '10px 12px', color: '#fca5a5', fontSize: 13 }}>{error}</div>}
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 8 }}>
           <HoloButton type="button" onClick={onClose}>Cancel</HoloButton>

--- a/internal/api/handlers/migration.go
+++ b/internal/api/handlers/migration.go
@@ -27,27 +27,28 @@ func NewMigrationHandler(repo repository.MigrationRepo, svc *service.NexusMigrat
 }
 
 type migrationJobResp struct {
-	ID                  string  `json:"id"`
-	SourceURL           string  `json:"sourceUrl"`
-	SourceUser          string  `json:"sourceUser"`
-	Status              string  `json:"status"`
-	MigrateRepos        bool    `json:"migrateRepos"`
-	MigrateUsers        bool    `json:"migrateUsers"`
-	MigrateBlobs        bool    `json:"migrateBlobs"`
-	MigratePolicies     bool    `json:"migratePolicies"`
-	MigratePrivileges   bool    `json:"migratePrivileges"`
-	MigrateRoles        bool    `json:"migrateRoles"`
-	MigrateRoutingRules bool    `json:"migrateRoutingRules"`
-	RepositoriesTotal   int     `json:"repositoriesTotal"`
-	RepositoriesDone    int     `json:"repositoriesDone"`
-	AssetsTotal         int64   `json:"assetsTotal"`
-	AssetsDone          int64   `json:"assetsDone"`
-	ErrorCount          int     `json:"errorCount"`
-	LastError           *string `json:"lastError,omitempty"`
-	StartedAt           *string `json:"startedAt,omitempty"`
-	FinishedAt          *string `json:"finishedAt,omitempty"`
-	CreatedAt           string  `json:"createdAt"`
-	UpdatedAt           string  `json:"updatedAt"`
+	ID                  string   `json:"id"`
+	SourceURL           string   `json:"sourceUrl"`
+	SourceUser          string   `json:"sourceUser"`
+	Status              string   `json:"status"`
+	MigrateRepos        bool     `json:"migrateRepos"`
+	MigrateUsers        bool     `json:"migrateUsers"`
+	MigrateBlobs        bool     `json:"migrateBlobs"`
+	MigratePolicies     bool     `json:"migratePolicies"`
+	MigratePrivileges   bool     `json:"migratePrivileges"`
+	MigrateRoles        bool     `json:"migrateRoles"`
+	MigrateRoutingRules bool     `json:"migrateRoutingRules"`
+	UserRealms          []string `json:"userRealms,omitempty"`
+	RepositoriesTotal   int      `json:"repositoriesTotal"`
+	RepositoriesDone    int      `json:"repositoriesDone"`
+	AssetsTotal         int64    `json:"assetsTotal"`
+	AssetsDone          int64    `json:"assetsDone"`
+	ErrorCount          int      `json:"errorCount"`
+	LastError           *string  `json:"lastError,omitempty"`
+	StartedAt           *string  `json:"startedAt,omitempty"`
+	FinishedAt          *string  `json:"finishedAt,omitempty"`
+	CreatedAt           string   `json:"createdAt"`
+	UpdatedAt           string   `json:"updatedAt"`
 }
 
 // toJobResp maps a job onto its API shape. SourcePassword is deliberately
@@ -65,6 +66,7 @@ func toJobResp(j domain.MigrationJob) migrationJobResp {
 		MigratePrivileges:   j.MigratePrivileges,
 		MigrateRoles:        j.MigrateRoles,
 		MigrateRoutingRules: j.MigrateRoutingRules,
+		UserRealms:          j.UserRealms,
 		RepositoriesTotal:   j.TotalRepos,
 		RepositoriesDone:    j.DoneRepos,
 		AssetsTotal:         j.TotalAssets,
@@ -126,6 +128,9 @@ type createJobReq struct {
 		MigratePrivileges   *bool `json:"migratePrivileges"`
 		MigrateRoles        *bool `json:"migrateRoles"`
 		MigrateRoutingRules *bool `json:"migrateRoutingRules"`
+		// UserRealms names the source realms user migration pulls accounts
+		// from ("default" = local). Empty means local-only (#342).
+		UserRealms []string `json:"userRealms"`
 	} `json:"scope"`
 }
 
@@ -159,6 +164,7 @@ func (h *MigrationHandler) CreateJob(c *gin.Context) {
 		MigratePrivileges:   boolDefault(req.Scope.MigratePrivileges, policies),
 		MigrateRoles:        boolDefault(req.Scope.MigrateRoles, policies),
 		MigrateRoutingRules: boolDefault(req.Scope.MigrateRoutingRules, policies),
+		UserRealms:          req.Scope.UserRealms,
 	}
 
 	if err := h.svc.Create(c.Request.Context(), job, req.Credentials.Password); err != nil {

--- a/internal/db/migrations/028_migration_user_realms.sql
+++ b/internal/db/migrations/028_migration_user_realms.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- #342: user migration is scoped to explicit source realms ("default" = the
+-- local realm). Empty means local-only — the only realm guaranteed to make
+-- sense on a fresh target.
+ALTER TABLE migration_jobs
+    ADD COLUMN user_realms TEXT[] NOT NULL DEFAULT '{}';
+
+-- +goose Down
+ALTER TABLE migration_jobs
+    DROP COLUMN user_realms;

--- a/internal/domain/migration.go
+++ b/internal/domain/migration.go
@@ -29,10 +29,16 @@ type MigrationJob struct {
 	// SourcePassword is the Nexus password sealed with the instance encryption
 	// key. It is persisted so a job can resume after a process restart, and is
 	// never included in an API response.
-	SourcePassword      string
-	Status              MigrationJobStatus
-	MigrateRepos        bool
-	MigrateUsers        bool
+	SourcePassword string
+	Status         MigrationJobStatus
+	MigrateRepos   bool
+	MigrateUsers   bool
+	// UserRealms names the source realms user migration pulls accounts from,
+	// via Nexus's own ?source= filter ("default" is the local realm). Empty
+	// means local-only — the only realm guaranteed to make sense on a fresh
+	// target: an externally-authenticated account migrated without its provider
+	// configured is a permanently-unusable login (#342).
+	UserRealms          []string
 	MigrateBlobs        bool
 	MigratePolicies     bool
 	MigratePrivileges   bool

--- a/internal/nexusclient/client.go
+++ b/internal/nexusclient/client.go
@@ -396,8 +396,20 @@ type userDTO struct {
 // ListUsers returns every security user. Requires admin credentials; Nexus OSS
 // returns the full list unpaginated.
 func (c *Client) ListUsers(ctx context.Context) ([]User, error) {
+	return c.listUsers(ctx, "/service/rest/v1/security/users")
+}
+
+// ListUsersBySource returns the accounts of one realm, via Nexus's own
+// ?source= filter ("default" is the local realm). Listing realms one at a
+// time keeps one poisoned realm's server-side failure from taking the whole
+// unfiltered listing down (#342).
+func (c *Client) ListUsersBySource(ctx context.Context, source string) ([]User, error) {
+	return c.listUsers(ctx, "/service/rest/v1/security/users?source="+url.QueryEscape(source))
+}
+
+func (c *Client) listUsers(ctx context.Context, path string) ([]User, error) {
 	var dto []userDTO
-	if err := c.getJSON(ctx, "/service/rest/v1/security/users", &dto); err != nil {
+	if err := c.getJSON(ctx, path, &dto); err != nil {
 		return nil, err
 	}
 	out := make([]User, 0, len(dto))

--- a/internal/repository/postgres/migration_repo.go
+++ b/internal/repository/postgres/migration_repo.go
@@ -22,17 +22,26 @@ func NewMigrationRepo(pool *pgxpool.Pool) *MigrationRepo {
 
 const migrationCols = `id, source_url, source_user, source_password, status,
 	migrate_repos, migrate_users, migrate_blobs, migrate_policies,
-	migrate_privileges, migrate_roles, migrate_routing_rules,
+	migrate_privileges, migrate_roles, migrate_routing_rules, user_realms,
 	total_repos, done_repos, total_assets, done_assets,
 	total_bytes, done_bytes, error_count, last_error,
 	started_at, finished_at, created_at, updated_at`
+
+// userRealmsValue maps a nil slice onto the empty array the NOT NULL column
+// expects; nil means "not specified", which the runner reads as local-only.
+func userRealmsValue(realms []string) []string {
+	if realms == nil {
+		return []string{}
+	}
+	return realms
+}
 
 func scanJob(row pgx.Row) (*domain.MigrationJob, error) {
 	var j domain.MigrationJob
 	err := row.Scan(
 		&j.ID, &j.SourceURL, &j.SourceUser, &j.SourcePassword, &j.Status,
 		&j.MigrateRepos, &j.MigrateUsers, &j.MigrateBlobs, &j.MigratePolicies,
-		&j.MigratePrivileges, &j.MigrateRoles, &j.MigrateRoutingRules,
+		&j.MigratePrivileges, &j.MigrateRoles, &j.MigrateRoutingRules, &j.UserRealms,
 		&j.TotalRepos, &j.DoneRepos, &j.TotalAssets, &j.DoneAssets,
 		&j.TotalBytes, &j.DoneBytes, &j.ErrorCount, &j.LastError,
 		&j.StartedAt, &j.FinishedAt, &j.CreatedAt, &j.UpdatedAt,
@@ -83,12 +92,12 @@ func (r *MigrationRepo) Create(ctx context.Context, job *domain.MigrationJob) er
 		INSERT INTO migration_jobs
 			(source_url, source_user, source_password, status,
 			 migrate_repos, migrate_users, migrate_blobs, migrate_policies,
-			 migrate_privileges, migrate_roles, migrate_routing_rules)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			 migrate_privileges, migrate_roles, migrate_routing_rules, user_realms)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 		RETURNING id, created_at, updated_at`,
 		job.SourceURL, job.SourceUser, job.SourcePassword, status,
 		job.MigrateRepos, job.MigrateUsers, job.MigrateBlobs, job.MigratePolicies,
-		job.MigratePrivileges, job.MigrateRoles, job.MigrateRoutingRules,
+		job.MigratePrivileges, job.MigrateRoles, job.MigrateRoutingRules, userRealmsValue(job.UserRealms),
 	).Scan(&job.ID, &job.CreatedAt, &job.UpdatedAt)
 }
 

--- a/internal/repository/postgres/migration_repo_integration_test.go
+++ b/internal/repository/postgres/migration_repo_integration_test.go
@@ -22,6 +22,7 @@ func TestMigrationRepo_CRUD(t *testing.T) {
 		SourceUser:   "admin",
 		MigrateRepos: true,
 		MigrateUsers: true,
+		UserRealms:   []string{"default", "LDAP"},
 	}
 	if err := repo.Create(ctx, job); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -42,6 +43,9 @@ func TestMigrationRepo_CRUD(t *testing.T) {
 	}
 	if !got.MigrateRepos || !got.MigrateUsers || got.MigrateBlobs || got.MigratePolicies {
 		t.Fatalf("Get bool flags mismatch: %+v", got)
+	}
+	if len(got.UserRealms) != 2 || got.UserRealms[0] != "default" || got.UserRealms[1] != "LDAP" {
+		t.Fatalf("UserRealms did not round-trip: %+v", got.UserRealms)
 	}
 
 	if err := repo.UpdateStatus(ctx, job.ID, domain.MigrationRunning); err != nil {

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -515,7 +515,7 @@ func (s *NexusMigrationService) runStages(ctx context.Context, client *nexusclie
 		}
 	}
 	if job.MigrateUsers {
-		if err := runStage("users", func() error { return s.migrateUsers(ctx, client, p) }); err != nil {
+		if err := runStage("users", func() error { return s.migrateUsers(ctx, client, job, p) }); err != nil {
 			return err
 		}
 	}
@@ -1360,33 +1360,51 @@ func sortedKeys(m map[string]nexusclient.Role) []string {
 
 // ── users ───────────────────────────────────────────────────────────────────
 
-func (s *NexusMigrationService) migrateUsers(ctx context.Context, client *nexusclient.Client, p *progress) error {
+func (s *NexusMigrationService) migrateUsers(ctx context.Context, client *nexusclient.Client,
+	job *domain.MigrationJob, p *progress,
+) error {
 	bg := context.Background()
 
-	source, err := client.ListUsers(ctx)
-	if err != nil {
-		return fmt.Errorf("list users on the source Nexus: %w", err)
+	// Realms are listed one at a time via ?source= (#342): an externally-
+	// authenticated account on a fresh target is a permanently-unusable login,
+	// so only the realms the operator asked for come across — local by default
+	// — and one poisoned realm's listing failure neither takes the others down
+	// nor is silently masked as stage success.
+	realms := job.UserRealms
+	if len(realms) == 0 {
+		realms = []string{"default"}
 	}
-	for _, src := range source {
+	var realmErrs []error
+	for _, realm := range realms {
 		if err := checkPaused(ctx); err != nil {
 			return err
 		}
-		if src.UserID == "" {
+		source, err := client.ListUsersBySource(ctx, realm)
+		if err != nil {
+			realmErrs = append(realmErrs, fmt.Errorf("realm %q: list users on the source Nexus: %w", realm, err))
 			continue
 		}
-		existing, err := s.users.Get(ctx, src.UserID)
-		if err != nil && !isNotFound(err) {
-			p.fail(bg, "user %q: %v", src.UserID, err)
-			continue
-		}
-		if existing != nil {
-			continue // an account of that name is already here; it is not overwritten
-		}
-		if err := s.createMigratedUser(ctx, src); err != nil {
-			p.fail(bg, "user %q: %v", src.UserID, err)
+		for _, src := range source {
+			if err := checkPaused(ctx); err != nil {
+				return err
+			}
+			if src.UserID == "" {
+				continue
+			}
+			existing, err := s.users.Get(ctx, src.UserID)
+			if err != nil && !isNotFound(err) {
+				p.fail(bg, "user %q: %v", src.UserID, err)
+				continue
+			}
+			if existing != nil {
+				continue // an account of that name is already here; it is not overwritten
+			}
+			if err := s.createMigratedUser(ctx, src); err != nil {
+				p.fail(bg, "user %q: %v", src.UserID, err)
+			}
 		}
 	}
-	return nil
+	return errors.Join(realmErrs...)
 }
 
 func (s *NexusMigrationService) createMigratedUser(ctx context.Context, src nexusclient.User) error {
@@ -1420,7 +1438,19 @@ func (s *NexusMigrationService) createMigratedUser(ctx context.Context, src nexu
 	}
 
 	if err := s.users.Create(ctx, user, password); err != nil {
-		return err
+		// An email colliding with an already-present account drops ONLY the
+		// email and retries (#342): "no email" is a first-class account state
+		// here (the partial unique index exists for LDAP users without a mail
+		// attribute), while dropping the whole account loses a credential an
+		// operator may depend on. Username collisions were already skipped by
+		// the existence check above.
+		if errors.Is(err, ErrAlreadyExists) && strings.Contains(err.Error(), "email") && user.Email != "" {
+			user.Email = ""
+			err = s.users.Create(ctx, user, password)
+		}
+		if err != nil {
+			return err
+		}
 	}
 
 	roleIDs := make([]string, 0, len(src.Roles))

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -28,13 +28,18 @@ import (
 // fakeNexus serves the slice of the Nexus OSS REST API the migration reads.
 // Every field is a raw JSON body; empty means "endpoint returns an empty list".
 type fakeNexus struct {
-	settings         string            // /service/rest/v1/repositorySettings
-	settingsCode     int               // non-zero forces this status instead of settings
-	repositories     string            // /service/rest/v1/repositories
-	components       map[string]string // repository name → one full component page
-	files            map[string]string // /repository/... path → body
-	users            string
-	usersCode        int // non-zero forces this status on /security/users
+	settings     string            // /service/rest/v1/repositorySettings
+	settingsCode int               // non-zero forces this status instead of settings
+	repositories string            // /service/rest/v1/repositories
+	components   map[string]string // repository name → one full component page
+	files        map[string]string // /repository/... path → body
+	users        string
+	usersCode    int // non-zero forces this status on /security/users
+	// usersBySource, when set, answers /security/users per its ?source= filter;
+	// a request WITHOUT the filter (or for an absent realm) then gets a 500 —
+	// modeling the real instance whose one poisoned realm broke the unfiltered
+	// listing (#342/10).
+	usersBySource    map[string]string
 	roles            string
 	privileges       string
 	routingRules     string
@@ -85,6 +90,15 @@ func (f *fakeNexus) start(t *testing.T) *httptest.Server {
 		case r.URL.Path == "/service/rest/v1/security/users":
 			if f.usersCode != 0 {
 				w.WriteHeader(f.usersCode)
+				return
+			}
+			if f.usersBySource != nil {
+				body, ok := f.usersBySource[r.URL.Query().Get("source")]
+				if !ok {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				_, _ = io.WriteString(w, orEmptyList(body))
 				return
 			}
 			_, _ = io.WriteString(w, orEmptyList(f.users))
@@ -156,6 +170,17 @@ func (s *fakeUserStore) Create(_ context.Context, u *domain.User, plainPassword 
 	defer s.mu.Unlock()
 	if s.createErr != nil {
 		return s.createErr
+	}
+	// Mirror UserService.Create's email-uniqueness translation: the DB's
+	// partial unique index allows any number of email-LESS accounts, but a
+	// duplicate email surfaces as ErrAlreadyExists naming the field. A fake
+	// that accepts everything hides exactly the account loss #342/9 is about.
+	if u.Email != "" {
+		for _, existing := range s.users {
+			if existing.Email == u.Email {
+				return fmt.Errorf("%w: user with this email", service.ErrAlreadyExists)
+			}
+		}
 	}
 	s.nextID++
 	u.ID = fmt.Sprintf("user-%d", s.nextID)
@@ -1032,6 +1057,92 @@ func TestNexusMigration_ResumeRelaunchesErroredJobs(t *testing.T) {
 	fake.usersCode = 0 // the operator fixed the source
 	require.NoError(t, h.svc.Resume(context.Background(), job.ID))
 	h.waitForStatus(t, job.ID, domain.MigrationDone)
+}
+
+// #342/9: two source accounts sharing one email (a real data-quality issue)
+// must both migrate — the second without the colliding email, the same state
+// any LDAP user without a mail attribute already lives in — instead of being
+// dropped entirely.
+func TestNexusMigration_EmailCollisionRetriesWithoutEmail(t *testing.T) {
+	fake := &fakeNexus{
+		users: `[
+			{"userId":"svc-ci","firstName":"CI","lastName":"Bot","emailAddress":"ops@example.com","source":"default","status":"active","roles":[]},
+			{"userId":"svc-deploy","firstName":"Deploy","lastName":"Bot","emailAddress":"ops@example.com","source":"default","status":"active","roles":[]}
+		]`,
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount, "both accounts must migrate: %v", done.LastError)
+
+	first := h.users.get("svc-ci")
+	require.NotNil(t, first)
+	assert.Equal(t, "ops@example.com", first.Email, "the first account keeps the email")
+
+	second := h.users.get("svc-deploy")
+	require.NotNil(t, second, "the colliding account must not be dropped")
+	assert.Empty(t, second.Email, "the collision is resolved by dropping only the email")
+	assert.NotEmpty(t, h.users.password("svc-deploy"), "the account is otherwise intact")
+}
+
+// #342/10: user migration defaults to the local realm only, via Nexus's own
+// ?source= filter — an externally-authenticated account migrated onto a fresh
+// target is a permanently-unusable login, and one poisoned realm must not take
+// the whole unfiltered listing down.
+func TestNexusMigration_UsersDefaultToLocalRealmOnly(t *testing.T) {
+	fake := &fakeNexus{
+		// No unfiltered entry: the real instance's unfiltered listing 500s.
+		usersBySource: map[string]string{
+			"default": `[{"userId":"jdoe","source":"default","status":"active","roles":[]}]`,
+		},
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount, "local-only migration must not touch the poisoned realm: %v", done.LastError)
+
+	require.NotNil(t, h.users.get("jdoe"))
+}
+
+// Opting into an external realm pulls its accounts too, each realm listed
+// independently.
+func TestNexusMigration_UserRealmsOptInLDAP(t *testing.T) {
+	fake := &fakeNexus{
+		usersBySource: map[string]string{
+			"default": `[{"userId":"jdoe","source":"default","status":"active","roles":[]}]`,
+			"LDAP":    `[{"userId":"ldap-user","source":"LDAP","status":"active","roles":[]}]`,
+		},
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t, func(j *domain.MigrationJob) {
+		j.UserRealms = []string{"default", "LDAP"}
+	})
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+	assert.Zero(t, done.ErrorCount, "%v", done.LastError)
+
+	require.NotNil(t, h.users.get("jdoe"))
+	ldap := h.users.get("ldap-user")
+	require.NotNil(t, ldap)
+	assert.Empty(t, h.users.password("ldap-user"), "an external account gets no local credential")
+}
+
+// A realm that fails to list is a named stage failure; realms that listed fine
+// still migrate their accounts.
+func TestNexusMigration_OneRealmListingFailureDoesNotMaskTheOthers(t *testing.T) {
+	fake := &fakeNexus{
+		usersBySource: map[string]string{
+			"default": `[{"userId":"jdoe","source":"default","status":"active","roles":[]}]`,
+			// "LDAP" absent → 500, modeling the poisoned realm.
+		},
+	}
+	h := newMigHarness(t, fake)
+	job := h.startJob(t, func(j *domain.MigrationJob) {
+		j.UserRealms = []string{"default", "LDAP"}
+	})
+	got := h.waitForStatus(t, job.ID, domain.MigrationError)
+	require.NotNil(t, got.LastError)
+	assert.Contains(t, *got.LastError, "LDAP", "the failing realm is named")
+	require.NotNil(t, h.users.get("jdoe"), "the healthy realm's accounts still migrate")
 }
 
 func TestNexusMigration_MigratesRoutingRules(t *testing.T) {


### PR DESCRIPTION
Items **9** and **10** of #342 — the user-migration pair, implemented per the issue's verified designs. Completes the #342 batch (items 1–8 landed in #343, #344, #345).

## Item 9 — email collision dropped the whole account

Two distinct source accounts sharing one email (observed live: two service accounts carrying one person's address) lost the second account outright to the email-uniqueness violation. On that specific collision the migration now retries the create **without the email** — "no email" is already a first-class account state in this schema (the partial unique index exists precisely so LDAP users without a `mail` attribute coexist) — keeping username, name, status and the generated must-reset password intact. Username collisions are unchanged: the earlier existence check still skips them.

The test `fakeUserStore` now mirrors `UserService.Create`'s email-uniqueness translation (the same mock-vs-reality divergence lesson as the privileges constraint in #343), which is what made the account loss visible to the suite.

## Item 10 — every realm pulled in by default

User migration listed every account in one unfiltered call: externally-authenticated accounts became permanently-unusable logins on a fresh target (no local credential, provider not configured), and — as item 1's live reproduction showed — one poisoned realm's server-side bug took the entire listing down even when the operator only wanted local accounts.

Jobs now carry **`UserRealms`** end-to-end:

- schema migration `028` (`user_realms TEXT[] NOT NULL DEFAULT '{}'`), round-tripped through the postgres repo (nil → empty array for the NOT NULL column),
- API: `scope.userRealms` on create, echoed in the job response,
- UI: Local/LDAP/OIDC/SAML checkboxes, shown only when user migration is enabled, with a note that an external realm needs its provider configured on the target,
- runner: empty = **local-only** (`"default"`), each requested realm fetched independently via Nexus's own `?source=` filter (new `nexusclient.ListUsersBySource`). A realm that fails to list is a named stage failure (`realm "LDAP": …`) that neither takes the other realms down nor is masked as success; per-account failures within a listed realm stay counted-not-fatal.

## Tests

Written first and observed failing:

- `TestNexusMigration_EmailCollisionRetriesWithoutEmail` (RED: second account dropped)
- `TestNexusMigration_UsersDefaultToLocalRealmOnly` (RED: unfiltered listing hit the poisoned fake and errored)
- `TestNexusMigration_UserRealmsOptInLDAP` (opted-in realm migrates, external account gets no local credential)
- `TestNexusMigration_OneRealmListingFailureDoesNotMaskTheOthers` (failing realm named, healthy realm's accounts migrate)
- UI: realm picker defaults/opt-in serialization and hidden-when-users-off; the existing scope-serialization test updated for the new field
- Integration: `UserRealms` round-trips through the postgres repo

Migration suite green under `-race`; full unit, frontend (538/538) and postgres integration suites green.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma