### PR TITLE
feat: RubyGems format — compact index, proxy, hosted publish/yank

### DIFF
--- a/frontend/src/pages/DocsPage.tsx
+++ b/frontend/src/pages/DocsPage.tsx
@@ -685,6 +685,30 @@ conan upload "mylib/1.0" -r=nexspence --confirm` },
     ],
   },
   {
+    id: 'rubygems',
+    name: 'RubyGems',
+    icon: '💎',
+    iconUrl: 'https://cdn.simpleicons.org/rubygems/E9573F',
+    description: 'RubyGems repository for Ruby packages. Serves the compact index Bundler resolves against, gem downloads, and gem push/yank for hosted repositories.',
+    sections: (base) => [
+      {
+        title: 'Bundler',
+        text: 'Point your Gemfile at the repository:',
+        codes: [{ lang: 'ruby', content: `source "${base}/repository/gems-hosted" do\n  gem "rails"\nend` }],
+      },
+      {
+        title: 'gem CLI',
+        text: 'Install directly, or add the repository as a source:',
+        codes: [{ lang: 'bash', content: `gem sources --add ${base}/repository/gems-hosted/\ngem install rails --source ${base}/repository/gems-hosted/` }],
+      },
+      {
+        title: 'Publish',
+        text: 'The gem client authenticates pushes with an API key; use your credentials encoded as HTTP Basic:',
+        codes: [{ lang: 'bash', content: `printf ':rubygems_api_key: Basic %s\\n' "$(printf 'USER:PASSWORD' | base64)" > ~/.gem/credentials\nchmod 600 ~/.gem/credentials\ngem push my-gem-1.0.0.gem --host ${base}/repository/gems-hosted` }],
+      },
+    ],
+  },
+  {
     id: 'conda',
     name: 'Conda',
     icon: '🐍',

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -69,6 +69,7 @@ const FORMAT_COLORS: Record<string, string> = {
   apt:       '#f59e0b',
   yum:       '#10b981',
   conda:     '#44b765',
+  rubygems:  '#e9573f',
   terraform: '#7b42bc',
 }
 
@@ -158,7 +159,7 @@ export default function RepositoriesPage() {
         <Select
           options={[
             { value: '', label: 'All formats' },
-            ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform'].map(f => ({ value: f, label: f })),
+            ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform','rubygems'].map(f => ({ value: f, label: f })),
           ]}
           value={formatFilter}
           onChange={setFormatFilter}
@@ -396,6 +397,7 @@ const PROXY_DEFAULTS: Record<string, string> = {
   yum:       'https://dl.fedoraproject.org/pub/epel/9/Everything/x86_64/',
   raw:       '',
   conda:     'https://conda.anaconda.org/conda-forge/',
+  rubygems:  'https://rubygems.org/',
   terraform: 'https://registry.terraform.io/',
 }
 
@@ -539,7 +541,7 @@ function CreateRepoModal({ onClose, onCreated }: {
       <div className={styles.formRow}>
         <label style={LABEL_STYLE}>Format</label>
         <Select
-          options={['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform'].map(f => ({ value: f, label: f }))}
+          options={['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform','rubygems'].map(f => ({ value: f, label: f }))}
           value={form.format}
           onChange={handleFormatChange}
         />

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -37,6 +37,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/formats/oci"
 	"github.com/nexspence-oss/nexspence/internal/formats/pypi"
 	"github.com/nexspence-oss/nexspence/internal/formats/raw"
+	"github.com/nexspence-oss/nexspence/internal/formats/rubygems"
 	"github.com/nexspence-oss/nexspence/internal/formats/terraform"
 	"github.com/nexspence-oss/nexspence/internal/formats/yum"
 	"github.com/nexspence-oss/nexspence/internal/logger"
@@ -280,6 +281,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		"conda":     conda.New(formatDeps),
 		"apt":       apt.New(formatDeps),
 		"terraform": terraform.New(formatDeps),
+		"rubygems":  rubygems.New(formatDeps),
 		"yum":       yum.New(formatDeps),
 		"docker":    oci.New(formatDeps),
 	}

--- a/internal/db/migrations/029_format_rubygems.sql
+++ b/internal/db/migrations/029_format_rubygems.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_format_check;
+ALTER TABLE repositories ADD CONSTRAINT repositories_format_check CHECK (format IN (
+    'maven2','npm','docker','oci','pypi','go','nuget','helm','raw',
+    'apt','yum','cargo','conan','conda','terraform','rubygems'
+));
+
+-- +goose Down
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_format_check;
+ALTER TABLE repositories ADD CONSTRAINT repositories_format_check CHECK (format IN (
+    'maven2','npm','docker','oci','pypi','go','nuget','helm','raw',
+    'apt','yum','cargo','conan','conda','terraform'
+));

--- a/internal/domain/site_formats_test.go
+++ b/internal/domain/site_formats_test.go
@@ -84,6 +84,7 @@ func TestSiteFormatTableListsEveryFormat(t *testing.T) {
 		domain.FormatRaw:       "Raw",
 		domain.FormatConda:     "Conda",
 		domain.FormatTerraform: "Terraform",
+		domain.FormatRubyGems:  "RubyGems",
 	}
 	for _, f := range domain.AllFormats {
 		label, ok := labels[f]

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -33,6 +33,7 @@ const (
 	FormatConan     RepoFormat = "conan"
 	FormatConda     RepoFormat = "conda"
 	FormatTerraform RepoFormat = "terraform"
+	FormatRubyGems  RepoFormat = "rubygems"
 
 	TypeHosted RepoType = "hosted"
 	TypeProxy  RepoType = "proxy"
@@ -58,6 +59,7 @@ var AllFormats = []RepoFormat{
 	FormatRaw,
 	FormatConda,
 	FormatTerraform,
+	FormatRubyGems,
 }
 
 // IsOCIRegistry reports whether a repository of this format speaks the OCI

--- a/internal/formats/rubygems/gemspec.go
+++ b/internal/formats/rubygems/gemspec.go
@@ -1,0 +1,179 @@
+// Package rubygems implements the RubyGems repository protocol: the compact
+// index Bundler resolves against (/versions, /info/<gem>, /names), gem
+// downloads (/gems/<file>.gem), publish (POST /api/v1/gems) and yank.
+package rubygems
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// maxGemspecBytes bounds the decompressed metadata read: a gemspec is a few KB
+// of YAML, and a .gem is attacker-supplied input on the publish path.
+const maxGemspecBytes = 4 << 20
+
+// GemDependency is one runtime dependency as the compact index lists it.
+type GemDependency struct {
+	Name string
+	// Requirements joins the version clauses with "&", the compact-index
+	// grammar for a multi-clause requirement (">= 1.0&< 2.0").
+	Requirements string
+}
+
+// GemSpec is the slice of a gemspec the registry needs: coordinates for
+// storage, dependencies and interpreter requirements for the compact index.
+type GemSpec struct {
+	Name     string
+	Version  string
+	Platform string // "ruby" for pure-ruby gems
+	// Dependencies holds the RUNTIME dependencies only, sorted by name —
+	// development dependencies never reach a resolver.
+	Dependencies     []GemDependency
+	RequiredRuby     string
+	RequiredRubygems string
+}
+
+// Filename is the canonical gem file name: name-version[.platform].gem, with
+// the platform suffix omitted for pure-ruby gems.
+func (s GemSpec) Filename() string {
+	return s.Name + "-" + s.VersionWithPlatform() + ".gem"
+}
+
+// VersionWithPlatform is the version as the compact index spells it: a
+// platform-specific build carries its platform as a suffix.
+func (s GemSpec) VersionWithPlatform() string {
+	if s.Platform == "" || s.Platform == "ruby" {
+		return s.Version
+	}
+	return s.Version + "-" + s.Platform
+}
+
+// InfoLine renders this version's compact-index /info line:
+//
+//	VERSION[-PLATFORM] [DEP:REQ[,DEP:REQ…]]|checksum:SHA256[,ruby:REQ][,rubygems:REQ]
+func (s GemSpec) InfoLine(sha256sum string) string {
+	deps := make([]string, 0, len(s.Dependencies))
+	for _, d := range s.Dependencies {
+		deps = append(deps, d.Name+":"+d.Requirements)
+	}
+	var b strings.Builder
+	b.WriteString(s.VersionWithPlatform())
+	b.WriteByte(' ')
+	b.WriteString(strings.Join(deps, ","))
+	b.WriteString("|checksum:" + sha256sum)
+	if s.RequiredRuby != "" {
+		b.WriteString(",ruby:" + s.RequiredRuby)
+	}
+	if s.RequiredRubygems != "" {
+		b.WriteString(",rubygems:" + s.RequiredRubygems)
+	}
+	return b.String()
+}
+
+// gemspecYAML mirrors the slice of Gem::Specification the registry reads. The
+// YAML carries ruby-object tags (!ruby/object:Gem::Specification etc.), which
+// yaml.v3 happily decodes as plain mappings.
+type gemspecYAML struct {
+	Name    string `yaml:"name"`
+	Version struct {
+		Version string `yaml:"version"`
+	} `yaml:"version"`
+	Platform     string `yaml:"platform"`
+	Dependencies []struct {
+		Name        string             `yaml:"name"`
+		Type        string             `yaml:"type"`
+		Requirement gemRequirementYAML `yaml:"requirement"`
+	} `yaml:"dependencies"`
+	RequiredRubyVersion     gemRequirementYAML `yaml:"required_ruby_version"`
+	RequiredRubygemsVersion gemRequirementYAML `yaml:"required_rubygems_version"`
+}
+
+// gemRequirementYAML decodes Gem::Requirement: a list of [operator, version]
+// pairs, where the version is itself a Gem::Version object.
+type gemRequirementYAML struct {
+	Requirements [][]yaml.Node `yaml:"requirements"`
+}
+
+// join renders the requirement in compact-index form (">= 1.0&< 2.0").
+func (r gemRequirementYAML) join() string {
+	clauses := make([]string, 0, len(r.Requirements))
+	for _, pair := range r.Requirements {
+		if len(pair) != 2 {
+			continue
+		}
+		op := pair[0].Value
+		var ver struct {
+			Version string `yaml:"version"`
+		}
+		if err := pair[1].Decode(&ver); err != nil || ver.Version == "" {
+			continue
+		}
+		clauses = append(clauses, op+" "+ver.Version)
+	}
+	return strings.Join(clauses, "&")
+}
+
+// ParseGem reads a .gem (a tar holding metadata.gz — the gzipped YAML
+// gemspec — beside the data archive) and extracts the spec.
+func ParseGem(r io.Reader) (*GemSpec, error) {
+	tr := tar.NewReader(r)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil, errors.New("not a gem: no metadata.gz entry")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("not a gem: %w", err)
+		}
+		if hdr.Name != "metadata.gz" && hdr.Name != "./metadata.gz" {
+			continue
+		}
+		gz, err := gzip.NewReader(tr)
+		if err != nil {
+			return nil, fmt.Errorf("metadata.gz: %w", err)
+		}
+		raw, err := io.ReadAll(io.LimitReader(gz, maxGemspecBytes))
+		if err != nil {
+			return nil, fmt.Errorf("metadata.gz: %w", err)
+		}
+		return parseGemspecYAML(raw)
+	}
+}
+
+func parseGemspecYAML(raw []byte) (*GemSpec, error) {
+	var doc gemspecYAML
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("gemspec metadata: %w", err)
+	}
+	if doc.Name == "" || doc.Version.Version == "" {
+		return nil, errors.New("gemspec metadata: name and version are required")
+	}
+	spec := &GemSpec{
+		Name:             doc.Name,
+		Version:          doc.Version.Version,
+		Platform:         doc.Platform,
+		RequiredRuby:     doc.RequiredRubyVersion.join(),
+		RequiredRubygems: doc.RequiredRubygemsVersion.join(),
+	}
+	for _, d := range doc.Dependencies {
+		// The type arrives as the ruby symbol ":runtime".
+		if !strings.Contains(d.Type, "runtime") {
+			continue
+		}
+		spec.Dependencies = append(spec.Dependencies, GemDependency{
+			Name:         d.Name,
+			Requirements: d.Requirement.join(),
+		})
+	}
+	sort.Slice(spec.Dependencies, func(i, j int) bool {
+		return spec.Dependencies[i].Name < spec.Dependencies[j].Name
+	})
+	return spec, nil
+}

--- a/internal/formats/rubygems/gemspec_test.go
+++ b/internal/formats/rubygems/gemspec_test.go
@@ -1,0 +1,145 @@
+package rubygems
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildGem assembles a minimal but structurally faithful .gem: a tar holding
+// metadata.gz (the gzipped YAML gemspec) and data.tar.gz.
+func buildGem(t *testing.T, specYAML string) []byte {
+	t.Helper()
+	var meta bytes.Buffer
+	gz := gzip.NewWriter(&meta)
+	_, err := gz.Write([]byte(specYAML))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	var data bytes.Buffer
+	dgz := gzip.NewWriter(&data)
+	inner := tar.NewWriter(dgz)
+	require.NoError(t, inner.WriteHeader(&tar.Header{Name: "lib/x.rb", Mode: 0o644, Size: 4}))
+	_, _ = inner.Write([]byte("# x\n"))
+	require.NoError(t, inner.Close())
+	require.NoError(t, dgz.Close())
+
+	var out bytes.Buffer
+	tw := tar.NewWriter(&out)
+	for _, f := range []struct {
+		name string
+		body []byte
+	}{
+		{"metadata.gz", meta.Bytes()},
+		{"data.tar.gz", data.Bytes()},
+	} {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: f.name, Mode: 0o644, Size: int64(len(f.body))}))
+		_, err := tw.Write(f.body)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	return out.Bytes()
+}
+
+const specYAML = `--- !ruby/object:Gem::Specification
+name: demo-gem
+version: !ruby/object:Gem::Version
+  version: 1.2.0
+platform: ruby
+dependencies:
+- !ruby/object:Gem::Dependency
+  name: rack
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '2.0'
+  type: :runtime
+- !ruby/object:Gem::Dependency
+  name: rspec
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.0'
+  type: :development
+- !ruby/object:Gem::Dependency
+  name: multi-req
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '1.0'
+    - - "<"
+      - !ruby/object:Gem::Version
+        version: '2.0'
+  type: :runtime
+required_ruby_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '2.6'
+required_rubygems_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '0'
+`
+
+func TestParseGem_ExtractsSpec(t *testing.T) {
+	gem := buildGem(t, specYAML)
+	spec, err := ParseGem(bytes.NewReader(gem))
+	require.NoError(t, err)
+
+	assert.Equal(t, "demo-gem", spec.Name)
+	assert.Equal(t, "1.2.0", spec.Version)
+	assert.Equal(t, "ruby", spec.Platform)
+	assert.Equal(t, "demo-gem-1.2.0.gem", spec.Filename())
+	assert.Equal(t, "1.2.0", spec.VersionWithPlatform())
+
+	// Only runtime dependencies matter to a resolver (rspec is :development and
+	// absent), sorted by name; requirements with several clauses join with "&"
+	// per the compact-index grammar.
+	require.Len(t, spec.Dependencies, 2)
+	assert.Equal(t, "multi-req", spec.Dependencies[0].Name)
+	assert.Equal(t, ">= 1.0&< 2.0", spec.Dependencies[0].Requirements)
+	assert.Equal(t, "rack", spec.Dependencies[1].Name)
+	assert.Equal(t, ">= 2.0", spec.Dependencies[1].Requirements)
+
+	assert.Equal(t, ">= 2.6", spec.RequiredRuby)
+	assert.Equal(t, ">= 0", spec.RequiredRubygems)
+}
+
+func TestParseGem_PlatformSpecificFilename(t *testing.T) {
+	yaml := `--- !ruby/object:Gem::Specification
+name: native-gem
+version: !ruby/object:Gem::Version
+  version: 2.0.0
+platform: x86_64-linux
+dependencies: []
+`
+	spec, err := ParseGem(bytes.NewReader(buildGem(t, yaml)))
+	require.NoError(t, err)
+	assert.Equal(t, "native-gem-2.0.0-x86_64-linux.gem", spec.Filename())
+	assert.Equal(t, "2.0.0-x86_64-linux", spec.VersionWithPlatform())
+}
+
+func TestParseGem_RejectsGarbage(t *testing.T) {
+	_, err := ParseGem(bytes.NewReader([]byte("not a gem at all")))
+	assert.Error(t, err)
+}
+
+// The compact-index /info line for one version: deps, then checksum and the
+// interpreter requirements after the pipe.
+func TestInfoLine(t *testing.T) {
+	spec, err := ParseGem(bytes.NewReader(buildGem(t, specYAML)))
+	require.NoError(t, err)
+	line := spec.InfoLine("abc123")
+	assert.Equal(t,
+		"1.2.0 multi-req:>= 1.0&< 2.0,rack:>= 2.0|checksum:abc123,ruby:>= 2.6,rubygems:>= 0",
+		line, "deps sorted by name; empty requirement fields omitted")
+}

--- a/internal/formats/rubygems/handler.go
+++ b/internal/formats/rubygems/handler.go
@@ -1,0 +1,398 @@
+package rubygems
+
+import (
+	"bytes"
+	"crypto/md5" //nolint:gosec // compact-index integrity hash, not security
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// Handler serves the RubyGems repository protocol:
+//
+//	GET  /versions                → compact index master list
+//	GET  /info/:gem               → one gem's versions, deps and checksums
+//	GET  /names                   → gem name list
+//	GET  /gems/:file.gem          → gem download
+//	POST /api/v1/gems             → publish (body is the .gem)
+//	DELETE /api/v1/gems/yank      → yank one version
+//
+// The compact index is what Bundler resolves against; it is generated from
+// the stored components (hosted) or proxied verbatim (proxy) — its entries
+// carry no embedded URLs, so no rewriting is needed.
+type Handler struct{ deps formats.Deps }
+
+// New creates a RubyGems format Handler with the given dependencies.
+func New(deps formats.Deps) *Handler { return &Handler{deps: deps} }
+
+// Name returns the format identifier.
+func (h *Handler) Name() string { return "rubygems" }
+
+// maxGemBytes bounds a published .gem read into memory for parsing. Real gems
+// run from KBs to a few MB; the largest on rubygems.org are tens of MB.
+const maxGemBytes = 256 << 20
+
+// gemInfoLineKey is the component Extra key holding the precomputed
+// compact-index /info line for that version.
+const gemInfoLineKey = "gem_info_line"
+
+func (h *Handler) ServeHTTP(c *gin.Context) {
+	p := normPath(c.Param("path"))
+	repoName := c.Param("repoName")
+
+	repo, err := h.deps.Repos.Get(c.Request.Context(), repoName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if repo != nil && repo.Type == domain.TypeProxy {
+		if repoproxy.RejectMutation(c, repo) {
+			return
+		}
+		// The compact index is mutable metadata (new versions appear); .gem
+		// files are immutable. Nothing embeds URLs, so nothing is rewritten.
+		var maxAge time.Duration
+		if !strings.HasPrefix(p, "/gems/") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", proxyCoords(p), "application/octet-stream", maxAge); err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		}
+		return
+	}
+
+	switch {
+	// The legacy Marshal indexes are not generated: modern gem/bundler fall
+	// back to the compact index on a clean 404 (verified live).
+	case c.Request.Method == http.MethodGet &&
+		(p == "/specs.4.8.gz" || p == "/latest_specs.4.8.gz" || p == "/prerelease_specs.4.8.gz"):
+		c.Status(http.StatusNotFound)
+	case c.Request.Method == http.MethodGet && p == "/versions":
+		h.serveVersions(c, repoName)
+	case c.Request.Method == http.MethodGet && p == "/names":
+		h.serveNames(c, repoName)
+	case c.Request.Method == http.MethodGet && strings.HasPrefix(p, "/info/"):
+		h.serveInfo(c, repoName, strings.TrimPrefix(p, "/info/"))
+	case (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) && strings.HasPrefix(p, "/gems/"):
+		h.serveGem(c, repoName, p)
+	case c.Request.Method == http.MethodPost && p == "/api/v1/gems":
+		h.handlePublish(c, repoName)
+	case c.Request.Method == http.MethodDelete && p == "/api/v1/gems/yank":
+		h.handleYank(c, repoName)
+	default:
+		c.Status(http.StatusMethodNotAllowed)
+	}
+}
+
+// proxyCoords derives component coordinates for a proxied path, so a cached
+// gem carries its real name and version (the #336 lesson: a path-fallback
+// name makes the component invisible to search and any future scanning).
+func proxyCoords(p string) base.Coords {
+	if file, ok := strings.CutPrefix(p, "/gems/"); ok && !strings.Contains(file, "/") {
+		if name, version, ok := parseGemFilename(file); ok {
+			return base.Coords{Name: name, Version: version}
+		}
+	}
+	if gem, ok := strings.CutPrefix(p, "/info/"); ok && gem != "" && !strings.Contains(gem, "/") {
+		return base.Coords{Name: gem, Version: "metadata"}
+	}
+	switch strings.TrimPrefix(p, "/") {
+	case "versions", "names":
+		return base.Coords{Name: "_index", Version: "metadata"}
+	}
+	return base.Coords{}
+}
+
+// parseGemFilename splits "name-version[-platform].gem" at the first hyphen
+// followed by a digit — gem names may carry hyphens, version segments start
+// numeric.
+func parseGemFilename(file string) (name, version string, ok bool) {
+	stem, found := strings.CutSuffix(file, ".gem")
+	if !found || stem == "" {
+		return "", "", false
+	}
+	for i := 1; i < len(stem)-1; i++ {
+		if stem[i] == '-' && stem[i+1] >= '0' && stem[i+1] <= '9' {
+			return stem[:i], stem[i+1:], true
+		}
+	}
+	return "", "", false
+}
+
+// ── hosted: compact index ─────────────────────────────────────────────────────
+
+// gemComponents returns every stored gem component of the repository, ordered
+// by name then version-with-platform.
+func (h *Handler) gemComponents(c *gin.Context, repoName string) ([]domain.Component, bool) {
+	var out []domain.Component
+	offset := 0
+	for {
+		page, err := h.deps.Components.Search(c.Request.Context(), domain.SearchParams{
+			Repository: repoName, Limit: 500, Offset: offset,
+		})
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return nil, false
+		}
+		out = append(out, page.Items...)
+		if page.ContinuationToken == nil {
+			break
+		}
+		offset += 500
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return versionLess(out[i].Version, out[j].Version)
+	})
+	return out, true
+}
+
+// infoBody renders the /info/<gem> document for the given components.
+func infoBody(comps []domain.Component) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	for _, comp := range comps {
+		if line, ok := comp.Extra[gemInfoLineKey].(string); ok && line != "" {
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+func (h *Handler) serveInfo(c *gin.Context, repoName, gem string) {
+	comps, ok := h.gemComponents(c, repoName)
+	if !ok {
+		return
+	}
+	var mine []domain.Component
+	for _, comp := range comps {
+		if comp.Name == gem {
+			mine = append(mine, comp)
+		}
+	}
+	if len(mine) == 0 {
+		c.Status(http.StatusNotFound)
+		return
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(infoBody(mine)))
+}
+
+func (h *Handler) serveNames(c *gin.Context, repoName string) {
+	comps, ok := h.gemComponents(c, repoName)
+	if !ok {
+		return
+	}
+	var b strings.Builder
+	b.WriteString("---\n")
+	last := ""
+	for _, comp := range comps {
+		if comp.Name != last {
+			b.WriteString(comp.Name)
+			b.WriteByte('\n')
+			last = comp.Name
+		}
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(b.String()))
+}
+
+func (h *Handler) serveVersions(c *gin.Context, repoName string) {
+	comps, ok := h.gemComponents(c, repoName)
+	if !ok {
+		return
+	}
+	// Group by gem, preserving the sorted order.
+	type gemEntry struct {
+		name  string
+		comps []domain.Component
+	}
+	var gems []gemEntry
+	for _, comp := range comps {
+		if len(gems) == 0 || gems[len(gems)-1].name != comp.Name {
+			gems = append(gems, gemEntry{name: comp.Name})
+		}
+		gems[len(gems)-1].comps = append(gems[len(gems)-1].comps, comp)
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "created_at: %s\n---\n", time.Now().UTC().Format(time.RFC3339))
+	for _, g := range gems {
+		versions := make([]string, 0, len(g.comps))
+		for _, comp := range g.comps {
+			versions = append(versions, comp.Version)
+		}
+		// The MD5 of the /info file is how Bundler validates the info it
+		// fetches — the two documents must be generated consistently.
+		sum := md5.Sum([]byte(infoBody(g.comps))) //nolint:gosec
+		fmt.Fprintf(&b, "%s %s %s\n", g.name, strings.Join(versions, ","), hex.EncodeToString(sum[:]))
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", []byte(b.String()))
+}
+
+// versionLess orders gem versions numerically segment by segment, falling back
+// to string order for non-numeric segments (prereleases, platforms).
+func versionLess(a, b string) bool {
+	as, bs := strings.Split(a, "."), strings.Split(b, ".")
+	for i := 0; i < len(as) && i < len(bs); i++ {
+		if as[i] == bs[i] {
+			continue
+		}
+		an, aerr := parseUint(as[i])
+		bn, berr := parseUint(bs[i])
+		if aerr == nil && berr == nil {
+			return an < bn
+		}
+		return as[i] < bs[i]
+	}
+	return len(as) < len(bs)
+}
+
+func parseUint(s string) (uint64, error) {
+	var n uint64
+	if s == "" {
+		return 0, fmt.Errorf("empty")
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0, fmt.Errorf("not numeric")
+		}
+		n = n*10 + uint64(r-'0')
+	}
+	return n, nil
+}
+
+// ── hosted: artifacts ─────────────────────────────────────────────────────────
+
+func (h *Handler) serveGem(c *gin.Context, repoName, p string) {
+	rc, asset, err := base.FetchArtifact(c.Request.Context(), h.deps, repoName, p)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+	defer func() { _ = rc.Close() }()
+	if c.Request.Method == http.MethodHead {
+		c.Header("Content-Length", fmt.Sprintf("%d", asset.SizeBytes))
+		c.Status(http.StatusOK)
+		return
+	}
+	c.DataFromReader(http.StatusOK, asset.SizeBytes, "application/octet-stream", rc, nil)
+}
+
+func (h *Handler) handlePublish(c *gin.Context, repoName string) {
+	repo, err := h.deps.Repos.Get(c.Request.Context(), repoName)
+	if err != nil || repo == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
+		return
+	}
+	if repoproxy.RejectMutation(c, repo) {
+		return
+	}
+
+	// The body IS the .gem. It is buffered because it is read twice: once to
+	// parse the gemspec (coordinates, dependencies), once to store.
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxGemBytes+1))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if len(body) > maxGemBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "gem exceeds the maximum size"})
+		return
+	}
+	spec, err := ParseGem(bytes.NewReader(body))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	sum := sha256.Sum256(body)
+	filePath := "/gems/" + spec.Filename()
+	coords := base.Coords{Name: spec.Name, Version: spec.VersionWithPlatform()}
+	res, err := base.StoreArtifact(c.Request.Context(), h.deps,
+		repoName, filePath, "application/octet-stream", coords,
+		bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		c.JSON(base.HTTPStatusForError(err), gin.H{"error": err.Error()})
+		return
+	}
+
+	// The compact-index line is computed once here and stored on the
+	// component; the index endpoints just concatenate.
+	if err := h.deps.Components.UpdateExtra(c.Request.Context(), res.Asset.ComponentID, map[string]any{
+		gemInfoLineKey: spec.InfoLine(hex.EncodeToString(sum[:])),
+	}); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.String(http.StatusOK, "Successfully registered gem: %s (%s)", spec.Name, spec.VersionWithPlatform())
+}
+
+func (h *Handler) handleYank(c *gin.Context, repoName string) {
+	repo, err := h.deps.Repos.Get(c.Request.Context(), repoName)
+	if err != nil || repo == nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
+		return
+	}
+	if repoproxy.RejectMutation(c, repo) {
+		return
+	}
+	// The gem client sends the parameters as a form-encoded DELETE body, which
+	// Go's FormValue does not parse for DELETE — read both places.
+	name := c.Query("gem_name")
+	version := c.Query("version")
+	if name == "" || version == "" {
+		body, _ := io.ReadAll(io.LimitReader(c.Request.Body, 1<<20))
+		if vals, err := url.ParseQuery(string(body)); err == nil {
+			if name == "" {
+				name = vals.Get("gem_name")
+			}
+			if version == "" {
+				version = vals.Get("version")
+			}
+		}
+	}
+	if name == "" || version == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "gem_name and version are required"})
+		return
+	}
+	filePath := "/gems/" + name + "-" + version + ".gem"
+	if err := base.DeleteArtifact(c.Request.Context(), h.deps, repoName, filePath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	// The compact index is generated from components, so the yanked version's
+	// component goes too — leaving it would keep advertising a gem whose file
+	// is gone.
+	page, err := h.deps.Components.Search(c.Request.Context(), domain.SearchParams{
+		Repository: repoName, Name: name, Version: version, Limit: 500,
+	})
+	if err == nil {
+		for _, comp := range page.Items {
+			if comp.Name == name && comp.Version == version {
+				_ = h.deps.Components.Delete(c.Request.Context(), comp.ID)
+			}
+		}
+	}
+	c.String(http.StatusOK, "Successfully yanked gem: %s (%s)", name, version)
+}
+
+func normPath(p string) string {
+	return path.Clean("/" + strings.TrimPrefix(p, "/"))
+}

--- a/internal/formats/rubygems/handler_test.go
+++ b/internal/formats/rubygems/handler_test.go
@@ -1,0 +1,284 @@
+package rubygems_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/md5" //nolint:gosec // compact-index integrity hash, not security
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+	"github.com/nexspence-oss/nexspence/internal/formats/rubygems"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// buildTestGem assembles a structurally faithful .gem for the given spec YAML.
+func buildTestGem(t *testing.T, specYAML string) []byte {
+	t.Helper()
+	var meta bytes.Buffer
+	gz := gzip.NewWriter(&meta)
+	_, err := gz.Write([]byte(specYAML))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	var out bytes.Buffer
+	tw := tar.NewWriter(&out)
+	for _, f := range []struct {
+		name string
+		body []byte
+	}{
+		{"metadata.gz", meta.Bytes()},
+		{"data.tar.gz", []byte("stub")},
+	} {
+		require.NoError(t, tw.WriteHeader(&tar.Header{Name: f.name, Mode: 0o644, Size: int64(len(f.body))}))
+		_, err := tw.Write(f.body)
+		require.NoError(t, err)
+	}
+	require.NoError(t, tw.Close())
+	return out.Bytes()
+}
+
+func gemYAML(name, version string, deps ...string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "--- !ruby/object:Gem::Specification\nname: %s\nversion: !ruby/object:Gem::Version\n  version: %s\nplatform: ruby\n", name, version)
+	if len(deps) == 0 {
+		b.WriteString("dependencies: []\n")
+	} else {
+		b.WriteString("dependencies:\n")
+	}
+	for _, d := range deps {
+		fmt.Fprintf(&b, `- !ruby/object:Gem::Dependency
+  name: %s
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '1.0'
+  type: :runtime
+`, d)
+	}
+	return b.String()
+}
+
+func setup(repo *domain.Repository) (*gin.Engine, formats.Deps) {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := rubygems.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, d
+}
+
+func publish(t *testing.T, r *gin.Engine, repo string, gem []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/repository/"+repo+"/api/v1/gems", bytes.NewReader(gem))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	req.ContentLength = int64(len(gem))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func get(r *gin.Engine, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ── hosted ────────────────────────────────────────────────────────────────────
+
+func TestRubyGems_PublishStoresAndServesTheGem(t *testing.T) {
+	repo := testutil.SimpleRepo("gems-hosted", "rubygems")
+	r, _ := setup(repo)
+
+	gem := buildTestGem(t, gemYAML("demo", "1.0.0", "rack"))
+	w := publish(t, r, "gems-hosted", gem)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	dl := get(r, "/repository/gems-hosted/gems/demo-1.0.0.gem")
+	require.Equal(t, http.StatusOK, dl.Code)
+	assert.Equal(t, gem, dl.Body.Bytes(), "the stored gem is byte-identical")
+}
+
+func TestRubyGems_CompactIndexListsPublishedGems(t *testing.T) {
+	repo := testutil.SimpleRepo("gems-idx", "rubygems")
+	r, _ := setup(repo)
+
+	require.Equal(t, http.StatusOK, publish(t, r, "gems-idx", buildTestGem(t, gemYAML("alpha", "1.0.0"))).Code)
+	require.Equal(t, http.StatusOK, publish(t, r, "gems-idx", buildTestGem(t, gemYAML("alpha", "1.1.0", "rack"))).Code)
+	require.Equal(t, http.StatusOK, publish(t, r, "gems-idx", buildTestGem(t, gemYAML("beta", "0.9.0"))).Code)
+
+	names := get(r, "/repository/gems-idx/names")
+	require.Equal(t, http.StatusOK, names.Code)
+	assert.Equal(t, "---\nalpha\nbeta\n", names.Body.String())
+
+	info := get(r, "/repository/gems-idx/info/alpha")
+	require.Equal(t, http.StatusOK, info.Code)
+	lines := strings.Split(strings.TrimSpace(info.Body.String()), "\n")
+	require.Len(t, lines, 3) // "---" + two versions
+	assert.Equal(t, "---", lines[0])
+	assert.True(t, strings.HasPrefix(lines[1], "1.0.0 |checksum:"), "no deps before the pipe: %q", lines[1])
+	assert.True(t, strings.HasPrefix(lines[2], "1.1.0 rack:>= 1.0|checksum:"), "runtime dep listed: %q", lines[2])
+
+	versions := get(r, "/repository/gems-idx/versions")
+	require.Equal(t, http.StatusOK, versions.Code)
+	body := versions.Body.String()
+	require.True(t, strings.HasPrefix(body, "created_at:"), body)
+	require.Contains(t, body, "\n---\n")
+
+	// The per-gem line carries the MD5 of the /info file — that is how Bundler
+	// validates the info it fetches.
+	sum := md5.Sum(info.Body.Bytes()) //nolint:gosec
+	assert.Contains(t, body, "alpha 1.0.0,1.1.0 "+hex.EncodeToString(sum[:])+"\n")
+	assert.Contains(t, body, "beta 0.9.0 ")
+}
+
+func TestRubyGems_ChecksumInInfoMatchesTheStoredGem(t *testing.T) {
+	repo := testutil.SimpleRepo("gems-sum", "rubygems")
+	r, _ := setup(repo)
+
+	gem := buildTestGem(t, gemYAML("summed", "3.1.4"))
+	require.Equal(t, http.StatusOK, publish(t, r, "gems-sum", gem).Code)
+
+	sum := sha256.Sum256(gem)
+	info := get(r, "/repository/gems-sum/info/summed")
+	assert.Contains(t, info.Body.String(), "checksum:"+hex.EncodeToString(sum[:]),
+		"Bundler verifies the downloaded gem against this digest")
+}
+
+func TestRubyGems_YankRemovesTheVersion(t *testing.T) {
+	repo := testutil.SimpleRepo("gems-yank", "rubygems")
+	r, _ := setup(repo)
+
+	require.Equal(t, http.StatusOK, publish(t, r, "gems-yank", buildTestGem(t, gemYAML("doomed", "1.0.0"))).Code)
+	require.Equal(t, http.StatusOK, publish(t, r, "gems-yank", buildTestGem(t, gemYAML("doomed", "2.0.0"))).Code)
+
+	form := url.Values{"gem_name": {"doomed"}, "version": {"1.0.0"}}
+	req := httptest.NewRequest(http.MethodDelete, "/repository/gems-yank/api/v1/gems/yank",
+		strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	assert.Equal(t, http.StatusNotFound, get(r, "/repository/gems-yank/gems/doomed-1.0.0.gem").Code)
+	info := get(r, "/repository/gems-yank/info/doomed")
+	assert.NotContains(t, info.Body.String(), "1.0.0 ")
+	assert.Contains(t, info.Body.String(), "2.0.0 ")
+}
+
+func TestRubyGems_InfoForUnknownGemIs404(t *testing.T) {
+	repo := testutil.SimpleRepo("gems-404", "rubygems")
+	r, _ := setup(repo)
+	assert.Equal(t, http.StatusNotFound, get(r, "/repository/gems-404/info/nope").Code)
+}
+
+func TestRubyGems_PublishRejectsGarbage(t *testing.T) {
+	repo := testutil.SimpleRepo("gems-bad", "rubygems")
+	r, _ := setup(repo)
+	w := publish(t, r, "gems-bad", []byte("not a gem"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── proxy ─────────────────────────────────────────────────────────────────────
+
+func proxySetup(t *testing.T, upstreamBody map[string]string) (*gin.Engine, formats.Deps, *httptest.Server) {
+	t.Helper()
+	orig := repoproxy.UpstreamClient
+	repoproxy.UpstreamClient = &http.Client{}
+	t.Cleanup(func() { repoproxy.UpstreamClient = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := upstreamBody[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	repo := &domain.Repository{
+		ID: "repo-gems-proxy", Name: "gems-proxy", Format: domain.RepoFormat("rubygems"),
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": srv.URL},
+	}
+	r, d := setup(repo)
+	return r, d, srv
+}
+
+func TestRubyGems_ProxyPassesThroughCompactIndexAndGems(t *testing.T) {
+	r, d, _ := proxySetup(t, map[string]string{
+		"/versions":             "created_at: 2026-01-01T00:00:00Z\n---\nrails 7.0.0 aaaa\n",
+		"/info/rails":           "---\n7.0.0 |checksum:bb\n",
+		"/names":                "---\nrails\n",
+		"/gems/rails-7.0.0.gem": "gem-bytes",
+	})
+
+	for path, want := range map[string]string{
+		"/repository/gems-proxy/versions":             "rails 7.0.0 aaaa",
+		"/repository/gems-proxy/info/rails":           "7.0.0 |checksum:bb",
+		"/repository/gems-proxy/names":                "rails",
+		"/repository/gems-proxy/gems/rails-7.0.0.gem": "gem-bytes",
+	} {
+		w := get(r, path)
+		require.Equal(t, http.StatusOK, w.Code, path)
+		assert.Contains(t, w.Body.String(), want, path)
+	}
+
+	// The cached gem carries real coordinates — the browse UI and any future
+	// scanning depend on them (#336's lesson).
+	comp, err := findComponent(d, "gems-proxy", "rails")
+	require.NoError(t, err)
+	assert.Equal(t, "7.0.0", comp.Version)
+}
+
+func TestRubyGems_ProxyRejectsPublish(t *testing.T) {
+	r, _, _ := proxySetup(t, nil)
+	w := publish(t, r, "gems-proxy", []byte("anything"))
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func findComponent(d formats.Deps, repo, name string) (*domain.Component, error) {
+	page, err := d.Components.Search(nil, domain.SearchParams{Repository: repo, Name: name, Limit: 10}) //nolint:staticcheck // mock ignores ctx
+	if err != nil {
+		return nil, err
+	}
+	for i := range page.Items {
+		if page.Items[i].Name == name {
+			return &page.Items[i], nil
+		}
+	}
+	return nil, fmt.Errorf("component %q not found", name)
+}
+
+// The legacy Marshal indexes are not generated; modern gem/bundler fall back
+// to the compact index on a clean 404 (verified live — a 405 produced only a
+// noisier warning on the way to the same fallback).
+func TestRubyGems_LegacySpecsAnswer404(t *testing.T) {
+	repo := testutil.SimpleRepo("gems-legacy", "rubygems")
+	r, _ := setup(repo)
+	for _, p := range []string{"/specs.4.8.gz", "/latest_specs.4.8.gz", "/prerelease_specs.4.8.gz"} {
+		assert.Equal(t, http.StatusNotFound, get(r, "/repository/gems-legacy"+p).Code, p)
+	}
+}

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -59,6 +59,7 @@ var nexusFormats = map[string]domain.RepoFormat{
 	"conan":     "conan",
 	"conda":     "conda",
 	"terraform": "terraform",
+	"rubygems":  domain.FormatRubyGems,
 }
 
 // nexusPrivilegeTypes maps Nexus privilege types onto the Nexspence ones. The

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -492,7 +492,7 @@ func TestNexusMigration_GroupCycleDoesNotHang(t *testing.T) {
 func TestNexusMigration_SkipsUnsupportedFormatAndCountsIt(t *testing.T) {
 	fake := &fakeNexus{
 		settings: `[
-			{"name":"gems","format":"rubygems","type":"hosted","online":true},
+			{"name":"bower-things","format":"bower","type":"hosted","online":true},
 			{"name":"raw-hosted","format":"raw","type":"hosted","online":true}
 		]`,
 	}
@@ -503,9 +503,9 @@ func TestNexusMigration_SkipsUnsupportedFormatAndCountsIt(t *testing.T) {
 	assert.Equal(t, 1, done.DoneRepos, "only the supported repository is created")
 	assert.Equal(t, 1, done.ErrorCount)
 	require.NotNil(t, done.LastError)
-	assert.Contains(t, *done.LastError, "rubygems")
+	assert.Contains(t, *done.LastError, "bower")
 
-	_, err := h.repos.Get(context.Background(), "gems")
+	_, err := h.repos.Get(context.Background(), "bower-things")
 	assert.Error(t, err)
 }
 

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -1024,6 +1024,7 @@ curl -sf http://localhost:8081/service/rest/v1/status/check</div></div>
       <tr><td>Go</td><td><code>/repository/{name}/</code></td><td data-i18n="repo.urls.go">Set as <code>GOPROXY</code></td></tr>
       <tr><td>NuGet</td><td><code>/repository/{name}/index.json</code></td><td data-i18n="repo.urls.nuget">v3 flat container endpoint</td></tr>
       <tr><td>Cargo</td><td><code>/repository/{name}/</code></td><td data-i18n="repo.urls.cargo">Sparse index endpoint</td></tr>
+      <tr><td>RubyGems</td><td><code>/repository/{name}/</code></td><td data-i18n="repo.urls.rubygems">Compact index + gem push</td></tr>
       <tr><td>Raw</td><td><code>/repository/{name}/</code></td><td data-i18n="repo.urls.raw">PUT/GET any path</td></tr>
     </tbody>
   </table>
@@ -1711,7 +1712,7 @@ export NEXSPENCE_OIDC_CLIENT_SECRET="..."</div></div>
       </section>
       <section id="sec-formats" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="fmt.title">Supported Formats</div>
-  <div class="doc-section-sub" data-i18n="fmt.sub">15 artifact formats — each supports Hosted, Proxy, and Group repository types.</div>
+  <div class="doc-section-sub" data-i18n="fmt.sub">16 artifact formats — each supports Hosted, Proxy, and Group repository types.</div>
   <table class="doc-table">
     <thead><tr><th>Format</th><th>Protocol</th><th>Hosted</th><th>Proxy</th><th>Group</th></tr></thead>
     <tbody>
@@ -1730,6 +1731,7 @@ export NEXSPENCE_OIDC_CLIENT_SECRET="..."</div></div>
       <tr><td>Raw</td><td>HTTP PUT/GET</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Conda</td><td>conda index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Terraform</td><td>Registry protocol v1</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
+      <tr><td>RubyGems</td><td>Compact index</td><td class="y">✓</td><td class="y">✓</td><td>—</td></tr>
     </tbody>
   </table>
       </section>
@@ -1862,6 +1864,7 @@ const TRANSLATIONS={
     'repo.urls.go':'Set as <code>GOPROXY</code>',
     'repo.urls.nuget':'v3 flat container endpoint',
     'repo.urls.cargo':'Sparse index endpoint',
+    'repo.urls.rubygems':'Compact index + gem push',
     'repo.urls.raw':'PUT/GET any path',
     'repo.anon.sep':'Anonymous Access',
     'repo.anon.info':'Enable <strong>Allow anonymous access</strong> on a repository to let unauthenticated users download artifacts. Write operations always require authentication.',
@@ -2125,7 +2128,7 @@ const TRANSLATIONS={
     'sb.native-install':'Native Install',
     'crumb.native-install':'native install',
     'fmt.title':'Supported Formats',
-    'fmt.sub':'15 artifact formats — each supports Hosted, Proxy, and Group repository types.',
+    'fmt.sub':'16 artifact formats — each supports Hosted, Proxy, and Group repository types.',
     'api.title':'API Reference','api.sub':'Nexspence exposes two API surfaces.',
     'api.auth.title':'Authentication',
     'api.auth.desc':'JWT Bearer token (from <code>POST /api/v1/auth/login</code>), API tokens (<code>nxs_*</code> prefix via Bearer or Basic password), or HTTP Basic with username + password.',
@@ -2232,6 +2235,7 @@ const TRANSLATIONS={
     'repo.urls.go':'Установите как <code>GOPROXY</code>',
     'repo.urls.nuget':'Endpoint v3 flat container',
     'repo.urls.cargo':'Sparse index endpoint',
+    'repo.urls.rubygems':'Compact index + gem push',
     'repo.urls.raw':'PUT/GET любого пути',
     'repo.anon.sep':'Анонимный доступ',
     'repo.anon.info':'Включите <strong>Allow anonymous access</strong> для репозитория, чтобы неаутентифицированные пользователи могли скачивать артефакты. Операции записи всегда требуют аутентификации.',
@@ -2502,7 +2506,7 @@ const TRANSLATIONS={
     'sb.native-install':'Нативная установка',
     'crumb.native-install':'нативная установка',
     'fmt.title':'Поддерживаемые форматы',
-    'fmt.sub':'15 форматов артефактов — каждый поддерживает типы Hosted, Proxy и Group.',
+    'fmt.sub':'16 форматов артефактов — каждый поддерживает типы Hosted, Proxy и Group.',
     'api.title':'Справочник API',
     'api.sub':'Nexspence предоставляет два API-интерфейса.',
     'api.auth.title':'Аутентификация',


### PR DESCRIPTION
Implements #326: RubyGems as a supported format — proxy and hosted repositories with the workflows the issue asks for (`bundle install` against the proxy, private gems on hosted, standard tooling untouched).

## Protocol surface

- **Compact index** — `/versions`, `/info/<gem>`, `/names` — the representation Bundler resolves against. Hosted repositories generate it from stored components: the publish step parses the gemspec once and stores the rendered `/info` line (runtime deps sorted by name, `&`-joined multi-clause requirements, sha256 checksum, ruby/rubygems requirements) on the component; the index endpoints just concatenate, and the `/versions` MD5 is computed from the exact `/info` rendering Bundler validates. Proxy repositories pass the index through the standard cache (mutable metadata TTL) — compact-index entries embed no URLs, so nothing is rewritten.
- **Downloads** — `/gems/<file>.gem`, immutable. Proxied gems register under their real name/version (#336's lesson), parsed at the first hyphen-digit boundary so hyphenated names (`nexspence-demo-0.1.0.gem`) survive.
- **Publish** — `POST /api/v1/gems`, the body being the `.gem` (a tar holding `metadata.gz`, the gzipped YAML gemspec). Size-capped, garbage rejected with 400.
- **Yank** — `DELETE /api/v1/gems/yank`; the gem client sends form params in the DELETE body, which Go's FormValue does not parse — read explicitly (query accepted too). The yanked version's component is removed so the index stops advertising it.
- **Legacy Marshal indexes** (`specs.4.8.gz`…) answer a clean 404; modern gem/bundler fall back to the compact index (verified live — RubyGems 3.5 installs fine, with only a warning on the legacy probe).

## Live verification (docker, real toolchain)

- `bundle install` with the Gemfile source pointed at a proxy of rubygems.org: metadata fetched, dependencies resolved, `rack 3.1.8` installed — the full compact-index flow.
- `gem build` → `gem push --host …` → `gem install nexspence-demo` from the hosted repository, with its runtime dependency resolved through the proxy source, and the installed library loading.
- `gem push` authentication: the gem client sends an API key, not Basic auth — the working recipe (documented on the in-app docs page) is `:rubygems_api_key: Basic <base64 user:pass>`, which arrives as a standard Basic header.
- The live run also caught that the repositories **DB format constraint hardcodes the format list** — migration `029` extends it; without it every create failed with a raw check-constraint violation.

## Registration

Domain format list (+ docs-site consistency test), router registry, Nexus-migration format map (`rubygems` sources now migrate instead of being skipped — the fixture that used rubygems as the unsupported example now uses `bower`), frontend format lists/color/proxy default, in-app docs entry, and the website docs table + counters (15 → 16).

## Deliberately deferred

**Group repositories** for rubygems (the docs table says so): merging compact indexes across members while keeping the per-gem MD5 consistent with the merged `/info` is its own piece of work — filed to follow.

## Tests

TDD throughout: gemspec parsing (deps filtering/sorting, multi-clause requirements, platform filenames, garbage), handler-level hosted flow (publish→index→checksum→yank→404s), proxy passthrough with coordinate checks, legacy-404s. Full backend, frontend (538) and postgres-integration suites green.

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma