### PR TITLE
fix(scan,cargo): maven2 ecosystem, metadata-placeholder refusal, working Cargo proxy against real registries

### DIFF
--- a/internal/formats/cargo/handler.go
+++ b/internal/formats/cargo/handler.go
@@ -15,12 +15,14 @@
 package cargo
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -32,7 +34,22 @@ import (
 )
 
 // Handler serves the Rust Cargo registry protocol.
-type Handler struct{ deps formats.Deps }
+type Handler struct {
+	deps formats.Deps
+
+	// dlMu/dlBases cache each proxy repository's upstream download base — the
+	// "dl" value of the UPSTREAM's own /config.json. The real crates.io splits
+	// its API across hosts (sparse index on index.crates.io, downloads on
+	// crates.io), so the download endpoint cannot be derived from remote_url
+	// (#347). Cached per repo for the metadata TTL.
+	dlMu    sync.Mutex
+	dlBases map[string]dlBaseEntry
+}
+
+type dlBaseEntry struct {
+	fetched time.Time
+	dl      string // empty = upstream has no usable config.json; fall back to remote_url
+}
 
 // New creates a Cargo format Handler with the given dependencies.
 func New(deps formats.Deps) *Handler { return &Handler{deps: deps} }
@@ -63,7 +80,18 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			maxAge = repoproxy.MetadataMaxAge(repo)
 		}
 		coords := proxyCoords(p)
-		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge); err != nil {
+		// The local /index/ route prefix is not part of any real registry's
+		// URL scheme; downloads may live on a different host than the index —
+		// both resolved into an explicit upstreamPath (#347).
+		upstreamPath := ""
+		if strings.HasPrefix(p, "/index/") {
+			upstreamPath = repoproxy.CargoIndexUpstreamPath(p)
+		} else if name, version, ok := parseDownloadPath(p); ok {
+			if dl := h.upstreamDlBase(c.Request.Context(), repo); dl != "" {
+				upstreamPath = cargoDownloadURL(dl, name, version)
+			}
+		}
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, upstreamPath, coords, "application/octet-stream", maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return
@@ -286,6 +314,97 @@ func proxyCoords(p string) base.Coords {
 		}
 	}
 	return base.Coords{}
+}
+
+// parseDownloadPath recognizes /api/v1/crates/<name>/<version>/download.
+func parseDownloadPath(p string) (name, version string, ok bool) {
+	rest, found := strings.CutPrefix(p, "/api/v1/crates/")
+	if !found {
+		return "", "", false
+	}
+	rest, found = strings.CutSuffix(rest, "/download")
+	if !found {
+		return "", "", false
+	}
+	name, version, found = strings.Cut(rest, "/")
+	if !found || name == "" || version == "" || strings.Contains(version, "/") {
+		return "", "", false
+	}
+	return name, version, true
+}
+
+// upstreamDlBase returns the upstream registry's own download base — the "dl"
+// value of ITS /config.json — cached per repository for the metadata TTL. An
+// unreachable or unparsable config yields "", and the download falls back to
+// remote_url + the local path (correct for single-host registries).
+func (h *Handler) upstreamDlBase(ctx context.Context, repo *domain.Repository) string {
+	h.dlMu.Lock()
+	if h.dlBases == nil {
+		h.dlBases = make(map[string]dlBaseEntry)
+	}
+	if e, ok := h.dlBases[repo.Name]; ok && time.Since(e.fetched) < repoproxy.MetadataMaxAge(repo) {
+		h.dlMu.Unlock()
+		return e.dl
+	}
+	h.dlMu.Unlock()
+
+	dl := fetchUpstreamDl(ctx, repo)
+
+	h.dlMu.Lock()
+	h.dlBases[repo.Name] = dlBaseEntry{fetched: time.Now(), dl: dl}
+	h.dlMu.Unlock()
+	return dl
+}
+
+func fetchUpstreamDl(ctx context.Context, repo *domain.Repository) string {
+	resp, err := repoproxy.FetchUpstreamOnce(ctx, repo, "/config.json", "", nil)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var cfg struct {
+		Dl string `json:"dl"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&cfg); err != nil {
+		return ""
+	}
+	if !strings.HasPrefix(cfg.Dl, "http://") && !strings.HasPrefix(cfg.Dl, "https://") {
+		return ""
+	}
+	return cfg.Dl
+}
+
+// cargoDownloadURL renders the registry's dl template for one crate. Per the
+// registry-index spec, dl may carry {crate}/{version}/{prefix}/{lowerprefix}
+// markers; a dl without any markers gets "/{crate}/{version}/download"
+// appended — exactly how cargo itself interprets it.
+func cargoDownloadURL(dl, name, version string) string {
+	if strings.Contains(dl, "{crate}") || strings.Contains(dl, "{version}") ||
+		strings.Contains(dl, "{prefix}") || strings.Contains(dl, "{lowerprefix}") {
+		out := strings.ReplaceAll(dl, "{crate}", name)
+		out = strings.ReplaceAll(out, "{version}", version)
+		out = strings.ReplaceAll(out, "{prefix}", cargoPrefix(name))
+		out = strings.ReplaceAll(out, "{lowerprefix}", cargoPrefix(strings.ToLower(name)))
+		return out
+	}
+	return strings.TrimRight(dl, "/") + "/" + name + "/" + version + "/download"
+}
+
+// cargoPrefix is the sparse-index sharding prefix ("se/rd" for serde).
+func cargoPrefix(name string) string {
+	switch {
+	case len(name) == 1:
+		return "1"
+	case len(name) == 2:
+		return "2"
+	case len(name) == 3:
+		return "3/" + name[:1]
+	default:
+		return name[:2] + "/" + name[2:4]
+	}
 }
 
 func normPath(p string) string {

--- a/internal/formats/cargo/proxy_coords_test.go
+++ b/internal/formats/cargo/proxy_coords_test.go
@@ -2,8 +2,10 @@ package cargo_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -89,4 +91,116 @@ func TestCargo_ProxyIndexEntry_RegistersMetadataCoords(t *testing.T) {
 	assert.Equal(t, "smallvec", page.Items[0].Name,
 		"the index entry is registered under the crate's name, not the sharded path")
 	assert.Equal(t, "metadata", page.Items[0].Version)
+}
+
+// ── #347: sparse index against a REAL registry's URL shape ───────────────────
+
+// realShapeIndexUpstream mimics index.crates.io: sparse-index keys live at the
+// ROOT ("/se/rd/serde"), never under "/index/..." (that prefix is this
+// codebase's own route), and /config.json advertises where downloads live —
+// possibly on a DIFFERENT host, exactly like the real crates.io split.
+func realShapeCargoUpstreams(t *testing.T) (indexHost *httptest.Server, dlHits *atomic.Int32) {
+	t.Helper()
+	var hits atomic.Int32
+	dlHost := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/crates/serde/1.0.0/download" {
+			hits.Add(1)
+			_, _ = w.Write([]byte("crate-bytes"))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(dlHost.Close)
+
+	indexHost = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/config.json":
+			_, _ = w.Write([]byte(`{"dl":"` + dlHost.URL + `/api/v1/crates","api":"` + dlHost.URL + `"}`))
+		case "/se/rd/serde":
+			_, _ = w.Write([]byte(`{"name":"serde","vers":"1.0.0","deps":[],"cksum":"aa"}` + "\n"))
+		default:
+			// The real index host is an S3 bucket: anything else — including
+			// the doubled "/index/..." path — is NoSuchKey.
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(indexHost.Close)
+	return indexHost, &hits
+}
+
+func setupCargoProxyAt(t *testing.T, upstreamURL string) (*gin.Engine, formats.Deps) {
+	t.Helper()
+	orig := repoproxy.UpstreamClient
+	repoproxy.UpstreamClient = &http.Client{}
+	t.Cleanup(func() { repoproxy.UpstreamClient = orig })
+
+	repo := &domain.Repository{
+		ID: "repo-cargo-real", Name: "cargo-real", Format: domain.RepoFormat("cargo"),
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstreamURL},
+	}
+	comps := testutil.NewComponentRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := cargo.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, d
+}
+
+func TestCargo_ProxyIndex_StripsLocalPrefixForUpstream(t *testing.T) {
+	indexHost, _ := realShapeCargoUpstreams(t)
+	r, _ := setupCargoProxyAt(t, indexHost.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/cargo-real/index/se/rd/serde", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code,
+		"the /index/ route prefix must be stripped before the request leaves for upstream: %d %s", w.Code, w.Body.String())
+	assert.Contains(t, w.Body.String(), `"serde"`)
+}
+
+// The real crates.io serves downloads on a different host than its sparse
+// index; the dl base comes from the upstream's own /config.json.
+func TestCargo_ProxyDownload_FollowsUpstreamConfigDl(t *testing.T) {
+	indexHost, dlHits := realShapeCargoUpstreams(t)
+	r, d := setupCargoProxyAt(t, indexHost.URL)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/cargo-real/api/v1/crates/serde/1.0.0/download", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code,
+		"the download must follow the upstream config.json dl host: %d %s", w.Code, w.Body.String())
+	assert.Equal(t, "crate-bytes", w.Body.String())
+	require.Equal(t, int32(1), dlHits.Load())
+
+	// The crate is cached: a second pull is served locally (immutable).
+	w2 := httptest.NewRecorder()
+	r.ServeHTTP(w2, httptest.NewRequest(http.MethodGet, "/repository/cargo-real/api/v1/crates/serde/1.0.0/download", nil))
+	require.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, "crate-bytes", w2.Body.String())
+	assert.Equal(t, int32(1), dlHits.Load(), "an immutable crate must be served from cache")
+
+	comp, err := findCargoComponent(d, "cargo-real", "serde")
+	require.NoError(t, err)
+	assert.Equal(t, "1.0.0", comp.Version)
+}
+
+func findCargoComponent(d formats.Deps, repo, name string) (*domain.Component, error) {
+	page, err := d.Components.Search(nil, domain.SearchParams{Repository: repo, Name: name, Limit: 10}) //nolint:staticcheck // mock ignores ctx
+	if err != nil {
+		return nil, err
+	}
+	for i := range page.Items {
+		if page.Items[i].Name == name {
+			return &page.Items[i], nil
+		}
+	}
+	return nil, fmt.Errorf("component %q not found", name)
 }

--- a/internal/formats/repoproxy/coverage_extra_test.go
+++ b/internal/formats/repoproxy/coverage_extra_test.go
@@ -160,3 +160,36 @@ func TestMinimumPackageAge_Parsing(t *testing.T) {
 		})
 	}
 }
+
+// CargoIndexUpstreamPath: the local /index/ prefix is this codebase's own
+// route, not part of any real registry's URL scheme (#347) — index.crates.io
+// keys are "se/rd/serde", not "index/se/rd/serde".
+func TestCargoIndexUpstreamPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/index/se/rd/serde", "/se/rd/serde"},
+		{"/index/2/cc", "/2/cc"},
+		{"/index/3/u/url", "/3/u/url"},
+		{"/index/config.json", "/config.json"},
+		{"/not-index/x", "/not-index/x"},
+	}
+	for _, tc := range cases {
+		if got := CargoIndexUpstreamPath(tc.in); got != tc.want {
+			t.Errorf("CargoIndexUpstreamPath(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// JoinURL passes an absolute upstream URL through untouched: format handlers
+// hand one over when the real registry splits its API across hosts (the
+// crates.io download endpoint lives on a different host than its sparse
+// index). Only handler code ever sets upstreamPath — client paths are
+// normalized relative paths — so this is not reachable from request input.
+func TestJoinURL_AbsoluteUpstreamPassesThrough(t *testing.T) {
+	got, err := JoinURL("https://index.crates.io", "https://crates.io/api/v1/crates/serde/1.0.0/download")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "https://crates.io/api/v1/crates/serde/1.0.0/download" {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -110,6 +110,18 @@ func RemoteURL(repo *domain.Repository) (string, error) {
 
 // JoinURL joins the remote base URL with the repository-relative artifact path.
 func JoinURL(remoteBase, repoRelativePath string) (string, error) {
+	// An absolute upstream URL passes through: a handler hands one over when
+	// the real registry splits its API across hosts (crates.io serves
+	// downloads on a different host than its sparse index, #347). Only
+	// handler code ever builds upstreamPath — client paths arrive normalized
+	// and relative — so this is not reachable from request input, and the
+	// SSRF guard on the upstream client still applies to the fetch itself.
+	if strings.HasPrefix(repoRelativePath, "http://") || strings.HasPrefix(repoRelativePath, "https://") {
+		if _, err := url.Parse(repoRelativePath); err != nil {
+			return "", fmt.Errorf("invalid upstream url: %w", err)
+		}
+		return repoRelativePath, nil
+	}
 	u, err := url.Parse(remoteBase)
 	if err != nil {
 		return "", fmt.Errorf("invalid remote_url: %w", err)
@@ -720,6 +732,17 @@ func DispatchProxyError(d formats.Deps, repoName, path, upstream string, cause e
 			"error":    cause.Error(),
 		},
 	})
+}
+
+// CargoIndexUpstreamPath strips the local /index/ route prefix before a
+// sparse-index request leaves for the upstream registry (#347): the prefix is
+// this codebase's own URL scheme, and index.crates.io's real keys are
+// "se/rd/serde", not "index/se/rd/serde". Non-index paths pass through.
+func CargoIndexUpstreamPath(p string) string {
+	if rest, ok := strings.CutPrefix(p, "/index/"); ok {
+		return "/" + rest
+	}
+	return p
 }
 
 // NPMMetadataPath returns the path segment npmjs.org uses for metadata (scoped packages use %2F).

--- a/internal/service/osv_client.go
+++ b/internal/service/osv_client.go
@@ -141,7 +141,7 @@ func maliciousID(id string, aliases []string) string {
 // Returns "" if the format is not supported.
 func FormatToEcosystem(format string) string {
 	switch strings.ToLower(format) {
-	case "maven":
+	case "maven", "maven2":
 		return "Maven"
 	case "npm":
 		return "npm"

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -326,6 +326,13 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 		return nil, fmt.Errorf("component %s not found", componentID)
 	}
 	format := strings.ToLower(comp.Format)
+	// A cached metadata placeholder (an npm packument, a cargo index entry, a
+	// pypi simple page) is not a package version: scanning it would answer
+	// "ok, 0 vulnerabilities" — indistinguishable from a clean scan of the
+	// real artifact and exactly the confusion #347 reports.
+	if metadataPlaceholderVersions[comp.Version] {
+		return nil, fmt.Errorf("component %q@%q is a cached metadata artifact, not a package version — scan the versioned package component instead", comp.Name, comp.Version)
+	}
 	switch {
 	case isImageFormat(format):
 		// Falls through to the Trivy path below. An oci repository holds the same
@@ -333,7 +340,7 @@ func (s *ScanService) Scan(ctx context.Context, componentID, imageRef string) (*
 		// so refusing it on its format label would be wrong. A non-image artifact
 		// (a chart, a signature) surfaces as a Trivy error instead of being
 		// refused up front, which is the more honest answer.
-	case format == "maven" || format == "npm" || format == "pypi" || format == "cargo":
+	case format == "maven" || format == "maven2" || format == "npm" || format == "pypi" || format == "cargo":
 		return s.scanOSV(ctx, comp)
 	default:
 		return nil, fmt.Errorf("vulnerability scanning is not supported for format %q", comp.Format)
@@ -475,7 +482,13 @@ func (s *ScanService) scanOSV(ctx context.Context, comp *domain.Component) (*dom
 		Status:    domain.ScanStatusOK,
 	}
 
-	vulns, err := s.OSVClient.Query(ctx, comp.Name, comp.Version, ecosystem)
+	// OSV identifies Maven packages as "group:artifact"; the bare artifact
+	// name matches nothing.
+	pkgName := comp.Name
+	if ecosystem == "Maven" && comp.Group != "" {
+		pkgName = comp.Group + ":" + comp.Name
+	}
+	vulns, err := s.OSVClient.Query(ctx, pkgName, comp.Version, ecosystem)
 	if err != nil {
 		result.Status = domain.ScanStatusFailed
 		result.Error = err.Error()
@@ -535,6 +548,16 @@ func (s *ScanService) persistScanRow(ctx context.Context, comp *domain.Component
 	if err := s.ScanResults.Insert(ctx, row); err != nil {
 		log.Printf("nexor: scan result row not inserted component=%s scanner=%s: %v", comp.ID, scanner, err)
 	}
+}
+
+// metadataPlaceholderVersions are the version labels format handlers register
+// cached metadata under (an npm packument, a pypi simple page, a cargo index
+// entry). They are files, not package versions — no advisory database can say
+// anything about them.
+var metadataPlaceholderVersions = map[string]bool{
+	"metadata":    true,
+	"simple-page": true,
+	"index":       true,
 }
 
 // isDigestAlias reports whether a component version is a content digest rather

--- a/internal/service/scan_service_extra_test.go
+++ b/internal/service/scan_service_extra_test.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
@@ -455,5 +458,69 @@ func TestScanExtra_TrivyErrorMessage_LeavesOtherFailuresAlone(t *testing.T) {
 	msg := svc.TrivyErrorMessage(errors.New("exit status 1"), "MANIFEST_UNKNOWN")
 	if !strings.Contains(msg, "re-push the image") {
 		t.Errorf("msg = %q, want the existing manifest message untouched", msg)
+	}
+}
+
+// #347 follow-ups: the reporter's zero-findings scan turned out to be a fixed
+// version (smallvec 1.6.1 IS the fix for RUSTSEC-2021-0003) — but the
+// investigation surfaced two real gaps.
+
+// Maven components carry format "maven2"; the scan path compared against
+// "maven", so Maven scanning has never actually worked.
+func TestScanService_Maven2_ReachesOSV(t *testing.T) {
+	comp := &domain.Component{ID: "m2", Repository: "maven-hosted", Format: "maven2",
+		Group: "org.apache.logging.log4j", Name: "log4j-core", Version: "2.14.1"}
+	comps := testutil.NewComponentRepo()
+	comps.Create(context.Background(), comp)
+
+	var gotEcosystem, gotName string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Package struct {
+				Name      string `json:"name"`
+				Ecosystem string `json:"ecosystem"`
+			} `json:"package"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotEcosystem, gotName = req.Package.Ecosystem, req.Package.Name
+		_ = json.NewEncoder(w).Encode(map[string]any{"vulns": []any{}})
+	}))
+	defer srv.Close()
+
+	svc := service.NewScanService(comps, "")
+	svc.WithScanResults(testutil.NewScanResultRepo())
+	svc.OSVClient.BaseURL = srv.URL
+
+	res, err := svc.Scan(context.Background(), comp.ID, "")
+	require.NoError(t, err, "a maven2 component must be scannable")
+	assert.Equal(t, domain.ScanStatusOK, res.Status)
+	assert.Equal(t, "Maven", gotEcosystem)
+	assert.Equal(t, "org.apache.logging.log4j:log4j-core", gotName,
+		"OSV identifies Maven packages as group:artifact")
+}
+
+// A cached metadata placeholder (an npm packument, a cargo index entry, a pypi
+// simple page) is not a package version: scanning it answered "ok, 0
+// vulnerabilities", indistinguishable from a clean scan of the real artifact.
+// It must refuse with an explanation instead.
+func TestScanService_MetadataPlaceholderRefused(t *testing.T) {
+	comps := testutil.NewComponentRepo()
+	var ids []string
+	for _, tc := range []struct{ format, version string }{
+		{"cargo", "metadata"},
+		{"npm", "metadata"},
+		{"pypi", "simple-page"},
+	} {
+		comp := &domain.Component{Repository: "r", Format: tc.format, Name: "pkg-" + tc.format, Version: tc.version}
+		require.NoError(t, comps.Create(context.Background(), comp))
+		ids = append(ids, comp.ID)
+	}
+	svc := service.NewScanService(comps, "")
+	svc.WithScanResults(testutil.NewScanResultRepo())
+
+	for _, id := range ids {
+		_, err := svc.Scan(context.Background(), id, "")
+		require.Error(t, err, "component %s", id)
+		assert.Contains(t, err.Error(), "metadata", "the refusal explains itself: %v", err)
 	}
 }

--- a/internal/service/scan_service_test.go
+++ b/internal/service/scan_service_test.go
@@ -56,7 +56,7 @@ func TestDockerScanImageRef(t *testing.T) {
 }
 
 func TestScanService_NonDocker(t *testing.T) {
-	comp := &domain.Component{ID: "x", Format: "maven2", Name: "spring-core", Version: "5.3.0"}
+	comp := &domain.Component{ID: "x", Format: "conan", Name: "openssl", Version: "3.0.0"}
 	comps := testutil.NewComponentRepo()
 	comps.Create(context.Background(), comp)
 


### PR DESCRIPTION
Closes #347 — the reported scan itself was correct (`smallvec@1.6.1` **is** the patched version for RUSTSEC-2021-0003, as @jorgemillan's audit in the thread confirmed independently), but the investigation surfaced three real gaps, all fixed here.

## 1. Maven scanning never worked

Components carry format `maven2`; the scan path compared against `"maven"`, so every Maven component answered "not supported". And OSV identifies Maven packages as `group:artifact` — the bare artifact name matches nothing. Both fixed: a `maven2` component reaches OSV with ecosystem `Maven` and the `group:artifact` name.

## 2. Metadata placeholders scanned as "clean"

Scanning a cached metadata artifact (an npm packument, a cargo index entry, a pypi simple page — versions `metadata`/`simple-page`/`index`) answered `ok, 0 vulnerabilities`, indistinguishable from a clean scan of the real package — exactly the confusion the issue reports and its "possible lead" pointed at. Those components now refuse with `…is a cached metadata artifact, not a package version — scan the versioned package component instead`.

## 3. Cargo proxy vs. real registries (from the issue thread)

Implemented per @jorgemillan's verified design: `CargoIndexUpstreamPath` (alongside `NPMMetadataPath`) strips the local `/index/` route prefix before the request leaves for upstream — `index.crates.io`'s real keys are `se/rd/serde`, and the unstripped path got S3 `NoSuchKey` for every crate, making every real `cargo build` through a proxy impossible.

The thread's **two-host caveat** (crates.io serves its sparse index on `index.crates.io` but downloads on `crates.io`) is resolved as well: download requests now follow the `dl` base of the **upstream's own `/config.json`** (cached per repository for the metadata TTL; the registry-index spec's `{crate}`/`{version}`/`{prefix}`/`{lowerprefix}` markers are honored, markerless bases get `/{crate}/{version}/download` appended — cargo's own interpretation). `JoinURL` passes an absolute, handler-built upstream URL through; client paths arrive normalized and relative, so this is not reachable from request input, and the SSRF-guarded upstream client still applies. A single-host self-hosted registry keeps today's behavior (no usable config.json → `remote_url` + local path).

## Live verification

A real `cargo build` in docker against a proxy with `remote_url = https://index.crates.io`: sparse index resolved through the proxy, `smallvec v1.6.1` downloaded `(registry nexspence)` — from crates.io via the config.json dl base — binary compiled and ran. The proxied crate is cached (second pull served locally) and registers under its real coordinates.

## Tests

All written first and observed failing:

- `TestScanService_Maven2_ReachesOSV` (RED: "not supported", then bare name)
- `TestScanService_MetadataPlaceholderRefused` (RED: scan succeeded with 0 findings)
- `TestCargoIndexUpstreamPath`, `TestJoinURL_AbsoluteUpstreamPassesThrough` unit cases
- `TestCargo_ProxyIndex_StripsLocalPrefixForUpstream` and `TestCargo_ProxyDownload_FollowsUpstreamConfigDl` — against a fake shaped like the REAL registry (root-level index keys, S3-like 404 for anything else, downloads on a second host) — the mock-vs-reality lesson #349 spells out

Full suite green (the webhook-handler failure is the known sandbox restriction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLvgmFSkBEDv6h413ikoma