### PR TITLE
fix(nuget): resolve v3 resources against the bare origin; real-shape proxy integration tests for every format (#349)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
             -coverpkg=./internal/storage/... \
             -coverprofile=storage_cov.out \
             ./internal/storage/...
+      - name: Run end-to-end integration tests (full router + real-shape registry fakes)
+        run: |
+          go test -tags=integration -count=1 ./internal/integration/...
       - name: Enforce storage package ≥80%
         run: |
           pct=$(go tool cover -func=storage_cov.out | awk '/^total:/ {gsub(/%/,"",$3); print $3}')

--- a/internal/formats/nuget/handler.go
+++ b/internal/formats/nuget/handler.go
@@ -66,6 +66,13 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			maxAge = repoproxy.MetadataMaxAge(repo)
 		}
 		coords := base.Coords{}
+		// Resource paths advertised by the rewritten index are the upstream's
+		// own paths re-rooted locally — forward them onto the bare origin,
+		// not onto a possibly /v3-suffixed remote_url (#349).
+		upstreamPath := ""
+		if origin := nugetRemoteOrigin(remoteURLOf(repo)); origin != "" {
+			upstreamPath = origin + p
+		}
 		// Registration pages embed absolute upstream URLs (packageContent,
 		// @id) — rewrite them on serve so clients pull packages through this
 		// proxy (#98); the cache keeps the upstream original.
@@ -74,7 +81,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 			localBase := strings.TrimRight(h.deps.BaseURL, "/") + "/repository/" + repo.Name
 			rewrite = func(b []byte) []byte { return RewriteRegistration(b, localBase) }
 		}
-		if err := repoproxy.ServeGETRewritten(c, h.deps, repo, p, "", coords, "application/octet-stream", maxAge, rewrite); err != nil {
+		if err := repoproxy.ServeGETRewritten(c, h.deps, repo, p, upstreamPath, coords, "application/octet-stream", maxAge, rewrite); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
 		return
@@ -345,7 +352,12 @@ func (h *Handler) fetchAndRewriteNuGetIndex(c *gin.Context, repo *domain.Reposit
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, remoteBase+"/index.json", nil)
+	// The v3 service index is the ONE fixed path in an otherwise fully
+	// discoverable protocol, and it lives at /v3/index.json on the real
+	// nuget.org (#349). remote_url is the bare origin; a legacy /v3-suffixed
+	// value is normalized so it neither breaks discovery nor doubles itself
+	// onto the resource paths the index advertises.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, nugetRemoteOrigin(remoteBase)+"/v3/index.json", nil)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid upstream URL: " + err.Error()})
 		return
@@ -398,6 +410,22 @@ func (h *Handler) fetchAndRewriteNuGetIndex(c *gin.Context, repo *domain.Reposit
 		return
 	}
 	c.JSON(http.StatusOK, index)
+}
+
+// nugetRemoteOrigin normalizes remote_url to the registry's bare origin: a
+// legacy configuration carried a /v3 suffix (once the only way the index fetch
+// worked), which would double itself onto every already-correct resource path.
+func nugetRemoteOrigin(remoteBase string) string {
+	return strings.TrimSuffix(strings.TrimRight(remoteBase, "/"), "/v3")
+}
+
+// remoteURLOf reads the repository's remote_url, empty when unset.
+func remoteURLOf(repo *domain.Repository) string {
+	base, err := repoproxy.RemoteURL(repo)
+	if err != nil {
+		return ""
+	}
+	return base
 }
 
 func normPath(p string) string {

--- a/internal/formats/nuget/handler_test.go
+++ b/internal/formats/nuget/handler_test.go
@@ -179,23 +179,40 @@ func TestNuGet_Download_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
-func TestNuGet_ProxyServiceIndex_RewritesURLs(t *testing.T) {
-	// Mock upstream NuGet v3 service index
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/index.json" {
-			http.NotFound(w, r)
-			return
-		}
+// realShapeNuGetUpstream mimics the REAL api.nuget.org (#349): the service
+// index lives at /v3/index.json — NOT /index.json — and its resources point at
+// /v3-flatcontainer/ (hyphenated, a sibling of /v3/, not nested inside it).
+// The old mock invented the nested shape the code's own wrong assumption used,
+// which is exactly how the bug survived its test.
+func realShapeNuGetUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{
+		switch r.URL.Path {
+		case "/v3/index.json":
+			fmt.Fprintf(w, `{
   "version": "3.0.0",
   "resources": [
-    {"@id": "https://api.nuget.org/v3/flatcontainer/", "@type": "PackageBaseAddress/3.0.0"},
-    {"@id": "https://api.nuget.org/v3/registration5-gz-semver2/", "@type": "RegistrationsBaseUrl/3.6.0"}
+    {"@id": "%s/v3-flatcontainer/", "@type": "PackageBaseAddress/3.0.0"},
+    {"@id": "%s/v3/registration5-gz-semver2/", "@type": "RegistrationsBaseUrl/3.6.0"}
   ]
-}`)
+}`, srv.URL, srv.URL)
+		case "/v3-flatcontainer/newtonsoft.json/index.json":
+			fmt.Fprint(w, `{"versions":["13.0.3"]}`)
+		case "/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			fmt.Fprint(w, "nupkg-bytes")
+		default:
+			http.NotFound(w, r)
+		}
 	}))
-	defer upstream.Close()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestNuGet_ProxyServiceIndex_RewritesURLs(t *testing.T) {
+	upstream := realShapeNuGetUpstream(t)
 
 	repo := &domain.Repository{
 		ID: "rp3", Name: "nuget-proxy", Format: "nuget",
@@ -208,14 +225,62 @@ func TestNuGet_ProxyServiceIndex_RewritesURLs(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
 	body := w.Body.String()
-	assert.Contains(t, body, "http://localhost:8080/repository/nuget-proxy/v3/flatcontainer/",
-		"PackageBaseAddress @id should be rewritten")
+	assert.Contains(t, body, "http://localhost:8080/repository/nuget-proxy/v3-flatcontainer/",
+		"PackageBaseAddress @id keeps the real hyphenated upstream path, re-rooted locally")
 	assert.Contains(t, body, "http://localhost:8080/repository/nuget-proxy/v3/registration5-gz-semver2/",
 		"RegistrationsBaseUrl @id should be rewritten")
-	assert.NotContains(t, body, "api.nuget.org",
+	assert.NotContains(t, body, upstream.URL,
 		"upstream host must not appear in rewritten index")
+}
+
+// The advertised resource paths must actually WORK when the client comes back
+// for them — with remote_url as the bare origin, the discovery fetch adds /v3
+// itself and the resource paths forward unchanged (#349's NuGet bug: a /v3'd
+// remote_url doubled itself onto every resource path and 404'd).
+func TestNuGet_ProxyFlatcontainer_ResolvesAgainstRealShape(t *testing.T) {
+	upstream := realShapeNuGetUpstream(t)
+
+	repo := &domain.Repository{
+		ID: "rp4", Name: "nuget-real", Format: "nuget",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL},
+	}
+	r := setup(repo)
+
+	list := httptest.NewRecorder()
+	r.ServeHTTP(list, httptest.NewRequest(http.MethodGet, "/repository/nuget-real/v3-flatcontainer/newtonsoft.json/index.json", nil))
+	require.Equal(t, http.StatusOK, list.Code, list.Body.String())
+	assert.Contains(t, list.Body.String(), "13.0.3")
+
+	pkg := httptest.NewRecorder()
+	r.ServeHTTP(pkg, httptest.NewRequest(http.MethodGet, "/repository/nuget-real/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg", nil))
+	require.Equal(t, http.StatusOK, pkg.Code, pkg.Body.String())
+	assert.Equal(t, "nupkg-bytes", pkg.Body.String())
+}
+
+// Legacy configurations kept remote_url with a /v3 suffix (it was the only way
+// the index fetch worked before); they must keep working unchanged.
+func TestNuGet_ProxyLegacyV3RemoteURL_StillWorks(t *testing.T) {
+	upstream := realShapeNuGetUpstream(t)
+
+	repo := &domain.Repository{
+		ID: "rp5", Name: "nuget-legacy", Format: "nuget",
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": upstream.URL + "/v3"},
+	}
+	r := setup(repo)
+
+	idx := httptest.NewRecorder()
+	r.ServeHTTP(idx, httptest.NewRequest(http.MethodGet, "/repository/nuget-legacy/index.json", nil))
+	require.Equal(t, http.StatusOK, idx.Code, idx.Body.String())
+
+	pkg := httptest.NewRecorder()
+	r.ServeHTTP(pkg, httptest.NewRequest(http.MethodGet, "/repository/nuget-legacy/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg", nil))
+	require.Equal(t, http.StatusOK, pkg.Code,
+		"a /v3-suffixed remote_url must not double itself onto resource paths: %d %s", pkg.Code, pkg.Body.String())
+	assert.Equal(t, "nupkg-bytes", pkg.Body.String())
 }
 
 func TestNuGet_ProxyServiceIndex_UpstreamError(t *testing.T) {

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -20,13 +20,16 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/nexspence-oss/nexspence/internal/api"
+	"github.com/nexspence-oss/nexspence/internal/auth"
 	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
 	"github.com/nexspence-oss/nexspence/internal/logger"
+	"github.com/nexspence-oss/nexspence/internal/repository/postgres"
 	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -43,9 +46,28 @@ func server(t *testing.T) *httptest.Server {
 	serverOnce.Do(func() {
 		pool := pgtest.Pool(t)
 
-		l, err := net.Listen("tcp", "127.0.0.1:0")
+		// The seed migration pre-creates the admin user with a placeholder
+		// hash; the configured password is normally applied by the server
+		// binary's bootstrap step, which lives in package main — set it here.
+		authSvc := auth.NewService("integration-test-secret-32bytes!!", 1, 4)
+		hash, err := authSvc.HashPassword("admin123")
 		if err != nil {
-			t.Fatalf("listen: %v", err)
+			t.Fatalf("hash admin password: %v", err)
+		}
+		if err := postgres.NewUserRepo(pool).UpdatePassword(context.Background(), "admin", hash); err != nil {
+			t.Fatalf("set admin password: %v", err)
+		}
+		// UpdatePassword bumps tokens_valid_after, and a JWT's second-granular
+		// iat issued within the same second reads as pre-cutoff — harmless for
+		// humans, fatal for a test that logs in milliseconds later. Rewind it.
+		if _, err := pool.Exec(context.Background(),
+			`UPDATE users SET tokens_valid_after = now() - interval '1 minute' WHERE username = 'admin'`); err != nil {
+			t.Fatalf("rewind token cutoff: %v", err)
+		}
+
+		l, lerr := net.Listen("tcp", "127.0.0.1:0")
+		if lerr != nil {
+			t.Fatalf("listen: %v", lerr)
 		}
 		baseURL := "http://" + l.Addr().String()
 
@@ -55,6 +77,7 @@ func server(t *testing.T) *httptest.Server {
 		cfg.Auth.BcryptCost = 4
 		cfg.Storage.Local.BasePath = t.TempDir()
 		cfg.HTTP.BaseURL = baseURL
+		cfg.HTTP.MaxBodyMB = 64 // a zero-value config means "0 bytes", not "unlimited"
 		cfg.Log.Level = "error"
 		cfg.Bootstrap.AdminUsername = "admin"
 		cfg.Bootstrap.AdminPassword = "admin123"
@@ -95,10 +118,12 @@ func login(t *testing.T, username, password string) string {
 	resp, err := http.Post(server(t).URL+"/api/v1/login", "application/json", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "login response: %s", raw)
 
 	var result map[string]any
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	require.NoError(t, json.Unmarshal(raw, &result))
 	token, ok := result["token"].(string)
 	require.True(t, ok, "response missing token")
 	return token
@@ -136,7 +161,7 @@ func TestLoginAndMe(t *testing.T) {
 
 	var me map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&me))
-	assert.Equal(t, "admin", me["userId"])
+	assert.Equal(t, "admin", me["username"])
 }
 
 func TestRepositoryCRUD(t *testing.T) {
@@ -204,8 +229,8 @@ func TestRawArtifactPushPull(t *testing.T) {
 }
 
 func TestMetricsEndpoint(t *testing.T) {
-	resp, err := http.Get(server(t).URL + "/api/v1/metrics")
-	require.NoError(t, err)
+	token := login(t, "admin", "admin123")
+	resp := authReq(t, http.MethodGet, "/api/v1/metrics", nil, token)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -1,76 +1,98 @@
 //go:build integration
 
-// Package integration contains end-to-end tests that require a running
-// PostgreSQL database and blob storage. Run with:
+// Package integration contains end-to-end tests that boot the real router over
+// a real PostgreSQL database (started automatically via dockertest, like the
+// repository-layer integration tests). Run with:
 //
-//	docker compose up -d postgres
-//	NEXSPENCE_DB_DSN="postgres://nexspence:nexspence@localhost:5432/nexspence" \
-//	    go test ./internal/integration/... -tags integration -v
+//	go test ./internal/integration/... -tags integration -v
 package integration
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/nexspence-oss/nexspence/internal/api"
 	"github.com/nexspence-oss/nexspence/internal/config"
-	"github.com/nexspence-oss/nexspence/internal/db"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
 	"github.com/nexspence-oss/nexspence/internal/logger"
+	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-var testServer *httptest.Server
+var (
+	serverOnce sync.Once
+	testServer *httptest.Server
+)
+
+// server boots the full application once per test binary: a migrated postgres
+// from pgtest, the real router, and an HTTP listener whose address is also the
+// configured BaseURL — proxy handlers rewrite upstream URLs onto it, so it
+// must be the address clients actually reach.
+func server(t *testing.T) *httptest.Server {
+	t.Helper()
+	serverOnce.Do(func() {
+		pool := pgtest.Pool(t)
+
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
+		}
+		baseURL := "http://" + l.Addr().String()
+
+		cfg := &config.Config{}
+		cfg.Auth.JWTSecret = "integration-test-secret-32bytes!!"
+		cfg.Auth.JWTExpiryHours = 1
+		cfg.Auth.BcryptCost = 4
+		cfg.Storage.Local.BasePath = t.TempDir()
+		cfg.HTTP.BaseURL = baseURL
+		cfg.Log.Level = "error"
+		cfg.Bootstrap.AdminUsername = "admin"
+		cfg.Bootstrap.AdminPassword = "admin123"
+		cfg.Bootstrap.AdminEmail = "admin@test.local"
+
+		log := logger.New("error", "json")
+		handler := api.NewRouter(context.Background(), cfg, pool, log, "integration-test")
+
+		ts := httptest.NewUnstartedServer(handler)
+		_ = ts.Listener.Close()
+		ts.Listener = l
+		ts.Start()
+		testServer = ts
+	})
+	if testServer == nil {
+		t.Fatal("integration server failed to start")
+	}
+	return testServer
+}
 
 func TestMain(m *testing.M) {
-	dsn := os.Getenv("NEXSPENCE_DB_DSN")
-	if dsn == "" {
-		dsn = "postgres://nexspence:nexspence@localhost:5432/nexspence?sslmode=disable"
+	// The proxy-format tests point repositories at loopback httptest fakes;
+	// the production upstream client is SSRF-guarded and would refuse them.
+	repoproxy.UpstreamClient = &http.Client{}
+
+	code := m.Run()
+	if testServer != nil {
+		testServer.Close()
 	}
-
-	// Run migrations
-	if err := db.Migrate(dsn, "up"); err != nil {
-		fmt.Fprintf(os.Stderr, "migration failed: %v\n", err)
-		os.Exit(1)
-	}
-
-	pool, err := db.Connect(dsn)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "db connect failed: %v\n", err)
-		os.Exit(1)
-	}
-	defer pool.Close()
-
-	cfg := &config.Config{}
-	cfg.Auth.JWTSecret = "integration-test-secret-32bytes!!"
-	cfg.Auth.JWTExpiryHours = 1
-	cfg.Auth.BcryptCost = 4
-	cfg.Storage.Local.BasePath = os.TempDir() + "/nexspence-integration-test"
-	cfg.HTTP.BaseURL = "http://localhost"
-	cfg.Log.Level = "error"
-	cfg.Bootstrap.AdminUsername = "admin"
-	cfg.Bootstrap.AdminPassword = "admin123"
-	cfg.Bootstrap.AdminEmail = "admin@test.local"
-
-	log := logger.New("error", "json")
-	handler := api.NewRouter(cfg, pool, log)
-	testServer = httptest.NewServer(handler)
-	defer testServer.Close()
-
-	os.Exit(m.Run())
+	pgtest.Cleanup()
+	os.Exit(code)
 }
 
 // login returns a Bearer token for the given credentials.
 func login(t *testing.T, username, password string) string {
 	t.Helper()
 	body := fmt.Sprintf(`{"username":%q,"password":%q}`, username, password)
-	resp, err := http.Post(testServer.URL+"/api/v1/login", "application/json", bytes.NewBufferString(body))
+	resp, err := http.Post(server(t).URL+"/api/v1/login", "application/json", bytes.NewBufferString(body))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
@@ -84,7 +106,7 @@ func login(t *testing.T, username, password string) string {
 
 func authReq(t *testing.T, method, path string, body io.Reader, token string) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest(method, testServer.URL+path, body)
+	req, err := http.NewRequest(method, server(t).URL+path, body)
 	require.NoError(t, err)
 	req.Header.Set("Authorization", "Bearer "+token)
 	if body != nil {
@@ -98,7 +120,7 @@ func authReq(t *testing.T, method, path string, body io.Reader, token string) *h
 // ── Tests ─────────────────────────────────────────────────────
 
 func TestStatusCheck(t *testing.T) {
-	resp, err := http.Get(testServer.URL + "/service/rest/v1/status/check")
+	resp, err := http.Get(server(t).URL + "/service/rest/v1/status/check")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -156,7 +178,7 @@ func TestRawArtifactPushPull(t *testing.T) {
 	// Push artifact
 	artifactData := []byte("integration test artifact content")
 	putReq, _ := http.NewRequest(http.MethodPut,
-		testServer.URL+"/repository/e2e-raw/integration/test/artifact.bin",
+		server(t).URL+"/repository/e2e-raw/integration/test/artifact.bin",
 		bytes.NewReader(artifactData))
 	putReq.Header.Set("Authorization", "Bearer "+token)
 	putReq.Header.Set("Content-Type", "application/octet-stream")
@@ -182,7 +204,7 @@ func TestRawArtifactPushPull(t *testing.T) {
 }
 
 func TestMetricsEndpoint(t *testing.T) {
-	resp, err := http.Get(testServer.URL + "/api/v1/metrics")
+	resp, err := http.Get(server(t).URL + "/api/v1/metrics")
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/internal/integration/proxy_formats_test.go
+++ b/internal/integration/proxy_formats_test.go
@@ -1,0 +1,344 @@
+//go:build integration
+
+// Real-shape proxy tests (#349): one test per proxy-capable format, each
+// against an httptest fake shaped like that format's REAL public registry —
+// the URL scheme the actual upstream serves, not the shape the handler's own
+// code assumes. Both #347's Cargo bug and #349's NuGet bug shipped because
+// unit-test mocks mirrored the handler's wrong assumption; every fake here is
+// modeled on a live audit of the real registry (see #349's table).
+package integration
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// createProxyRepo creates a proxy repository of the given format through the
+// real API and registers cleanup.
+func createProxyRepo(t *testing.T, format, name, remoteURL string) {
+	t.Helper()
+	token := login(t, "admin", "admin123")
+	body := fmt.Sprintf(`{"name":%q,"online":true,"proxyConfig":{"remote_url":%q}}`, name, remoteURL)
+	resp := authReq(t, http.MethodPost, "/service/rest/v1/repositories/"+format+"/proxy",
+		strings.NewReader(body), token)
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	require.Equal(t, http.StatusCreated, resp.StatusCode, "create %s proxy: %s", format, raw)
+	t.Cleanup(func() {
+		del := authReq(t, http.MethodDelete, "/service/rest/v1/repositories/"+name, nil, token)
+		del.Body.Close()
+	})
+}
+
+// get fetches a path from the running server with admin auth and returns the
+// response; the caller owns the body.
+func get(t *testing.T, p string) *http.Response {
+	t.Helper()
+	token := login(t, "admin", "admin123")
+	return authReq(t, http.MethodGet, p, nil, token)
+}
+
+func fetchOK(t *testing.T, p string) string {
+	t.Helper()
+	resp := get(t, p)
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode, "GET %s: %s", p, raw)
+	return string(raw)
+}
+
+// ── apt (archive.ubuntu.com shape) ───────────────────────────────
+
+func TestProxyApt_RealShape(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dists/jammy/InRelease":
+			fmt.Fprint(w, "-----BEGIN PGP SIGNED MESSAGE-----\nSuite: jammy\n")
+		case "/dists/jammy/main/binary-amd64/Packages":
+			fmt.Fprint(w, "Package: hello\nVersion: 2.10-3\nFilename: pool/main/h/hello/hello_2.10-3_amd64.deb\n")
+		case "/pool/main/h/hello/hello_2.10-3_amd64.deb":
+			fmt.Fprint(w, "deb-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "apt", "apt-real", up.URL)
+
+	assert.Contains(t, fetchOK(t, "/repository/apt-real/dists/jammy/InRelease"), "Suite: jammy")
+	assert.Contains(t, fetchOK(t, "/repository/apt-real/dists/jammy/main/binary-amd64/Packages"), "Package: hello")
+	assert.Equal(t, "deb-bytes", fetchOK(t, "/repository/apt-real/pool/main/h/hello/hello_2.10-3_amd64.deb"))
+}
+
+// ── yum (EPEL shape) ─────────────────────────────────────────────
+
+func TestProxyYum_RealShape(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repodata/repomd.xml":
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, `<?xml version="1.0"?><repomd><data type="primary"><location href="repodata/primary.xml.gz"/></data></repomd>`)
+		case "/Packages/h/hello-2.10-1.el9.x86_64.rpm":
+			fmt.Fprint(w, "rpm-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "yum", "yum-real", up.URL)
+
+	assert.Contains(t, fetchOK(t, "/repository/yum-real/repodata/repomd.xml"), "repomd")
+	assert.Equal(t, "rpm-bytes", fetchOK(t, "/repository/yum-real/Packages/h/hello-2.10-1.el9.x86_64.rpm"))
+}
+
+// ── conda (conda-forge channel shape) ────────────────────────────
+
+func TestProxyConda_RealShape(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/noarch/repodata.json":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"info":{"subdir":"noarch"},"packages":{"tzdata-2024a-h0c530f3_0.tar.bz2":{"name":"tzdata","version":"2024a"}},"packages.conda":{}}`)
+		case "/noarch/tzdata-2024a-h0c530f3_0.tar.bz2":
+			fmt.Fprint(w, "conda-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "conda", "conda-real", up.URL)
+
+	assert.Contains(t, fetchOK(t, "/repository/conda-real/noarch/repodata.json"), "tzdata-2024a")
+	assert.Equal(t, "conda-bytes", fetchOK(t, "/repository/conda-real/noarch/tzdata-2024a-h0c530f3_0.tar.bz2"))
+}
+
+// ── conan (center2.conan.io v2 shape) ────────────────────────────
+
+func TestProxyConan_RealShape(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/conans/zlib/1.2.11/_/_/latest":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"revision":"a1b2c3","time":"2024-01-01T00:00:00.000+0000"}`)
+		case "/v2/conans/zlib/1.2.11/_/_/revisions/a1b2c3/files/conanfile.py":
+			fmt.Fprint(w, "conanfile-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "conan", "conan-real", up.URL)
+
+	assert.Contains(t, fetchOK(t, "/repository/conan-real/v2/conans/zlib/1.2.11/_/_/latest"), "a1b2c3")
+	assert.Equal(t, "conanfile-bytes",
+		fetchOK(t, "/repository/conan-real/v2/conans/zlib/1.2.11/_/_/revisions/a1b2c3/files/conanfile.py"))
+}
+
+// ── go modules (proxy.golang.org shape) ──────────────────────────
+
+func TestProxyGoModules_RealShape(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/rsc.io/quote/@v/list":
+			fmt.Fprint(w, "v1.5.2\nv1.5.1\n")
+		case "/rsc.io/quote/@v/v1.5.2.zip":
+			w.Header().Set("Content-Type", "application/zip")
+			fmt.Fprint(w, "zip-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	// The format segment is "go" (domain.FormatGo), not the package name.
+	createProxyRepo(t, "go", "go-real", up.URL)
+
+	assert.Contains(t, fetchOK(t, "/repository/go-real/rsc.io/quote/@v/list"), "v1.5.2")
+	assert.Equal(t, "zip-bytes", fetchOK(t, "/repository/go-real/rsc.io/quote/@v/v1.5.2.zip"))
+}
+
+// ── helm (chart repo shape, absolute chart URLs in index.yaml) ───
+
+func TestProxyHelm_RealShape(t *testing.T) {
+	var up *httptest.Server
+	up = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/index.yaml":
+			w.Header().Set("Content-Type", "application/yaml")
+			fmt.Fprintf(w, "apiVersion: v1\nentries:\n  demo:\n    - name: demo\n      version: 1.0.0\n      urls:\n        - %s/demo-1.0.0.tgz\n", up.URL)
+		case "/demo-1.0.0.tgz":
+			fmt.Fprint(w, "chart-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "helm", "helm-real", up.URL)
+
+	idx := fetchOK(t, "/repository/helm-real/index.yaml")
+	assert.Contains(t, idx, "/repository/helm-real/demo-1.0.0.tgz",
+		"chart URLs must be rewritten onto the proxy")
+	assert.NotContains(t, idx, up.URL, "upstream host must not leak into the rewritten index")
+	assert.Equal(t, "chart-bytes", fetchOK(t, "/repository/helm-real/demo-1.0.0.tgz"))
+}
+
+// ── terraform (registry.terraform.io shape) ──────────────────────
+
+func TestProxyTerraform_RealShape(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/providers/hashicorp/null/versions":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"id":"hashicorp/null","versions":[{"version":"3.2.2","platforms":[{"os":"linux","arch":"amd64"}]}]}`)
+		case "/v1/modules/hashicorp/consul/aws/0.11.0.tar.gz":
+			fmt.Fprint(w, "module-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "terraform", "tf-real", up.URL)
+
+	assert.Contains(t, fetchOK(t, "/repository/tf-real/v1/providers/hashicorp/null/versions"), "3.2.2")
+	assert.Equal(t, "module-bytes", fetchOK(t, "/repository/tf-real/v1/modules/hashicorp/consul/aws/0.11.0.tar.gz"))
+}
+
+// ── npm (registry.npmjs.org shape, scoped package) ───────────────
+
+func TestProxyNpmScoped_RealShape(t *testing.T) {
+	// registry.npmjs.org answers 405 to /@scope/name — the slash must reach it
+	// percent-encoded exactly once (found live; the double-escape regression
+	// was fixed alongside #347's investigation).
+	var up *httptest.Server
+	up = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.RequestURI {
+		case "/@types%2Fnode":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"name":"@types/node","versions":{"20.0.0":{"name":"@types/node","version":"20.0.0","dist":{"tarball":"%s/@types/node/-/node-20.0.0.tgz"}}}}`, up.URL)
+		case "/@types/node/-/node-20.0.0.tgz":
+			fmt.Fprint(w, "tgz-bytes")
+		default:
+			// The real registry 405s the decoded form of the packument path.
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "npm", "npm-real", up.URL)
+
+	pack := fetchOK(t, "/repository/npm-real/@types/node")
+	assert.Contains(t, pack, "/repository/npm-real/@types/node/-/node-20.0.0.tgz",
+		"tarball URLs must be rewritten onto the proxy")
+	assert.NotContains(t, pack, up.URL)
+	assert.Equal(t, "tgz-bytes", fetchOK(t, "/repository/npm-real/@types/node/-/node-20.0.0.tgz"))
+}
+
+// ── pypi (pypi.org shape: /simple pages, files on a second host) ─
+
+func TestProxyPyPI_RealShape(t *testing.T) {
+	files := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/packages/aa/bb/requests-2.31.0.tar.gz" {
+			fmt.Fprint(w, "sdist-bytes")
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer files.Close()
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// The handler pins Accept to text/html (#191); the real pypi.org would
+		// otherwise serve PEP 691 JSON, which the rewriter can't process.
+		case r.URL.Path == "/simple/requests" || r.URL.Path == "/simple/requests/":
+			require.Contains(t, r.Header.Get("Accept"), "text/html",
+				"simple-page fetch must force the HTML representation")
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<html><body><a href="%s/packages/aa/bb/requests-2.31.0.tar.gz#sha256=deadbeef">requests-2.31.0.tar.gz</a></body></html>`, files.URL)
+		// pypi.org itself answers /packages/ with a redirect to
+		// files.pythonhosted.org — a different host, which the proxy's
+		// upstream client must follow.
+		case strings.HasPrefix(r.URL.Path, "/packages/"):
+			http.Redirect(w, r, files.URL+r.URL.Path, http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "pypi", "pypi-real", up.URL)
+
+	page := fetchOK(t, "/repository/pypi-real/simple/requests")
+	assert.Contains(t, page, "/repository/pypi-real/packages/aa/bb/requests-2.31.0.tar.gz#sha256=deadbeef",
+		"file hrefs must be rewritten onto the proxy, fragment preserved")
+	assert.NotContains(t, page, files.URL)
+	assert.Equal(t, "sdist-bytes", fetchOK(t, "/repository/pypi-real/packages/aa/bb/requests-2.31.0.tar.gz"),
+		"file downloads follow the real registry's redirect to the file host")
+}
+
+// ── cargo (crates.io shape: sparse index + separate dl host) ─────
+
+func TestProxyCargo_RealShape(t *testing.T) {
+	dl := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/crates/serde/1.0.0/download" {
+			fmt.Fprint(w, "crate-bytes")
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer dl.Close()
+	// index.crates.io: config.json + prefix-sharded lines at the ROOT — no
+	// /index/ segment exists upstream (#347's bug: the local route prefix
+	// leaked into upstream requests).
+	idx := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/config.json":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"dl":"%s/api/v1/crates","api":"%s"}`, dl.URL, dl.URL)
+		case "/se/rd/serde":
+			fmt.Fprint(w, `{"name":"serde","vers":"1.0.0","deps":[],"cksum":"abc","features":{},"yanked":false}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer idx.Close()
+	createProxyRepo(t, "cargo", "cargo-real", idx.URL)
+
+	line := fetchOK(t, "/repository/cargo-real/index/se/rd/serde")
+	assert.Contains(t, line, `"name":"serde"`)
+	assert.Equal(t, "crate-bytes", fetchOK(t, "/repository/cargo-real/api/v1/crates/serde/1.0.0/download"),
+		"downloads must follow the dl base from the upstream's own config.json (a different host on real crates.io)")
+}
+
+// ── nuget (api.nuget.org shape: /v3/index.json, /v3-flatcontainer) ─
+
+func TestProxyNuGet_RealShape(t *testing.T) {
+	var up *httptest.Server
+	up = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3/index.json":
+			fmt.Fprintf(w, `{"version":"3.0.0","resources":[{"@id":"%s/v3-flatcontainer/","@type":"PackageBaseAddress/3.0.0"}]}`, up.URL)
+		case "/v3-flatcontainer/newtonsoft.json/index.json":
+			fmt.Fprint(w, `{"versions":["13.0.3"]}`)
+		case "/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg":
+			w.Header().Set("Content-Type", "application/octet-stream")
+			fmt.Fprint(w, "nupkg-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "nuget", "nuget-real", up.URL)
+
+	svcIdx := fetchOK(t, "/repository/nuget-real/index.json")
+	assert.Contains(t, svcIdx, "/repository/nuget-real/v3-flatcontainer/",
+		"service index resources keep the real hyphenated path, re-rooted locally")
+	assert.NotContains(t, svcIdx, up.URL)
+	assert.Contains(t, fetchOK(t, "/repository/nuget-real/v3-flatcontainer/newtonsoft.json/index.json"), "13.0.3")
+	assert.Equal(t, "nupkg-bytes",
+		fetchOK(t, "/repository/nuget-real/v3-flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg"))
+}


### PR DESCRIPTION
Fixes #349.

## NuGet proxy fix

The v3 service index lives at `/v3/index.json` on the real registry — the one fixed path in an otherwise fully discoverable protocol. `remote_url` previously needed a `/v3` suffix for the discovery fetch to work, which then doubled itself onto every already-correct flatcontainer/registration path and 404'd (same bug family as #347's Cargo issue).

- Discovery now hardcodes `<origin>/v3/index.json`; `remote_url` should be the bare origin, and legacy `/v3`-suffixed values are normalized so they keep working.
- The generic proxy branch forwards resource paths onto the bare origin (via the absolute-URL passthrough in `JoinURL`).
- The old unit test's mock had invented the code's own wrong shape (`/v3/flatcontainer/` nested); it now mirrors the real hyphenated `/v3-flatcontainer/` sibling layout, plus new tests for the end-to-end flatcontainer flow and the legacy remote_url form.

## internal/integration compiles and runs again

- Updated to the post-context `db.Connect`/`NewRouter` signatures; the suite is now self-sufficient: it boots a migrated postgres via `pgtest` (dockertest) and binds the listener before building the router so `BaseURL` matches the address proxy rewrites hand to clients.
- The harness applies the admin password over the seed placeholder (rewinding `tokens_valid_after` — a JWT's second-granular `iat` issued in the same second reads as revoked), sets a non-zero `MaxBodyMB`, and swaps the SSRF-guarded upstream client for loopback fakes.

## Real-shape proxy tests (the ask in the issue)

`internal/integration/proxy_formats_test.go`: one test per proxy-capable format — apt, yum, conda, conan, go, helm, terraform, npm (scoped), pypi, cargo, nuget — each against an `httptest` fake shaped like that format's **real** registry URL scheme from the issue's live audit table (crates.io's separate dl host, pypi.org's redirect to the file host and forced-HTML simple pages, npm's percent-encoded scoped packument path, nuget.org's `/v3-flatcontainer/` sibling, etc.). This is the class of test that would have caught both #347 and this issue's NuGet bug before shipping.

CI's integration job now runs the package.