### PR TITLE
feat(maven): dynamic maven-metadata.xml generation; migration plan reconciled against the full asset listing (#350)

### DIFF
--- a/internal/formats/maven/groupindex.go
+++ b/internal/formats/maven/groupindex.go
@@ -49,6 +49,19 @@ func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
 
 // MergeGroupIndex implements formats.GroupIndexMerger.
 func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	// The two metadata shapes need different merges (#350): the aggregate
+	// shape unions versions across members, but the per-SNAPSHOT-version shape
+	// describes ONE latest timestamped build — fed to the union merge, the XML
+	// decoder silently leaves its fields as zero values and the result is a
+	// content-free document. Dispatch on the directory being merged.
+	docPath := p
+	for _, ext := range []string{".sha1", ".md5", ".sha256"} {
+		docPath = strings.TrimSuffix(docPath, ext)
+	}
+	if isSnapshotDir(path.Dir(docPath)) {
+		return mergePerVersionGroupIndex(p, parts)
+	}
+
 	merged := mavenMetadata{}
 	seen := map[string]bool{}
 	for _, part := range parts {
@@ -100,4 +113,40 @@ func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) (
 		return []byte(fmt.Sprintf("%x", sha256.Sum256(doc))), "text/plain", nil
 	}
 	return doc, "application/xml", nil
+}
+
+// mergePerVersionGroupIndex picks the member reporting the single latest
+// (timestamp, buildNumber) build and serves its document unchanged — snapshot
+// builds are not unioned, the newest one simply wins.
+func mergePerVersionGroupIndex(p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	var winner []byte
+	var bestTS string
+	bestBuild := -1
+	for _, part := range parts {
+		var m perVersionMetadata
+		if err := xml.Unmarshal(part.Body, &m); err != nil {
+			continue
+		}
+		ts, bn := m.Versioning.Snapshot.Timestamp, m.Versioning.Snapshot.BuildNumber
+		if ts == "" {
+			continue
+		}
+		if ts > bestTS || (ts == bestTS && bn > bestBuild) {
+			bestTS, bestBuild = ts, bn
+			winner = part.Body
+		}
+	}
+	if winner == nil {
+		return nil, "", fmt.Errorf("maven group merge: no parsable per-version maven-metadata.xml among %d members", len(parts))
+	}
+
+	switch path.Ext(path.Base(p)) {
+	case ".sha1":
+		return []byte(fmt.Sprintf("%x", sha1.Sum(winner))), "text/plain", nil //nolint:gosec
+	case ".md5":
+		return []byte(fmt.Sprintf("%x", md5.Sum(winner))), "text/plain", nil //nolint:gosec
+	case ".sha256":
+		return []byte(fmt.Sprintf("%x", sha256.Sum256(winner))), "text/plain", nil
+	}
+	return winner, "application/xml", nil
 }

--- a/internal/formats/maven/groupindex_test.go
+++ b/internal/formats/maven/groupindex_test.go
@@ -108,3 +108,45 @@ func TestMaven_MergeGroupIndex_MalformedPartSkipped(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(body), "<version>1.0</version>")
 }
+
+func perVersionXML(timestamp string, buildNumber int) []byte {
+	return []byte(fmt.Sprintf(`<metadata modelVersion="1.1.0"><groupId>com.foo</groupId><artifactId>bar</artifactId><version>2.0-SNAPSHOT</version><versioning><snapshot><timestamp>%s</timestamp><buildNumber>%d</buildNumber></snapshot><lastUpdated>%s</lastUpdated><snapshotVersions><snapshotVersion><extension>jar</extension><value>2.0-%s-%d</value></snapshotVersion></snapshotVersions></versioning></metadata>`,
+		timestamp, buildNumber, timestamp, timestamp, buildNumber))
+}
+
+// The per-SNAPSHOT-version metadata shape (#350): merging it as if it were the
+// aggregate shape silently produced a content-free document — the XML decoder
+// leaves an unrecognized shape as zero values instead of failing. The merge
+// must dispatch on the requested path and, for a SNAPSHOT directory, pick the
+// member reporting the single latest (timestamp, buildNumber) build.
+func TestMaven_MergeGroupIndex_PerVersionShape_PicksLatestBuild(t *testing.T) {
+	h := maven.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: perVersionXML("20260829.101010", 5)},
+		{Member: "m2", Body: perVersionXML("20260830.123456", 3)},
+	}
+
+	body, ct, err := h.MergeGroupIndex("g", "/com/foo/bar/2.0-SNAPSHOT/maven-metadata.xml", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "xml")
+	out := string(body)
+	assert.Contains(t, out, "<timestamp>20260830.123456</timestamp>", "later timestamp wins regardless of member order")
+	assert.Contains(t, out, "<buildNumber>3</buildNumber>")
+	assert.Contains(t, out, "<value>2.0-20260830.123456-3</value>")
+	assert.NotContains(t, out, "20260829.101010")
+	assert.NotContains(t, out, "<versions>", "must not degrade into an empty aggregate document")
+}
+
+func TestMaven_MergeGroupIndex_PerVersionShape_ChecksumOfWinner(t *testing.T) {
+	h := maven.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: perVersionXML("20260830.123456", 3)},
+	}
+
+	doc, _, err := h.MergeGroupIndex("g", "/com/foo/bar/2.0-SNAPSHOT/maven-metadata.xml", parts)
+	require.NoError(t, err)
+	sum, ct, err := h.MergeGroupIndex("g", "/com/foo/bar/2.0-SNAPSHOT/maven-metadata.xml.sha1", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "text/plain")
+	assert.Equal(t, fmt.Sprintf("%x", sha1.Sum(doc)), string(sum)) //nolint:gosec
+}

--- a/internal/formats/maven/handler.go
+++ b/internal/formats/maven/handler.go
@@ -61,11 +61,28 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		}
 		// Serve .sha1/.md5/.sha256 checksums from DB without separate blob
 		if isChecksum(filePath) {
-			h.serveChecksum(c, repoName, filePath)
+			main := strings.TrimSuffix(filePath, path.Ext(filePath))
+			if a, err := h.deps.Assets.GetByPath(c.Request.Context(), repoName, main); err == nil && a != nil {
+				h.serveChecksum(c, repoName, filePath)
+				return
+			}
+			// No stored file to hash — a maven-metadata.xml sidecar is computed
+			// over the generated document instead (#350).
+			if h.serveGeneratedMetadata(c, repoName, filePath) {
+				return
+			}
+			c.JSON(http.StatusNotFound, gin.H{"error": "checksum not available"})
 			return
 		}
 		rc, asset, err := base.FetchArtifact(c.Request.Context(), h.deps, repoName, filePath)
 		if err != nil {
+			// Neither metadata shape is ever stored as a literal asset (Nexus
+			// has no component to attach them to; see #350) — generate it from
+			// the repository's real contents. A stored file, when a client did
+			// upload one, was already served above.
+			if h.serveGeneratedMetadata(c, repoName, filePath) {
+				return
+			}
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
 			return
 		}

--- a/internal/formats/maven/metadata.go
+++ b/internal/formats/maven/metadata.go
@@ -1,0 +1,260 @@
+package maven
+
+// Dynamic maven-metadata.xml generation (#350). Nexus never attaches either
+// metadata shape to a component, so migrations cannot carry them over — and
+// nexspence's own schema requires every asset to belong to a component, so a
+// literal copy could not even be stored. Instead both shapes are generated on
+// demand from the repository's real stored assets, the same way the npm
+// handler computes packuments from stored components. A generated document can
+// never go stale: it always reflects exactly what the repository holds.
+
+import (
+	"crypto/md5"  //nolint:gosec // maven protocol checksum, not security
+	"crypto/sha1" //nolint:gosec // maven protocol checksum, not security
+	"crypto/sha256"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+)
+
+// perVersionMetadata is the per-SNAPSHOT-version maven-metadata.xml shape
+// (modelVersion 1.1.0): the single latest timestamped build plus one
+// snapshotVersion entry per extension/classifier seen on that build.
+type perVersionMetadata struct {
+	XMLName      xml.Name `xml:"metadata"`
+	ModelVersion string   `xml:"modelVersion,attr"`
+	GroupID      string   `xml:"groupId"`
+	ArtifactID   string   `xml:"artifactId"`
+	Version      string   `xml:"version"`
+	Versioning   struct {
+		Snapshot struct {
+			Timestamp   string `xml:"timestamp"`
+			BuildNumber int    `xml:"buildNumber"`
+		} `xml:"snapshot"`
+		LastUpdated      string            `xml:"lastUpdated,omitempty"`
+		SnapshotVersions []snapshotVersion `xml:"snapshotVersions>snapshotVersion"`
+	} `xml:"versioning"`
+}
+
+type snapshotVersion struct {
+	Classifier string `xml:"classifier,omitempty"`
+	Extension  string `xml:"extension"`
+	Value      string `xml:"value"`
+	Updated    string `xml:"updated,omitempty"`
+}
+
+// snapshotFileRe matches the unique-snapshot remainder of a file name after
+// "<artifact>-<baseVersion>-" is cut: "<timestamp>-<buildNumber>[-<classifier>].<ext>".
+var snapshotFileRe = regexp.MustCompile(`^(\d{8}\.\d{6})-(\d+)(?:-([^.]+))?\.(.+)$`)
+
+// isSnapshotDir reports whether the last path segment names a SNAPSHOT version
+// directory — the discriminator between the two metadata shapes.
+func isSnapshotDir(dir string) bool {
+	return strings.HasSuffix(path.Base(dir), "-SNAPSHOT")
+}
+
+// generateMetadata builds the maven-metadata.xml for the given metadata path
+// from the repository's stored assets. Returns nil when the directory holds
+// nothing to describe (the caller then 404s).
+func (h *Handler) generateMetadata(c *gin.Context, repoName, metadataPath string) []byte {
+	dir := path.Dir(metadataPath)
+	if dir == "/" || dir == "." {
+		return nil
+	}
+	assets, err := h.deps.Assets.ListByRepoAndPath(c.Request.Context(), repoName, dir+"/")
+	if err != nil || len(assets) == 0 {
+		return nil
+	}
+	if isSnapshotDir(dir) {
+		return generatePerVersionMetadata(dir, assets)
+	}
+	return generateAggregateMetadata(dir, assets)
+}
+
+func splitGroupArtifact(segments []string) (groupID, artifactID string) {
+	if len(segments) < 2 {
+		return "", strings.Join(segments, ".")
+	}
+	return strings.Join(segments[:len(segments)-1], "."), segments[len(segments)-1]
+}
+
+// generateAggregateMetadata lists the artifact's real versions: the immediate
+// child directories of the artifact directory that actually contain files.
+func generateAggregateMetadata(dir string, assets []domain.Asset) []byte {
+	segments := strings.Split(strings.TrimPrefix(dir, "/"), "/")
+	groupID, artifactID := splitGroupArtifact(segments)
+
+	versions := map[string]bool{}
+	var lastCreated time.Time
+	for _, a := range assets {
+		rest := strings.TrimPrefix(a.Path, dir+"/")
+		child, remainder, found := strings.Cut(rest, "/")
+		if !found || remainder == "" {
+			continue // a file directly in the artifact dir, not a version
+		}
+		versions[child] = true
+		if a.CreatedAt.After(lastCreated) {
+			lastCreated = a.CreatedAt
+		}
+	}
+	if len(versions) == 0 {
+		return nil
+	}
+
+	m := mavenMetadata{GroupID: groupID, ArtifactID: artifactID}
+	for v := range versions {
+		m.Versioning.Versions = append(m.Versioning.Versions, v)
+	}
+	sort.Slice(m.Versioning.Versions, func(i, j int) bool {
+		return base.CompareLooseVersions(m.Versioning.Versions[i], m.Versioning.Versions[j]) < 0
+	})
+	for _, v := range m.Versioning.Versions {
+		if base.CompareLooseVersions(v, m.Versioning.Latest) > 0 {
+			m.Versioning.Latest = v
+		}
+		if !strings.Contains(strings.ToUpper(v), "SNAPSHOT") &&
+			base.CompareLooseVersions(v, m.Versioning.Release) > 0 {
+			m.Versioning.Release = v
+		}
+	}
+	if !lastCreated.IsZero() {
+		m.Versioning.LastUpdated = lastCreated.UTC().Format("20060102150405")
+	}
+
+	out, err := xml.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	return append([]byte(xml.Header), out...)
+}
+
+// generatePerVersionMetadata reports the single latest (timestamp,
+// buildNumber) build under one X.Y.Z-SNAPSHOT directory, with one
+// snapshotVersion entry per extension/classifier present on that build.
+func generatePerVersionMetadata(dir string, assets []domain.Asset) []byte {
+	segments := strings.Split(strings.TrimPrefix(dir, "/"), "/")
+	if len(segments) < 2 {
+		return nil
+	}
+	version := segments[len(segments)-1]
+	groupID, artifactID := splitGroupArtifact(segments[:len(segments)-1])
+	baseVersion := strings.TrimSuffix(version, "-SNAPSHOT")
+	prefix := artifactID + "-" + baseVersion + "-"
+
+	type build struct {
+		timestamp string
+		number    int
+	}
+	var latest build
+	type entry struct {
+		classifier, extension string
+	}
+	byBuild := map[build][]entry{}
+
+	for _, a := range assets {
+		name := strings.TrimPrefix(a.Path, dir+"/")
+		if strings.Contains(name, "/") || isChecksum(name) || name == metadataFile {
+			continue
+		}
+		rest, ok := strings.CutPrefix(name, prefix)
+		if !ok {
+			continue
+		}
+		m := snapshotFileRe.FindStringSubmatch(rest)
+		if m == nil {
+			continue
+		}
+		num, err := strconv.Atoi(m[2])
+		if err != nil {
+			continue
+		}
+		b := build{timestamp: m[1], number: num}
+		byBuild[b] = append(byBuild[b], entry{classifier: m[3], extension: m[4]})
+		if b.timestamp > latest.timestamp ||
+			(b.timestamp == latest.timestamp && b.number > latest.number) {
+			latest = b
+		}
+	}
+	if latest.timestamp == "" {
+		return nil
+	}
+
+	doc := perVersionMetadata{ModelVersion: "1.1.0", GroupID: groupID, ArtifactID: artifactID, Version: version}
+	doc.Versioning.Snapshot.Timestamp = latest.timestamp
+	doc.Versioning.Snapshot.BuildNumber = latest.number
+	doc.Versioning.LastUpdated = strings.ReplaceAll(latest.timestamp, ".", "")
+	value := baseVersion + "-" + latest.timestamp + "-" + strconv.Itoa(latest.number)
+	entries := byBuild[latest]
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].extension != entries[j].extension {
+			return entries[i].extension < entries[j].extension
+		}
+		return entries[i].classifier < entries[j].classifier
+	})
+	for _, e := range entries {
+		doc.Versioning.SnapshotVersions = append(doc.Versioning.SnapshotVersions, snapshotVersion{
+			Classifier: e.classifier,
+			Extension:  e.extension,
+			Value:      value,
+			Updated:    doc.Versioning.LastUpdated,
+		})
+	}
+
+	out, err := xml.Marshal(doc)
+	if err != nil {
+		return nil
+	}
+	return append([]byte(xml.Header), out...)
+}
+
+// serveGeneratedMetadata serves a generated maven-metadata.xml, or a checksum
+// over it, and reports whether it handled the request.
+func (h *Handler) serveGeneratedMetadata(c *gin.Context, repoName, filePath string) bool {
+	metadataPath := filePath
+	hashExt := ""
+	if isChecksum(filePath) {
+		hashExt = path.Ext(filePath)
+		metadataPath = strings.TrimSuffix(filePath, hashExt)
+	}
+	if path.Base(metadataPath) != metadataFile {
+		return false
+	}
+	doc := h.generateMetadata(c, repoName, metadataPath)
+	if doc == nil {
+		return false
+	}
+	var body []byte
+	contentType := "application/xml"
+	switch hashExt {
+	case ".sha1":
+		body = []byte(fmt.Sprintf("%x", sha1.Sum(doc))) //nolint:gosec // maven checksum
+		contentType = "text/plain"
+	case ".md5":
+		body = []byte(fmt.Sprintf("%x", md5.Sum(doc))) //nolint:gosec // maven checksum
+		contentType = "text/plain"
+	case ".sha256":
+		body = []byte(fmt.Sprintf("%x", sha256.Sum256(doc)))
+		contentType = "text/plain"
+	default:
+		body = doc
+	}
+	c.Header("Content-Length", strconv.Itoa(len(body)))
+	c.Header("Content-Type", contentType)
+	if c.Request.Method == http.MethodHead {
+		c.Status(http.StatusOK)
+		return true
+	}
+	c.Data(http.StatusOK, contentType, body)
+	return true
+}

--- a/internal/formats/maven/metadata_test.go
+++ b/internal/formats/maven/metadata_test.go
@@ -1,0 +1,118 @@
+package maven_test
+
+import (
+	"crypto/sha1" //nolint:gosec // maven protocol checksum, not security
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// Dynamic maven-metadata.xml generation (#350): Nexus never attaches either
+// metadata document to a component, so migrations can't carry them over — and
+// without them a real mvn client can't resolve versions or SNAPSHOTs at all.
+// Both shapes are generated from stored components on demand, npm-packument
+// style; a literal client-uploaded file, when present, still wins.
+
+func putFile(t *testing.T, r http.Handler, repo, p, body string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repo+p, strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "PUT %s: %s", p, w.Body.String())
+}
+
+func getPath(r http.Handler, repo, p string) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/repository/"+repo+p, nil))
+	return w
+}
+
+func TestMaven_AggregateMetadata_GeneratedFromStoredVersions(t *testing.T) {
+	repo := testutil.SimpleRepo("mvn-meta", "maven2")
+	r, _ := setup(repo)
+
+	putFile(t, r, "mvn-meta", "/com/example/widget-app/1.0/widget-app-1.0.jar", "jar-1.0")
+	putFile(t, r, "mvn-meta", "/com/example/widget-app/1.1/widget-app-1.1.jar", "jar-1.1")
+	putFile(t, r, "mvn-meta", "/com/example/widget-app/2.0-SNAPSHOT/widget-app-2.0-20260830.123456-1.jar", "jar-snap")
+
+	w := getPath(r, "mvn-meta", "/com/example/widget-app/maven-metadata.xml")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	body := w.Body.String()
+	assert.Contains(t, body, "<groupId>com.example</groupId>")
+	assert.Contains(t, body, "<artifactId>widget-app</artifactId>")
+	assert.Contains(t, body, "<version>1.0</version>")
+	assert.Contains(t, body, "<version>1.1</version>")
+	assert.Contains(t, body, "<version>2.0-SNAPSHOT</version>")
+	assert.Contains(t, body, "<latest>2.0-SNAPSHOT</latest>")
+	assert.Contains(t, body, "<release>1.1</release>", "release must skip SNAPSHOT versions")
+}
+
+func TestMaven_AggregateMetadata_NoVersions_404(t *testing.T) {
+	repo := testutil.SimpleRepo("mvn-meta-404", "maven2")
+	r, _ := setup(repo)
+
+	w := getPath(r, "mvn-meta-404", "/com/example/nothing/maven-metadata.xml")
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestMaven_PerVersionSnapshotMetadata_Generated(t *testing.T) {
+	repo := testutil.SimpleRepo("mvn-snap", "maven2")
+	r, _ := setup(repo)
+
+	base := "/com/example/widget-app/2.0-SNAPSHOT/"
+	// An older build and the current one — only the latest (timestamp,
+	// buildNumber) pair may be reported, with one entry per extension /
+	// classifier seen on that build.
+	putFile(t, r, "mvn-snap", base+"widget-app-2.0-20260829.101010-2.jar", "old-jar")
+	putFile(t, r, "mvn-snap", base+"widget-app-2.0-20260830.123456-3.jar", "new-jar")
+	putFile(t, r, "mvn-snap", base+"widget-app-2.0-20260830.123456-3.pom", "new-pom")
+	putFile(t, r, "mvn-snap", base+"widget-app-2.0-20260830.123456-3-sources.jar", "new-sources")
+
+	w := getPath(r, "mvn-snap", base+"maven-metadata.xml")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	body := w.Body.String()
+	assert.Contains(t, body, `modelVersion="1.1.0"`)
+	assert.Contains(t, body, "<version>2.0-SNAPSHOT</version>")
+	assert.Contains(t, body, "<timestamp>20260830.123456</timestamp>")
+	assert.Contains(t, body, "<buildNumber>3</buildNumber>")
+	assert.Contains(t, body, "<value>2.0-20260830.123456-3</value>")
+	assert.Contains(t, body, "<extension>pom</extension>")
+	assert.Contains(t, body, "<classifier>sources</classifier>")
+	assert.NotContains(t, body, "20260829.101010", "stale builds must not be reported")
+}
+
+func TestMaven_GeneratedMetadataChecksum_MatchesDocument(t *testing.T) {
+	repo := testutil.SimpleRepo("mvn-meta-cs", "maven2")
+	r, _ := setup(repo)
+
+	putFile(t, r, "mvn-meta-cs", "/com/example/widget-app/1.0/widget-app-1.0.jar", "jar-1.0")
+
+	doc := getPath(r, "mvn-meta-cs", "/com/example/widget-app/maven-metadata.xml")
+	require.Equal(t, http.StatusOK, doc.Code)
+
+	cs := getPath(r, "mvn-meta-cs", "/com/example/widget-app/maven-metadata.xml.sha1")
+	require.Equal(t, http.StatusOK, cs.Code, cs.Body.String())
+	assert.Equal(t, fmt.Sprintf("%x", sha1.Sum(doc.Body.Bytes())), cs.Body.String(), //nolint:gosec
+		"sidecar must be computed over the generated document")
+}
+
+func TestMaven_ClientUploadedMetadata_TakesPriority(t *testing.T) {
+	repo := testutil.SimpleRepo("mvn-meta-lit", "maven2")
+	r, _ := setup(repo)
+
+	putFile(t, r, "mvn-meta-lit", "/com/example/widget-app/1.0/widget-app-1.0.jar", "jar-1.0")
+	literal := `<?xml version="1.0"?><metadata><groupId>com.example</groupId><artifactId>widget-app</artifactId><versioning><versions><version>9.9</version></versions></versioning></metadata>`
+	putFile(t, r, "mvn-meta-lit", "/com/example/widget-app/maven-metadata.xml", literal)
+
+	w := getPath(r, "mvn-meta-lit", "/com/example/widget-app/maven-metadata.xml")
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, literal, w.Body.String(), "a real stored metadata file must be served untouched")
+}

--- a/internal/nexusclient/client.go
+++ b/internal/nexusclient/client.go
@@ -305,6 +305,56 @@ func (c *Client) ListComponents(ctx context.Context, repo, continuationToken str
 	return out, page.ContinuationToken, nil
 }
 
+// assetPageDTO mirrors GET /service/rest/v1/assets.
+type assetPageDTO struct {
+	Items []struct {
+		Path        string `json:"path"`
+		DownloadURL string `json:"downloadUrl"`
+		ContentType string `json:"contentType"`
+		FileSize    int64  `json:"fileSize"`
+		Checksum    struct {
+			SHA256 string `json:"sha256"`
+			SHA1   string `json:"sha1"`
+			MD5    string `json:"md5"`
+		} `json:"checksum"`
+	} `json:"items"`
+	ContinuationToken string `json:"continuationToken"`
+}
+
+// ListAssets returns one page of the repository's FULL asset listing — unlike
+// ListComponents, this includes assets Nexus cannot group under any component
+// (#350: aggregate and per-SNAPSHOT-version maven-metadata.xml and their
+// checksum sidecars). Pagination works like ListComponents.
+func (c *Client) ListAssets(ctx context.Context, repo, continuationToken string) ([]Asset, string, error) {
+	reqURL := c.baseURL + "/service/rest/v1/assets?repository=" + url.QueryEscape(repo)
+	if continuationToken != "" {
+		reqURL += "&continuationToken=" + url.QueryEscape(continuationToken)
+	}
+	resp, err := c.do(ctx, reqURL)
+	if err != nil {
+		return nil, "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	var page assetPageDTO
+	if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+		return nil, "", err
+	}
+	out := make([]Asset, 0, len(page.Items))
+	for _, it := range page.Items {
+		out = append(out, Asset{
+			Path:        it.Path,
+			DownloadURL: it.DownloadURL,
+			ContentType: it.ContentType,
+			SizeBytes:   it.FileSize,
+			SHA256:      it.Checksum.SHA256,
+			SHA1:        it.Checksum.SHA1,
+			MD5:         it.Checksum.MD5,
+		})
+	}
+	return out, page.ContinuationToken, nil
+}
+
 // DownloadAsset streams an asset from its absolute download URL. The caller
 // closes the returned reader.
 func (c *Client) DownloadAsset(ctx context.Context, downloadURL string) (io.ReadCloser, error) {

--- a/internal/nexusclient/client_test.go
+++ b/internal/nexusclient/client_test.go
@@ -336,3 +336,55 @@ func TestDownloadManifest_SurfacesHTTPError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "404")
 }
+
+func TestListAssets_FollowsContinuationToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/service/rest/v1/assets", r.URL.Path)
+		require.Equal(t, "mvn-hosted", r.URL.Query().Get("repository"))
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("continuationToken") == "" {
+			_, _ = io.WriteString(w, `{"items":[
+				{"path":"com/example/widget-app/1.0/widget-app-1.0.jar",
+				 "downloadUrl":"http://n/repository/mvn-hosted/com/example/widget-app/1.0/widget-app-1.0.jar",
+				 "contentType":"application/java-archive","fileSize":3,"checksum":{"sha1":"bb"}}
+			],"continuationToken":"tok2"}`)
+			return
+		}
+		require.Equal(t, "tok2", r.URL.Query().Get("continuationToken"))
+		// The whole point of this listing (#350): it also returns assets with
+		// no owning component, like maven-metadata.xml.
+		_, _ = io.WriteString(w, `{"items":[
+			{"path":"com/example/widget-app/maven-metadata.xml",
+			 "downloadUrl":"http://n/repository/mvn-hosted/com/example/widget-app/maven-metadata.xml",
+			 "contentType":"application/xml","fileSize":10}
+		],"continuationToken":null}`)
+	}))
+	defer srv.Close()
+
+	c := newClient(t, srv)
+	first, tok, err := c.ListAssets(context.Background(), "mvn-hosted", "")
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "com/example/widget-app/1.0/widget-app-1.0.jar", first[0].Path)
+	assert.Equal(t, "application/java-archive", first[0].ContentType)
+	assert.Equal(t, int64(3), first[0].SizeBytes)
+	assert.Equal(t, "bb", first[0].SHA1)
+	require.Equal(t, "tok2", tok)
+
+	second, tok, err := c.ListAssets(context.Background(), "mvn-hosted", tok)
+	require.NoError(t, err)
+	require.Len(t, second, 1)
+	assert.Equal(t, "com/example/widget-app/maven-metadata.xml", second[0].Path)
+	assert.Empty(t, tok)
+}
+
+func TestListAssets_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	c := newClient(t, srv)
+	_, _, err := c.ListAssets(context.Background(), "gone", "")
+	require.Error(t, err)
+}

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -758,7 +759,7 @@ func (s *NexusMigrationService) migrateAssets(ctx context.Context, client *nexus
 // planAssets lists every component in the repository and turns it into the set
 // of files to transfer, ordered so a manifest never lands before its blobs.
 func (s *NexusMigrationService) planAssets(ctx context.Context, client *nexusclient.Client,
-	m migratedRepo, _ *progress,
+	m migratedRepo, p *progress,
 ) ([]plannedAsset, error) {
 	src := m.src
 	isOCI := nexusFormats[src.Format].IsOCIRegistry()
@@ -809,7 +810,69 @@ func (s *NexusMigrationService) planAssets(ctx context.Context, client *nexuscli
 		token = next
 	}
 
+	// The Components API only lists assets it can group under a component;
+	// anything else (#350: both maven-metadata.xml shapes and their checksum
+	// sidecars) is invisible to the plan. Reconcile against the FULL asset
+	// listing so nothing vanishes without a trace. OCI repositories are
+	// exempt: their blob assets are deliberately unplanned — they come across
+	// with the manifests that name them.
+	if !isOCI {
+		s.reconcilePlanAgainstAssetListing(ctx, client, m, planned, p)
+	}
+
 	return planned, nil
+}
+
+// reconcilePlanAgainstAssetListing walks GET /service/rest/v1/assets and
+// records every asset the component-based plan missed. maven-metadata.xml and
+// its sidecars are the known — and by design unmigrated — population: both
+// shapes are generated dynamically from stored components on every GET, so a
+// literal copy would only go stale. Anything else is counted through the
+// job's error path. A source without the endpoint skips the check.
+func (s *NexusMigrationService) reconcilePlanAgainstAssetListing(ctx context.Context,
+	client *nexusclient.Client, m migratedRepo, planned []plannedAsset, p *progress,
+) {
+	known := make(map[string]bool, len(planned))
+	for _, pa := range planned {
+		known[pa.path] = true
+	}
+	token := ""
+	for {
+		if err := checkPaused(ctx); err != nil {
+			return
+		}
+		assets, next, err := client.ListAssets(ctx, m.src.Name, token)
+		if err != nil {
+			s.logf(ctx, "migration: asset listing unavailable for %s — completeness check skipped: %v", m.src.Name, err)
+			return
+		}
+		for _, a := range assets {
+			ap := normalizeAssetPath(a.Path)
+			if known[ap] || isMavenMetadataSidecarPath(ap) {
+				continue
+			}
+			p.fail(ctx, "repo %s: asset %s has no owning component and was not planned for transfer", m.src.Name, ap)
+		}
+		if next == "" {
+			return
+		}
+		token = next
+	}
+}
+
+// isMavenMetadataSidecarPath reports whether the path names an aggregate or
+// per-version maven-metadata.xml or one of its checksum sidecars.
+func isMavenMetadataSidecarPath(p string) bool {
+	name := path.Base(p)
+	if name == "maven-metadata.xml" {
+		return true
+	}
+	for _, ext := range []string{".sha1", ".md5", ".sha256"} {
+		if name == "maven-metadata.xml"+ext {
+			return true
+		}
+	}
+	return false
 }
 
 // transferAsset brings one planned unit across, skipping whatever is already

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -32,6 +32,8 @@ type fakeNexus struct {
 	settingsCode int               // non-zero forces this status instead of settings
 	repositories string            // /service/rest/v1/repositories
 	components   map[string]string // repository name → one full component page
+	assetPages   map[string]string // repository name → one full /v1/assets page
+	assetsCode   int               // non-zero forces this status on /v1/assets
 	files        map[string]string // /repository/... path → body
 	users        string
 	usersCode    int // non-zero forces this status on /security/users
@@ -83,6 +85,16 @@ func (f *fakeNexus) start(t *testing.T) *httptest.Server {
 			_, _ = io.WriteString(w, orEmptyList(f.repositories))
 		case r.URL.Path == "/service/rest/v1/components":
 			body := f.components[r.URL.Query().Get("repository")]
+			if body == "" {
+				body = `{"items":[],"continuationToken":null}`
+			}
+			_, _ = io.WriteString(w, body)
+		case r.URL.Path == "/service/rest/v1/assets":
+			if f.assetsCode != 0 {
+				w.WriteHeader(f.assetsCode)
+				return
+			}
+			body := f.assetPages[r.URL.Query().Get("repository")]
 			if body == "" {
 				body = `{"items":[],"continuationToken":null}`
 			}
@@ -1407,4 +1419,100 @@ func TestFakeNexusFixturesAreValidJSON(t *testing.T) {
 		var v any
 		require.NoError(t, json.Unmarshal([]byte(doc), &v))
 	}
+}
+
+// ── #350: assets with no owning component must be counted, not vanish ────────
+
+// The Components API only returns assets it can group under a component;
+// anything else was never planned, never transferred, and never counted. The
+// plan is now reconciled against /service/rest/v1/assets — the full listing —
+// and every unplanned asset is recorded through the error count.
+func TestNexusMigration_NonComponentAssetCountedAsError(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"raw-hosted": `{"items":[{"name":"a.txt","version":null,"group":"/","format":"raw","assets":[
+				{"path":"a.txt","downloadUrl":"%BASE%/repository/raw-hosted/a.txt",
+				 "contentType":"text/plain","fileSize":5}]}],"continuationToken":null}`,
+		},
+		assetPages: map[string]string{
+			"raw-hosted": `{"items":[
+				{"path":"a.txt","downloadUrl":"%BASE%/repository/raw-hosted/a.txt","contentType":"text/plain","fileSize":5},
+				{"path":"orphan.bin","downloadUrl":"%BASE%/repository/raw-hosted/orphan.bin","contentType":"application/octet-stream","fileSize":9}
+			],"continuationToken":null}`,
+		},
+		files: map[string]string{"/repository/raw-hosted/a.txt": "hello"},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["raw-hosted"] = strings.ReplaceAll(fake.components["raw-hosted"], "%BASE%", h.nexus.URL)
+	fake.assetPages["raw-hosted"] = strings.ReplaceAll(fake.assetPages["raw-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	assert.Equal(t, 1, done.ErrorCount, "the orphan asset must be counted, not silently dropped")
+	require.NotNil(t, done.LastError)
+	assert.Contains(t, *done.LastError, "orphan.bin")
+
+	// The componentized asset still migrates normally.
+	stored, err := h.assets.GetByPath(context.Background(), "raw-hosted", "/a.txt")
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+}
+
+// maven-metadata.xml and its checksum sidecars are the known population of
+// non-componentized assets (#350's audit found nothing else, format-wide).
+// They are deliberately NOT migrated — both shapes are generated dynamically
+// from stored components on every GET — so they must not inflate the error
+// count either.
+func TestNexusMigration_MavenMetadataAssetsAreNotErrors(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"mvn-hosted","format":"maven2","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"mvn-hosted": `{"items":[{"name":"widget-app","version":"1.0","group":"com.example","format":"maven2","assets":[
+				{"path":"com/example/widget-app/1.0/widget-app-1.0.jar",
+				 "downloadUrl":"%BASE%/repository/mvn-hosted/com/example/widget-app/1.0/widget-app-1.0.jar",
+				 "contentType":"application/java-archive","fileSize":3}]}],"continuationToken":null}`,
+		},
+		assetPages: map[string]string{
+			"mvn-hosted": `{"items":[
+				{"path":"com/example/widget-app/1.0/widget-app-1.0.jar","downloadUrl":"%BASE%/repository/mvn-hosted/com/example/widget-app/1.0/widget-app-1.0.jar","contentType":"application/java-archive","fileSize":3},
+				{"path":"com/example/widget-app/maven-metadata.xml","downloadUrl":"%BASE%/repository/mvn-hosted/com/example/widget-app/maven-metadata.xml","contentType":"application/xml","fileSize":10},
+				{"path":"com/example/widget-app/maven-metadata.xml.sha1","downloadUrl":"%BASE%/repository/mvn-hosted/com/example/widget-app/maven-metadata.xml.sha1","contentType":"text/plain","fileSize":40}
+			],"continuationToken":null}`,
+		},
+		files: map[string]string{"/repository/mvn-hosted/com/example/widget-app/1.0/widget-app-1.0.jar": "jar"},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["mvn-hosted"] = strings.ReplaceAll(fake.components["mvn-hosted"], "%BASE%", h.nexus.URL)
+	fake.assetPages["mvn-hosted"] = strings.ReplaceAll(fake.assetPages["mvn-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	assert.Zero(t, done.ErrorCount,
+		"maven-metadata.xml is generated dynamically, its absence from the plan is by design: %v", done.LastError)
+}
+
+// An older Nexus without the assets endpoint (or a hardened one refusing it)
+// must not fail the migration — the completeness check is best-effort.
+func TestNexusMigration_AssetListingUnavailable_Tolerated(t *testing.T) {
+	fake := &fakeNexus{
+		settings: `[{"name":"raw-hosted","format":"raw","type":"hosted","online":true}]`,
+		components: map[string]string{
+			"raw-hosted": `{"items":[{"name":"a.txt","version":null,"group":"/","format":"raw","assets":[
+				{"path":"a.txt","downloadUrl":"%BASE%/repository/raw-hosted/a.txt",
+				 "contentType":"text/plain","fileSize":5}]}],"continuationToken":null}`,
+		},
+		assetsCode: 404,
+		files:      map[string]string{"/repository/raw-hosted/a.txt": "hello"},
+	}
+	h := newMigHarness(t, fake)
+	fake.components["raw-hosted"] = strings.ReplaceAll(fake.components["raw-hosted"], "%BASE%", h.nexus.URL)
+
+	job := h.startJob(t)
+	done := h.waitForStatus(t, job.ID, domain.MigrationDone)
+
+	assert.Zero(t, done.ErrorCount)
+	assert.Equal(t, int64(1), done.DoneAssets)
 }


### PR DESCRIPTION
Fixes #350.

## The format-level fix (restores working Maven repositories)

Nexus never attaches either `maven-metadata.xml` shape to a component, so migrations couldn't carry them over — and nexspence's own schema requires every asset to belong to a component, so a literal copy couldn't even be stored. Both shapes are now **generated on demand from stored assets** (the npm hosted-packument pattern), exactly as the issue's verified design describes:

- **Aggregate shape**: real child version directories, `latest`/`release` recomputed via `CompareLooseVersions` (release skips SNAPSHOTs) — same logic the group merge already uses.
- **Per-SNAPSHOT-version shape** (`modelVersion="1.1.0"`): unique-snapshot file names are parsed to the single latest `(timestamp, buildNumber)` build, one `snapshotVersion` entry per extension/classifier on that build.
- Checksum sidecars (`.sha1`/`.md5`/`.sha256`) are computed over the generated document.
- A literal client-uploaded metadata file, when present, is served untouched — the generator is a fallback only.

## Group merge companion fix

Fed the per-version shape, `MergeGroupIndex` silently produced a content-free document (the XML decoder leaves an unrecognized shape as zero values). It now dispatches on the requested directory: for a `-SNAPSHOT` dir, the member reporting the latest `(timestamp, buildNumber)` build wins outright, and sidecars hash the winning document.

## Migration observability

New `nexusclient.ListAssets` (`GET /service/rest/v1/assets`, the `replication_service` pattern), and `planAssets` now reconciles its component-based plan against that full listing: every unplanned asset is recorded through the job's error count instead of vanishing. `maven-metadata.xml` + sidecars are exempt by design (generated dynamically); a source without the endpoint skips the check; OCI repos are exempt (their blob assets are deliberately unplanned).

All behavior TDD'd: aggregate/per-version generation, generated checksums, literal-file priority, group-merge per-version dispatch, orphan-asset error counting, metadata exemption, endpoint-absent tolerance.