### PR TITLE
fix(proxy,events,s3): unblock the cache-fill pipe, close the broker dispatch race, persist S3 parts as they flush

### DIFF
--- a/internal/events/broker.go
+++ b/internal/events/broker.go
@@ -66,14 +66,18 @@ func (b *Broker) Unsubscribe(s *Subscription) {
 
 // Dispatch broadcasts the payload to every active subscriber.
 // Implements domain.WebhookDispatcher.
+// The whole send loop runs under the read lock, not just the snapshot of the
+// subscriber map: Unsubscribe closes a subscriber's channel under the write
+// lock, so a send left outside the lock could land on a channel a concurrent
+// Unsubscribe had just closed and panic with "send on closed channel" (#369).
+// Holding RLock across the sends makes the two orderings the only ones
+// possible — Unsubscribe waits for an in-flight Dispatch, or Dispatch never
+// sees the subscriber at all. Sends never block (the default arm drops), so
+// holding the lock cannot stall Unsubscribe on a slow reader.
 func (b *Broker) Dispatch(payload domain.WebhookPayload) {
 	b.mu.RLock()
-	subs := make([]*Subscription, 0, len(b.subs))
+	defer b.mu.RUnlock()
 	for s := range b.subs {
-		subs = append(subs, s)
-	}
-	b.mu.RUnlock()
-	for _, s := range subs {
 		select {
 		case s.out <- payload:
 		default:

--- a/internal/events/broker_test.go
+++ b/internal/events/broker_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -88,5 +89,31 @@ func TestBroker_NilTargetTolerated(t *testing.T) {
 	b.Dispatch(mkPayload(domain.EventRepoCreated, ""))
 	if b.Count() != 0 {
 		t.Fatalf("Count() should be 0 with no subscribers")
+	}
+}
+
+// Dispatch used to snapshot the subscriber map under RLock and send outside any
+// lock, so an Unsubscribe running in the gap closed a channel a pending send was
+// about to use — "send on closed channel" (#369). Nothing wires the broker up
+// yet, but one goroutine per subscriber calling Unsubscribe on disconnect while
+// another dispatches is exactly the shape the package exists to serve.
+func TestBroker_ConcurrentDispatchAndUnsubscribe_NoPanic(t *testing.T) {
+	b := NewBroker(1)
+	for i := 0; i < 2000; i++ {
+		s := b.Subscribe()
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			b.Dispatch(mkPayload(domain.EventArtifactPublished, "race"))
+		}()
+		go func() {
+			defer wg.Done()
+			b.Unsubscribe(s)
+		}()
+		wg.Wait()
+	}
+	if b.Count() != 0 {
+		t.Fatalf("subscriber count = %d, want 0", b.Count())
 	}
 }

--- a/internal/formats/repoproxy/cachefill_hang_test.go
+++ b/internal/formats/repoproxy/cachefill_hang_test.go
@@ -1,0 +1,119 @@
+package repoproxy_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// earlyFailStore is a blob store whose Put gives up before draining the reader,
+// exactly as a real one does when the destination cannot be created at all
+// (permission denied, disk full, a backend timeout on the first write).
+type earlyFailStore struct {
+	*testutil.BlobStore
+	readFirst int
+}
+
+func (s *earlyFailStore) Put(_ context.Context, _ string, r io.Reader, _ int64) error {
+	if s.readFirst > 0 {
+		_, _ = io.ReadFull(r, make([]byte, s.readFirst))
+	}
+	return errors.New("blob store unavailable")
+}
+
+// The cache-fill pipe is written by the goroutine serving the client's own HTTP
+// request, so a Put that stops reading early used to block that request on
+// pw.Write forever: no response, no error, no timeout, and a connection held
+// open for good (#367). The fill must fail fast instead.
+func TestServeGET_CacheFill_PutFailsEarly_DoesNotHang(t *testing.T) {
+	useUnguardedUpstream(t)
+
+	body := make([]byte, 256*1024) // larger than io.Copy's buffer, so the copy writes more than once
+	for i := range body {
+		body[i] = byte('a' + i%26)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name      string
+		readFirst int
+	}{
+		{"put fails before reading anything", 0},
+		{"put fails after a partial read", 1024},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := proxyRepo("hangfill", srv.URL)
+			d := formats.Deps{
+				Repos:      testutil.NewRepoRepo(repo),
+				Blobs:      testutil.NewBlobStoreRepo(),
+				Components: testutil.NewComponentRepo(),
+				Assets:     testutil.NewAssetRepo(),
+				BlobStore:  &earlyFailStore{BlobStore: testutil.NewBlobStore(), readFirst: tc.readFirst},
+			}
+
+			done := make(chan *httptest.ResponseRecorder, 1)
+			go func() { done <- revalGET(d, repo, "/pkg/1.0/big.bin", 10*time.Minute) }()
+
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Fatal("the request never completed: the cache-fill pipe blocked the client's own goroutine")
+			}
+		})
+	}
+}
+
+// A blob store that fails this way must not be mistaken for a successful fill.
+func TestServeGET_CacheFill_PutFailsEarly_RegistersNoAsset(t *testing.T) {
+	useUnguardedUpstream(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("artifact-bytes"))
+	}))
+	defer srv.Close()
+
+	const path = "/pkg/1.0/a.txt"
+	repo := proxyRepo("hangfill2", srv.URL)
+	assets := testutil.NewAssetRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     assets,
+		BlobStore:  &earlyFailStore{BlobStore: testutil.NewBlobStore()},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		revalGET(d, repo, path, 10*time.Minute)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("the request never completed")
+	}
+
+	a, err := assets.GetByPath(context.Background(), "hangfill2", path)
+	if err == nil {
+		assert.Nil(t, a, "a failed cache fill must not leave an asset row behind")
+	}
+}

--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -593,7 +593,15 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 	pr, pw := io.Pipe()
 	putErrCh := make(chan error, 1)
 	go func() {
-		putErrCh <- physStore.Put(ctx, blobKey, pr, resp.ContentLength)
+		err := physStore.Put(ctx, blobKey, pr, resp.ContentLength)
+		// The io.Copy below runs on the client's own request goroutine, so a Put
+		// that returns without draining pr — a disk-full or permission failure
+		// fails before reading a single byte — would block that copy on
+		// pw.Write forever: no response, no error, no timeout (#367). Closing
+		// the read end makes the pending write return io.ErrClosedPipe at once,
+		// and is a no-op once the pipe has already drained normally.
+		_ = pr.Close()
+		putErrCh <- err
 	}()
 
 	hashes := io.MultiWriter(sha256h, sha1h, md5h)

--- a/internal/storage/s3_append.go
+++ b/internal/storage/s3_append.go
@@ -89,6 +89,16 @@ func (s *S3BlobStore) AppendBlob(ctx context.Context, key string, r io.Reader) (
 				if err := s.flushPart(ctx, key, st, buf); err != nil {
 					return 0, err
 				}
+				// A flushed part is real, billable S3 storage the moment
+				// UploadPart returns, so it is recorded before anything later in
+				// this same call can fail: a read error on the request body, or
+				// a later part's own upload failure, used to return before the
+				// single saveAppendState at the end of the loop and lose both
+				// the part and the upload id that could reclaim it (#370).
+				st.Pending = buf.Bytes()
+				if err := s.saveAppendState(ctx, key, st); err != nil {
+					return 0, err
+				}
 			}
 		}
 		if rerr == io.EOF {

--- a/internal/storage/s3_append_integration_test.go
+++ b/internal/storage/s3_append_integration_test.go
@@ -5,6 +5,7 @@ package storage_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -297,4 +298,55 @@ func TestS3BlobStore_Delete_AbortsInFlightAppend(t *testing.T) {
 	_, ok, err := as.AppendedSize(ctx, key)
 	require.NoError(t, err)
 	assert.False(t, ok, "delete must leave no append session behind")
+}
+
+// failAfterReader hands over data and then fails, modeling a client that aborts
+// (or a proxy that drops) partway through a single PATCH.
+type failAfterReader struct {
+	data []byte
+	off  int
+	err  error
+}
+
+func (r *failAfterReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}
+
+// A chunk larger than the part minimum flushes a real, billable part mid-call.
+// The session state used to be written only after the whole call succeeded, so
+// an error later in that same call — this read failure, or a later part's own
+// upload error — returned with the part sitting in S3 and nothing on record
+// naming it, not even the upload id that could abort it (#370).
+func TestS3BlobStore_AppendBlob_PersistsPartAfterLaterReadFailure(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap09eeee11112222"
+
+	const mib = 1024 * 1024
+	content := bytes.Repeat([]byte("Z"), 6*mib)
+
+	_, err := as.AppendBlob(ctx, key, &failAfterReader{data: content, err: errors.New("client went away")})
+	require.Error(t, err)
+
+	staged, ok, err := as.AppendedSize(ctx, key)
+	require.NoError(t, err)
+	require.True(t, ok, "the append session must survive: a real part is already in the bucket")
+	// The 1 MiB tail never reached S3, so it is legitimately dropped — the
+	// client re-sends it from the offset reported here at no cost.
+	require.EqualValues(t, 5*mib, staged)
+
+	// Resuming from that offset must still produce the original bytes.
+	_, err = as.AppendBlob(ctx, key, bytes.NewReader(content[5*mib:]))
+	require.NoError(t, err)
+	require.NoError(t, as.FinalizeAppend(ctx, key))
+
+	got := s3Content(t, bs, key)
+	require.Len(t, got, 6*mib)
+	assert.True(t, bytes.Equal(content, got), "resumed blob does not match the original content")
 }


### PR DESCRIPTION
Three independent defects reported together by @jorgemillan.

### `repoproxy`: a failing `Put` hangs the client's own request (#367)

`storeAndServeResponse` writes the upstream body into an `io.Pipe` whose read end is drained by a background `physStore.Put`. The `io.Copy` doing the writing runs on the goroutine serving the client's HTTP request, so a `Put` that returns without draining the pipe (a permission error or a full disk fails before reading a single byte) left that goroutine blocked on `pw.Write` forever — no response, no error, no timeout, and a client connection held open permanently. Repeated storage failures accumulate blocked goroutines.

The background goroutine now closes the pipe's read end once `Put` returns, so any pending write fails immediately with `io.ErrClosedPipe`. It is a no-op when the pipe drained normally, mirroring the fix already applied to `base.StoreArtifact`.

Two new tests cover a `Put` that fails before reading anything and one that fails after a partial read; both hang against the previous code (verified with a bounded wait) and complete instantly now.

### `events`: `Dispatch` could panic on a concurrent `Unsubscribe` (#369)

`Dispatch` snapshotted the subscriber map under `RLock`, released the lock, then sent to each channel. `Unsubscribe` takes the write lock, removes the subscriber and closes its channel — landing in that gap turns a pending send into "send on closed channel". The send loop now runs under the same `RLock` (and drops the now-pointless snapshot). Sends never block — the `default` arm drops on overflow — so holding the lock across the loop cannot stall `Unsubscribe`.

The package has no live HTTP path today (its SSE handler is not mounted), so this is a fix to the package's concurrency contract before something wires it up. A new test dispatching and unsubscribing concurrently 2000 times reports a data race under `-race` against the old code and passes cleanly now.

### `storage/s3`: a flushed multipart part could be orphaned (#370)

`AppendBlob` persisted its session state only once, after a fully successful call. A single call that flushed a part (a Docker/OCI `PATCH` larger than S3's 5 MiB minimum) and then hit an error — a read failure on the request body, a later part's own upload failure — returned with real, billable bytes in the bucket and nothing on record naming them, not even the upload id that could abort them. With no `AbortIncompleteMultipartUpload` lifecycle rule, the leak accumulates on every such retry.

`saveAppendState` now runs immediately after each successful `flushPart`. A new integration test against real MinIO (`-tags=integration`) reproduces the loss and asserts the flushed part survives, that resuming from the reported offset completes, and that the final bytes match the original.

Closes #367
Closes #369
Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSY7bGzTGQtrMNs6RdPWgh