### PR TITLE
fix(cleanup,gc,migration): count only bytes that actually left the store; stop long runs at their lock TTL

### DIFF
--- a/frontend/src/pages/CleanupPage.tsx
+++ b/frontend/src/pages/CleanupPage.tsx
@@ -703,13 +703,18 @@ export default function CleanupPage() {
     try {
       // A single-policy run is synchronous and returns its outcome.
       const res = await nexusApi.runCleanupPolicy(id)
-      const r = res.data as { deleted?: number; freedBytes?: number; dryRun?: boolean; skipped?: boolean; skippedReason?: string } | undefined
+      const r = res.data as { deleted?: number; freedBytes?: number; dryRun?: boolean; skipped?: boolean; skippedReason?: string; aborted?: boolean } | undefined
       if (r?.skipped) {
         setRunResult({ tone: 'warn', text: `Skipped: ${r.skippedReason ?? 'nothing to do'}` })
       } else if (r) {
         const freedKb = Math.round((r.freedBytes ?? 0) / 1024)
         const verb = r.dryRun ? 'Would delete' : 'Deleted'
-        setRunResult({ tone: 'ok', text: `${verb} ${r.deleted ?? 0} asset(s), ${freedKb} KB${r.dryRun ? ' (dry run)' : ''}` })
+        const text = `${verb} ${r.deleted ?? 0} asset(s), ${freedKb} KB${r.dryRun ? ' (dry run)' : ''}`
+        // An aborted run hit its lock time limit: the counts are partial and the
+        // rest of the backlog waits for the next run.
+        setRunResult(r.aborted
+          ? { tone: 'warn', text: `${text} — stopped early at the run time limit, the rest is left for the next run` }
+          : { tone: 'ok', text })
       } else {
         setRunResult({ tone: 'ok', text: 'Cleanup started' })
       }

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -541,6 +541,10 @@ type CleanupRunResult struct {
 	DryRun        bool   `json:"dryRun"`
 	Skipped       bool   `json:"skipped"`
 	SkippedReason string `json:"skippedReason,omitempty"`
+	// Aborted reports a run that stopped early because it reached its
+	// distributed lock's TTL: Deleted/FreedBytes are then partial, and the rest
+	// of the policy's backlog is left for the next run (#371).
+	Aborted bool `json:"aborted,omitempty"`
 }
 
 // ── Audit Event ──────────────────────────────────────────────

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -262,7 +262,7 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 	var doneBytes int64
 
 	for _, row := range rows {
-		if !deadline.IsZero() && !time.Now().Before(deadline) {
+		if pastDeadline(deadline) {
 			msg := fmt.Sprintf("aborted: exceeded the lock's TTL after migrating %d of %d assets", doneAssets, len(rows))
 			_ = s.migrations.FinishMigration(bgCtx, m.ID, "cancelled", &msg) //nolint:misspell // API/DB status value consumed by frontend (status === 'cancelled')
 			return

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -108,6 +108,7 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 	// the lock is lost — so a row created first would stay "pending" forever and
 	// wedge every later Start for this repo as "already running".
 	var migLock distlock.Lock
+	var deadline time.Time
 	if s.locker != nil {
 		var lockErr error
 		migLock, lockErr = s.locker.Acquire(ctx, blobMigLockKey(repoName), blobMigLockTTL)
@@ -117,6 +118,12 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 		if lockErr != nil {
 			return nil, fmt.Errorf("acquire migration lock: %w", lockErr)
 		}
+		// Nothing renews the lock, so at blobMigLockTTL another node can start a
+		// second migration of this repo. Two runMigration goroutines interleaving
+		// their UpdateBlobStoreForBlobKey and FinishMigration calls is the one
+		// case here that is not merely duplicate work, so the run stops at its
+		// deadline instead (#371).
+		deadline = time.Now().Add(blobMigLockTTL)
 	}
 
 	m := &domain.BlobStoreMigration{
@@ -145,7 +152,7 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 	s.cancels[m.ID] = cancel
 	s.mu.Unlock()
 
-	go s.runMigration(migCtx, m, migLock) //nolint:gosec // detached context is intentional: background migration must outlive the request
+	go s.runMigration(migCtx, m, migLock, deadline) //nolint:gosec // detached context is intentional: background migration must outlive the request
 	return m, nil
 }
 
@@ -189,7 +196,11 @@ func (s *BlobStoreMigrationService) ResumeAll(ctx context.Context) error {
 	return nil
 }
 
-func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.BlobStoreMigration, lock distlock.Lock) {
+// runMigration copies every asset of the repo to the target store. deadline is
+// when the migration's distributed lock expires; a zero deadline means no lock
+// is held and the run has nothing to outlive.
+func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.BlobStoreMigration,
+	lock distlock.Lock, deadline time.Time) {
 	defer func() {
 		if lock != nil {
 			_ = lock.Release(context.Background())
@@ -251,6 +262,11 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 	var doneBytes int64
 
 	for _, row := range rows {
+		if !deadline.IsZero() && !time.Now().Before(deadline) {
+			msg := fmt.Sprintf("aborted: exceeded the lock's TTL after migrating %d of %d assets", doneAssets, len(rows))
+			_ = s.migrations.FinishMigration(bgCtx, m.ID, "cancelled", &msg) //nolint:misspell // API/DB status value consumed by frontend (status === 'cancelled')
+			return
+		}
 		select {
 		case <-ctx.Done():
 			_ = s.migrations.FinishMigration(bgCtx, m.ID, "cancelled", nil) //nolint:misspell // API/DB status value consumed by frontend (status === 'cancelled')

--- a/internal/service/cleanup_accounting_test.go
+++ b/internal/service/cleanup_accounting_test.go
@@ -1,0 +1,87 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/storage"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// deleteFailStore is a store whose physical delete always fails — a full disk, a
+// read-only shard directory, a backend timeout.
+type deleteFailStore struct {
+	*testutil.BlobStore
+}
+
+func (s deleteFailStore) Delete(_ context.Context, _ string) error {
+	return errors.New("permission denied")
+}
+
+func accountingPolicy(id string) *domain.CleanupPolicy {
+	return &domain.CleanupPolicy{
+		ID: id, Name: id, Enabled: true, Format: "maven2",
+		Criteria: map[string]any{"artifactAgeDays": float64(30)},
+	}
+}
+
+func accountingRepos(policyID string) *testutil.RepoRepo {
+	return testutil.NewRepoRepo(&domain.Repository{
+		Name: "mvn", ID: "r1", Format: domain.FormatMaven2, CleanupPolicyIDs: []string{policyID},
+	})
+}
+
+// One object can carry several assets (an OCI manifest's tag and its digest
+// alias): expiring one of them deletes the row but must leave the bytes, since
+// the sibling still points at them. The run used to count those bytes as freed
+// anyway (#368).
+func TestRunPolicyResult_SharedBlobKey_ReportsNoBytesFreed(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(accountingPolicy("shared"))
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", Repository: "mvn", BlobKey: "bk-shared", SizeBytes: 49, Path: "/stale.jar"}}
+	// The sibling asset that survives this run and keeps referencing the blob.
+	assets.SeedAsset(&domain.Asset{
+		ID: "a2", Repository: "mvn", BlobKey: "bk-shared", SizeBytes: 49, Path: "/live.jar",
+	})
+	blobs := testutil.NewBlobStore()
+	require.NoError(t, blobs.Put(context.Background(), "bk-shared", testutil.MakeReader("x"), 1))
+
+	svc := service.NewCleanupService(policies, accountingRepos("shared"), assets, testutil.NewBlobStoreRepo(), blobs, nopLog())
+	res, err := svc.RunPolicyResult(context.Background(), "shared")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, res.Deleted, "the stale row is still removed")
+	assert.Equal(t, int64(0), res.FreedBytes, "the bytes are still there — the sibling asset references them")
+	assert.Empty(t, blobs.Deleted, "a blob a live asset points at must not be deleted")
+	exists, err := blobs.Exists(context.Background(), "bk-shared")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+// A physical delete that fails leaves the bytes on disk. The row is still gone
+// (the DB row and the blob's own lifecycle are independent, and the blob GC
+// reclaims the orphan later) but nothing was freed (#368).
+func TestRunPolicyResult_PhysicalDeleteFails_ReportsNoBytesFreed(t *testing.T) {
+	policies := testutil.NewCleanupPolicyRepo(accountingPolicy("failing"))
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", Repository: "mvn", BlobKey: "bk1", SizeBytes: 49, Path: "/stale.jar"}}
+	inner := testutil.NewBlobStore()
+	require.NoError(t, inner.Put(context.Background(), "bk1", testutil.MakeReader("x"), 1))
+	var blobs storage.BlobStore = deleteFailStore{BlobStore: inner}
+
+	svc := service.NewCleanupService(policies, accountingRepos("failing"), assets, testutil.NewBlobStoreRepo(), blobs, nopLog())
+	res, err := svc.RunPolicyResult(context.Background(), "failing")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, res.Deleted)
+	assert.Equal(t, int64(0), res.FreedBytes, "the delete failed — those bytes never left the store")
+	exists, err := inner.Exists(context.Background(), "bk1")
+	require.NoError(t, err)
+	assert.True(t, exists, "the blob is still on disk")
+}

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -316,7 +316,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy, 
 	noProgress := 0
 	aborted := false
 	for {
-		if !deadline.IsZero() && !time.Now().Before(deadline) {
+		if pastDeadline(deadline) {
 			log.Warn("cleanup: stopping — the run reached its lock TTL, another node may already hold the lock",
 				"policy", p.Name, "deleted", deleted, "freed_bytes", freed)
 			aborted = true

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -183,7 +183,9 @@ var errAcquireLock = errors.New("cleanup: acquire lock")
 // The lock is per policy, so unrelated policies still run in parallel.
 func (s *CleanupService) runPolicyLocked(ctx context.Context, p domain.CleanupPolicy) (*domain.CleanupRunResult, error) {
 	if s.locker == nil {
-		return s.runPolicy(ctx, p)
+		// No locker, no exclusivity to lose: a single-node deployment has no TTL
+		// to run out of.
+		return s.runPolicy(ctx, p, time.Time{})
 	}
 
 	lock, err := s.locker.Acquire(ctx, cleanupPolicyLockPrefix+p.ID, cleanupLockTTL)
@@ -199,7 +201,13 @@ func (s *CleanupService) runPolicyLocked(ctx context.Context, p domain.CleanupPo
 	}
 	defer func() { _ = lock.Release(ctx) }()
 
-	return s.runPolicy(ctx, p)
+	// The lock expires on its own after cleanupLockTTL whether or not this run
+	// has finished, and nothing renews it — so past that moment another node can
+	// acquire the same lock and start the same policy alongside this one (#371).
+	// A run that reaches its deadline stops instead of continuing unprotected;
+	// what it already deleted is kept and reported, and the next run picks up
+	// the rest.
+	return s.runPolicy(ctx, p, time.Now().Add(cleanupLockTTL))
 }
 
 // RunAll executes all enabled cleanup policies once and returns a summary.
@@ -252,7 +260,10 @@ func (s *CleanupService) RunPolicyResult(ctx context.Context, id string) (*domai
 	return s.runPolicyLocked(ctx, *p)
 }
 
-func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) (*domain.CleanupRunResult, error) {
+// runPolicy executes p. deadline is the moment this run's distributed lock
+// expires; a zero deadline means the run holds no lock and has nothing to
+// outlive.
+func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy, deadline time.Time) (*domain.CleanupRunResult, error) {
 	// Every line this run logs carries the run's trace_id, so a warning like
 	// "blob delete failed" can be jumped to the exact cleanup.run trace it
 	// happened in (#321). With tracing disabled this is s.log unchanged.
@@ -303,7 +314,14 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 	var freed int64
 	var deleted int
 	noProgress := 0
+	aborted := false
 	for {
+		if !deadline.IsZero() && !time.Now().Before(deadline) {
+			log.Warn("cleanup: stopping — the run reached its lock TTL, another node may already hold the lock",
+				"policy", p.Name, "deleted", deleted, "freed_bytes", freed)
+			aborted = true
+			break
+		}
 		stale, err := s.assets.ListStale(ctx, p.Format, repoNames, lastDownloadedDays, artifactAgeDays, pathPrefix, nameGlob, p.RetainNVersions, batchLimit)
 		if err != nil {
 			return nil, fmt.Errorf("cleanup: list stale assets: %w", err)
@@ -337,7 +355,6 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 						"id", a.ID, "path", a.Path, "repo", a.Repository)
 					return nil
 				}
-				freed += a.SizeBytes
 				deleted++
 				// One object can carry several assets — an OCI manifest's tag and its
 				// digest alias, a mounted layer — and expiring one of them says
@@ -355,6 +372,13 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 					if err := s.storeForAsset(ctx, &asset).Delete(ctx, a.BlobKey); err != nil {
 						log.Warn("cleanup: blob delete failed", "key", a.BlobKey, "err", err)
 					} else {
+						// Bytes count as freed on exactly the same condition as
+						// used_bytes moves: the physical delete succeeded. A row
+						// whose blob is shared with a surviving asset, or whose
+						// delete failed, leaves the bytes on disk — reporting them
+						// as freed tells the operator storage was reclaimed that
+						// never was (#368).
+						freed += a.SizeBytes
 						// used_bytes is how full the store is, so it only moves when
 						// bytes actually left it (#146).
 						_ = base.DecrementBlobStoreUsage(ctx, s.blobs, &asset)
@@ -413,6 +437,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy) 
 
 	res.Deleted = deleted
 	res.FreedBytes = freed
+	res.Aborted = aborted
 	return res, nil
 }
 

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -204,7 +204,7 @@ func (s *BlobGCService) compact(ctx context.Context, name, storeID string, store
 
 	var removed int64
 	for _, e := range entries {
-		if !deadline.IsZero() && !time.Now().Before(deadline) {
+		if pastDeadline(deadline) {
 			s.log().Warn("blob gc: stopping — the run reached its lock TTL, another node may already hold the lock",
 				"store", name, "orphans", result.Orphans, "freed_bytes", removed)
 			result.Aborted = true

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -37,6 +37,10 @@ type GCResult struct {
 	FreedBytes   int64    `json:"freedBytes"`
 	DryRun       bool     `json:"dryRun"`
 	Errors       []string `json:"errors,omitempty"`
+	// Aborted reports a pass that stopped early because the GC run reached its
+	// distributed lock's TTL: the counts above are partial and the store still
+	// holds orphans for the next run (#371).
+	Aborted bool `json:"aborted,omitempty"`
 }
 
 // BlobGCService finds and removes blobs not referenced by any asset (orphans),
@@ -123,7 +127,8 @@ func (s *BlobGCService) CompactStore(ctx context.Context, name string, opts GCOp
 	if err != nil {
 		return nil, fmt.Errorf("resolve blob store %q: %w", name, err)
 	}
-	return s.compact(ctx, name, row.ID, store, referenced, opts), nil
+	// A single-store compaction takes no lock, so it has no TTL to outlive.
+	return s.compact(ctx, name, row.ID, store, referenced, opts, time.Time{}), nil
 }
 
 // CompactAll compacts every blob store. It holds a distributed lock so only one
@@ -132,6 +137,7 @@ func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCRe
 	// Root span: GC runs from cron with no HTTP request behind it (#302).
 	ctx, span := tracing.StartRoot(ctx, "gc.compact_all")
 	defer span.End()
+	var deadline time.Time
 	if s.Locker != nil {
 		lock, err := s.Locker.Acquire(ctx, gcLockKey, gcLockTTL)
 		if errors.Is(err, distlock.ErrLockHeld) {
@@ -142,6 +148,10 @@ func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCRe
 			return nil, fmt.Errorf("blob gc: acquire lock: %w", err)
 		}
 		defer func() { _ = lock.Release(ctx) }()
+		// Nothing renews the lock, so once gcLockTTL is up another node can
+		// acquire it and start compacting the same stores alongside this run.
+		// Passes stop at that moment rather than deleting unprotected (#371).
+		deadline = time.Now().Add(gcLockTTL)
 	}
 
 	referenced, err := s.referencedSet(ctx)
@@ -168,14 +178,16 @@ func (s *BlobGCService) CompactAll(ctx context.Context, opts GCOptions) ([]*GCRe
 			})
 			continue
 		}
-		results = append(results, s.compact(ctx, row.Name, row.ID, store, referenced, opts))
+		results = append(results, s.compact(ctx, row.Name, row.ID, store, referenced, opts, deadline))
 	}
 	return results, nil
 }
 
-// compact runs the core scan/delete for a single resolved store.
+// compact runs the core scan/delete for a single resolved store. deadline is
+// when the run's distributed lock expires; a zero deadline means no lock is
+// held and the pass runs to the end.
 func (s *BlobGCService) compact(ctx context.Context, name, storeID string, store storage.BlobStore,
-	referenced refIndex, opts GCOptions) *GCResult {
+	referenced refIndex, opts GCOptions, deadline time.Time) *GCResult {
 	minAge := opts.MinAge
 	if minAge <= 0 {
 		minAge = s.DefaultMinAge
@@ -192,6 +204,12 @@ func (s *BlobGCService) compact(ctx context.Context, name, storeID string, store
 
 	var removed int64
 	for _, e := range entries {
+		if !deadline.IsZero() && !time.Now().Before(deadline) {
+			s.log().Warn("blob gc: stopping — the run reached its lock TTL, another node may already hold the lock",
+				"store", name, "orphans", result.Orphans, "freed_bytes", removed)
+			result.Aborted = true
+			break
+		}
 		if referenced.has(storeID, e.Key) {
 			continue // still referenced in this store
 		}

--- a/internal/service/lock_deadline.go
+++ b/internal/service/lock_deadline.go
@@ -1,0 +1,13 @@
+package service
+
+import "time"
+
+// pastDeadline reports whether a long-running job has reached the moment its
+// distributed lock expires. Nothing renews those locks, so past that point
+// another node can acquire the same lock and start the same work — cleanup, GC
+// and blob-store migration each stop there instead of continuing unprotected
+// (#371). A zero deadline means the job holds no lock and has nothing to
+// outlive.
+func pastDeadline(deadline time.Time) bool {
+	return !deadline.IsZero() && !time.Now().Before(deadline)
+}

--- a/internal/service/lock_deadline_internal_test.go
+++ b/internal/service/lock_deadline_internal_test.go
@@ -20,8 +20,8 @@ import (
 // TTLs are 30 minutes and 2 hours, so these tests drive the unexported entry
 // points with a deadline that has already passed.
 
-func pastDeadline() time.Time   { return time.Now().Add(-time.Minute) }
-func futureDeadline() time.Time { return time.Now().Add(time.Hour) }
+func expiredDeadline() time.Time { return time.Now().Add(-time.Minute) }
+func futureDeadline() time.Time  { return time.Now().Add(time.Hour) }
 
 func deadlineCleanupService(assets *testutil.AssetRepo) (*CleanupService, *testutil.CleanupPolicyRepo) {
 	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
@@ -43,7 +43,7 @@ func TestCleanup_RunPolicy_AbortsAtLockDeadline(t *testing.T) {
 	p, err := policies.Get(context.Background(), "p")
 	require.NoError(t, err)
 
-	res, err := svc.runPolicy(context.Background(), *p, pastDeadline())
+	res, err := svc.runPolicy(context.Background(), *p, expiredDeadline())
 	require.NoError(t, err)
 	assert.True(t, res.Aborted, "a run past its lock TTL must stop instead of deleting unprotected")
 	assert.Equal(t, 0, res.Deleted, "no further work is attempted after the deadline")
@@ -74,7 +74,7 @@ func TestGC_Compact_AbortsAtLockDeadline(t *testing.T) {
 	referenced, err := svc.referencedSet(ctx)
 	require.NoError(t, err)
 
-	res := svc.compact(ctx, "default", "store-1", store, referenced, GCOptions{}, pastDeadline())
+	res := svc.compact(ctx, "default", "store-1", store, referenced, GCOptions{}, expiredDeadline())
 	assert.True(t, res.Aborted, "a pass past the GC lock's TTL must stop")
 	assert.Equal(t, 0, res.Orphans, "no orphan is deleted after the deadline")
 	assert.Empty(t, store.Deleted)
@@ -107,7 +107,7 @@ func TestBlobStoreMigration_RunMigration_AbortsAtLockDeadline(t *testing.T) {
 	m := &domain.BlobStoreMigration{RepositoryName: "my-repo", SourceStoreID: source.ID, TargetStoreID: target.ID, Status: "pending"}
 	require.NoError(t, migs.Create(ctx, m))
 
-	svc.runMigration(ctx, m, nil, pastDeadline())
+	svc.runMigration(ctx, m, nil, expiredDeadline())
 
 	got, err := migs.GetLatestByRepo(ctx, "my-repo")
 	require.NoError(t, err)

--- a/internal/service/lock_deadline_internal_test.go
+++ b/internal/service/lock_deadline_internal_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/storage"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// Nothing renews a distributed lock, so a run that outlives its TTL is no longer
+// exclusive: another node can acquire the same lock and start the same work
+// (#371). Each long-running job therefore stops at its own deadline. The real
+// TTLs are 30 minutes and 2 hours, so these tests drive the unexported entry
+// points with a deadline that has already passed.
+
+func pastDeadline() time.Time   { return time.Now().Add(-time.Minute) }
+func futureDeadline() time.Time { return time.Now().Add(time.Hour) }
+
+func deadlineCleanupService(assets *testutil.AssetRepo) (*CleanupService, *testutil.CleanupPolicyRepo) {
+	policies := testutil.NewCleanupPolicyRepo(&domain.CleanupPolicy{
+		ID: "p", Name: "p", Enabled: true, Format: "maven2",
+		Criteria: map[string]any{"artifactAgeDays": float64(30)},
+	})
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		Name: "mvn", ID: "r1", Format: domain.FormatMaven2, CleanupPolicyIDs: []string{"p"},
+	})
+	svc := NewCleanupService(policies, repos, assets, testutil.NewBlobStoreRepo(), testutil.NewBlobStore(), zap.NewNop().Sugar())
+	return svc, policies
+}
+
+func TestCleanup_RunPolicy_AbortsAtLockDeadline(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", Repository: "mvn", BlobKey: "bk1", SizeBytes: 10, Path: "/a.jar"}}
+	svc, policies := deadlineCleanupService(assets)
+
+	p, err := policies.Get(context.Background(), "p")
+	require.NoError(t, err)
+
+	res, err := svc.runPolicy(context.Background(), *p, pastDeadline())
+	require.NoError(t, err)
+	assert.True(t, res.Aborted, "a run past its lock TTL must stop instead of deleting unprotected")
+	assert.Equal(t, 0, res.Deleted, "no further work is attempted after the deadline")
+	// Partial results are still recorded, so the operator sees what the run did.
+	assert.Len(t, policies.RunRecords, 1)
+}
+
+func TestCleanup_RunPolicy_RunsNormallyBeforeDeadline(t *testing.T) {
+	assets := testutil.NewAssetRepo()
+	assets.Stale = []domain.Asset{{ID: "a1", Repository: "mvn", BlobKey: "bk1", SizeBytes: 10, Path: "/a.jar"}}
+	svc, policies := deadlineCleanupService(assets)
+
+	p, err := policies.Get(context.Background(), "p")
+	require.NoError(t, err)
+
+	res, err := svc.runPolicy(context.Background(), *p, futureDeadline())
+	require.NoError(t, err)
+	assert.False(t, res.Aborted)
+	assert.Equal(t, 1, res.Deleted)
+}
+
+func TestGC_Compact_AbortsAtLockDeadline(t *testing.T) {
+	ctx := context.Background()
+	store := testutil.NewBlobStore()
+	require.NoError(t, store.Put(ctx, "orphan-1", testutil.MakeReader("xxxx"), 4))
+
+	svc := &BlobGCService{Assets: testutil.NewAssetRepo(), Stores: testutil.NewBlobStoreRepo()}
+	referenced, err := svc.referencedSet(ctx)
+	require.NoError(t, err)
+
+	res := svc.compact(ctx, "default", "store-1", store, referenced, GCOptions{}, pastDeadline())
+	assert.True(t, res.Aborted, "a pass past the GC lock's TTL must stop")
+	assert.Equal(t, 0, res.Orphans, "no orphan is deleted after the deadline")
+	assert.Empty(t, store.Deleted)
+
+	res = svc.compact(ctx, "default", "store-1", store, referenced, GCOptions{}, futureDeadline())
+	assert.False(t, res.Aborted)
+	assert.Equal(t, 1, res.Orphans, "the ordinary, well-within-TTL pass is unchanged")
+}
+
+func TestBlobStoreMigration_RunMigration_AbortsAtLockDeadline(t *testing.T) {
+	ctx := context.Background()
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+	source := &domain.BlobStore{ID: "src", Name: "source", Type: "local", Config: map[string]any{"path": srcDir}}
+	target := &domain.BlobStore{ID: "tgt", Name: "target", Type: "local", Config: map[string]any{"path": dstDir}}
+
+	srcID := source.ID
+	repos := testutil.NewRepoRepo(&domain.Repository{
+		ID: "repo-1", Name: "my-repo", Format: domain.RepoFormat("raw"),
+		Type: domain.TypeHosted, Online: true, BlobStoreID: &srcID,
+	})
+	assets := testutil.NewAssetRepo()
+	assets.MigrationRows = []domain.MigrationAssetRow{
+		{BlobKey: "bk1", SizeBytes: 4, SourceBlobStoreID: source.ID},
+	}
+	migs := testutil.NewBlobStoreMigrationRepo()
+	defaultStore, err := storage.NewLocalBlobStore(srcDir)
+	require.NoError(t, err)
+
+	svc := NewBlobStoreMigrationService(migs, assets, repos, testutil.NewBlobStoreRepo(source, target), storage.NewRegistry(defaultStore))
+	m := &domain.BlobStoreMigration{RepositoryName: "my-repo", SourceStoreID: source.ID, TargetStoreID: target.ID, Status: "pending"}
+	require.NoError(t, migs.Create(ctx, m))
+
+	svc.runMigration(ctx, m, nil, pastDeadline())
+
+	got, err := migs.GetLatestByRepo(ctx, "my-repo")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "cancelled", got.Status, //nolint:misspell // API/DB status value consumed by frontend
+		"two migrations interleaving their asset repointing is the one case here that is not merely duplicate work")
+	require.NotNil(t, got.ErrorMessage)
+	assert.Contains(t, *got.ErrorMessage, "exceeded the lock's TTL")
+}


### PR DESCRIPTION
Two findings from @jorgemillan, both in the long-running background jobs.

### Cleanup reported bytes as "freed" that were never deleted (#368)

`freed += a.SizeBytes` ran right after the asset row was deleted — before the code even attempted the physical blob delete a few lines later. Two real cases inflated the number:

- **Shared blob key** — the row is one of several assets on the same blob (an OCI manifest's tag and its digest alias). The physical delete is correctly skipped, but the bytes were counted anyway.
- **Physical delete failure** — disk full, permission error, backend timeout. The row is gone, the blob is still on disk, and the bytes were counted anyway.

The blob store's own `used_bytes` was already gated on the delete succeeding; `freed` now moves on exactly the same condition and is paired with it. That fixes both the immediate JSON response and the inflated history `RecordRun` persists. The row-before-bytes deletion order is unchanged — it is load-bearing for the TOCTOU fix in that closure; only the accounting moved.

Two new tests cover the shared-key case and a store whose `Delete` always fails: the row goes (`deleted: 1`) while `freedBytes` stays `0`.

### Long runs silently lost exclusivity past their lock TTL (#371)

`Acquire` takes a fixed TTL and nothing renews it, so a cleanup run, a GC pass over a large S3 bucket, or a migration of a big repository that outlives its TTL kept working while another node could already have taken the same lock.

Each of the three callers now computes `deadline := time.Now().Add(<its own TTL>)` right after acquiring its lock, and its long-running loop checks it:

- `cleanup_service.go` — checked at the top of every batch pass; the run aborts with `Aborted = true` and its partial `deleted`/`freedBytes` still recorded.
- `gc_service.go` — checked while scanning a store's entries; the pass aborts with `Aborted = true`, partial counts kept.
- `blob_store_migration_service.go` — checked between assets; the migration finishes as `cancelled` with `aborted: exceeded the lock's TTL after migrating N of M assets`. This is the one case that is not merely duplicate work: two `runMigration` goroutines interleaving their asset repointing is unpredictable.

The `Locker`/`Lock` interfaces are untouched — no heartbeat/renew method, exactly the narrow per-caller shape the report asked for. A run that holds no lock (single-node `NoopLocker`, or the per-store `CompactStore` endpoint) gets a zero deadline and behaves exactly as before.

Three white-box tests drive the unexported `runPolicy`/`compact`/`runMigration` with an already-past deadline (the real TTLs — 30 minutes and 2 hours — are not waitable) and confirm each aborts with correct partial results, while a future deadline behaves as before. The cleanup page now labels an aborted run as stopped early rather than reporting its partial counts as a clean success.

Closes #368
Closes #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSY7bGzTGQtrMNs6RdPWgh