### PR TITLE
fix(promotion): refuse a promotion when more than one rule covers the component

### DIFF
--- a/internal/api/handlers/promotion.go
+++ b/internal/api/handlers/promotion.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -121,6 +122,13 @@ func (h *PromotionHandler) Promote(c *gin.Context) {
 
 	requests, err := h.svc.Promote(c.Request.Context(), body.RuleID, body.ComponentIDs, uid)
 	if err != nil {
+		// Two rules covering the same component is a conflict in the rules, not
+		// a malformed request: the caller is told to make the configuration
+		// unambiguous rather than to fix its own payload (#366).
+		if errors.Is(err, service.ErrAmbiguousPromotionRule) {
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusUnprocessableEntity, gin.H{"error": err.Error()})
 		return
 	}
@@ -146,6 +154,12 @@ func (h *PromotionHandler) Approve(c *gin.Context) {
 	reviewerID, _ := c.Get("userID")
 	uid, _ := reviewerID.(string)
 	if err := h.svc.Approve(c.Request.Context(), c.Param("id"), uid); err != nil {
+		// A rule created while the request sat pending can make it ambiguous
+		// only at approval time; same answer as on Promote (#366).
+		if errors.Is(err, service.ErrAmbiguousPromotionRule) {
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/promotion_extra_test.go
+++ b/internal/api/handlers/promotion_extra_test.go
@@ -210,3 +210,21 @@ func TestPromotionExtra_Reject_OK(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, true, body["ok"])
 }
+
+// Two rules covering the same component is a conflict in the configuration, not
+// a malformed request: 409, with a message naming both rules (#366).
+func TestPromotionExtra_Promote_AmbiguousRules_409(t *testing.T) {
+	r, repo, comps := mountPromotion2(t)
+	comp := &domain.Component{Name: "lib", Repository: "staging", Format: "maven2"}
+	require.NoError(t, comps.Create(testContext(), comp))
+	strict := &domain.PromotionRule{Name: "strict", FromRepo: "staging", ToRepo: "prod", RequireScanPass: true}
+	lax := &domain.PromotionRule{Name: "lax", FromRepo: "staging", ToRepo: "prod"}
+	require.NoError(t, repo.CreateRule(testContext(), strict))
+	require.NoError(t, repo.CreateRule(testContext(), lax))
+
+	rec := do(t, r, http.MethodPost, "/api/v1/promotion/promote", map[string]any{
+		"rule_id": lax.ID, "component_ids": []string{comp.ID},
+	})
+	assert.Equal(t, http.StatusConflict, rec.Code, "body=%s", rec.Body.String())
+	assert.Contains(t, rec.Body.String(), "strict")
+}

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -106,6 +106,11 @@ func (s *PromotionService) evalPathFilter(rule domain.PromotionRule, comp *domai
 	return matched, nil
 }
 
+// ErrAmbiguousPromotionRule reports that more than one promotion rule covers the
+// same component for the same repository pair. Callers map it to 409: it is not
+// a malformed request, it is a configuration the server refuses to guess at.
+var ErrAmbiguousPromotionRule = errors.New("more than one promotion rule applies")
+
 // ruleAppliesTo reports whether the rule actually covers the component: the
 // component lives in the rule's from_repo and passes its path filter. This is
 // the same test ListRulesForComponent offers rules by — but offering is not
@@ -114,7 +119,7 @@ func (s *PromotionService) evalPathFilter(rule domain.PromotionRule, comp *domai
 // arbitrary component with whichever rule has the laxest gates, bypassing a
 // stricter rule's require_scan_pass/require_manual_approval on the pair that
 // actually covers it (#255).
-func (s *PromotionService) ruleAppliesTo(rule *domain.PromotionRule, comp *domain.Component) error {
+func (s *PromotionService) ruleAppliesTo(ctx context.Context, rule *domain.PromotionRule, comp *domain.Component) error {
 	if comp.Repository != rule.FromRepo {
 		return fmt.Errorf("component %s lives in repository %q, which rule %q does not promote from (%q)",
 			comp.ID, comp.Repository, rule.Name, rule.FromRepo)
@@ -127,6 +132,43 @@ func (s *PromotionService) ruleAppliesTo(rule *domain.PromotionRule, comp *domai
 	}
 	if !matched {
 		return fmt.Errorf("component %s does not match rule %q's path filter", comp.ID, rule.Name)
+	}
+	return s.noSiblingRuleApplies(ctx, rule, comp)
+}
+
+// noSiblingRuleApplies refuses a promotion that more than one rule covers.
+//
+// Confirming the named rule covers the component is not enough: two rules on
+// the same repository pair can both cover it with different gates, and naming
+// the laxer one then completes a promotion the stricter one's
+// require_scan_pass/require_manual_approval would have blocked — no error, no
+// warning, nothing recording that a gate was routed around (#366). Since the
+// server cannot tell which rule the caller meant, the refusal is symmetric:
+// naming either one is refused, including the stricter one, until an operator
+// deletes or narrows a rule so exactly one applies.
+func (s *PromotionService) noSiblingRuleApplies(ctx context.Context, rule *domain.PromotionRule, comp *domain.Component) error {
+	siblings, err := s.promotionRepo.ListRulesByFromRepo(ctx, comp.Repository)
+	if err != nil {
+		return fmt.Errorf("cannot check whether other rules cover component %s: %w", comp.ID, err)
+	}
+	for i := range siblings {
+		sib := siblings[i]
+		if sib.ID == rule.ID || sib.ToRepo != rule.ToRepo {
+			continue
+		}
+		matched, ferr := s.evalPathFilter(sib, comp)
+		if ferr != nil {
+			// A sibling whose filter cannot be evaluated may well cover this
+			// component; letting the promotion through would be exactly the
+			// bypass this check exists to prevent.
+			return fmt.Errorf("%w: rule %q also promotes %q→%q and its path filter could not be evaluated: %w",
+				ErrAmbiguousPromotionRule, sib.Name, sib.FromRepo, sib.ToRepo, ferr)
+		}
+		if matched {
+			return fmt.Errorf("%w: rules %q and %q both cover component %s from %q to %q — "+
+				"delete or narrow one of them, since naming either decides which gates apply",
+				ErrAmbiguousPromotionRule, rule.Name, sib.Name, comp.ID, rule.FromRepo, rule.ToRepo)
+		}
 	}
 	return nil
 }
@@ -253,7 +295,7 @@ func (s *PromotionService) Promote(ctx context.Context, ruleID string, component
 		if cerr != nil || comp == nil {
 			return nil, fmt.Errorf("component not found: %s", compID)
 		}
-		if aerr := s.ruleAppliesTo(rule, comp); aerr != nil {
+		if aerr := s.ruleAppliesTo(ctx, rule, comp); aerr != nil {
 			return nil, aerr
 		}
 		if serr := s.scanGate(ctx, rule, compID); serr != nil {
@@ -384,7 +426,7 @@ func (s *PromotionService) executeCopy(ctx context.Context, req *domain.Promotio
 	// runs later, and the component may have moved, the rule changed, or a
 	// scan found something while the request sat pending — the invariants
 	// have to hold when the bytes actually move.
-	if err := s.ruleAppliesTo(rule, comp); err != nil {
+	if err := s.ruleAppliesTo(ctx, rule, comp); err != nil {
 		return err
 	}
 	if err := s.scanGate(ctx, rule, comp.ID); err != nil {

--- a/internal/service/promotion_service_ambiguity_test.go
+++ b/internal/service/promotion_service_ambiguity_test.go
@@ -1,0 +1,177 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// Two rules on the same repository pair can both cover a component with
+// different gates. Confirming only that the named rule covers it lets a caller
+// pick the lax one and complete a promotion the strict one would have blocked
+// (#366). The refusal is symmetric: the server cannot tell which rule the
+// caller meant, so naming either is refused.
+func TestPromotionService_Promote_RefusesAmbiguousSiblingRules(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+
+	comp := &domain.Component{
+		ID: "comp-ambiguous", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	strict := &domain.PromotionRule{
+		Name: "strict", FromRepo: "staging", ToRepo: "production", RequireScanPass: true,
+	}
+	lax := &domain.PromotionRule{Name: "lax", FromRepo: "staging", ToRepo: "production"}
+	for _, r := range []*domain.PromotionRule{strict, lax} {
+		if err := promoRepo.CreateRule(ctx, r); err != nil {
+			t.Fatalf("CreateRule: %v", err)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		rule *domain.PromotionRule
+	}{
+		{"naming the lax rule", lax},
+		{"naming the strict rule", strict},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.Promote(ctx, tc.rule.ID, []string{comp.ID}, "user-1")
+			if !errors.Is(err, service.ErrAmbiguousPromotionRule) {
+				t.Fatalf("expected an ambiguity refusal, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "strict") || !strings.Contains(err.Error(), "lax") {
+				t.Fatalf("the refusal must name both rules, got: %v", err)
+			}
+		})
+	}
+
+	reqs, err := promoRepo.ListRequests(ctx, "")
+	if err != nil {
+		t.Fatalf("ListRequests: %v", err)
+	}
+	if len(reqs) != 0 {
+		t.Fatalf("a refused promotion must leave no request rows, got %d", len(reqs))
+	}
+
+	// Removing the ambiguity restores normal behavior: the strict rule falls
+	// through to its own scan gate rather than being refused as ambiguous.
+	if err := promoRepo.DeleteRule(ctx, lax.ID); err != nil {
+		t.Fatalf("DeleteRule: %v", err)
+	}
+	_, err = svc.Promote(ctx, strict.ID, []string{comp.ID}, "user-1")
+	if err == nil || !strings.Contains(err.Error(), "scan required") {
+		t.Fatalf("expected the strict rule's own scan gate, got: %v", err)
+	}
+}
+
+// A sibling rule on a different target repository is not ambiguous: the two
+// rules promote to different places, so naming one says which.
+func TestPromotionService_Promote_SiblingToOtherRepo_IsNotAmbiguous(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	for _, name := range []string{"staging", "production", "archive"} {
+		repoRepo.Create(ctx, testutil.SimpleRepo(name, "raw"))
+	}
+	comp := &domain.Component{
+		ID: "comp-two-targets", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	toProd := &domain.PromotionRule{Name: "to-prod", FromRepo: "staging", ToRepo: "production"}
+	toArchive := &domain.PromotionRule{Name: "to-archive", FromRepo: "staging", ToRepo: "archive"}
+	for _, r := range []*domain.PromotionRule{toProd, toArchive} {
+		if err := promoRepo.CreateRule(ctx, r); err != nil {
+			t.Fatalf("CreateRule: %v", err)
+		}
+	}
+
+	reqs, err := svc.Promote(ctx, toProd.ID, []string{comp.ID}, "user-1")
+	if err != nil || len(reqs) != 1 {
+		t.Fatalf("Promote must succeed with distinct targets, got %v (%d requests)", err, len(reqs))
+	}
+}
+
+// A sibling on the same pair whose path filter excludes this component covers
+// something else entirely — nothing to be ambiguous about.
+func TestPromotionService_Promote_SiblingWithDisjointFilter_IsNotAmbiguous(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+
+	comp := &domain.Component{
+		ID: "comp-scoped", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	open := &domain.PromotionRule{Name: "open", FromRepo: "staging", ToRepo: "production"}
+	elsewhere := &domain.PromotionRule{
+		Name: "elsewhere", FromRepo: "staging", ToRepo: "production",
+		PathFilter: `path.startsWith("/com/other/")`,
+	}
+	for _, r := range []*domain.PromotionRule{open, elsewhere} {
+		if err := promoRepo.CreateRule(ctx, r); err != nil {
+			t.Fatalf("CreateRule: %v", err)
+		}
+	}
+
+	reqs, err := svc.Promote(ctx, open.ID, []string{comp.ID}, "user-1")
+	if err != nil || len(reqs) != 1 {
+		t.Fatalf("Promote must succeed when the sibling's filter excludes the component, got %v (%d requests)", err, len(reqs))
+	}
+}
+
+// The re-check at copy time matters here too: a sibling rule created while a
+// request sat pending makes it ambiguous only at approval time.
+func TestPromotionService_Approve_RefusesRuleThatBecameAmbiguous(t *testing.T) {
+	svc, promoRepo, compRepo, _, _, repoRepo, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+
+	comp := &domain.Component{
+		ID: "comp-pending", Repository: "staging", Format: "raw",
+		Group: "com/example", Name: "mylib", Version: "1.0.0",
+	}
+	compRepo.AddComponent(comp)
+
+	gated := &domain.PromotionRule{
+		Name: "gated", FromRepo: "staging", ToRepo: "production", RequireManualApproval: true,
+	}
+	if err := promoRepo.CreateRule(ctx, gated); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+	reqs, err := svc.Promote(ctx, gated.ID, []string{comp.ID}, "user-1")
+	if err != nil || len(reqs) != 1 {
+		t.Fatalf("Promote: %v (%d requests)", err, len(reqs))
+	}
+
+	// A second rule on the same pair appears while the request is pending.
+	if err := promoRepo.CreateRule(ctx, &domain.PromotionRule{
+		Name: "added-later", FromRepo: "staging", ToRepo: "production",
+	}); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	err = svc.Approve(ctx, reqs[0].ID, "admin-1")
+	if !errors.Is(err, service.ErrAmbiguousPromotionRule) {
+		t.Fatalf("expected Approve to refuse the now-ambiguous request, got: %v", err)
+	}
+}


### PR DESCRIPTION
Reported by @jorgemillan — the backend half of #337, still open after the frontend fix in #339.

`ruleAppliesTo` checked only that the *named* rule's repo pair and path filter covered the component, never whether it was the only rule that did. Two rules sharing a `from_repo`/`to_repo` with different gates both applied to the same component, so naming the laxer one completed a promotion the stricter one's `require_scan_pass` / `require_manual_approval` would have blocked — no error, no warning, nothing recording that a gate was routed around. Anyone with promotion permission (a careless user, a compromised CI credential, a client-side bug picking the wrong rule) could use it to skip a gate an operator specifically configured.

## What changed

After confirming the named rule covers the component, `ruleAppliesTo` lists the sibling rules of the component's repository (`ListRulesByFromRepo`) and refuses when another rule with the same `to_repo` also covers it, evaluating each sibling's path filter the same way.

- **Symmetric.** Naming *either* rule is refused, the strict one included: the server cannot tell which the caller meant, so it refuses to guess rather than silently picking. An operator resolves it by deleting or narrowing a rule.
- **Fails closed.** A sibling whose own path filter cannot be evaluated might cover the component, so it is treated as ambiguous rather than waved through.
- **Both call sites.** `Promote` and `executeCopy` (re-run inside `Approve` for a pending request), so a sibling rule created *while* a request sits pending is caught at approval time.
- **409, not 422.** A new `service.ErrAmbiguousPromotionRule` sentinel lets the handler answer `409 Conflict` on both `Promote` and `Approve`: the conflict is in the rules, not in the request.

Behavior for a single applicable rule is unchanged — including the existing cross-repo refusal and the path-filter refusal.

## Tests

Five new tests: the symmetric refusal (naming either rule), that deleting the sibling restores normal behavior (the strict rule falls through to its own scan gate), a sibling with a different `to_repo` (not ambiguous), a sibling whose path filter excludes the component (not ambiguous), the newly-ambiguous-at-`Approve` case, and a handler test asserting the `409` and that the message names both rules.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VSY7bGzTGQtrMNs6RdPWgh