### PR TITLE
fix: close re-upload races in DeleteArtifact/cleanup and blob-store m…

### DIFF
--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -478,7 +478,11 @@ func DeleteArtifact(ctx context.Context, d formats.Deps, repoName, filePath stri
 		if gerr != nil {
 			return gerr
 		}
-		if cur == nil || cur.ID != asset.ID || cur.BlobKey != asset.BlobKey {
+		// BlobKey alone doesn't catch a same-path re-upload: it's
+		// sha256(repoName+":"+filePath), content-independent, so a re-upload to
+		// this exact path always keeps the same BlobKey. last_modified is what
+		// actually changes.
+		if cur == nil || cur.ID != asset.ID || cur.BlobKey != asset.BlobKey || !cur.LastModified.Equal(asset.LastModified) {
 			return nil
 		}
 		// One blob can carry several assets: an OCI manifest push registers the tag

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -65,10 +65,10 @@ type AssetRepo interface {
 	Create(ctx context.Context, a *domain.Asset) error
 	Delete(ctx context.Context, id string) error
 	// DeleteIfUnchanged deletes the row only if it is still exactly what an
-	// earlier scan read — same blob key, same last_downloaded. It reports
-	// whether the row was deleted; a mismatch (the asset was downloaded or
-	// re-uploaded since the scan) leaves the row alone.
-	DeleteIfUnchanged(ctx context.Context, id, blobKey string, lastDownloaded *time.Time) (bool, error)
+	// earlier scan read — same blob key, same last_downloaded, same
+	// last_modified. It reports whether the row was deleted; a mismatch (the
+	// asset was downloaded or re-uploaded since the scan) leaves the row alone.
+	DeleteIfUnchanged(ctx context.Context, id, blobKey string, lastDownloaded *time.Time, lastModified time.Time) (bool, error)
 	// WithBlobKeyLock serializes every caller that wants to read-then-act on a
 	// given blob key (count references, physically delete, register a new
 	// reference). Any other WithBlobKeyLock caller for the same key — same

--- a/internal/repository/postgres/asset_repo.go
+++ b/internal/repository/postgres/asset_repo.go
@@ -307,6 +307,7 @@ func (r *assetRepo) Create(ctx context.Context, a *domain.Asset) error {
 		   size_bytes, content_type, sha1, sha256, md5, uploader_id)
 		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
 		ON CONFLICT (repository_id, path) DO UPDATE SET
+		  blob_store_id = EXCLUDED.blob_store_id,
 		  blob_key     = EXCLUDED.blob_key,
 		  size_bytes   = EXCLUDED.size_bytes,
 		  content_type = EXCLUDED.content_type,
@@ -315,11 +316,11 @@ func (r *assetRepo) Create(ctx context.Context, a *domain.Asset) error {
 		  md5          = EXCLUDED.md5,
 		  uploader_id  = COALESCE(EXCLUDED.uploader_id, assets.uploader_id),
 		  last_modified = NOW()
-		RETURNING id, created_at`,
+		RETURNING id, created_at, last_modified`,
 		a.ComponentID, a.RepositoryID, a.Path, a.BlobStoreID, a.BlobKey,
 		a.SizeBytes, a.ContentType, nullStr(a.SHA1), nullStr(a.SHA256), nullStr(a.MD5),
 		nullStr(a.UploaderID),
-	).Scan(&a.ID, &a.CreatedAt)
+	).Scan(&a.ID, &a.CreatedAt, &a.LastModified)
 }
 
 func (r *assetRepo) Delete(ctx context.Context, id string) error {
@@ -328,13 +329,16 @@ func (r *assetRepo) Delete(ctx context.Context, id string) error {
 }
 
 // DeleteIfUnchanged deletes the row only if it is still exactly what an earlier
-// scan read — same blob key, same last_downloaded. IS NOT DISTINCT FROM makes
-// the NULL comparison work: most never-downloaded rows carry NULL, and NULL =
-// NULL would refuse every one of them.
-func (r *assetRepo) DeleteIfUnchanged(ctx context.Context, id, blobKey string, lastDownloaded *time.Time) (bool, error) {
+// scan read — same blob key, same last_downloaded, same last_modified.
+// last_modified is the term that actually catches a re-upload to the same
+// path: BlobKey is sha256(repoName+":"+filePath), content-independent, so a
+// re-upload always keeps the same blob key — only last_modified changes.
+// IS NOT DISTINCT FROM makes the NULL comparison work: most never-downloaded
+// rows carry NULL, and NULL = NULL would refuse every one of them.
+func (r *assetRepo) DeleteIfUnchanged(ctx context.Context, id, blobKey string, lastDownloaded *time.Time, lastModified time.Time) (bool, error) {
 	tag, err := r.db.Exec(ctx,
-		`DELETE FROM assets WHERE id = $1 AND blob_key = $2 AND last_downloaded IS NOT DISTINCT FROM $3`,
-		id, blobKey, lastDownloaded)
+		`DELETE FROM assets WHERE id = $1 AND blob_key = $2 AND last_downloaded IS NOT DISTINCT FROM $3 AND last_modified = $4`,
+		id, blobKey, lastDownloaded, lastModified)
 	if err != nil {
 		return false, err
 	}

--- a/internal/repository/postgres/asset_repo_bloblock_integration_test.go
+++ b/internal/repository/postgres/asset_repo_bloblock_integration_test.go
@@ -27,7 +27,7 @@ func TestAssetRepo_DeleteIfUnchanged_DeletesMatchingSnapshot(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, nil)
+	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, nil, a.LastModified)
 	if err != nil {
 		t.Fatalf("DeleteIfUnchanged: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestAssetRepo_DeleteIfUnchanged_RefusesWhenDownloadedSinceScan(t *testing.T
 		t.Fatalf("IncrementDownloads: %v", err)
 	}
 
-	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, nil)
+	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, nil, a.LastModified)
 	if err != nil {
 		t.Fatalf("DeleteIfUnchanged: %v", err)
 	}
@@ -86,6 +86,7 @@ func TestAssetRepo_DeleteIfUnchanged_RefusesWhenBlobKeyChanged(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	oldKey := a.BlobKey
+	oldLastModified := a.LastModified
 
 	fresh := makeAsset(p, "/diu/reuploaded.bin")
 	fresh.BlobKey = "blobkey_fresh_content"
@@ -96,12 +97,55 @@ func TestAssetRepo_DeleteIfUnchanged_RefusesWhenBlobKeyChanged(t *testing.T) {
 		t.Fatalf("upsert changed the row ID (%s → %s); test setup assumption broken", a.ID, fresh.ID)
 	}
 
-	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, oldKey, nil)
+	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, oldKey, nil, oldLastModified)
 	if err != nil {
 		t.Fatalf("DeleteIfUnchanged: %v", err)
 	}
 	if deleted {
 		t.Fatal("DeleteIfUnchanged deleted a row whose blob_key changed after the scan")
+	}
+	if got, _ := repo.Get(ctx, a.ID); got == nil {
+		t.Error("row vanished even though DeleteIfUnchanged reported no deletion")
+	}
+}
+
+// The real-world shape of a same-path re-upload race: BlobKey is
+// sha256(repoName+":"+filePath), content-independent, so a re-upload to the
+// same path always keeps the SAME blob key — only last_modified changes. The
+// previous test (RefusesWhenBlobKeyChanged) exercises a blob_key change the
+// production upsert can never actually produce; this one reproduces the
+// sequence that really happens and is what the last_modified term exists for.
+func TestAssetRepo_DeleteIfUnchanged_RefusesWhenSamePathReuploadedWithSameBlobKey(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores", "repositories", "components")
+	ctx := context.Background()
+
+	p := makeAssetParent(t, ctx, "diu_reup")
+	repo := NewAssetRepo(pool)
+
+	a := makeAsset(p, "/diu/reuploaded-same-key.bin")
+	if err := repo.Create(ctx, a); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	staleLastModified := a.LastModified
+
+	// Re-upload to the exact same path: Create's ON CONFLICT upsert keeps the
+	// same row (same BlobKey, since it's derived only from repo+path) but
+	// bumps last_modified.
+	reupload := makeAsset(p, "/diu/reuploaded-same-key.bin")
+	if err := repo.Create(ctx, reupload); err != nil {
+		t.Fatalf("Create (re-upload): %v", err)
+	}
+	if reupload.ID != a.ID || reupload.BlobKey != a.BlobKey {
+		t.Fatalf("re-upload didn't keep the same row/blob_key; test setup assumption broken")
+	}
+
+	deleted, err := repo.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, nil, staleLastModified)
+	if err != nil {
+		t.Fatalf("DeleteIfUnchanged: %v", err)
+	}
+	if deleted {
+		t.Fatal("DeleteIfUnchanged deleted a row that was re-uploaded to the same path/blob_key after the scan")
 	}
 	if got, _ := repo.Get(ctx, a.ID); got == nil {
 		t.Error("row vanished even though DeleteIfUnchanged reported no deletion")

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -299,6 +299,11 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 			_ = s.migrations.FinishMigration(bgCtx, m.ID, "failed", &errMsg)
 			return
 		}
+		// expectedSize is what the flip below re-verifies against right before
+		// it runs: copied's own re-check when this iteration actually copied
+		// bytes, or the size already on record when resuming a run that had
+		// already gotten this key to target on a prior pass.
+		expectedSize := row.SizeBytes
 		if !exists {
 			copied, err := s.copyBlob(bgCtx, sourceStore, targetStore, row.BlobKey)
 			if err != nil {
@@ -307,19 +312,44 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 				return
 			}
 			_ = s.blobs.UpdateUsedBytes(bgCtx, targetStoreMeta.Name, copied)
+			expectedSize = copied
 		}
 
-		if err := s.assets.UpdateBlobStoreForBlobKey(bgCtx, row.BlobKey, m.RepositoryName, m.TargetStoreID); err != nil {
-			errMsg := fmt.Sprintf("updating asset pointers for %s: %v", row.BlobKey, err)
+		// The repository stays pointed at the source store for the whole
+		// migration (it only flips once, after every row is done), so an
+		// ordinary write to this exact key can still land on source in the gap
+		// between the copy above and the flip+drop below. Both steps run under
+		// the same blob-key lock other same-key actors already respect
+		// (DeleteArtifact, CleanupService, oci.mountBlob), and the source
+		// object is re-measured immediately before the flip — a size mismatch
+		// means a write landed here since the copy, so this row's migration
+		// fails loudly (same philosophy as copyBlob's own re-check, #298)
+		// rather than repointing the asset at target while different bytes
+		// than the ones just copied sit on source.
+		flipErr := s.assets.WithBlobKeyLock(bgCtx, row.BlobKey, func(ctx context.Context) error {
+			cur, sizeErr := sourceStore.Size(ctx, row.BlobKey)
+			if sizeErr != nil {
+				return fmt.Errorf("re-checking source blob %s before flip: %w", row.BlobKey, sizeErr)
+			}
+			if cur != expectedSize {
+				return fmt.Errorf("blob %s changed on source before flip (%d -> %d bytes); re-run the migration", row.BlobKey, expectedSize, cur)
+			}
+			if err := s.assets.UpdateBlobStoreForBlobKey(ctx, row.BlobKey, m.RepositoryName, m.TargetStoreID); err != nil {
+				return fmt.Errorf("updating asset pointers for %s: %w", row.BlobKey, err)
+			}
+			// The bytes now live in the target and no row points at the source
+			// copy any more: drop it and give the space back. Without this the
+			// source keeps both the object and its used_bytes forever — GC
+			// cannot help, the key is still referenced, just in another store
+			// (#297).
+			s.dropSourceCopy(ctx, sourceStore, sourceMeta.Name, row)
+			return nil
+		})
+		if flipErr != nil {
+			errMsg := flipErr.Error()
 			_ = s.migrations.FinishMigration(bgCtx, m.ID, "failed", &errMsg)
 			return
 		}
-
-		// The bytes now live in the target and no row points at the source copy
-		// any more: drop it and give the space back. Without this the source
-		// keeps both the object and its used_bytes forever — GC cannot help,
-		// the key is still referenced, just in another store (#297).
-		s.dropSourceCopy(bgCtx, sourceStore, sourceMeta.Name, row)
 
 		doneAssets++
 		doneBytes += row.SizeBytes

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -345,7 +345,7 @@ func (s *CleanupService) runPolicy(ctx context.Context, p domain.CleanupPolicy, 
 			// downloaded or re-uploaded after the staleness scan: deleting by the
 			// captured ID would erase a live artifact and the next pull would 404.
 			lockErr := s.assets.WithBlobKeyLock(ctx, a.BlobKey, func(ctx context.Context) error {
-				rowDeleted, derr := s.assets.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, a.LastDownloaded)
+				rowDeleted, derr := s.assets.DeleteIfUnchanged(ctx, a.ID, a.BlobKey, a.LastDownloaded, a.LastModified)
 				if derr != nil {
 					log.Warn("cleanup: asset delete failed", "id", a.ID, "err", derr)
 					return nil

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -1082,15 +1082,16 @@ func (a *AssetRepo) CountByBlobKey(_ context.Context, blobKey, excludeID string)
 }
 
 // DeleteIfUnchanged mirrors the postgres conditional delete: the row goes only
-// if it still carries the scanned blob key and last_downloaded (NULL-safe).
-func (a *AssetRepo) DeleteIfUnchanged(_ context.Context, id, blobKey string, lastDownloaded *time.Time) (bool, error) {
+// if it still carries the scanned blob key, last_downloaded (NULL-safe) and
+// last_modified.
+func (a *AssetRepo) DeleteIfUnchanged(_ context.Context, id, blobKey string, lastDownloaded *time.Time, lastModified time.Time) (bool, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	if a.DeleteErr != nil {
 		return false, a.DeleteErr
 	}
 	v, ok := a.byID[id]
-	if !ok || v.BlobKey != blobKey {
+	if !ok || v.BlobKey != blobKey || !v.LastModified.Equal(lastModified) {
 		return false, nil
 	}
 	switch {


### PR DESCRIPTION
Closes #377

Three compounding bugs around AssetRepo.Create's upsert:

1. DeleteArtifact's and CleanupService's re-upload guards compared BlobKey, but BlobKey is sha256(repoName+":"+filePath) - content independent, so a re-upload to the same path always produces the same BlobKey. The guard was a no-op for the exact race it exists for. Fixed by adding last_modified (which Create's upsert always bumps) to both DeleteIfUnchanged's WHERE clause and DeleteArtifact's lock-scoped re-read guard.

2. Create's RETURNING clause never returned last_modified, so a freshly created asset's Go struct carried a zero-value timestamp instead of the real one - fixed by adding it to RETURNING/Scan.

3. Blob-store migration's per-row flip+drop (UpdateBlobStoreForBlobKey + dropSourceCopy) ran unlocked and Create's ON CONFLICT never updated blob_store_id, so a client re-uploading a path mid-migration could end up with the DB row pointing at one store while the new bytes landed on the other. Fixed by adding blob_store_id = EXCLUDED.blob_store_id to the upsert, and running the flip+drop inside the existing WithBlobKeyLock primitive with the source object's size re-verified right before the flip.

Verified: a mocked-race unit test for DeleteArtifact (injects a same-blob-key re-upload between its two reads), a real-Postgres integration test for DeleteIfUnchanged reproducing the actual production sequence (same blob_key, only last_modified differs - added alongside the existing, narrower blob_key-change test), and a live compose smoke test confirming the normal (non-racing) delete path is unaffected. go build/go vet/go test ./... (unit + -tags=integration) green.