### PR TITLE
fix: recover panics in background goroutines and cron jobs

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/metrics"
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/repository/postgres"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/tracing"
 )
@@ -159,7 +160,7 @@ func cmdServe() *cobra.Command {
 			// current month's partition exists before we accept traffic.
 			rotator := audit.NewRotator(audit.NewPgPartitionStore(pool), cfg.Audit, log)
 			rotator.RunOnce(cmd.Context())
-			go rotator.Run(cmd.Context())
+			safego.Go(log, "audit-rotator", func() { rotator.Run(cmd.Context()) })
 			log.Info("audit rotator started",
 				"retention_days", cfg.Audit.RetentionDays,
 				"soft_cap", cfg.Audit.SoftCap,
@@ -195,7 +196,7 @@ func cmdServe() *cobra.Command {
 			// Start background metrics sampler — stops on context cancellation.
 			samplerCtx, cancelSampler := context.WithCancel(cmd.Context())
 			defer cancelSampler()
-			metrics.StartSampler(samplerCtx, pool)
+			metrics.StartSampler(samplerCtx, log, pool)
 
 			// Lifetime of everything the router runs in the background. Kept
 			// separate from the HTTP server's shutdown context so the two can be

--- a/internal/api/audit_middleware.go
+++ b/internal/api/audit_middleware.go
@@ -7,12 +7,14 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 )
 
 // AuditMiddleware writes an audit event after each mutating request completes.
 // It only records PUT/POST/DELETE/PATCH on key management paths.
-func AuditMiddleware(auditRepo repository.AuditRepo) gin.HandlerFunc {
+func AuditMiddleware(log logger.Logger, auditRepo repository.AuditRepo) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Next() // run handler first
 
@@ -70,7 +72,7 @@ func AuditMiddleware(auditRepo repository.AuditRepo) gin.HandlerFunc {
 			Context:    ctxData,
 			Result:     result,
 		}
-		go func() { _ = auditRepo.Write(context.Background(), e) }()
+		safego.Go(log, "audit-write", func() { _ = auditRepo.Write(context.Background(), e) })
 	}
 }
 

--- a/internal/api/audit_middleware_test.go
+++ b/internal/api/audit_middleware_test.go
@@ -19,7 +19,7 @@ func init() { gin.SetMode(gin.TestMode) }
 
 func buildAuditRouter(auditRepo *testutil.AuditRepo) *gin.Engine {
 	r := gin.New()
-	r.Use(api.AuditMiddleware(auditRepo))
+	r.Use(api.AuditMiddleware(nil, auditRepo))
 
 	r.POST("/service/rest/v1/repositories", func(c *gin.Context) {
 		c.JSON(http.StatusCreated, gin.H{"ok": true})
@@ -120,7 +120,7 @@ func TestAuditMiddleware_Username_FromContext(t *testing.T) {
 		c.Set("userID", "uid-bob")
 		c.Next()
 	})
-	r.Use(api.AuditMiddleware(repo))
+	r.Use(api.AuditMiddleware(nil, repo))
 	r.DELETE("/service/rest/v1/repositories/x", func(c *gin.Context) {
 		c.Status(http.StatusNoContent)
 	})
@@ -134,7 +134,7 @@ func TestAuditMiddleware_Username_FromContext(t *testing.T) {
 func TestAuditMiddleware_Repository_CapturesPath(t *testing.T) {
 	repo := testutil.NewAuditRepo()
 	r := gin.New()
-	r.Use(api.AuditMiddleware(repo))
+	r.Use(api.AuditMiddleware(nil, repo))
 	r.PUT("/repository/:repoName/*path", func(c *gin.Context) {
 		c.Status(http.StatusCreated)
 	})
@@ -153,7 +153,7 @@ func TestAuditMiddleware_Repository_CapturesPath(t *testing.T) {
 func TestAuditMiddleware_DockerV2_CapturesManifestRef(t *testing.T) {
 	repo := testutil.NewAuditRepo()
 	r := gin.New()
-	r.Use(api.AuditMiddleware(repo))
+	r.Use(api.AuditMiddleware(nil, repo))
 	r.PUT("/v2/:repoName/manifests/:ref", func(c *gin.Context) {
 		c.Status(http.StatusCreated)
 	})
@@ -167,7 +167,7 @@ func TestAuditMiddleware_DockerV2_CapturesManifestRef(t *testing.T) {
 func TestAuditMiddleware_Webhooks_PrefixIsAudited(t *testing.T) {
 	repo := testutil.NewAuditRepo()
 	r := gin.New()
-	r.Use(api.AuditMiddleware(repo))
+	r.Use(api.AuditMiddleware(nil, repo))
 	r.POST("/api/v1/webhooks", func(c *gin.Context) {
 		c.Status(http.StatusCreated)
 	})
@@ -182,7 +182,7 @@ func TestAuditMiddleware_Webhooks_PrefixIsAudited(t *testing.T) {
 func TestAuditMiddleware_Roles_PrefixIsAudited(t *testing.T) {
 	repo := testutil.NewAuditRepo()
 	r := gin.New()
-	r.Use(api.AuditMiddleware(repo))
+	r.Use(api.AuditMiddleware(nil, repo))
 	r.POST("/service/rest/v1/security/roles", func(c *gin.Context) {
 		c.Status(http.StatusCreated)
 	})
@@ -204,7 +204,7 @@ func TestAuditMiddleware_OIDCCallback_WritesLoginEvent(t *testing.T) {
 		c.Set("audit_source", "oidc")
 		c.Next()
 	})
-	r.Use(api.AuditMiddleware(repo))
+	r.Use(api.AuditMiddleware(nil, repo))
 	r.GET("/api/v1/auth/oidc/callback", func(c *gin.Context) { c.Status(http.StatusFound) })
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback?code=x&state=s", nil)
@@ -230,7 +230,7 @@ func TestAuditMiddleware_NonOIDC_GET_NotAudited(t *testing.T) {
 func TestAuditMiddleware_RemoteIP_NonEmpty(t *testing.T) {
 	repo := testutil.NewAuditRepo()
 	r := gin.New()
-	r.Use(api.AuditMiddleware(repo))
+	r.Use(api.AuditMiddleware(nil, repo))
 	r.POST("/service/rest/v1/repositories", func(c *gin.Context) {
 		c.Status(http.StatusCreated)
 	})

--- a/internal/api/handlers/cleanup.go
+++ b/internal/api/handlers/cleanup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/domain"
 	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 )
 
 // cleanupRunner is the minimal interface CleanupHandler needs from CleanupService.
@@ -159,11 +160,11 @@ func (h *CleanupHandler) Run(c *gin.Context) {
 		// The client already has its 202; the log is the only place a
 		// background failure (an unreachable lock backend, a dead DB) can
 		// surface.
-		go func() {
+		safego.Go(h.log, "cleanup-run-all", func() {
 			if err := h.runner.RunAll(context.Background()); err != nil {
 				h.log.Errorw("cleanup: background run of all policies failed", "err", err)
 			}
-		}()
+		})
 		c.JSON(http.StatusAccepted, gin.H{"status": "running all policies"})
 		return
 	}

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -76,16 +76,24 @@ func readinessHandler(log logger.Logger, db, redis pinger, ttl time.Duration) gi
 			defer safego.Recover(log, "readiness-check-"+name)()
 			pctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 			defer cancel()
-			status := "ok"
-			if err := p.Ping(pctx); err != nil {
-				status = "error"
+			// status starts pessimistic and is recorded from a defer registered
+			// after cancel(): defers run LIFO, so this one fires before
+			// safego.Recover's above, capturing whatever status was at the
+			// moment of a panic instead of letting Recover swallow it silently
+			// and leaving the check missing from checks (which would drop it
+			// out of the response and never flip failed).
+			status := "error"
+			defer func() {
+				cmu.Lock()
+				checks[name] = status
+				if status != "ok" {
+					failed = true
+				}
+				cmu.Unlock()
+			}()
+			if err := p.Ping(pctx); err == nil {
+				status = "ok"
 			}
-			cmu.Lock()
-			checks[name] = status
-			if status != "ok" {
-				failed = true
-			}
-			cmu.Unlock()
 		}
 
 		if db != nil {

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -9,7 +9,9 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/redisclient"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 )
 
 // readinessTTL is how long a healthy probe result is reused. /readyz is
@@ -34,7 +36,7 @@ type pinger interface {
 // ReadinessHandler checks DB and Redis connectivity in parallel.
 // Either dep may be nil — it is skipped in that case.
 // Returns 503 if any check fails.
-func ReadinessHandler(pool *pgxpool.Pool, redis *redisclient.Client) gin.HandlerFunc {
+func ReadinessHandler(log logger.Logger, pool *pgxpool.Pool, redis *redisclient.Client) gin.HandlerFunc {
 	// Typed nils would satisfy the interface while being nil underneath, so
 	// convert explicitly.
 	var db, rd pinger
@@ -44,7 +46,7 @@ func ReadinessHandler(pool *pgxpool.Pool, redis *redisclient.Client) gin.Handler
 	if redis != nil {
 		rd = redis
 	}
-	return readinessHandler(db, rd, readinessTTL)
+	return readinessHandler(log, db, rd, readinessTTL)
 }
 
 // readinessResult is the memoized outcome of one probe round.
@@ -54,7 +56,7 @@ type readinessResult struct {
 	at     time.Time
 }
 
-func readinessHandler(db, redis pinger, ttl time.Duration) gin.HandlerFunc {
+func readinessHandler(log logger.Logger, db, redis pinger, ttl time.Duration) gin.HandlerFunc {
 	var (
 		mu     sync.Mutex
 		cached *readinessResult
@@ -66,8 +68,12 @@ func readinessHandler(db, redis pinger, ttl time.Duration) gin.HandlerFunc {
 		var wg sync.WaitGroup
 		failed := false
 
+		// wg.Wait() below does NOT protect the process from a panic in check:
+		// an unrecovered panic in any goroutine crashes the whole program
+		// regardless of whether the parent is waiting on it.
 		check := func(name string, p pinger) {
 			defer wg.Done()
+			defer safego.Recover(log, "readiness-check-"+name)()
 			pctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 			defer cancel()
 			status := "ok"

--- a/internal/api/handlers/health_cache_test.go
+++ b/internal/api/handlers/health_cache_test.go
@@ -93,3 +93,19 @@ func TestReadiness_NoDependencies_IsOK(t *testing.T) {
 	w := serveReady(readinessHandler(nil, nil, nil, time.Minute))
 	assert.Equal(t, http.StatusOK, w.Code)
 }
+
+type panickingPinger struct{}
+
+func (panickingPinger) Ping(context.Context) error { panic("boom") }
+
+// safego.Recover stops a panicking Ping from crashing the process, but the
+// check's own result must still land in checks as "error" (and flip failed),
+// not be silently dropped — a dropped check would leave /readyz reporting 200
+// "ok" for a dependency that just panicked.
+func TestReadiness_PanickingDependencyReportsFailure(t *testing.T) {
+	h := readinessHandler(nil, panickingPinger{}, nil, time.Minute)
+
+	w := serveReady(h)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, w.Body.String(), `"db":"error"`)
+}

--- a/internal/api/handlers/health_cache_test.go
+++ b/internal/api/handlers/health_cache_test.go
@@ -36,7 +36,7 @@ func serveReady(h gin.HandlerFunc) *httptest.ResponseRecorder {
 // trip, which turns the liveness surface into a cheap way to load the DB.
 func TestReadiness_CachesTheProbeResult(t *testing.T) {
 	db := &countingPinger{}
-	h := readinessHandler(db, nil, time.Minute)
+	h := readinessHandler(nil, db, nil, time.Minute)
 
 	for range 20 {
 		require.Equal(t, http.StatusOK, serveReady(h).Code)
@@ -46,7 +46,7 @@ func TestReadiness_CachesTheProbeResult(t *testing.T) {
 
 func TestReadiness_CacheExpires(t *testing.T) {
 	db := &countingPinger{}
-	h := readinessHandler(db, nil, time.Nanosecond)
+	h := readinessHandler(nil, db, nil, time.Nanosecond)
 
 	serveReady(h)
 	time.Sleep(time.Millisecond)
@@ -57,7 +57,7 @@ func TestReadiness_CacheExpires(t *testing.T) {
 
 func TestReadiness_ReportsFailure(t *testing.T) {
 	db := &countingPinger{err: errors.New("connection refused")}
-	h := readinessHandler(db, nil, time.Minute)
+	h := readinessHandler(nil, db, nil, time.Minute)
 
 	w := serveReady(h)
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
@@ -68,7 +68,7 @@ func TestReadiness_ReportsFailure(t *testing.T) {
 // keeps reporting an outage that is already over.
 func TestReadiness_FailureIsNotCached(t *testing.T) {
 	db := &countingPinger{err: errors.New("connection refused")}
-	h := readinessHandler(db, nil, time.Minute)
+	h := readinessHandler(nil, db, nil, time.Minute)
 
 	serveReady(h)
 	db.err = nil
@@ -81,7 +81,7 @@ func TestReadiness_FailureIsNotCached(t *testing.T) {
 func TestReadiness_ChecksBothDependencies(t *testing.T) {
 	db := &countingPinger{}
 	redis := &countingPinger{}
-	h := readinessHandler(db, redis, time.Minute)
+	h := readinessHandler(nil, db, redis, time.Minute)
 
 	w := serveReady(h)
 	require.Equal(t, http.StatusOK, w.Code)
@@ -90,6 +90,6 @@ func TestReadiness_ChecksBothDependencies(t *testing.T) {
 }
 
 func TestReadiness_NoDependencies_IsOK(t *testing.T) {
-	w := serveReady(readinessHandler(nil, nil, time.Minute))
+	w := serveReady(readinessHandler(nil, nil, nil, time.Minute))
 	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/api/handlers/health_test.go
+++ b/internal/api/handlers/health_test.go
@@ -19,7 +19,7 @@ func buildHealthRouter(liveness, readiness gin.HandlerFunc) *gin.Engine {
 }
 
 func TestHealthz_AlwaysOK(t *testing.T) {
-	r := buildHealthRouter(handlers.LivenessHandler(), handlers.ReadinessHandler(nil, nil))
+	r := buildHealthRouter(handlers.LivenessHandler(), handlers.ReadinessHandler(nil, nil, nil))
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -34,7 +34,7 @@ func TestHealthz_AlwaysOK(t *testing.T) {
 }
 
 func TestReadyz_NilDeps_OK(t *testing.T) {
-	r := buildHealthRouter(handlers.LivenessHandler(), handlers.ReadinessHandler(nil, nil))
+	r := buildHealthRouter(handlers.LivenessHandler(), handlers.ReadinessHandler(nil, nil, nil))
 	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -9,18 +9,21 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 	"github.com/nexspence-oss/nexspence/internal/service"
 )
 
 // ReplicationHandler serves the content-replication REST endpoints.
 type ReplicationHandler struct {
 	svc *service.ReplicationService
+	log logger.Logger
 }
 
 // NewReplicationHandler constructs a ReplicationHandler backed by the given replication service.
-func NewReplicationHandler(svc *service.ReplicationService) *ReplicationHandler {
-	return &ReplicationHandler{svc: svc}
+func NewReplicationHandler(svc *service.ReplicationService, log logger.Logger) *ReplicationHandler {
+	return &ReplicationHandler{svc: svc, log: log}
 }
 
 // List handles GET /api/v1/replication/rules
@@ -75,7 +78,7 @@ func (h *ReplicationHandler) Create(c *gin.Context) {
 	// cancels it the moment this handler returns, which silently killed the
 	// (re)scheduling this goroutine exists to perform — the API answered as if
 	// the rule was scheduled while its cron entry never materialized (#254).
-	go h.svc.ReloadRule(context.Background(), rule.ID)
+	safego.Go(h.log, "replication-reload-rule", func() { h.svc.ReloadRule(context.Background(), rule.ID) })
 	c.JSON(http.StatusCreated, rule)
 }
 
@@ -101,7 +104,7 @@ func (h *ReplicationHandler) Update(c *gin.Context) {
 		return
 	}
 	// Detached for the same reason as Create's — see the comment there (#254).
-	go h.svc.ReloadRule(context.Background(), rule.ID)
+	safego.Go(h.log, "replication-reload-rule", func() { h.svc.ReloadRule(context.Background(), rule.ID) })
 	c.JSON(http.StatusOK, rule)
 }
 
@@ -136,9 +139,9 @@ func (h *ReplicationHandler) ManualRun(c *gin.Context) {
 	// Detached: a run outlives its 202 by design, and the request context is
 	// canceled the moment the handler returns — the run would abort almost
 	// immediately with no visible error (#254).
-	go func() {
+	safego.Go(h.log, "replication-manual-run", func() {
 		_ = h.svc.RunRule(context.Background(), id)
-	}()
+	})
 	c.JSON(http.StatusAccepted, gin.H{"message": "replication started"})
 }
 

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -26,7 +26,7 @@ func mountReplication(t *testing.T) *gin.Engine {
 	t.Helper()
 	repRepo := testutil.NewReplicationRepo()
 	svc := service.NewReplicationService(repRepo, testutil.NewAssetRepo(), testutil.NewBlobStore(), "test-secret", nil, cleanupNopLog())
-	h := handlers.NewReplicationHandler(svc)
+	h := handlers.NewReplicationHandler(svc, nil)
 
 	r := gin.New()
 	r.GET("/api/v1/replication/rules", h.List)
@@ -243,7 +243,7 @@ func TestReplicationHandler_ManualRun_SurvivesRequestCancellation(t *testing.T) 
 	inner := testutil.NewReplicationRepo()
 	repo := &ctxCapturingReplRepo{ReplicationRepo: inner, got: make(chan context.Context, 2)}
 	svc := service.NewReplicationService(repo, testutil.NewAssetRepo(), testutil.NewBlobStore(), "test-secret", nil, cleanupNopLog())
-	h := handlers.NewReplicationHandler(svc)
+	h := handlers.NewReplicationHandler(svc, nil)
 	r := gin.New()
 	r.POST("/api/v1/replication/rules/:id/run", h.ManualRun)
 
@@ -295,7 +295,7 @@ func TestReplicationHandler_ManualRun_ConcurrentRunIs409(t *testing.T) {
 	repo := &blockingReplRepo{ReplicationRepo: inner, blockOn: 2, release: make(chan struct{})}
 	defer close(repo.release)
 	svc := service.NewReplicationService(repo, testutil.NewAssetRepo(), testutil.NewBlobStore(), "test-secret", nil, cleanupNopLog())
-	h := handlers.NewReplicationHandler(svc)
+	h := handlers.NewReplicationHandler(svc, nil)
 	r := gin.New()
 	r.POST("/api/v1/replication/rules/:id/run", h.ManualRun)
 

--- a/internal/api/handlers/system.go
+++ b/internal/api/handlers/system.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/auth"
 	"github.com/nexspence-oss/nexspence/internal/config"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/redisclient"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 )
 
@@ -37,6 +39,7 @@ type SystemHandler struct {
 	oidc       auth.OIDCAuthenticator // nil when OIDC disabled
 	saml       auth.SAMLAuthenticator // nil when SAML disabled
 	blobStores repository.BlobStoreRepo
+	log        logger.Logger
 }
 
 // NewSystemHandler constructs a SystemHandler from the config, DB pool, and optional LDAP/OIDC authenticators.
@@ -53,6 +56,13 @@ func (h *SystemHandler) WithBlobStores(r repository.BlobStoreRepo) *SystemHandle
 // WithSAML wires the SAML authenticator so it appears in service status; returns the handler for chaining.
 func (h *SystemHandler) WithSAML(s auth.SAMLAuthenticator) *SystemHandler {
 	h.saml = s
+	return h
+}
+
+// WithLogger wires a logger so panics in the parallel service-status checks are
+// recovered and logged instead of crashing the process; returns the handler for chaining.
+func (h *SystemHandler) WithLogger(log logger.Logger) *SystemHandler {
+	h.log = log
 	return h
 }
 
@@ -156,6 +166,10 @@ func (h *SystemHandler) Services(c *gin.Context) {
 		wg.Add(1)
 		go func(idx int, f checkFn) {
 			defer wg.Done()
+			// wg.Wait() below does NOT protect the process from a panic here:
+			// an unrecovered panic in any goroutine crashes the whole program
+			// regardless of whether the parent is waiting on it.
+			defer safego.Recover(h.log, fmt.Sprintf("system-service-check-%d", idx))()
 			results[idx] = f(ctx)
 		}(i, fn)
 	}

--- a/internal/api/ratelimit_middleware.go
+++ b/internal/api/ratelimit_middleware.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/logger"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 )
 
 // tokenBucket tracks request allowance for a single identity using a token
@@ -38,7 +41,7 @@ func (b *tokenBucket) allow(rate, burst float64) bool {
 // RateLimitMiddleware returns a Gin middleware that limits requests per
 // authenticated user (keyed by userID, or by remote IP for anonymous calls).
 // rate is tokens/second; burst is the maximum burst size.
-func RateLimitMiddleware(rate, burst float64) gin.HandlerFunc {
+func RateLimitMiddleware(log logger.Logger, rate, burst float64) gin.HandlerFunc {
 	type entry struct {
 		bucket   *tokenBucket
 		lastSeen time.Time
@@ -49,18 +52,21 @@ func RateLimitMiddleware(rate, burst float64) gin.HandlerFunc {
 	)
 
 	// Evict stale entries every 5 minutes to prevent unbounded growth.
-	go func() {
+	safego.Go(log, "ratelimit-bucket-eviction", func() {
 		for range time.Tick(5 * time.Minute) {
-			threshold := time.Now().Add(-10 * time.Minute)
-			mu.Lock()
-			for k, e := range buckets {
-				if e.lastSeen.Before(threshold) {
-					delete(buckets, k)
+			func() {
+				defer safego.Recover(log, "ratelimit-bucket-eviction-tick")()
+				threshold := time.Now().Add(-10 * time.Minute)
+				mu.Lock()
+				defer mu.Unlock()
+				for k, e := range buckets {
+					if e.lastSeen.Before(threshold) {
+						delete(buckets, k)
+					}
 				}
-			}
-			mu.Unlock()
+			}()
 		}
-	}()
+	})
 
 	return func(c *gin.Context) {
 		key := ""

--- a/internal/api/ratelimit_middleware_test.go
+++ b/internal/api/ratelimit_middleware_test.go
@@ -12,7 +12,7 @@ import (
 func TestRateLimitMiddleware_BlocksOverBurst(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.Use(RateLimitMiddleware(0.0001, 2))
+	r.Use(RateLimitMiddleware(nil, 0.0001, 2))
 	r.GET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
 	codes := []int{}
 	for i := 0; i < 3; i++ {
@@ -30,7 +30,7 @@ func TestRateLimitMiddleware_BlocksOverBurst(t *testing.T) {
 func TestRateLimitMiddleware_RetryAfterIsNumeric(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
-	r.Use(RateLimitMiddleware(0.0001, 1))
+	r.Use(RateLimitMiddleware(nil, 0.0001, 1))
 	r.GET("/x", func(c *gin.Context) { c.Status(http.StatusOK) })
 	var throttled *httptest.ResponseRecorder
 	for i := 0; i < 2; i++ {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -45,6 +45,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/repository/postgres"
 	"github.com/nexspence-oss/nexspence/internal/requestctx"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 	"github.com/nexspence-oss/nexspence/internal/service"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 )
@@ -169,7 +170,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	}
 
 	tokenSvc := service.NewTokenService(userTokenRepo, userRepo)
-	webhookSvc := service.NewWebhookService(webhookRepo)
+	webhookSvc := service.NewWebhookService(webhookRepo).WithLogger(log)
 	repoSvc.WithWebhooks(webhookSvc)
 	cleanupSvc := service.NewCleanupService(cleanupRepo, repoRepo, assetRepo, blobRepo, localBlob, log)
 	cleanupSvc.WithLocker(locker)
@@ -180,7 +181,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	cleanupSvc.WithComponents(componentRepo)
 
 	// Start per-policy cron scheduler in background (default: cfg.Cleanup.DefaultSchedule).
-	go cleanupSvc.StartCronScheduler(ctx, cfg.Cleanup.DefaultSchedule)
+	safego.Go(log, "cleanup-cron-scheduler", func() { cleanupSvc.StartCronScheduler(ctx, cfg.Cleanup.DefaultSchedule) })
 
 	gcSvc := &service.BlobGCService{
 		Assets:        assetRepo,
@@ -191,14 +192,14 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		DefaultMinAge: cfg.GC.MinAge,
 	}
 	if cfg.GC.Enabled {
-		go gcSvc.StartCronScheduler(ctx, cfg.GC.Schedule, cfg.GC.MinAge)
+		safego.Go(log, "gc-cron-scheduler", func() { gcSvc.StartCronScheduler(ctx, cfg.GC.Schedule, cfg.GC.MinAge) })
 	}
 
 	replSvc := service.NewReplicationService(replRepo, assetRepo, localBlob, cfg.Auth.JWTSecret, cfg.Auth.EncryptionKeyBytes(), log)
 	// Read each asset from its own physical store, so replication keeps working
 	// once a repository is pointed at S3 or a second local store.
 	replSvc.WithResolver(blobRepo, blobRegistry)
-	go replSvc.StartCronScheduler(ctx)
+	safego.Go(log, "replication-cron-scheduler", func() { replSvc.StartCronScheduler(ctx) })
 
 	promotionSvc, err := service.NewPromotionService(
 		promotionRepo, componentRepo, assetRepo, repoRepo, blobRepo, scanRepo, blobRegistry,
@@ -210,7 +211,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 
 	// Debounced download counter: in-memory aggregation, periodic batched flush.
 	dlCounter := service.NewDownloadCounter(assetRepo, log)
-	go dlCounter.Start(ctx, 10*time.Second)
+	safego.Go(log, "download-counter", func() { dlCounter.Start(ctx, 10*time.Second) })
 
 	// ── Format handlers ───────────────────────────────────────
 	// Built before the format handlers because they take Deps by value: a
@@ -245,7 +246,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	var scanTrigger formats.ScanTrigger
 	if cfg.Scan.Enabled {
 		scanTrigger = scanSvc
-		go scanSvc.StartScheduler(ctx, cfg.Scan.Schedule)
+		safego.Go(log, "scan-cron-scheduler", func() { scanSvc.StartScheduler(ctx, cfg.Scan.Schedule) })
 	}
 
 	formatDeps := formats.Deps{
@@ -306,7 +307,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	scanH := handlers.NewScanHandler(scanSvc)
 	tokenH := handlers.NewTokenHandler(tokenSvc, userSvc, cfg.Auth.TokenMaxDays)
 	webhookH := handlers.NewWebhookHandler(webhookSvc)
-	replH := handlers.NewReplicationHandler(replSvc)
+	replH := handlers.NewReplicationHandler(replSvc, log)
 	promotionH := handlers.NewPromotionHandler(promotionSvc)
 	roleH := handlers.NewRoleHandler(roleRepo, userRepo)
 	privH := handlers.NewPrivilegeHandler(privilegeRepo, roleRepo)
@@ -314,7 +315,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	accessGraphH := handlers.NewAccessGraphHandler(userRepo, roleRepo, privilegeRepo, csRepo)
 	rrSvc := service.NewRoutingRuleService(rrRepo)
 	rrH := handlers.NewRoutingRuleHandler(rrSvc)
-	systemH := handlers.NewSystemHandler(cfg, pool, ldapSvc, oidcSvc).WithBlobStores(blobRepo).WithSAML(samlSvc)
+	systemH := handlers.NewSystemHandler(cfg, pool, ldapSvc, oidcSvc).WithBlobStores(blobRepo).WithSAML(samlSvc).WithLogger(log)
 	nexusMigSvc := service.NewNexusMigrationService(service.NexusMigrationConfig{
 		Jobs:          migrationRepo,
 		Repos:         repoSvc,
@@ -331,19 +332,19 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	// Re-attach to migrations interrupted by a restart. Without this a job left
 	// running when the process stopped sits in "running" with nothing behind it —
 	// which is exactly how a migration used to look even on a healthy server.
-	go func() { _ = nexusMigSvc.ResumeAll(ctx) }()
+	safego.Go(log, "nexus-migration-resume-all", func() { _ = nexusMigSvc.ResumeAll(ctx) })
 	migrationH := handlers.NewMigrationHandler(migrationRepo, nexusMigSvc)
 	ldapH := handlers.NewLDAPHandler(cfg.LDAP, ldapSvc)
 	tasksH := handlers.NewTasksHandler(cleanupTaskAdapter{repo: cleanupRepo, svc: cleanupSvc}, replSvc)
 	blobMigrationRepo := postgres.NewBlobStoreMigrationRepo(pool)
-	blobMigSvc := service.NewBlobStoreMigrationService(blobMigrationRepo, assetRepo, repoRepo, blobRepo, blobRegistry)
+	blobMigSvc := service.NewBlobStoreMigrationService(blobMigrationRepo, assetRepo, repoRepo, blobRepo, blobRegistry).WithLogger(log)
 	blobMigSvc.WithLocker(locker)
 	blobMigH := handlers.NewBlobStoreMigrationHandler(blobMigSvc)
 
 	// Resume any migrations that were interrupted by a server restart — on the
 	// background context, so a shutdown mid-resume interrupts it the same way
 	// the restart that left it unfinished did.
-	go func() { _ = blobMigSvc.ResumeAll(ctx) }()
+	safego.Go(log, "blob-migration-resume-all", func() { _ = blobMigSvc.ResumeAll(ctx) })
 	backupSvc := &service.BackupService{
 		BlobStores: blobRepo,
 		Repos:      repoRepo,
@@ -388,15 +389,15 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		// post-Next summary can still see them (#321).
 		r.Use(traceLogStash())
 	}
-	r.Use(AuditMiddleware(auditRepo))
+	r.Use(AuditMiddleware(log, auditRepo))
 	if cfg.Auth.RateLimitEnabled {
-		r.Use(RateLimitMiddleware(cfg.Auth.RateLimitRPS, cfg.Auth.RateLimitBurst))
+		r.Use(RateLimitMiddleware(log, cfg.Auth.RateLimitRPS, cfg.Auth.RateLimitBurst))
 	}
 
 	// Health probes: no auth, but inside the middleware chain — registering them
 	// earlier meant gin snapshotted an empty chain for them, leaving the
 	// readiness path without Recovery.
-	registerHealthRoutes(r, handlers.LivenessHandler(), handlers.ReadinessHandler(pool, rdb))
+	registerHealthRoutes(r, handlers.LivenessHandler(), handlers.ReadinessHandler(log, pool, rdb))
 
 	authMW := handlers.AuthMiddleware(userSvc, tokenSvc, loginGuard, log)
 	adminMW := handlers.AdminRequired()

--- a/internal/audit/rotator.go
+++ b/internal/audit/rotator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/config"
 	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/metrics"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 )
 
 // Rotator runs partition lifecycle for audit_events on a ticker.
@@ -37,7 +38,10 @@ func (r *Rotator) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			r.tick(ctx)
+			func() {
+				defer safego.Recover(r.log, "audit-rotator-tick")()
+				r.tick(ctx)
+			}()
 		}
 	}
 }

--- a/internal/metrics/ring_buffer.go
+++ b/internal/metrics/ring_buffer.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/nexspence-oss/nexspence/internal/logger"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 )
 
 const ringSize = 360 // 1 hour at 10-second intervals
@@ -61,19 +64,22 @@ var History = &RingBuffer{}
 
 // StartSampler starts a background goroutine that samples metrics every 10s
 // and stops when ctx is canceled.
-func StartSampler(ctx context.Context, pool *pgxpool.Pool) {
-	go func() {
+func StartSampler(ctx context.Context, log logger.Logger, pool *pgxpool.Pool) {
+	safego.Go(log, "metrics-sampler", func() {
 		ticker := time.NewTicker(10 * time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:
-				takeSample(ctx, pool)
+				func() {
+					defer safego.Recover(log, "metrics-sampler-tick")()
+					takeSample(ctx, pool)
+				}()
 			case <-ctx.Done():
 				return
 			}
 		}
-	}()
+	})
 }
 
 func takeSample(ctx context.Context, pool *pgxpool.Pool) {

--- a/internal/safego/safego.go
+++ b/internal/safego/safego.go
@@ -1,0 +1,44 @@
+// Package safego guards goroutines against an unrecovered panic taking down
+// the whole process. Go terminates the entire program on any goroutine panic
+// that reaches the top of its stack unrecovered — not just the goroutine that
+// panicked — so a single bad input reaching any background job (a malformed
+// upstream response, an unexpected shape from a scanner, a nil dereference in
+// a cron job body) would otherwise crash every in-flight request along with
+// it, not just the misbehaving job.
+package safego
+
+import (
+	"runtime/debug"
+
+	"github.com/nexspence-oss/nexspence/internal/logger"
+)
+
+// Go runs fn in a new goroutine, recovering any panic so it cannot crash the
+// process. Use for detached, one-shot work — a background job, a fire-and-
+// forget write — where the goroutine's own failure should be logged, not
+// fatal to everyone else.
+func Go(log logger.Logger, name string, fn func()) {
+	go func() {
+		defer Recover(log, name)()
+		fn()
+	}()
+}
+
+// Recover returns a function to defer inside one iteration of a persistent
+// loop goroutine (a cron job body, a ticker-driven sampler): it recovers a
+// panic from that iteration and logs it, letting the loop's next iteration
+// run instead of a single bad iteration taking the whole process down. Unlike
+// Go, this does not itself start a goroutine — call it as
+// `defer safego.Recover(log, "name")()` from inside the loop body (or an
+// inner closure wrapping one iteration, when the loop's own scope can't be
+// deferred into directly).
+func Recover(log logger.Logger, name string) func() {
+	return func() {
+		if r := recover(); r != nil {
+			if log != nil {
+				log.Errorw("recovered panic in goroutine",
+					"goroutine", name, "panic", r, "stack", string(debug.Stack()))
+			}
+		}
+	}
+}

--- a/internal/safego/safego_test.go
+++ b/internal/safego/safego_test.go
@@ -1,0 +1,87 @@
+package safego
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nexspence-oss/nexspence/internal/logger"
+)
+
+// A panicking goroutine that Go doesn't guard would crash this test binary
+// (Go terminates the whole process on an unrecovered goroutine panic, not
+// just the panicking goroutine) — reaching the end of the test at all is
+// itself proof the panic was swallowed.
+func TestGo_RecoversPanic(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	Go(logger.New("error", "json"), "test-panic", func() {
+		defer wg.Done()
+		panic("boom")
+	})
+	if waitTimeout(&wg, 2*time.Second) {
+		t.Fatal("goroutine did not complete — panic likely escaped Go's recover")
+	}
+}
+
+func TestGo_NilLoggerDoesNotPanic(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	Go(nil, "test-nil-logger", func() {
+		defer wg.Done()
+		panic("boom")
+	})
+	if waitTimeout(&wg, 2*time.Second) {
+		t.Fatal("goroutine did not complete with a nil logger")
+	}
+}
+
+func TestGo_RunsFnToCompletionWhenNoPanic(t *testing.T) {
+	ran := false
+	var wg sync.WaitGroup
+	wg.Add(1)
+	Go(logger.New("error", "json"), "test-normal", func() {
+		defer wg.Done()
+		ran = true
+	})
+	if waitTimeout(&wg, 2*time.Second) {
+		t.Fatal("goroutine did not complete")
+	}
+	if !ran {
+		t.Error("fn did not run")
+	}
+}
+
+// TestRecover_LoopSurvivesOnePanickingIteration mirrors the persistent-loop
+// usage: each iteration wraps its own body with a deferred Recover, so one
+// bad iteration doesn't stop the ones after it.
+func TestRecover_LoopSurvivesOnePanickingIteration(t *testing.T) {
+	log := logger.New("error", "json")
+	completed := 0
+	for i := 0; i < 3; i++ {
+		func() {
+			defer Recover(log, "test-loop")()
+			completed++
+			if i == 1 {
+				panic("bad iteration")
+			}
+		}()
+	}
+	if completed != 3 {
+		t.Errorf("completed = %d, want 3 (the panic in iteration 1 should not have stopped the loop)", completed)
+	}
+}
+
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) (timedOut bool) {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return false
+	case <-time.After(timeout):
+		return true
+	}
+}

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/nexspence-oss/nexspence/internal/distlock"
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 	"github.com/nexspence-oss/nexspence/internal/storage"
 	"github.com/nexspence-oss/nexspence/internal/tracing"
 )
@@ -30,6 +32,7 @@ type BlobStoreMigrationService struct {
 	blobs      repository.BlobStoreRepo
 	registry   *storage.Registry
 	locker     distlock.Locker
+	log        logger.Logger
 
 	mu      sync.Mutex
 	cancels map[string]context.CancelFunc
@@ -56,6 +59,12 @@ func NewBlobStoreMigrationService(
 // WithLocker sets the distributed locker used to prevent concurrent migrations on the same repo across nodes.
 func (s *BlobStoreMigrationService) WithLocker(l distlock.Locker) *BlobStoreMigrationService {
 	s.locker = l
+	return s
+}
+
+// WithLogger sets the logger used to recover and report a panic in a detached migration run.
+func (s *BlobStoreMigrationService) WithLogger(log logger.Logger) *BlobStoreMigrationService {
+	s.log = log
 	return s
 }
 
@@ -152,7 +161,8 @@ func (s *BlobStoreMigrationService) Start(ctx context.Context, repoName, targetS
 	s.cancels[m.ID] = cancel
 	s.mu.Unlock()
 
-	go s.runMigration(migCtx, m, migLock, deadline) //nolint:gosec // detached context is intentional: background migration must outlive the request
+	//nolint:gosec // detached context is intentional: background migration must outlive the request
+	safego.Go(s.log, "blob-store-migration-run", func() { s.runMigration(migCtx, m, migLock, deadline) })
 	return m, nil
 }
 

--- a/internal/service/cleanup_service.go
+++ b/internal/service/cleanup_service.go
@@ -101,7 +101,11 @@ func (s *CleanupService) storeForAsset(ctx context.Context, a *domain.Asset) sto
 func (s *CleanupService) StartCronScheduler(ctx context.Context, defaultSchedule string) {
 	s.mu.Lock()
 	s.defaultSchedule = defaultSchedule
-	s.cronScheduler = cron.New()
+	// cron.Recover: a job panic (e.g. an unexpected shape from a bad policy
+	// row) would otherwise crash the whole process — cron's own internal
+	// scheduler goroutine invokes registered jobs directly, so this is not
+	// covered by the safego.Go wrapping the outer StartCronScheduler call.
+	s.cronScheduler = cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger)))
 	s.mu.Unlock()
 
 	policies, err := s.policies.List(ctx)

--- a/internal/service/gc_service.go
+++ b/internal/service/gc_service.go
@@ -248,7 +248,10 @@ func (s *BlobGCService) StartCronScheduler(ctx context.Context, schedule string,
 		s.log().Info("blob gc scheduler disabled: empty schedule")
 		return
 	}
-	c := cron.New()
+	// cron.Recover: without it, a panic inside CompactAll runs on cron's own
+	// internal scheduler goroutine and crashes the whole process — not
+	// covered by the safego.Go wrapping the outer StartCronScheduler call.
+	c := cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger)))
 	_, err := c.AddFunc(schedule, func() {
 		if _, err := s.CompactAll(context.Background(), GCOptions{MinAge: minAge}); err != nil {
 			s.log().Error("blob gc cron error", "err", err)

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/netguard"
 	"github.com/nexspence-oss/nexspence/internal/nexusclient"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 	"github.com/nexspence-oss/nexspence/internal/tracing"
 )
 
@@ -310,7 +311,7 @@ func (s *NexusMigrationService) launch(id string) {
 	s.dones[id] = make(chan struct{})
 	s.mu.Unlock()
 
-	go s.run(ctx, id)
+	safego.Go(s.log, "nexus-migration-run", func() { s.run(ctx, id) })
 }
 
 // ── preview ─────────────────────────────────────────────────────────────────

--- a/internal/service/replication_service.go
+++ b/internal/service/replication_service.go
@@ -238,7 +238,10 @@ func (s *ReplicationService) ReEncryptCredentials(ctx context.Context) int {
 // StartCronScheduler loads all enabled rules and registers cron jobs. Run as a goroutine.
 func (s *ReplicationService) StartCronScheduler(ctx context.Context) {
 	s.mu.Lock()
-	s.cronScheduler = cron.New()
+	// cron.Recover: a job panic runs on cron's own internal scheduler
+	// goroutine and would otherwise crash the whole process — not covered by
+	// the safego.Go wrapping the outer StartCronScheduler call.
+	s.cronScheduler = cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger)))
 	s.mu.Unlock()
 
 	rules, err := s.repo.ListRules(ctx)

--- a/internal/service/scan_service.go
+++ b/internal/service/scan_service.go
@@ -227,7 +227,10 @@ func (s *ScanService) StartScheduler(ctx context.Context, schedule string) {
 	// OSV.dev per component and re-runs Trivy per image, so on a large registry
 	// it can outlast its own interval. Overlapping runs would queue up behind
 	// trivyMu and never catch up.
-	c := cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DiscardLogger)))
+	// Recover goes first (outermost) so a job panic can't also skip
+	// SkipIfStillRunning's own cleanup — the wrapping wouldn't survive a panic
+	// escaping through it otherwise.
+	c := cron.New(cron.WithChain(cron.Recover(cron.DefaultLogger), cron.SkipIfStillRunning(cron.DiscardLogger)))
 	if _, err := c.AddFunc(schedule, func() {
 		scanned, failed, err := s.BulkScan(ctx, "")
 		if err != nil {

--- a/internal/service/webhook_service.go
+++ b/internal/service/webhook_service.go
@@ -12,14 +12,17 @@ import (
 	"time"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/netguard"
 	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/safego"
 )
 
 // WebhookService handles CRUD for webhooks and fires delivery goroutines.
 type WebhookService struct {
 	repo   repository.WebhookRepo
 	client *http.Client
+	log    logger.Logger
 }
 
 // NewWebhookService constructs a service for managing and delivering webhooks.
@@ -30,6 +33,12 @@ func NewWebhookService(repo repository.WebhookRepo) *WebhookService {
 		repo:   repo,
 		client: netguard.Client(10 * time.Second),
 	}
+}
+
+// WithLogger sets the logger used to recover and report a panic in a detached webhook delivery.
+func (s *WebhookService) WithLogger(log logger.Logger) *WebhookService {
+	s.log = log
+	return s
 }
 
 // WithHTTPClient overrides the delivery HTTP client. Intended for tests that
@@ -124,7 +133,7 @@ func (s *WebhookService) Test(ctx context.Context, id string) (*TestResult, erro
 // Dispatch fires the payload to all active webhooks subscribed to payload.Event.
 // Delivery is asynchronous — errors are silently dropped.
 func (s *WebhookService) Dispatch(payload domain.WebhookPayload) {
-	go func() {
+	safego.Go(s.log, "webhook-dispatch", func() {
 		hooks, err := s.repo.ListByEvent(context.Background(), payload.Event)
 		if err != nil || len(hooks) == 0 {
 			return
@@ -139,7 +148,7 @@ func (s *WebhookService) Dispatch(payload domain.WebhookPayload) {
 			}
 			s.deliver(wh, body, payload.Event)
 		}
-	}()
+	})
 }
 
 func (s *WebhookService) deliver(wh domain.Webhook, body []byte, event domain.WebhookEvent) {


### PR DESCRIPTION
Closes #378

grep -rn "recover()" across the whole repository (excluding tests) returned zero matches. Go terminates the entire process on any unrecovered goroutine panic - not just the goroutine that panicked - so a single bad input reaching any background job (a malformed response from a source Nexus instance being migrated, an unexpected shape from Trivy/OSV.dev, a nil dereference in a cron job body) took the whole server down, every in-flight request included. robfig/cron/v3 does not recover job panics by default either - the cron.Recover chain wrapper has to be added explicitly, and none of the three plain cron.New() calls had it.

Adds internal/safego: Go(log, name, fn) for one-shot detached goroutines (a background job, a fire-and-forget write), Recover(log, name) as a defer for a persistent loop iteration (a cron job body, a ticker-driven sampler) so one bad iteration doesn't take the next ones down with it. Applied at every detached-goroutine and parallel-checks call site: cron scheduler starts, the download-counter and metrics- sampler loops, migration ResumeAll/run, cleanup/replication manual- trigger and reload goroutines, the audit-write and webhook-dispatch goroutines, the audit partition rotator, the rate-limit bucket-eviction loop, and the parallel service/readiness health checks (whose wg.Wait() does not itself protect the process from a child panic). Left out deliberately: the two io.Pipe copy goroutines in store.go/repoproxy.go (tight io.Copy over hash writers, not complex/adversarial-data parsing) and main.go's HTTP listener goroutine (already funnels a real listen failure to os.Exit(1) by design).

cron.WithChain(cron.Recover(cron.DefaultLogger)) added to the three bare cron.New() calls (cleanup, gc, replication schedulers) and merged into scan_service.go's existing SkipIfStillRunning chain, Recover outermost so a job panic can't also skip SkipIfStillRunning's own cleanup.

A few constructors gained a logger parameter/WithLogger option where none existed (RateLimitMiddleware, AuditMiddleware, ReadinessHandler, SystemHandler, ReplicationHandler, BlobStoreMigrationService, WebhookService, metrics.StartSampler) - existing tests updated to pass nil, which safego handles safely (skips logging, still recovers).

Verified: internal/safego/safego_test.go (a panicking goroutine is swallowed - the test itself would otherwise crash the test binary; a nil logger doesn't itself panic; a loop survives one panicking iteration). Full suite green: go build/go vet/go test ./... (unit + -tags=integration against a real dockertest Postgres). Live compose smoke test (real Postgres/MinIO/Trivy): server boots clean, /healthz and /readyz OK, logged in and browsed Repositories and System Admin -> Service Connections (the parallel-check path this fix touches) in Chrome with zero console errors.