### PR TITLE
fix: S3 blob GC can abort an in-progress OCI upload session

### DIFF
--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -207,9 +207,29 @@ func (s *S3BlobStore) ListKeys(ctx context.Context) ([]string, error) {
 	return keys, nil
 }
 
+// blobKeyFromObjectKey reverses objectKey's two-level sharding:
+// "ab/cd/abcdef..." → "abcdef...".
+func blobKeyFromObjectKey(objKey string) string {
+	parts := strings.SplitN(objKey, "/", 3)
+	if len(parts) == 3 {
+		return parts[2]
+	}
+	return objKey
+}
+
 // ListEntries returns every object's blob key, size and last-modified time.
 func (s *S3BlobStore) ListEntries(ctx context.Context) ([]BlobEntry, error) {
 	var entries []BlobEntry
+	// A chunked OCI upload session's real activity — every AppendBlob call —
+	// only ever rewrites the .append-meta side-object (saveAppendState),
+	// never the plain placeholder Put that create() makes at session start.
+	// Left alone, an entry's ModTime stays pinned to session start no matter
+	// how recently a chunk landed, and GC's min_age grace period can abort a
+	// session that is still actively receiving data. Track each key's most
+	// recent .append-meta ModTime here (still excluded from the returned
+	// entries themselves) and use it below when it postdates the
+	// placeholder's own.
+	metaModTimes := make(map[string]time.Time)
 	paginator := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),
 	})
@@ -219,14 +239,20 @@ func (s *S3BlobStore) ListEntries(ctx context.Context) ([]BlobEntry, error) {
 			return entries, fmt.Errorf("s3 list entries: %w", err)
 		}
 		for _, obj := range page.Contents {
-			if obj.Key == nil || isAppendMetaObject(*obj.Key) {
+			if obj.Key == nil {
 				continue
 			}
-			parts := strings.SplitN(*obj.Key, "/", 3)
-			key := *obj.Key
-			if len(parts) == 3 {
-				key = parts[2]
+			if isAppendMetaObject(*obj.Key) {
+				if obj.LastModified == nil {
+					continue
+				}
+				key := blobKeyFromObjectKey(strings.TrimSuffix(*obj.Key, s3AppendMetaSuffix))
+				if mt := *obj.LastModified; mt.After(metaModTimes[key]) {
+					metaModTimes[key] = mt
+				}
+				continue
 			}
+			key := blobKeyFromObjectKey(*obj.Key)
 			var size int64
 			if obj.Size != nil {
 				size = *obj.Size
@@ -236,6 +262,14 @@ func (s *S3BlobStore) ListEntries(ctx context.Context) ([]BlobEntry, error) {
 				mt = *obj.LastModified
 			}
 			entries = append(entries, BlobEntry{Key: key, Size: size, ModTime: mt})
+		}
+	}
+	// A page split between a placeholder and its .append-meta companion (list
+	// order is lexicographic, not paired) means the correlation can only
+	// happen once every page has been seen.
+	for i := range entries {
+		if mt, ok := metaModTimes[entries[i].Key]; ok && mt.After(entries[i].ModTime) {
+			entries[i].ModTime = mt
 		}
 	}
 	return entries, nil

--- a/internal/storage/s3_append_integration_test.go
+++ b/internal/storage/s3_append_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -281,6 +282,54 @@ func TestS3BlobStore_AppendState_HiddenFromListings(t *testing.T) {
 	for _, e := range entries {
 		assert.NotContains(t, e.Key, ".append-meta", "append bookkeeping must not list as a blob")
 	}
+}
+
+// GC's min_age grace period reads ListEntries' ModTime for a key. An OCI
+// chunked upload session starts with a real empty placeholder Put at the
+// blob key (mirroring oci.uploadStore.create) — separate from whatever
+// AppendBlob's own multipart machinery does later. Every subsequent chunk
+// only ever rewrites the .append-meta side-object; without correlating it,
+// ListEntries reports the placeholder's frozen session-start ModTime no
+// matter how recently a chunk landed, and a long/slow upload can be aborted
+// by GC purely because it has been open a while.
+func TestS3BlobStore_ListEntries_TracksMostRecentAppendActivity(t *testing.T) {
+	bs := minioPool(t)
+	as := s3Appendable(t, bs)
+	ctx := context.Background()
+	key := "ap99aaaa88889999"
+
+	require.NoError(t, bs.Put(ctx, key, bytes.NewReader(nil), 0))
+	t.Cleanup(func() { _ = as.AbortAppend(ctx, key) })
+
+	entriesAtStart, err := bs.ListEntries(ctx)
+	require.NoError(t, err)
+	startModTime := findEntry(t, entriesAtStart, key).ModTime
+
+	time.Sleep(1200 * time.Millisecond)
+
+	// A real chunk landing well after session start — the same shape an
+	// in-progress, slow OCI upload would produce.
+	_, err = as.AppendBlob(ctx, key, bytes.NewReader([]byte("late chunk")))
+	require.NoError(t, err)
+
+	entriesAfter, err := bs.ListEntries(ctx)
+	require.NoError(t, err)
+	afterModTime := findEntry(t, entriesAfter, key).ModTime
+
+	assert.True(t, afterModTime.After(startModTime),
+		"ListEntries ModTime should track the most recent AppendBlob activity, not stay pinned to session start (start=%v after=%v)", startModTime, afterModTime)
+	assert.GreaterOrEqual(t, afterModTime.Sub(startModTime), 900*time.Millisecond)
+}
+
+func findEntry(t *testing.T, entries []storage.BlobEntry, key string) storage.BlobEntry {
+	t.Helper()
+	for _, e := range entries {
+		if e.Key == key {
+			return e
+		}
+	}
+	t.Fatalf("entry %q not found in ListEntries result", key)
+	return storage.BlobEntry{}
 }
 
 // Deleting a key mid-session is how GC collects an abandoned upload, and it has


### PR DESCRIPTION
Closes #380

An OCI chunked upload session starts with a real empty object at the plain blob key (oci.uploadStore.create -> a plain BlobStore.Put), separate from whatever AppendBlob's own multipart machinery does later. On LocalBlobStore, every subsequent chunk reopens the real file with O_APPEND, so the file's mtime keeps advancing with real activity. On S3BlobStore, chunks go to multipart parts and a .append-meta side-object - neither touches that original plain-key placeholder, so ListEntries' ModTime for it stayed frozen at session start no matter how recently a chunk landed (ListEntries explicitly excludes .append-meta from its scan, so the more-recent timestamp was invisible to it). GC's min_age grace period reads exactly that ModTime - a long upload with a slow client, or an admin running GC with a shortened min_age to free space urgently, could abort (via Delete -> AbortAppend) a session that was still actively receiving data, purely because it had been open a while. Backend-specific data loss: the same upload outlives min_age silently on S3/MinIO but not on local storage.

ListEntries now collects each key's .append-meta ModTime into a map during the same listing pass (still excluded from the returned entries themselves) and overrides an entry's ModTime with it when newer - a page can split a placeholder from its .append-meta companion (listing order is lexicographic, not paired), so the correlation only happens once every page has been seen.

Verified against a real MinIO (dockertest): a new integration test (TestS3BlobStore_ListEntries_TracksMostRecentAppendActivity) mirrors the real create()+AppendBlob sequence - a plain Put, a 1.2s wait, then a real chunk - and asserts ListEntries' ModTime tracks the chunk, not session start. Confirmed it fails without the fix (0s gap, ModTime pinned to session start) and passes with it. Full storage package suite green (go test -tags=integration ./internal/storage/...), including the existing TestS3BlobStore_AppendState_HiddenFromListings regression check and TestS3BlobStore_ListKeys (unaffected - it doesn't correlate .append-meta, only excludes it, same as before).