### PR TITLE
fix: Yum and NuGet proxies never derive real package coordinates

### DIFF
--- a/internal/formats/nuget/handler.go
+++ b/internal/formats/nuget/handler.go
@@ -65,7 +65,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		if !strings.HasSuffix(p, ".nupkg") {
 			maxAge = repoproxy.MetadataMaxAge(repo)
 		}
-		coords := base.Coords{}
+		coords := proxyCoords(p)
 		// Resource paths advertised by the rewritten index are the upstream's
 		// own paths re-rooted locally — forward them onto the bare origin,
 		// not onto a possibly /v3-suffixed remote_url (#349).
@@ -162,6 +162,41 @@ func (h *Handler) serveVersionList(c *gin.Context, repoName, pkgID string) {
 		versions = append(versions, comp.Version)
 	}
 	c.JSON(http.StatusOK, gin.H{"versions": versions})
+}
+
+// proxyCoords derives component coordinates for a proxied path. A cached
+// package must carry its real name and version — the OSV/Trivy scan queries
+// by them, so the path-derived fallback name and placeholder version made
+// every package pulled through a NuGet proxy invisible to vulnerability
+// scanning, the same root cause #336 closed for Cargo.
+//
+// A proxy repo forwards whatever local path the client requested straight
+// onto upstream (upstreamPath := origin + p, above) — unlike a hosted repo,
+// it never goes through this file's own "/v3/flatcontainer/" switch-case
+// routes. A real client (nuget.exe, dotnet) requests packages at whatever
+// address the upstream's own index.json/config.json advertised, which for
+// nuget.org and most feeds is "/v3-flatcontainer/" (hyphenated, a sibling of
+// "/v3/", not nested inside it — see TestNuGet_ProxyFlatcontainer_
+// ResolvesAgainstRealShape). Matching on a specific prefix would silently
+// miss that real shape, so this matches by suffix instead: any ".nupkg" path
+// is exactly ":id/:ver/:id.:ver.nupkg" — the same 3-segment split
+// serveFlatContainerDownload already does for hosted downloads, applied to
+// the path's last 3 segments regardless of what comes before them.
+// Registration/index pages are versionless metadata and keep the generic
+// fallback.
+func proxyCoords(p string) base.Coords {
+	if !strings.HasSuffix(p, ".nupkg") {
+		return base.Coords{}
+	}
+	parts := strings.Split(strings.Trim(p, "/"), "/")
+	if len(parts) < 3 {
+		return base.Coords{}
+	}
+	id, ver := parts[len(parts)-3], parts[len(parts)-2]
+	if id == "" || ver == "" {
+		return base.Coords{}
+	}
+	return base.Coords{Name: strings.ToLower(id), Version: ver}
 }
 
 func (h *Handler) serveFlatContainerDownload(c *gin.Context, repoName, p string) {

--- a/internal/formats/nuget/proxy_coords_test.go
+++ b/internal/formats/nuget/proxy_coords_test.go
@@ -1,0 +1,108 @@
+package nuget_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/nuget"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A proxied package must be registered under its real name and version: the
+// OSV/Trivy scan queries by comp.Name/comp.Version, so a path-fallback name
+// and placeholder version make every package pulled through a NuGet proxy
+// invisible to vulnerability scanning — the same root cause #336 closed for
+// Cargo. UpstreamClient is unguarded package-wide via TestMain
+// (proxy_testmain_test.go).
+func setupNuGetProxy(t *testing.T, upstreamBody string) (*gin.Engine, *testutil.ComponentRepo) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	repo := &domain.Repository{
+		ID: "repo-nuget-proxy", Name: "nuget-proxy", Format: domain.RepoFormat("nuget"),
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": srv.URL},
+	}
+	comps := testutil.NewComponentRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := nuget.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps
+}
+
+// A proxy repo forwards whatever local path the client requested straight
+// onto upstream — a real client (nuget.exe, dotnet) requests packages at
+// "/v3-flatcontainer/" (hyphenated, the shape nuget.org and most real feeds
+// advertise via config.json/index.json), not the "/v3/flatcontainer/"
+// (slash) convention this handler's own hosted-repo routes use locally.
+func TestNuGet_ProxyDownload_RegistersRealPackageCoords(t *testing.T) {
+	r, comps := setupNuGetProxy(t, "nupkg-bytes")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/nuget-proxy/v3-flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{Repository: "nuget-proxy", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1, "the cached package must be registered as one component")
+	assert.Equal(t, "newtonsoft.json", page.Items[0].Name,
+		"the component carries the package's real name — the OSV query is built from it")
+	assert.Equal(t, "13.0.1", page.Items[0].Version,
+		"the component carries the package's real version — a placeholder never matches an advisory range")
+}
+
+// The slash convention this handler's own hosted routes use locally must
+// keep working too — proxyCoords matches by .nupkg suffix, not a fixed
+// prefix, so either shape resolves.
+func TestNuGet_ProxyDownload_SlashConventionAlsoRegistersRealCoords(t *testing.T) {
+	r, comps := setupNuGetProxy(t, "nupkg-bytes")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/nuget-proxy/v3/flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{Repository: "nuget-proxy", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "newtonsoft.json", page.Items[0].Name)
+	assert.Equal(t, "13.0.1", page.Items[0].Version)
+}
+
+// The registration-index page is versionless metadata and keeps the generic
+// path-fallback treatment.
+func TestNuGet_ProxyRegistrationIndex_KeepsMetadataFallback(t *testing.T) {
+	r, comps := setupNuGetProxy(t, `{"count":0,"items":[]}`)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/nuget-proxy/v3/registration/newtonsoft.json/index.json", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{Repository: "nuget-proxy", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.NotEqual(t, "13.0.1", page.Items[0].Version, "a registration index page must not register with .nupkg-style coords")
+}

--- a/internal/formats/yum/handler.go
+++ b/internal/formats/yum/handler.go
@@ -57,7 +57,7 @@ func (h *Handler) ServeHTTP(c *gin.Context) {
 		if strings.Contains(p, "/repodata/") {
 			maxAge = repoproxy.MetadataMaxAge(repo)
 		}
-		coords := base.Coords{}
+		coords := proxyCoords(p)
 		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", coords, ct, maxAge); err != nil {
 			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		}
@@ -198,10 +198,10 @@ func (h *Handler) serveOtherMetadata(c *gin.Context, repoName, p string) {
 	c.Data(http.StatusOK, "application/xml; charset=utf-8", plain)
 }
 
-func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
-	filename := path.Base(p)
-	// Parse NVR: name-version-release.arch.rpm — the last two dash segments
-	// are version and release ("curl-8.0.0-1.x86_64.rpm" → curl / 8.0.0).
+// rpmCoords parses NVR (name-version-release) coordinates from an RPM
+// filename: name-version-release.arch.rpm — the last two dash segments are
+// version and release ("curl-8.0.0-1.x86_64.rpm" → curl / 8.0.0).
+func rpmCoords(filename string) base.Coords {
 	name := strings.TrimSuffix(filename, ".rpm")
 	if dot := strings.LastIndex(name, "."); dot > 0 { // strip .arch
 		name = name[:dot]
@@ -214,8 +214,24 @@ func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
 	} else if len(parts) == 2 {
 		pkgName, version = parts[0], parts[1]
 	}
+	return base.Coords{Name: pkgName, Version: version}
+}
 
-	coords := base.Coords{Name: pkgName, Version: version}
+// proxyCoords derives component coordinates for a proxied path. A cached RPM
+// must carry its real name and version — the OSV/Trivy scan queries by them,
+// so the path-derived fallback name and placeholder version "1" made every
+// RPM pulled through a Yum proxy invisible to vulnerability scanning, the
+// same root cause #336 closed for Cargo. repodata/ holds mutable index files,
+// not versioned packages, and keeps the generic fallback.
+func proxyCoords(p string) base.Coords {
+	if strings.HasSuffix(p, ".rpm") {
+		return rpmCoords(path.Base(p))
+	}
+	return base.Coords{}
+}
+
+func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
+	coords := rpmCoords(path.Base(p))
 	if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
 		repoName, p, "application/x-rpm",
 		coords, c.Request.Body, c.Request.ContentLength); err != nil {

--- a/internal/formats/yum/proxy_coords_test.go
+++ b/internal/formats/yum/proxy_coords_test.go
@@ -1,0 +1,89 @@
+package yum_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+	"github.com/nexspence-oss/nexspence/internal/formats/yum"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A proxied RPM must be registered under its real NVR (name-version-release):
+// the OSV/Trivy scan queries by comp.Name/comp.Version, so a path-fallback
+// name and placeholder version make every RPM pulled through a Yum proxy
+// invisible to vulnerability scanning — the same root cause #336 closed for
+// Cargo.
+
+func setupYumProxy(t *testing.T, upstreamBody string) (*gin.Engine, *testutil.ComponentRepo) {
+	t.Helper()
+	orig := repoproxy.UpstreamClient
+	repoproxy.UpstreamClient = &http.Client{}
+	t.Cleanup(func() { repoproxy.UpstreamClient = orig })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(upstreamBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	repo := &domain.Repository{
+		ID: "repo-yum-proxy", Name: "yum-proxy", Format: domain.RepoFormat("yum"),
+		Type: domain.TypeProxy, Online: true,
+		ProxyConfig: map[string]any{"remote_url": srv.URL},
+	}
+	comps := testutil.NewComponentRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := yum.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps
+}
+
+func TestYum_ProxyDownload_RegistersRealRPMCoords(t *testing.T) {
+	r, comps := setupYumProxy(t, "rpm-bytes")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/yum-proxy/openssl-1.1.1k-1.el8.x86_64.rpm", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{Repository: "yum-proxy", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1, "the cached RPM must be registered as one component")
+	assert.Equal(t, "openssl", page.Items[0].Name,
+		"the component carries the RPM's real name — the OSV query is built from it")
+	assert.Equal(t, "1.1.1k", page.Items[0].Version,
+		"the component carries the RPM's real version — a placeholder never matches an advisory range")
+}
+
+// repodata/ holds mutable index files, not versioned packages, and keeps the
+// generic path-fallback metadata treatment.
+func TestYum_ProxyRepomd_KeepsMetadataFallback(t *testing.T) {
+	r, comps := setupYumProxy(t, `<?xml version="1.0"?><repomd/>`)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/yum-proxy/repodata/repomd.xml", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	page, err := comps.Search(context.Background(), domain.SearchParams{Repository: "yum-proxy", Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.NotEqual(t, "openssl", page.Items[0].Name, "an index file must not register with RPM-style coords")
+}


### PR DESCRIPTION
Closes #381

Same root cause #336 closed for Cargo, in two more formats: both proxy branches passed an empty base.Coords{} for everything cached from upstream, including real downloads, even though each format's hosted-upload path already parses real coordinates. A cached artifact registered under a path-derived name and placeholder version, so OSV/Trivy scanning could never match it to a real advisory.

Yum: the NVR (name-version-release) parser inside handleUpload is now a shared rpmCoords(filename), used by a new proxyCoords(p) (any .rpm suffix) for the proxy branch too; repodata/* index files keep the path-based metadata fallback.

NuGet: a new proxyCoords(p) recognizes any .nupkg path by suffix and splits its last 3 segments (:id/:ver/:id.:ver.nupkg) - not the "/v3/flatcontainer/" prefix this handler's own hosted routes use locally. A proxy repo forwards whatever local path the client requested straight onto upstream, and a real client (nuget.exe, dotnet) requests packages at whatever address the upstream's index.json/config.json actually advertised - "/v3-flatcontainer/" (hyphenated) for nuget.org and most real feeds, confirmed against the existing TestNuGet_ProxyFlatcontainer_ResolvesAgainstRealShape test. Matching by suffix instead of a fixed prefix handles both shapes. Registration/index pages keep the metadata fallback.

Verified: new tests per format confirm a proxied download registers under its real coordinates and a metadata/index page keeps the fallback (TestYum_ProxyDownload_RegistersRealRPMCoords, TestYum_ProxyRepomd_KeepsMetadataFallback,
TestNuGet_ProxyDownload_RegistersRealPackageCoords - and a second NuGet test confirming the slash convention also still resolves, TestNuGet_ProxyRegistrationIndex_KeepsMetadataFallback). Live compose verification against real upstreams: proxied openssl3-3.5.5-6.el8 from a real Fedora EPEL 8 mirror through a live Yum proxy repo, and newtonsoft.json 13.0.1 from api.nuget.org (real /v3-flatcontainer/ shape) through a live NuGet proxy repo - both registered with their real name/version (not path-derived placeholders), confirmed via the API and visually in Chrome's Search page. go build/go vet/go test ./... green save for the pre-existing, environment-only TestWebhookHandler_Test_200 flake.