### PR TITLE
fix: unbounded read of rewritten proxy metadata (npm/PyPI/NuGet) - me…

### DIFF
--- a/internal/formats/repoproxy/repoproxy.go
+++ b/internal/formats/repoproxy/repoproxy.go
@@ -174,6 +174,18 @@ func applyChecksumHeaders(c *gin.Context, a *domain.Asset) {
 // addressed by digest) are never revalidated — callers pass maxAge == 0 for those.
 const DefaultMetadataMaxAge = 10 * time.Minute
 
+// maxRewrittenMetadataBytes caps storeAndServeResponse's and
+// serveCachedAsset's buffered io.ReadAll — the only unbounded reads in this
+// codebase, both gated on rewrite != nil (npm packuments, PyPI simple pages,
+// NuGet registration/flatcontainer indexes: the shared path any proxy that
+// rewrites a response before serving it goes through). Every other metadata
+// read here (OCI manifests/referrers, npm's own age-filter packument read,
+// PyPI's simple index reader, RubyGems gemspecs) already caps its ReadAll
+// with a LimitReader; this was the one exception, reachable from any proxy
+// repository whose remote_url a caller can point at a hostile, compromised,
+// or simply oversized-by-accident upstream.
+const maxRewrittenMetadataBytes = 32 << 20
+
 // MetadataMaxAge returns the freshness TTL to use for proxied metadata on this
 // repository. It reads proxy_config["metadata_max_age"], interpreted as a number
 // of seconds (JSON numbers arrive as float64; strings are parsed). Any unset,
@@ -295,9 +307,17 @@ func serveCachedAsset(c *gin.Context, d formats.Deps, asset *domain.Asset, rc io
 		return
 	}
 	if rewrite != nil {
-		body, err := io.ReadAll(rc)
+		// Reading one byte past the cap is what makes an overflow visible: a
+		// reader limited to exactly the cap returns the trimmed prefix and a
+		// nil error, which would rewrite (and serve) a silently truncated
+		// document instead of rejecting it.
+		body, err := io.ReadAll(io.LimitReader(rc, maxRewrittenMetadataBytes+1))
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "cache read: " + err.Error()})
+			return
+		}
+		if len(body) > maxRewrittenMetadataBytes {
+			c.JSON(http.StatusBadGateway, gin.H{"error": "cached metadata exceeds the rewrite size limit"})
 			return
 		}
 		c.Data(http.StatusOK, asset.ContentType, rewrite(body))
@@ -545,9 +565,15 @@ func storeAndServeResponse(c *gin.Context, d formats.Deps, repo *domain.Reposito
 	// ORIGINAL to the cache (hashes over the original), and serve the client
 	// the transformed copy. Metadata documents are small, so buffering is fine.
 	if rewrite != nil {
-		body, readErr := io.ReadAll(resp.Body)
+		// Same cap and +1 trick as serveCachedAsset's re-read below: a
+		// hostile, compromised, or simply oversized-by-accident upstream
+		// otherwise buffers without limit before any quota/size check runs.
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxRewrittenMetadataBytes+1))
 		if readErr != nil {
 			return fmt.Errorf("proxy metadata read: %w", readErr)
+		}
+		if len(body) > maxRewrittenMetadataBytes {
+			return fmt.Errorf("proxy metadata exceeds the %d byte rewrite size limit", maxRewrittenMetadataBytes)
 		}
 		if err := storeOriginal(ctx, c, d, repo, repoRelativePath, ct, coords, body); err != nil {
 			return err

--- a/internal/formats/repoproxy/rewrite_size_limit_test.go
+++ b/internal/formats/repoproxy/rewrite_size_limit_test.go
@@ -1,0 +1,97 @@
+package repoproxy_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// maxRewrittenMetadataBytesForTest mirrors the unexported
+// repoproxy.maxRewrittenMetadataBytes (32 MiB). Kept in sync manually since
+// the constant isn't exported — a mismatch would fail these tests loudly
+// (an "at limit" body would either get rejected or an "oversized" body would
+// get accepted), not silently.
+const maxRewrittenMetadataBytesForTest = 32 << 20
+
+// storeAndServeResponse's buffered read (cache fill) is the first of the two
+// unbounded reads this codebase had on the shared path npm/PyPI/NuGet proxy
+// metadata through. A hostile, compromised, or simply oversized-by-accident
+// upstream must not be able to exhaust server memory before any quota/size
+// check runs.
+func TestServeGETRewritten_CacheFill_OversizedBody_Rejected(t *testing.T) {
+	useUnguardedUpstream(t)
+	oversized := bytes.Repeat([]byte("a"), maxRewrittenMetadataBytesForTest+1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(oversized)
+	}))
+	defer upstream.Close()
+
+	repo := proxyRepo("rwbig1", upstream.URL)
+	d := makeDeps(repo)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/meta.json", nil)
+	err := repoproxy.ServeGETRewritten(c, d, repo, "/meta.json", "", base.Coords{}, "text/plain", 0, bytes.ToUpper)
+	require.Error(t, err, "an oversized rewritten-metadata response must be rejected, not buffered without limit")
+
+	_, getErr := d.Assets.GetByPath(context.Background(), "rwbig1", "/meta.json")
+	assert.Error(t, getErr, "a rejected response must not be cached")
+}
+
+// A body exactly at the cap must still be served normally — the limit
+// rejects an overflow, it does not truncate a legitimate response one byte
+// short of it.
+func TestServeGETRewritten_CacheFill_AtLimit_Served(t *testing.T) {
+	useUnguardedUpstream(t)
+	atLimit := bytes.Repeat([]byte("a"), maxRewrittenMetadataBytesForTest)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(atLimit)
+	}))
+	defer upstream.Close()
+
+	repo := proxyRepo("rwbig2", upstream.URL)
+	d := makeDeps(repo)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/meta.json", nil)
+	err := repoproxy.ServeGETRewritten(c, d, repo, "/meta.json", "", base.Coords{}, "text/plain", 0, bytes.ToUpper)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Len(t, w.Body.Bytes(), maxRewrittenMetadataBytesForTest)
+}
+
+// serveCachedAsset's own re-read (rewriting a cache HIT, not just a cache
+// fill) is the second of the two unbounded reads — it needs the same cap
+// independently of storeAndServeResponse's, since a cache entry could in
+// principle predate this fix. Seed the cache directly (bypassing the
+// fetch-time guard entirely) and confirm the re-read path still rejects it.
+func TestServeGETRewritten_CacheHit_OversizedCachedBody_Rejected(t *testing.T) {
+	useUnguardedUpstream(t)
+	repo := proxyRepo("rwbig3", "http://unused.invalid")
+	d := makeDeps(repo)
+
+	oversized := bytes.Repeat([]byte("a"), maxRewrittenMetadataBytesForTest+1)
+	_, err := base.StoreArtifact(context.Background(), d, "rwbig3", "/meta.json", "text/plain",
+		base.Coords{}, bytes.NewReader(oversized), int64(len(oversized)))
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/meta.json", nil)
+	// maxAge 0 (immutable): served straight from cache, no upstream contact —
+	// exercises serveCachedAsset's read, not storeAndServeResponse's.
+	err = repoproxy.ServeGETRewritten(c, d, repo, "/meta.json", "", base.Coords{}, "text/plain", 0, bytes.ToUpper)
+	require.NoError(t, err, "the error is written directly onto the response, not returned")
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+}


### PR DESCRIPTION
Closes #382

storeAndServeResponse and serveCachedAsset - the shared path npm (packument), PyPI (simple index) and NuGet (registration/flatcontainer index) proxy through whenever they need to rewrite a response before serving it - did a bare io.ReadAll with no io.LimitReader, both when populating the cache from upstream and when re-reading the cache to rewrite it again. Every other metadata read in this codebase (OCI manifests/referrers, npm's own age-filter packument read, PyPI's simple index reader, RubyGems gemspecs) already caps its io.ReadAll with io.LimitReader and a dedicated constant - this was the one unbounded read, reachable from any proxy repository whose remote_url a caller can point at a hostile, compromised, or simply oversized-by-accident upstream.

Added maxRewrittenMetadataBytes = 32 << 20 and wrapped both reads with io.LimitReader(reader, cap+1) - the same "+1" trick oci/handler.go and rubygems/handler.go already use, so a reader capped at exactly the limit can't silently return a trimmed prefix with a nil error instead of a rejection. Both now return an explicit error (502 from the format handlers, which already wrap ServeGET/ServeGETRewritten errors that way) instead of buffering past the cap.

Verified: new tests confirm a body one byte over the cap is rejected without being cached (storeAndServeResponse) and without being served (serveCachedAsset, seeded directly to bypass the fetch-time guard and exercise the cache re-read path independently), and a body exactly at the cap is still served normally. Confirmed both new tests fail without the fix (nil error / 200 where an error / 502 was expected) and pass with it. go build/go vet/go test ./... green. Live compose verification: a real npm proxy against registry.npmjs.org still serves a real packument (lodash, 117 versions, 241.8 KB) correctly under the new cap, confirmed via the API and visually in Chrome's Search page.