### PR TITLE
fix: frontend stale-response races in SecurityPage roles and connection tests

### DIFF
--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1915,6 +1915,12 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
   const [err, setErr] = useState('')
   const [testResult, setTestResult] = useState<{ ok: boolean; error?: string } | null>(null)
   const [testBusy, setTestBusy] = useState(false)
+  // Bumped by handleTest and by every field onChange that feeds its config.
+  // A field edited after a test started must not let that test's late
+  // response land as if it verified the (now different) config a moment
+  // later — same request-sequence-guard pattern issue 12 applies to
+  // SecurityPage.tsx's openEdit.
+  const testReqSeq = useRef(0)
   const [groupFillPolicy, setGroupFillPolicy] = useState<'round_robin' | 'write_to_first_fill'>('round_robin')
   const [groupMemberIds, setGroupMemberIds] = useState<string[]>([])
 
@@ -1945,6 +1951,7 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
   })
 
   const handleTest = async () => {
+    const seq = ++testReqSeq.current
     setTestBusy(true)
     setTestResult(null)
     try {
@@ -1952,10 +1959,16 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
         ? { path }
         : { bucket, region, endpoint, prefix, access_key: accessKey, secret_key: secretKey }
       const res = await nexusApi.testBlobStore(type === 'group' ? 'local' : type, cfg)
+      if (seq !== testReqSeq.current) return // a field changed since this test started
       setTestResult(res.data)
     } catch {
+      if (seq !== testReqSeq.current) return
       setTestResult({ ok: false, error: 'Request failed' })
     } finally {
+      // Unlike setTestResult above, this must run regardless of seq: nothing
+      // else ever clears testBusy for a superseded request (no new test was
+      // started), so gating it the same way would leave the button stuck
+      // showing "Testing…" forever after an edit invalidates an in-flight one.
       setTestBusy(false)
     }
   }
@@ -1971,44 +1984,44 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
           <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Type</label>
           <Select
             value={type}
-            onChange={v => { setType(v as 'local' | 's3' | 'group'); setTestResult(null) }}
+            onChange={v => { testReqSeq.current++; setType(v as 'local' | 's3' | 'group'); setTestResult(null) }}
             options={[{ value: 'local', label: 'Local filesystem' }, { value: 's3', label: 'S3-compatible' }, { value: 'group', label: 'Group' }]}
           />
         </div>
         {type === 'local' && (
           <div>
             <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Path</label>
-            <HoloInput value={path} onChange={e => setPath(e.target.value)} placeholder="./data/blobs/fast-ssd" />
+            <HoloInput value={path} onChange={e => { testReqSeq.current++; setTestResult(null); setPath(e.target.value) }} placeholder="./data/blobs/fast-ssd" />
           </div>
         )}
         {type === 's3' && (
           <>
             <div>
               <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Bucket</label>
-              <HoloInput value={bucket} onChange={e => setBucket(e.target.value)} />
+              <HoloInput value={bucket} onChange={e => { testReqSeq.current++; setTestResult(null); setBucket(e.target.value) }} />
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
               <div>
                 <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Region</label>
-                <HoloInput value={region} onChange={e => setRegion(e.target.value)} />
+                <HoloInput value={region} onChange={e => { testReqSeq.current++; setTestResult(null); setRegion(e.target.value) }} />
               </div>
               <div>
                 <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Prefix (optional)</label>
-                <HoloInput value={prefix} onChange={e => setPrefix(e.target.value)} />
+                <HoloInput value={prefix} onChange={e => { testReqSeq.current++; setTestResult(null); setPrefix(e.target.value) }} />
               </div>
             </div>
             <div>
               <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Endpoint (leave empty for AWS)</label>
-              <HoloInput value={endpoint} onChange={e => setEndpoint(e.target.value)} placeholder="https://minio.example.com" />
+              <HoloInput value={endpoint} onChange={e => { testReqSeq.current++; setTestResult(null); setEndpoint(e.target.value) }} placeholder="https://minio.example.com" />
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
               <div>
                 <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Access Key</label>
-                <HoloInput value={accessKey} onChange={e => setAccessKey(e.target.value)} />
+                <HoloInput value={accessKey} onChange={e => { testReqSeq.current++; setTestResult(null); setAccessKey(e.target.value) }} />
               </div>
               <div>
                 <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Secret Key</label>
-                <HoloInput type="password" value={secretKey} onChange={e => setSecretKey(e.target.value)} />
+                <HoloInput type="password" value={secretKey} onChange={e => { testReqSeq.current++; setTestResult(null); setSecretKey(e.target.value) }} />
               </div>
             </div>
           </>

--- a/frontend/src/pages/MigrationPage.tsx
+++ b/frontend/src/pages/MigrationPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { ArrowRightLeft, Play, Pause, RefreshCw, Plus, PlugZap } from 'lucide-react'
 import { nexspenceApi, apiErrorMessage } from '@/api/client'
@@ -175,10 +175,17 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
   const [testing, setTesting] = useState(false)
   const [preview, setPreview] = useState<PreviewResult | null>(null)
   const [previewError, setPreviewError] = useState('')
+  // Bumped by handleTest and by every field set() feeds into it. A field
+  // edited after a test started must not let that test's late response land
+  // as if it verified the (now different) details a moment later — same
+  // request-sequence-guard pattern issue 12 applies to SecurityPage.tsx's
+  // openEdit.
+  const testReqSeq = useRef(0)
 
   const set = (k: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement>) => {
     // A connection result belongs to the details it was tested with. Once any
     // of them changes it is stale, and a stale green banner is worse than none.
+    testReqSeq.current++
     setPreview(null)
     setPreviewError('')
     setForm(f => ({ ...f, [k]: e.target.value }))
@@ -190,6 +197,7 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
     setUserRealms(r => (r.includes(realm) ? r.filter(x => x !== realm) : [...r, realm]))
 
   const handleTest = async () => {
+    const seq = ++testReqSeq.current
     setPreview(null)
     setPreviewError('')
     setTesting(true)
@@ -199,10 +207,17 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
         username: form.username,
         password: form.password,
       })
+      if (seq !== testReqSeq.current) return // a field changed since this test started
       setPreview(data as PreviewResult)
     } catch (err) {
+      if (seq !== testReqSeq.current) return
       setPreviewError(apiErrorMessage(err, 'Could not reach that Nexus'))
     } finally {
+      // Unlike setPreview/setPreviewError above, this must run regardless of
+      // seq: nothing else ever clears testing for a superseded request (no
+      // new test was started), so gating it the same way would leave the
+      // button stuck showing "Testing…" forever after an edit invalidates an
+      // in-flight one.
       setTesting(false)
     }
   }

--- a/frontend/src/pages/SecurityPage.tsx
+++ b/frontend/src/pages/SecurityPage.tsx
@@ -280,6 +280,13 @@ function RolesTab({ roles, loading, onRefresh, admin }: { roles: Role[]; loading
   const [rolePrivCache, setRolePrivCache] = useState<Map<string, Privilege[]>>(new Map())
   const [loadingExpand, setLoadingExpand] = useState<Set<string>>(new Set())
 
+  // Responses are applied in resolution order, not request order: opening
+  // Edit on role A, then closing/opening Edit on role B before A's slower
+  // request resolves, otherwise lets A's late response land after B's fast
+  // one and silently overwrite the checklist the admin is now looking at for
+  // B — the same bug class #337 fixed via vulnReqSeq further down this file.
+  const editReqSeq = useRef(0)
+
   const { data: allSelectors = [] } = useQuery<{ id: string; name: string }[]>({
     queryKey: ['content-selectors'],
     queryFn: () => nexusApi.listContentSelectors().then(r => r.data),
@@ -316,6 +323,7 @@ function RolesTab({ roles, loading, onRefresh, admin }: { roles: Role[]; loading
   }
 
   async function openEdit(r: Role) {
+    const seq = ++editReqSeq.current
     setEditRole(r)
     setEditForm({ name: r.name, description: r.description })
     setLoadingPrivs(true)
@@ -324,9 +332,12 @@ function RolesTab({ roles, loading, onRefresh, admin }: { roles: Role[]; loading
         nexusApi.listPrivileges().then(res => res.data as Privilege[]),
         nexusApi.listRolePrivileges(r.id).then(res => res.data as Privilege[]),
       ])
+      if (seq !== editReqSeq.current) return // superseded by a newer edit
       setAllPrivs(privList)
       setEditPrivIds(rolePrivs.map(p => p.id))
-    } finally { setLoadingPrivs(false) }
+    } finally {
+      if (seq === editReqSeq.current) setLoadingPrivs(false)
+    }
   }
 
   async function openCreate() {
@@ -512,7 +523,7 @@ function RolesTab({ roles, loading, onRefresh, admin }: { roles: Role[]; loading
           onSave={() => saveEdit.mutate()}
           saving={saveEdit.isPending}
           saveDisabled={!editForm.name.trim()}
-          onCancel={() => { setEditRole(null); setEditError(null) }}
+          onCancel={() => { editReqSeq.current++; setEditRole(null); setEditError(null) }}
           onDelete={() => { if (confirm(`Delete role ${editRole.name}?`)) { del.mutate(editRole.id); setEditRole(null) } }}
           error={editError}
         />


### PR DESCRIPTION
Closes #383

Two missing request-sequence-guard bugs in the same class #337 already fixed once (VulnDashTab's vulnReqSeq, in SecurityPage.tsx itself):

- SecurityPage.tsx's openEdit(role) fired Promise.all([listPrivileges(), listRolePrivileges(role.id)]) with no sequence guard. Opening Edit on role A, then closing/opening Edit on role B before A's slower request resolved, let A's late response land after B's fast one and silently overwrite the privilege checklist the admin was looking at (and would save) for B. Added editReqSeq (useRef), bumped at the start of every openEdit and on Cancel, checked before applying the response.

- AdminPage.tsx's CreateBlobStoreModal showed a "Connection successful" banner after handleTest, but none of the S3/path field onChange handlers cleared testResult - editing any of them after a successful test left the stale green banner describing a config that was never actually tested. The fields also weren't disabled during the test, so a fast edit could race a still-in-flight test's late response landing after the fields already changed. MigrationPage.tsx's equivalent handleTest already cleared its preview state on edit (better than AdminPage) but had the same missing race guard. Added a testReqSeq ref to both, bumped by every relevant field's onChange (also clearing the result/preview immediately) and by handleTest/the test itself at start; the response handler discards a reply whose seq no longer matches current. testBusy/testing is cleared in every case regardless of seq - nothing else ever resets it for a superseded request, so gating it the same way as the result would leave the button stuck showing "Testing..." forever after an edit invalidated an in-flight test (caught live in Chrome while verifying the first version of this fix, see below).

Verified live in a real Chrome browser (Playwright) against the running app (docker compose build, real tsc/vite build):
- SecurityPage: delayed the "Acceso Anonimo" role's privilege fetch via network interception, opened its Edit, immediately cancelled and edited "DAC" instead - the modal correctly showed "Edit Role: DAC" / 0 selected privileges both immediately and after the delayed Acceso Anonimo response landed (screenshots at both points confirm no corruption).
- AdminPage: ran a real local-filesystem connection test to success, edited the Path field, confirmed the banner vanished immediately; then delayed a second test via network interception, edited the field again while it was in flight, and confirmed after the delayed response landed that no stale "successful" banner appeared and the button returned to "Test Connection" (not stuck on "Testing..."). No console errors across the sweep.