### PR TITLE
fix: Update handlers skip the field validation Create enforces

### DIFF
--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -86,6 +86,13 @@ func (h *ReplicationHandler) Update(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
+	// Mirrors Create's validation: without it, a client could blank out
+	// target_url/source_repo on an existing rule — the cron then fails every
+	// tick (unsupported protocol scheme "") with no signal at update time.
+	if inp.Name == "" || inp.SourceRepo == "" || inp.TargetURL == "" || inp.TargetRepo == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name, source_repo, target_url, target_repo are required"})
+		return
+	}
 	rule := &domain.ReplicationRule{
 		ID:             c.Param("id"),
 		Name:           inp.Name,

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -134,6 +134,24 @@ func TestReplicationHandler_Update_BadJSON_400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// Without this check, a client could blank out target_url/source_repo on an
+// existing rule — the cron then fails every tick with no signal at update time.
+func TestReplicationHandler_Update_MissingFields_400(t *testing.T) {
+	r := mountReplication(t)
+	id := replicationCreate(t, r, "before")
+	// each row drops exactly one required field
+	cases := []map[string]any{
+		{"source_repo": "src", "target_url": "http://x/", "target_repo": "dst"}, // no name
+		{"name": "n", "target_url": "http://x/", "target_repo": "dst"},          // no source_repo
+		{"name": "n", "source_repo": "src", "target_repo": "dst"},               // no target_url
+		{"name": "n", "source_repo": "src", "target_url": "http://x/"},          // no target_repo
+	}
+	for i, body := range cases {
+		rec := do(t, r, http.MethodPut, "/api/v1/replication/rules/"+id, body)
+		assert.Equalf(t, http.StatusBadRequest, rec.Code, "case %d body=%s", i, rec.Body.String())
+	}
+}
+
 func TestReplicationHandler_Update_UnknownID_400(t *testing.T) {
 	r := mountReplication(t)
 	// mock UpdateRule returns an error for an unknown id → handler maps to 400.

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -213,6 +213,13 @@ func (s *PromotionService) UpdateRule(ctx context.Context, rule *domain.Promotio
 	if rule.Name == "" {
 		return fmt.Errorf("name is required")
 	}
+	// Mirrors CreateRule's validation: FromRepo == ToRepo also happens to
+	// catch the both-empty case (since "" == ""), but not "one side blank" —
+	// without this, PUT .../rules/:id with from_repo:"" could persist an
+	// orphaned rule.
+	if rule.FromRepo == "" || rule.ToRepo == "" {
+		return fmt.Errorf("from_repo and to_repo are required")
+	}
 	if rule.FromRepo == rule.ToRepo {
 		return fmt.Errorf("from_repo and to_repo must be different")
 	}

--- a/internal/service/promotion_service_extra_test.go
+++ b/internal/service/promotion_service_extra_test.go
@@ -352,6 +352,33 @@ func TestPromotionService_UpdateRule_Validation(t *testing.T) {
 		}
 	})
 
+	// FromRepo == ToRepo also happens to catch the both-empty case (since
+	// "" == ""), but not "one side blank" — without this check,
+	// PUT .../rules/:id with from_repo:"" could persist an orphaned rule.
+	t.Run("blank from_repo", func(t *testing.T) {
+		err := svc.UpdateRule(ctx, &domain.PromotionRule{
+			ID:       "any",
+			Name:     "r",
+			FromRepo: "",
+			ToRepo:   "b",
+		})
+		if err == nil || !strings.Contains(err.Error(), "from_repo and to_repo are required") {
+			t.Fatalf("expected from_repo/to_repo required error, got %v", err)
+		}
+	})
+
+	t.Run("blank to_repo", func(t *testing.T) {
+		err := svc.UpdateRule(ctx, &domain.PromotionRule{
+			ID:       "any",
+			Name:     "r",
+			FromRepo: "a",
+			ToRepo:   "",
+		})
+		if err == nil || !strings.Contains(err.Error(), "from_repo and to_repo are required") {
+			t.Fatalf("expected from_repo/to_repo required error, got %v", err)
+		}
+	})
+
 	t.Run("invalid CEL", func(t *testing.T) {
 		err := svc.UpdateRule(ctx, &domain.PromotionRule{
 			ID:         "any",


### PR DESCRIPTION
Closes #384

Two instances of the same "Update skips Create's validation" pattern:

- ReplicationHandler.Update: Create requires name/source_repo/ target_url/target_repo non-empty; Update had no such check, so a client could blank out target_url/source_repo on an existing rule - the cron then fails every tick (unsupported protocol scheme "") with no signal at update time. Mirrored Create's validation into Update.

- PromotionService.UpdateRule: CreateRule rejects an empty FromRepo/ ToRepo; UpdateRule only checked FromRepo == ToRepo (which also happens to catch the both-empty case, since "" == "", but not "one side blank"), so PUT /api/v1/promotion/rules/:id with from_repo:"" could persist an orphaned rule. Admin-only endpoint, hence low severity. Added the same non-empty check CreateRule has.

Verified: new tests mirror each Create-side test onto Update/UpdateRule (TestReplicationHandler_Update_MissingFields_400, and two new subtests in TestPromotionService_UpdateRule_Validation for a blank FromRepo/ ToRepo). Confirmed both fail without the fix (200 instead of 400 / nil error instead of the expected message) and pass with it. go build/go vet/go test ./... green. Live compose verification: created a real replication rule and a real promotion rule, confirmed blanking target_url (replication) and from_repo (promotion) via their Update endpoints now correctly returns 400 with the same message Create uses, and that the existing rules still render correctly in Chrome's Replication and Promotion tabs with zero console errors.