### PR TITLE
fix(replication,promotion): apply Create's field validation in the Update siblings

### DIFF
--- a/internal/api/handlers/replication.go
+++ b/internal/api/handlers/replication.go
@@ -44,6 +44,30 @@ type ruleInput struct {
 	Enabled        bool   `json:"enabled"`
 }
 
+// defaultReplicationCron is the schedule a rule falls back to when the caller
+// sends none: nightly at 02:00.
+const defaultReplicationCron = "0 2 * * *"
+
+// validate rejects an input that would persist a rule the replication cron
+// cannot actually run, and fills in the default schedule. Update needs exactly
+// the same guard Create does: a PUT that blanks target_url or source_repo used
+// to be accepted, and the only signal was the cron failing every tick after
+// the fact ("unsupported protocol scheme \"\""). An empty cron_expr is likewise
+// accepted by validateCronExpr, so leaving it blank on update silently
+// unscheduled the rule instead of keeping it on its old schedule.
+//
+// It writes the 400 itself and reports whether the caller may proceed.
+func (inp *ruleInput) validate(c *gin.Context) bool {
+	if inp.Name == "" || inp.SourceRepo == "" || inp.TargetURL == "" || inp.TargetRepo == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name, source_repo, target_url, target_repo are required"})
+		return false
+	}
+	if inp.CronExpr == "" {
+		inp.CronExpr = defaultReplicationCron
+	}
+	return true
+}
+
 // Create handles POST /api/v1/replication/rules
 func (h *ReplicationHandler) Create(c *gin.Context) {
 	var inp ruleInput
@@ -51,12 +75,8 @@ func (h *ReplicationHandler) Create(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	if inp.Name == "" || inp.SourceRepo == "" || inp.TargetURL == "" || inp.TargetRepo == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "name, source_repo, target_url, target_repo are required"})
+	if !inp.validate(c) {
 		return
-	}
-	if inp.CronExpr == "" {
-		inp.CronExpr = "0 2 * * *"
 	}
 	rule := &domain.ReplicationRule{
 		Name:           inp.Name,
@@ -84,6 +104,9 @@ func (h *ReplicationHandler) Update(c *gin.Context) {
 	var inp ruleInput
 	if err := c.ShouldBindJSON(&inp); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if !inp.validate(c) {
 		return
 	}
 	rule := &domain.ReplicationRule{

--- a/internal/api/handlers/replication_test.go
+++ b/internal/api/handlers/replication_test.go
@@ -146,6 +146,48 @@ func TestReplicationHandler_Update_UnknownID_400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+// A PUT used to skip Create's required-field check entirely, so blanking
+// target_url (or source_repo) on an existing rule was accepted with a 200 and
+// only surfaced later, as the cron failing every tick with "unsupported
+// protocol scheme \"\"".
+func TestReplicationHandler_Update_RejectsBlankedRequiredFields(t *testing.T) {
+	r := mountReplication(t)
+	id := replicationCreate(t, r, "before")
+	full := map[string]any{
+		"name":        "after",
+		"source_repo": "src",
+		"target_url":  "http://127.0.0.1:1/",
+		"target_repo": "dst",
+	}
+	for _, blank := range []string{"name", "source_repo", "target_url", "target_repo"} {
+		body := map[string]any{}
+		for k, v := range full {
+			body[k] = v
+		}
+		body[blank] = ""
+		rec := do(t, r, http.MethodPut, "/api/v1/replication/rules/"+id, body)
+		assert.Equalf(t, http.StatusBadRequest, rec.Code, "blanked %s, body=%s", blank, rec.Body.String())
+	}
+}
+
+// validateCronExpr accepts an empty expression, so an update omitting
+// cron_expr used to persist a rule with no schedule at all — silently
+// unscheduling it. Update applies Create's default instead.
+func TestReplicationHandler_Update_DefaultsMissingCronExpr(t *testing.T) {
+	r := mountReplication(t)
+	id := replicationCreate(t, r, "before")
+	rec := do(t, r, http.MethodPut, "/api/v1/replication/rules/"+id, map[string]any{
+		"name":        "after",
+		"source_repo": "src",
+		"target_url":  "http://127.0.0.1:1/",
+		"target_repo": "dst",
+	})
+	require.Equal(t, http.StatusOK, rec.Code, "body=%s", rec.Body.String())
+	var rule domain.ReplicationRule
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &rule))
+	assert.Equal(t, "0 2 * * *", rule.CronExpr)
+}
+
 // ── Delete ──────────────────────────────────────────────────────────────────
 
 func TestReplicationHandler_Delete_204(t *testing.T) {

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -213,6 +213,14 @@ func (s *PromotionService) UpdateRule(ctx context.Context, rule *domain.Promotio
 	if rule.Name == "" {
 		return fmt.Errorf("name is required")
 	}
+	// CreateRule's own emptiness check, which this sibling was missing. The
+	// FromRepo == ToRepo test below happens to catch a rule with *both* sides
+	// blank ("" == ""), but not one with a single side blank, so a PUT with
+	// from_repo:"" persisted an orphaned rule that no promotion could ever
+	// match.
+	if rule.FromRepo == "" || rule.ToRepo == "" {
+		return fmt.Errorf("from_repo and to_repo are required")
+	}
 	if rule.FromRepo == rule.ToRepo {
 		return fmt.Errorf("from_repo and to_repo must be different")
 	}

--- a/internal/service/promotion_service_test.go
+++ b/internal/service/promotion_service_test.go
@@ -39,6 +39,46 @@ func newTestPromotionSvc(t *testing.T) (
 	return svc, promoRepo, compRepo, assetRepo, blobStore, repoRepo, blobRepo, scanRepo
 }
 
+// UpdateRule used to check only FromRepo == ToRepo, which catches a rule with
+// *both* sides blank ("" == "") but not one with a single side blank — a PUT
+// with from_repo:"" persisted an orphaned rule no promotion could ever match.
+func TestPromotionService_UpdateRule_RejectsBlankRepo(t *testing.T) {
+	svc, promoRepo, _, _, _, _, _, _ := newTestPromotionSvc(t)
+	ctx := context.Background()
+
+	rule := &domain.PromotionRule{Name: "staging-to-prod", FromRepo: "staging", ToRepo: "production"}
+	if err := svc.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		fromRepo string
+		toRepo   string
+	}{
+		{"blank from_repo", "", "production"},
+		{"blank to_repo", "staging", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := svc.UpdateRule(ctx, &domain.PromotionRule{
+				ID: rule.ID, Name: rule.Name, FromRepo: tc.fromRepo, ToRepo: tc.toRepo,
+			})
+			if err == nil || !strings.Contains(err.Error(), "are required") {
+				t.Fatalf("expected from_repo/to_repo required error, got: %v", err)
+			}
+		})
+	}
+
+	// The stored rule is untouched by the rejected updates.
+	stored, err := promoRepo.GetRule(ctx, rule.ID)
+	if err != nil {
+		t.Fatalf("GetRule: %v", err)
+	}
+	if stored.FromRepo != "staging" || stored.ToRepo != "production" {
+		t.Fatalf("rule was mutated by a rejected update: %+v", stored)
+	}
+}
+
 // TestPromotionService_CreateRule_Validation checks that invalid rule inputs are rejected.
 func TestPromotionService_CreateRule_Validation(t *testing.T) {
 	svc, _, _, _, _, _, _, _ := newTestPromotionSvc(t)


### PR DESCRIPTION
Closes #384

Two instances of the same pattern, where a `PUT` could persist a rule its own `POST` would have rejected.

**`ReplicationHandler.Update`** never ran `Create`'s required-field check, so blanking `target_url` or `source_repo` on an existing rule was accepted with a 200 and only surfaced afterwards, as the cron failing every tick with `unsupported protocol scheme ""`. Both handlers now share a `ruleInput.validate`. It also applies `Create`'s cron default: `validateCronExpr` accepts an empty expression, so an update that omitted `cron_expr` silently unscheduled the rule instead of leaving it on a schedule.

**`PromotionService.UpdateRule`** checked only `FromRepo == ToRepo`. That happens to catch a rule with *both* sides blank (`"" == ""`) but not one with a single side blank, so a `PUT` with `from_repo:""` persisted an orphaned rule no promotion could ever match. It now runs `CreateRule`'s own emptiness check first.

**Verified**: three new tests — `TestReplicationHandler_Update_RejectsBlankedRequiredFields` (each of the four fields blanked in turn), `TestReplicationHandler_Update_DefaultsMissingCronExpr`, and `TestPromotionService_UpdateRule_RejectsBlankRepo` (which also asserts the stored rule is untouched by a rejected update). Confirmed all three fail against the unpatched code (200 instead of 400, `""` instead of the default cron, `<nil>` instead of an error) and pass with it. `go build` / `go vet` / `go test ./...` green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnmG6Yeh64hPJjqLGDnS6o