### PR TITLE
fix(migration): drop the concurrency option that was never implemented

### DIFF
--- a/docs/api-spec.yaml
+++ b/docs/api-spec.yaml
@@ -1146,10 +1146,6 @@ paths:
                   properties:
                     username: { type: string }
                     password: { type: string, description: "Stored sealed; never returned." }
-                options:
-                  type: object
-                  properties:
-                    concurrency: { type: integer, default: 4 }
                 scope:
                   type: object
                   description: |

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -2307,7 +2307,7 @@ function MigrationJobCard({ job, onPause, onResume }: { job: MigrationJobData; o
 
 function CreateMigrationJobModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
   const [form, setForm] = useState({
-    sourceUrl: '', username: 'admin', password: '', concurrency: '4',
+    sourceUrl: '', username: 'admin', password: '',
   })
   const [scope, setScope] = useState({
     migrateRepos: true, migrateUsers: true, migratePolicies: true, migrateBlobs: true,
@@ -2340,7 +2340,6 @@ function CreateMigrationJobModal({ onClose, onCreated }: { onClose: () => void; 
       await nexspenceApi.createMigrationJob({
         sourceUrl: form.sourceUrl,
         credentials: { username: form.username, password: form.password },
-        options: { concurrency: parseInt(form.concurrency) || 4 },
         scope: {
           migrateRepos: scope.migrateRepos,
           migrateUsers: scope.migrateUsers,
@@ -2407,10 +2406,6 @@ function CreateMigrationJobModal({ onClose, onCreated }: { onClose: () => void; 
 
   const step3 = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-        <label style={LABEL}>Concurrency</label>
-        <HoloInput type="number" min={1} max={16} value={form.concurrency} onChange={set('concurrency')} />
-      </div>
       <div style={{
         background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(124,92,255,0.15)',
         borderRadius: 10, padding: '12px 14px', display: 'flex', flexDirection: 'column', gap: 6,
@@ -2422,9 +2417,6 @@ function CreateMigrationJobModal({ onClose, onCreated }: { onClose: () => void; 
         <div style={{ fontSize: 12, color: 'var(--holo-text-dim)' }}>
           <b style={{ color: 'var(--holo-text)' }}>Scope:</b>{' '}
           {scopeItems.filter(i => scope[i.key]).map(i => i.label).join(', ') || 'none'}
-        </div>
-        <div style={{ fontSize: 12, color: 'var(--holo-text-dim)' }}>
-          <b style={{ color: 'var(--holo-text)' }}>Concurrency:</b> {form.concurrency}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/MigrationPage.tsx
+++ b/frontend/src/pages/MigrationPage.tsx
@@ -165,7 +165,7 @@ const USER_REALMS = [
 ] as const
 
 function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
-  const [form, setForm] = useState({ sourceUrl: '', username: 'admin', password: '', concurrency: '4' })
+  const [form, setForm] = useState({ sourceUrl: '', username: 'admin', password: '' })
   const [scope, setScope] = useState<Record<ScopeKey, boolean>>(
     () => Object.fromEntries(SCOPES.map(s => [s.key, true])) as Record<ScopeKey, boolean>,
   )
@@ -215,7 +215,6 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
       await nexspenceApi.createMigrationJob({
         sourceUrl: form.sourceUrl,
         credentials: { username: form.username, password: form.password },
-        options: { concurrency: parseInt(form.concurrency) || 4 },
         scope: { ...scope, userRealms },
       })
       onCreated()
@@ -268,10 +267,6 @@ function CreateMigrationModal({ onClose, onCreated }: { onClose: () => void; onC
             <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Password *</label>
             <HoloInput type="password" value={form.password} onChange={set('password')} required />
           </div>
-        </div>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
-          <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>Concurrency</label>
-          <HoloInput type="number" min={1} max={16} value={form.concurrency} onChange={set('concurrency')} />
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           <label style={{ fontSize: 11, fontWeight: 600, color: 'var(--holo-text-dim)', textTransform: 'uppercase', letterSpacing: '0.04em' }}>What to migrate</label>

--- a/internal/api/handlers/migration.go
+++ b/internal/api/handlers/migration.go
@@ -111,15 +111,22 @@ func (h *MigrationHandler) GetJob(c *gin.Context) {
 	c.JSON(http.StatusOK, toJobResp(*job))
 }
 
+// createJobReq is the body of POST /api/v1/migration/jobs.
+//
+// It carries no concurrency knob: migrateAssets transfers one asset at a time,
+// and the safe unit of parallelism would be a whole repository rather than
+// individual assets within one (an OCI manifest must never transfer before the
+// blobs it references). The field this struct used to bind, options.concurrency,
+// was read nowhere else in the codebase, so a caller asking for 10 got the same
+// single-threaded transfer with no error or warning that the setting was
+// ignored. An options object on an older client's request is still accepted and
+// ignored, as any unknown field is.
 type createJobReq struct {
 	SourceURL   string `json:"sourceUrl" binding:"required"`
 	Credentials struct {
 		Username string `json:"username"`
 		Password string `json:"password"`
 	} `json:"credentials"`
-	Options struct {
-		Concurrency int `json:"concurrency"`
-	} `json:"options"`
 	Scope struct {
 		MigrateRepos        *bool `json:"migrateRepos"`
 		MigrateUsers        *bool `json:"migrateUsers"`


### PR DESCRIPTION
Closes #386

`createJobReq` bound an `options.concurrency` int that nothing else in the codebase read. `migrateAssets` transfers one asset at a time, so a caller sending `"options":{"concurrency":10}` got identical single-threaded behavior with no error or warning that the setting was ignored — and both the migration wizard (`AdminPage`) and the migration form (`MigrationPage`) offered it as a real control, defaulting it to 4 and echoing it back in the summary.

Removes the field, its OpenAPI entry, and the two UI inputs that fed it, and records on `createJobReq` why there is no such knob: the safe unit of parallelism would be a whole repository rather than individual assets within one, since an OCI manifest must never transfer before the blobs it references.

Chose removal over implementation per the issue's first option. **This breaks no existing caller**: an `options` object on an older client's request is still accepted and ignored, as any unknown field is.

**Verified**: `go build` / `go vet` / `go test ./internal/api/handlers/` green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`; `tsc --noEmit` clean on the frontend.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnmG6Yeh64hPJjqLGDnS6o