### PR TITLE
chore: ignore AGENTS.md and Graphify output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 .superpowers/
 
 #LLM
+AGENTS.md
 CLAUDE.md
 bugs.md
 findings.md
@@ -56,6 +57,7 @@ task_plan.md
 docs/superpowers/brainstorm/
 docs/superpowers/plans/
 docs/superpowers/specs/
+graphify-out
 
 # Monitoring — API token
 deploy/monitoring/prometheus-token


### PR DESCRIPTION
## Summary

This keeps local AI-agent files out of git, in the same spirit as the existing `CLAUDE.md` ignore.

- **AGENTS.md** is a vendor-neutral convention for instructing coding agents (not specific to one tool). Like `CLAUDE.md`, it is a local working file and does not belong in the repository.
- **graphify-out/** is the on-disk output of [Graphify](https://github.com/safedep/graphify): a local knowledge graph built from the checkout (code, docs, and related artifacts). Those files are machine- and session-specific and should stay untracked.
