### PR TITLE
fix: RBAC missing on four sibling read endpoints

### DIFF
--- a/internal/api/handlers/promotion.go
+++ b/internal/api/handlers/promotion.go
@@ -33,8 +33,12 @@ func (h *PromotionHandler) WithRBAC(repos repository.RepositoryRepo, rbacSvc *se
 	return h
 }
 
-// visibleRules filters rules to ones the caller can browse either FromRepo or
-// ToRepo. Nil-safe: with WithRBAC unset, returns rules unchanged.
+// visibleRules filters rules to ones the caller can browse both FromRepo and
+// ToRepo. A rule names both repositories, so browse on only one side would
+// still leak the other side's name, path filter, and approval gate — e.g.
+// someone with access to a "staging" repo could enumerate the production
+// repositories it promotes into. Nil-safe: with WithRBAC unset, returns rules
+// unchanged.
 func (h *PromotionHandler) visibleRules(c *gin.Context, rules []domain.PromotionRule) []domain.PromotionRule {
 	if h.repos == nil || h.rbacSvc == nil {
 		return rules
@@ -61,7 +65,7 @@ func (h *PromotionHandler) visibleRules(c *gin.Context, rules []domain.Promotion
 
 	visible := make([]domain.PromotionRule, 0, len(rules))
 	for _, r := range rules {
-		if canBrowse(r.FromRepo) || canBrowse(r.ToRepo) {
+		if canBrowse(r.FromRepo) && canBrowse(r.ToRepo) {
 			visible = append(visible, r)
 		}
 	}

--- a/internal/api/handlers/promotion.go
+++ b/internal/api/handlers/promotion.go
@@ -7,17 +7,65 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 )
 
 // PromotionHandler serves the staging and build-promotion REST endpoints.
 type PromotionHandler struct {
-	svc *service.PromotionService
+	svc     *service.PromotionService
+	repos   repository.RepositoryRepo
+	rbacSvc *service.RBACService
 }
 
 // NewPromotionHandler constructs a PromotionHandler backed by the given promotion service.
 func NewPromotionHandler(svc *service.PromotionService) *PromotionHandler {
 	return &PromotionHandler{svc: svc}
+}
+
+// WithRBAC wires the repository repo and RBAC service so ListRules/
+// GetComponentRules hide rules naming a repository the caller has no browse
+// privilege over. Nil-safe: unset, both endpoints keep their prior
+// (unfiltered) behavior.
+func (h *PromotionHandler) WithRBAC(repos repository.RepositoryRepo, rbacSvc *service.RBACService) *PromotionHandler {
+	h.repos = repos
+	h.rbacSvc = rbacSvc
+	return h
+}
+
+// visibleRules filters rules to ones the caller can browse either FromRepo or
+// ToRepo. Nil-safe: with WithRBAC unset, returns rules unchanged.
+func (h *PromotionHandler) visibleRules(c *gin.Context, rules []domain.PromotionRule) []domain.PromotionRule {
+	if h.repos == nil || h.rbacSvc == nil {
+		return rules
+	}
+	ctx := c.Request.Context()
+	userID, _ := c.Get("userID")
+	roles, _ := c.Get("roles")
+	userIDStr, _ := userID.(string)
+	rolesSlice, _ := roles.([]string)
+
+	repoCache := map[string]*domain.Repository{}
+	canBrowse := func(name string) bool {
+		repo, cached := repoCache[name]
+		if !cached {
+			repo, _ = h.repos.Get(ctx, name)
+			repoCache[name] = repo
+		}
+		if repo == nil {
+			return false
+		}
+		ok, _ := h.rbacSvc.CanAccessRepo(ctx, userIDStr, rolesSlice, repo, "", "browse")
+		return ok
+	}
+
+	visible := make([]domain.PromotionRule, 0, len(rules))
+	for _, r := range rules {
+		if canBrowse(r.FromRepo) || canBrowse(r.ToRepo) {
+			visible = append(visible, r)
+		}
+	}
+	return visible
 }
 
 // ListRules handles GET /api/v1/promotion/rules
@@ -30,6 +78,10 @@ func (h *PromotionHandler) ListRules(c *gin.Context) {
 	if rules == nil {
 		rules = []domain.PromotionRule{}
 	}
+	// This endpoint sits under the non-admin authed group and, unfiltered,
+	// returns every promotion rule system-wide — full topology (source repo,
+	// target repo, path filter, approval gate) regardless of privilege.
+	rules = h.visibleRules(c, rules)
 	c.JSON(http.StatusOK, rules)
 }
 
@@ -99,6 +151,7 @@ func (h *PromotionHandler) GetComponentRules(c *gin.Context) {
 	if rules == nil {
 		rules = []domain.PromotionRule{}
 	}
+	rules = h.visibleRules(c, rules)
 	c.JSON(http.StatusOK, rules)
 }
 

--- a/internal/api/handlers/promotion_handler_test.go
+++ b/internal/api/handlers/promotion_handler_test.go
@@ -123,6 +123,60 @@ func TestPromotionHandler_ListRules_HidesRulesForReposWithoutPrivilege(t *testin
 	}
 }
 
+// A rule names both repositories, so browse on only one side would still leak
+// the other side's name, path filter, and approval gate — e.g. someone with
+// access to "staging" could enumerate the production repos it promotes into.
+func TestPromotionHandler_ListRules_HidesRuleWhenOnlyOneSideIsVisible(t *testing.T) {
+	promoRepo := testutil.NewPromotionRepo()
+	compRepo := testutil.NewComponentRepo()
+	assetRepo := testutil.NewAssetRepo()
+	blobStore := testutil.NewBlobStore()
+	blobRepo := testutil.NewBlobStoreRepo()
+	scanRepo := testutil.NewScanResultRepo()
+	repoRepo := testutil.NewRepoRepo()
+	svc, err := service.NewPromotionService(promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, testutil.NewFakeResolver(blobStore))
+	if err != nil {
+		t.Fatalf("NewPromotionService: %v", err)
+	}
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
+	h := handlers.NewPromotionHandler(svc).WithRBAC(repoRepo, rbacSvc)
+
+	if err := repoRepo.Create(testContext(), &domain.Repository{ID: "staging", Name: "staging", Format: domain.FormatRaw, Type: domain.TypeHosted, AllowAnonymous: true}); err != nil {
+		t.Fatalf("seed staging repo: %v", err)
+	}
+	if err := repoRepo.Create(testContext(), &domain.Repository{ID: "production", Name: "production", Format: domain.FormatRaw, Type: domain.TypeHosted, AllowAnonymous: false}); err != nil {
+		t.Fatalf("seed production repo: %v", err)
+	}
+	if err := promoRepo.CreateRule(testContext(), &domain.PromotionRule{
+		Name: "staging-to-prod", FromRepo: "staging", ToRepo: "production",
+	}); err != nil {
+		t.Fatalf("seed rule: %v", err)
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("userID", "eve")
+		c.Set("roles", []string{"nx-viewer"})
+		c.Next()
+	})
+	r.GET("/api/v1/promotion/rules", h.ListRules)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/promotion/rules", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var rules []domain.PromotionRule
+	if err := json.Unmarshal(w.Body.Bytes(), &rules); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(rules) != 0 {
+		t.Fatalf("want empty array for a caller who can browse only staging (not production), got %d rules: %+v", len(rules), rules)
+	}
+}
+
 // TestPromotionHandler_CreateRule verifies POST returns 201 with a rule that has an ID.
 func TestPromotionHandler_CreateRule(t *testing.T) {
 	r := buildPromotionRouter(t)

--- a/internal/api/handlers/promotion_handler_test.go
+++ b/internal/api/handlers/promotion_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
@@ -64,6 +65,61 @@ func TestPromotionHandler_ListRules_Empty(t *testing.T) {
 	}
 	if len(rules) != 0 {
 		t.Fatalf("want empty array, got %d rules", len(rules))
+	}
+}
+
+// This endpoint sits under the non-admin authed group and, unfiltered,
+// returned every promotion rule's full topology (source repo, target repo,
+// path filter, approval gate) regardless of privilege — ListRules in
+// particular returns all rules system-wide, not scoped to one component.
+func TestPromotionHandler_ListRules_HidesRulesForReposWithoutPrivilege(t *testing.T) {
+	promoRepo := testutil.NewPromotionRepo()
+	compRepo := testutil.NewComponentRepo()
+	assetRepo := testutil.NewAssetRepo()
+	blobStore := testutil.NewBlobStore()
+	blobRepo := testutil.NewBlobStoreRepo()
+	scanRepo := testutil.NewScanResultRepo()
+	repoRepo := testutil.NewRepoRepo()
+	svc, err := service.NewPromotionService(promoRepo, compRepo, assetRepo, repoRepo, blobRepo, scanRepo, testutil.NewFakeResolver(blobStore))
+	if err != nil {
+		t.Fatalf("NewPromotionService: %v", err)
+	}
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repoRepo, zap.NewNop().Sugar(), true)
+	h := handlers.NewPromotionHandler(svc).WithRBAC(repoRepo, rbacSvc)
+
+	if err := repoRepo.Create(testContext(), &domain.Repository{ID: "staging", Name: "staging", Format: domain.FormatRaw, Type: domain.TypeHosted, AllowAnonymous: false}); err != nil {
+		t.Fatalf("seed staging repo: %v", err)
+	}
+	if err := repoRepo.Create(testContext(), &domain.Repository{ID: "production", Name: "production", Format: domain.FormatRaw, Type: domain.TypeHosted, AllowAnonymous: false}); err != nil {
+		t.Fatalf("seed production repo: %v", err)
+	}
+	if err := promoRepo.CreateRule(testContext(), &domain.PromotionRule{
+		Name: "staging-to-prod", FromRepo: "staging", ToRepo: "production",
+	}); err != nil {
+		t.Fatalf("seed rule: %v", err)
+	}
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("userID", "eve")
+		c.Set("roles", []string{"nx-viewer"})
+		c.Next()
+	})
+	r.GET("/api/v1/promotion/rules", h.ListRules)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/promotion/rules", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 got %d body=%s", w.Code, w.Body.String())
+	}
+	var rules []domain.PromotionRule
+	if err := json.Unmarshal(w.Body.Bytes(), &rules); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if len(rules) != 0 {
+		t.Fatalf("want empty array for a caller with no privilege on either repo, got %d rules", len(rules))
 	}
 }
 

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -57,6 +57,19 @@ func (h *RepositoryHandler) Get(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
+	// List and ComponentHandler.GetQuota both filter by RBAC (GetQuota citing
+	// #295 explicitly); this sibling get-by-name endpoint didn't, letting any
+	// authenticated user read a private repository's full config (format,
+	// blob store, remote proxy URL, allowAnonymous) just by knowing or
+	// guessing its name.
+	userID, _ := c.Get("userID")
+	roles, _ := c.Get("roles")
+	visible := h.rbacSvc.FilterRepos(c.Request.Context(),
+		stringVal(userID), stringSliceVal(roles), []domain.Repository{*r})
+	if len(visible) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "repository not found"})
+		return
+	}
 	c.JSON(http.StatusOK, domain.RedactedRepository(*r))
 }
 

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -115,6 +115,35 @@ func TestRepositoryHandler_Get_RepoError_500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// List and ComponentHandler.GetQuota both filter by RBAC; Get (by name) didn't
+// — a privilege-less caller could read a private repository's full config just
+// by knowing its name. 404, not 403, keeps the name from being distinguishable
+// from "doesn't exist" (#291's convention on the sibling component endpoint).
+func TestRepositoryHandler_Get_DeniedWithoutPrivilege(t *testing.T) {
+	repos := testutil.NewRepoRepo()
+	blobs := testutil.NewBlobStoreRepo()
+	policies := testutil.NewCleanupPolicyRepo()
+	store := testutil.NewBlobStore()
+	repoSvc := service.NewRepositoryService(repos, blobs, store, policies)
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar(), true)
+	h := handlers.NewRepositoryHandler(repoSvc, rbacSvc)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("userID", "eve")
+		c.Set("roles", []string{"nx-viewer"})
+		c.Next()
+	})
+	r.GET("/service/rest/v1/repositories/:name", h.Get)
+
+	require.NoError(t, repos.Create(testContext(), &domain.Repository{
+		ID: "r1", Name: "private-raw", Format: domain.FormatRaw, Type: domain.TypeHosted, AllowAnonymous: false,
+	}))
+
+	rec := do(t, r, http.MethodGet, "/service/rest/v1/repositories/private-raw", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
 // ── Create ────────────────────────────────────────────────────
 
 func TestRepositoryHandler_Create_OK(t *testing.T) {

--- a/internal/api/handlers/scan.go
+++ b/internal/api/handlers/scan.go
@@ -8,17 +8,31 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 )
 
 // ScanHandler serves the vulnerability-scan REST endpoints.
 type ScanHandler struct {
-	svc *service.ScanService
+	svc        *service.ScanService
+	components repository.ComponentRepo
+	repos      repository.RepositoryRepo
+	rbacSvc    *service.RBACService
 }
 
 // NewScanHandler constructs a ScanHandler backed by the given scan service.
 func NewScanHandler(svc *service.ScanService) *ScanHandler {
 	return &ScanHandler{svc: svc}
+}
+
+// WithRBAC wires the component/repository repos and RBAC service so
+// GetScanResult can hide a scan result the caller has no browse privilege
+// over. Nil-safe: unset, GetScanResult keeps its prior (unfiltered) behavior.
+func (h *ScanHandler) WithRBAC(components repository.ComponentRepo, repos repository.RepositoryRepo, rbacSvc *service.RBACService) *ScanHandler {
+	h.components = components
+	h.repos = repos
+	h.rbacSvc = rbacSvc
+	return h
 }
 
 // Scan triggers a Trivy vulnerability scan for a Docker component.
@@ -59,6 +73,32 @@ func (h *ScanHandler) GetScanResult(c *gin.Context) {
 	}
 
 	id := c.Param("id")
+
+	// Unlike ComponentHandler.Get (which filters by RBAC and cites #291: "a
+	// direct GET by id must answer the same question... or knowing a UUID
+	// becomes a key to metadata and scan results the caller has no privilege
+	// over"), this sibling endpoint never checked repository visibility. 404
+	// (not 403) on denial keeps the id unguessable, matching that convention.
+	if h.rbacSvc != nil && h.components != nil && h.repos != nil {
+		comp, cerr := h.components.Get(c.Request.Context(), id)
+		if cerr != nil || comp == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "component not found"})
+			return
+		}
+		repo, rerr := h.repos.Get(c.Request.Context(), comp.Repository)
+		if rerr != nil || repo == nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "component not found"})
+			return
+		}
+		userID, _ := c.Get("userID")
+		roles, _ := c.Get("roles")
+		ok, aerr := h.rbacSvc.CanAccessRepo(c.Request.Context(), stringVal(userID), stringSliceVal(roles), repo, "", "browse")
+		if aerr != nil || !ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": "component not found"})
+			return
+		}
+	}
+
 	result, err := h.svc.GetResult(c.Request.Context(), id)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/internal/api/handlers/scan_test.go
+++ b/internal/api/handlers/scan_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/nexspence-oss/nexspence/internal/api/handlers"
 	"github.com/nexspence-oss/nexspence/internal/domain"
@@ -133,6 +134,35 @@ func TestScanHandler_GetScanResult_RepoError_500(t *testing.T) {
 	comps.Err = errors.New("db down")
 	rec := do(t, r, http.MethodGet, "/api/v1/components/any/scan", nil)
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+// Unlike ComponentHandler.Get (#291), this sibling endpoint never checked
+// repository visibility — any authenticated user who knew or enumerated a
+// component UUID from a private repository could read its full vulnerability
+// report. 404, not 403, keeps the id unguessable.
+func TestScanHandler_GetScanResult_DeniedWithoutPrivilege(t *testing.T) {
+	comps := testutil.NewComponentRepo()
+	scanRepo := testutil.NewScanResultRepo()
+	repos := testutil.NewRepoRepo()
+
+	require.NoError(t, repos.Create(testContext(), &domain.Repository{
+		ID: "repo1", Name: "repo1", Format: domain.FormatMaven2, Type: domain.TypeHosted, AllowAnonymous: false,
+	}))
+	svc := service.NewScanService(comps, "http://localhost").WithScanResults(scanRepo)
+	rbacSvc := service.NewRBACService(emptyRBACRepo{}, repos, zap.NewNop().Sugar(), true)
+	h := handlers.NewScanHandler(svc).WithRBAC(comps, repos, rbacSvc)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("userID", "eve")
+		c.Set("roles", []string{"nx-viewer"})
+		c.Next()
+	})
+	r.GET("/api/v1/components/:id/scan", h.GetScanResult)
+
+	c := seedComponent(t, comps, "maven", "pkg", "1.0")
+	rec := do(t, r, http.MethodGet, "/api/v1/components/"+c.ID+"/scan", nil)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }
 
 // ── Summary ────────────────────────────────────────────────────────────────────

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"io/fs"
 	"net/http"
@@ -304,11 +305,11 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 	browseH := handlers.NewBrowseHandler(formatDeps, rbacSvc)
 	cleanupH := handlers.NewCleanupHandler(cleanupRepo, repoRepo, cleanupSvc, log)
 	auditH := handlers.NewAuditHandler(auditRepo)
-	scanH := handlers.NewScanHandler(scanSvc)
+	scanH := handlers.NewScanHandler(scanSvc).WithRBAC(componentRepo, repoRepo, rbacSvc)
 	tokenH := handlers.NewTokenHandler(tokenSvc, userSvc, cfg.Auth.TokenMaxDays)
 	webhookH := handlers.NewWebhookHandler(webhookSvc)
 	replH := handlers.NewReplicationHandler(replSvc, log)
-	promotionH := handlers.NewPromotionHandler(promotionSvc)
+	promotionH := handlers.NewPromotionHandler(promotionSvc).WithRBAC(repoRepo, rbacSvc)
 	roleH := handlers.NewRoleHandler(roleRepo, userRepo)
 	privH := handlers.NewPrivilegeHandler(privilegeRepo, roleRepo)
 	csH := handlers.NewContentSelectorHandler(selectorSvc)
@@ -477,11 +478,34 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		authed.GET("/service/rest/v1/assets/:id", func(c *gin.Context) {
 			id := c.Param("id")
 			a, err := assetRepo.Get(c.Request.Context(), id)
+			if errors.Is(err, repository.ErrNotFound) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "asset not found"})
+				return
+			}
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 				return
 			}
 			if a == nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "asset not found"})
+				return
+			}
+			// SearchAssets/FilterAssets filter by RBAC; this direct GET by id
+			// didn't, letting any authenticated user who knows or enumerates a
+			// UUID read full metadata and a download URL for an asset in a
+			// private repository. 404 on denial keeps the id unguessable, same
+			// convention ComponentHandler.Get uses (#291).
+			repo, rerr := repoRepo.Get(c.Request.Context(), a.Repository)
+			if rerr != nil || repo == nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "asset not found"})
+				return
+			}
+			userID, _ := c.Get("userID")
+			roles, _ := c.Get("roles")
+			userIDStr, _ := userID.(string)
+			rolesSlice, _ := roles.([]string)
+			ok, aerr := rbacSvc.CanAccessRepo(c.Request.Context(), userIDStr, rolesSlice, repo, a.Path, "browse")
+			if aerr != nil || !ok {
 				c.JSON(http.StatusNotFound, gin.H{"error": "asset not found"})
 				return
 			}

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -228,6 +228,69 @@ func TestRawArtifactPushPull(t *testing.T) {
 	delResp.Body.Close()
 }
 
+// SearchAssets/FilterAssets filter what they return through RBAC; the direct
+// GET /service/rest/v1/assets/:id endpoint didn't, letting any authenticated
+// user who knew or enumerated an asset UUID from a private repository read
+// its full metadata and download URL. 404, not 403, keeps the id unguessable.
+func TestAssetGetByID_DeniedWithoutPrivilege(t *testing.T) {
+	admin := login(t, "admin", "admin123")
+
+	createBody := `{"name":"e2e-asset-rbac","online":true,"storage":{"blobStoreName":"default","strictContentTypeValidation":false}}`
+	resp := authReq(t, http.MethodPost, "/service/rest/v1/repositories/raw/hosted", bytes.NewBufferString(createBody), admin)
+	resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	t.Cleanup(func() {
+		d := authReq(t, http.MethodDelete, "/service/rest/v1/repositories/e2e-asset-rbac", nil, admin)
+		d.Body.Close()
+	})
+
+	putReq, _ := http.NewRequest(http.MethodPut,
+		server(t).URL+"/repository/e2e-asset-rbac/secret.bin", bytes.NewReader([]byte("shh")))
+	putReq.Header.Set("Authorization", "Bearer "+admin)
+	putReq.Header.Set("Content-Type", "application/octet-stream")
+	putResp, err := http.DefaultClient.Do(putReq)
+	require.NoError(t, err)
+	putResp.Body.Close()
+	require.Equal(t, http.StatusCreated, putResp.StatusCode)
+
+	searchResp := authReq(t, http.MethodGet, "/service/rest/v1/search/assets?repository=e2e-asset-rbac", nil, admin)
+	defer searchResp.Body.Close()
+	require.Equal(t, http.StatusOK, searchResp.StatusCode)
+	var page struct {
+		Items []struct {
+			ID string `json:"id"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.NewDecoder(searchResp.Body).Decode(&page))
+	require.Len(t, page.Items, 1)
+	assetID := page.Items[0].ID
+
+	userBody := `{"userId":"asset-rbac-eve","firstName":"Eve","lastName":"NoPriv","emailAddress":"asset-rbac-eve@example.com","password":"evePass123!","status":"active","roles":[]}`
+	createUserResp := authReq(t, http.MethodPost, "/service/rest/v1/security/users", bytes.NewBufferString(userBody), admin)
+	createUserResp.Body.Close()
+	require.Equal(t, http.StatusCreated, createUserResp.StatusCode)
+	t.Cleanup(func() {
+		d := authReq(t, http.MethodDelete, "/service/rest/v1/security/users/asset-rbac-eve", nil, admin)
+		d.Body.Close()
+	})
+	// Same second-granularity race as the admin setup in server(): a freshly
+	// created user's tokens_valid_after defaults to now(), and logging in
+	// milliseconds later can produce a JWT whose iat reads as pre-cutoff.
+	_, err = pgtest.Pool(t).Exec(context.Background(),
+		`UPDATE users SET tokens_valid_after = now() - interval '1 minute' WHERE username = 'asset-rbac-eve'`)
+	require.NoError(t, err)
+
+	eve := login(t, "asset-rbac-eve", "evePass123!")
+
+	deniedResp := authReq(t, http.MethodGet, "/service/rest/v1/assets/"+assetID, nil, eve)
+	defer deniedResp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, deniedResp.StatusCode)
+
+	allowedResp := authReq(t, http.MethodGet, "/service/rest/v1/assets/"+assetID, nil, admin)
+	defer allowedResp.Body.Close()
+	assert.Equal(t, http.StatusOK, allowedResp.StatusCode)
+}
+
 func TestMetricsEndpoint(t *testing.T) {
 	token := login(t, "admin", "admin123")
 	resp := authReq(t, http.MethodGet, "/api/v1/metrics", nil, token)


### PR DESCRIPTION
Rebase of #391 by @jorgemillan onto current `main`, opened from a repo branch because the one-line conflict with #390 (now merged) had to be resolved before this could land. Commits keep their original authorship; the only change from #391 is the conflict resolution in `internal/api/router.go`, where `NewReplicationHandler(replSvc, log)` from #390 and `NewPromotionHandler(promotionSvc).WithRBAC(repoRepo, rbacSvc)` from this branch are both kept.

---

Closes #379

ComponentHandler.Get and RepositoryHandler.List both filter by RBAC (the former citing #291 explicitly), but four sibling read endpoints across the API didn't, letting any authenticated user read private data just by knowing or guessing an id or name:

- GET /api/v1/components/:id/scan (ScanHandler.GetScanResult) — full Trivy vulnerability report, CVE list included.
- GET /service/rest/v1/assets/:id (inline handler in router.go) — full asset metadata and download URL.
- GET /service/rest/v1/repositories/:name (RepositoryHandler.Get) — full repo config: format, blob store, remote proxy URL, allowAnonymous.
- GET /api/v1/promotion/rules and GET /api/v1/components/:id/promotion-rules (PromotionHandler.ListRules/GetComponentRules) — every rule's full topology (source/target repo, path filter, approval gate); ListRules in particular returns all rules system-wide, not scoped to one component.

All four now resolve the relevant repository (or, for promotion rules, both FromRepo and ToRepo) and check RBACService.CanAccessRepo/FilterRepos/FilterComponents before responding — 404, not 403, on denial, so an id or name stays unguessable rather than confirming it exists. A promotion rule is visible only when the caller can browse **both** ends of it.

Verified on the rebased branch: `go build` and `go vet` clean, `go test ./internal/api/... ./internal/service/...` green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diVB5qCSUXhPkxXzJfF7D
