### PR TITLE
fix(blobstore): resolve an implicit blob store without requiring one named "default"

### DIFF
--- a/internal/formats/base/base_extra_test.go
+++ b/internal/formats/base/base_extra_test.go
@@ -372,3 +372,62 @@ func TestStoreArtifact_GroupStore_DefaultFillPolicy(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "dfp-member-a", result.Asset.BlobStoreID)
 }
+
+// ── Implicit blob store when none is named "default" ──────────
+
+// An operator who deletes the seeded stores and keeps a single store of their
+// own ("minio", say) leaves every repository pointing at no blob store at all.
+// Uploading to one used to fail with "default blob store not found" (#402);
+// the only configured store is now what an implicit reference means.
+func TestStoreArtifact_NoDefaultStore_UsesTheOnlyOne(t *testing.T) {
+	repo := testutil.SimpleRepo("raw-hosted", "raw")
+	blobStore := testutil.NewBlobStore()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(&domain.BlobStore{ID: "bs-minio", Name: "minio", Type: "s3"}),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  blobStore,
+		Registry:   storage.NewRegistry(blobStore),
+		BaseURL:    "http://localhost",
+	}
+
+	content := "artifact bytes"
+	_, err := base.StoreArtifact(context.Background(), d,
+		"raw-hosted", "/dir/file.txt", "text/plain",
+		base.Coords{Group: "/dir", Name: "file.txt", Version: "1.0"},
+		strings.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+
+	assets, err := d.Assets.ListByRepoAndPath(context.Background(), "raw-hosted", "")
+	require.NoError(t, err)
+	require.NotEmpty(t, assets)
+	assert.Equal(t, "bs-minio", assets[0].BlobStoreID)
+}
+
+// Several stores and none named "default" is ambiguous, and picking one at
+// random would scatter blobs. The write fails, and the message says what to do.
+func TestStoreArtifact_SeveralStoresNoDefault_FailsWithGuidance(t *testing.T) {
+	repo := testutil.SimpleRepo("raw-hosted", "raw")
+	blobStore := testutil.NewBlobStore()
+	d := formats.Deps{
+		Repos: testutil.NewRepoRepo(repo),
+		Blobs: testutil.NewBlobStoreRepo(
+			&domain.BlobStore{ID: "bs-minio", Name: "minio", Type: "s3"},
+			&domain.BlobStore{ID: "bs-cold", Name: "cold", Type: "s3"},
+		),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  blobStore,
+		Registry:   storage.NewRegistry(blobStore),
+		BaseURL:    "http://localhost",
+	}
+
+	content := "artifact bytes"
+	_, err := base.StoreArtifact(context.Background(), d,
+		"raw-hosted", "/dir/file.txt", "text/plain",
+		base.Coords{Group: "/dir", Name: "file.txt", Version: "1.0"},
+		strings.NewReader(content), int64(len(content)))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assign repository.blobStoreId")
+}

--- a/internal/formats/base/store.go
+++ b/internal/formats/base/store.go
@@ -632,14 +632,7 @@ func resolveBlobStoreObj(ctx context.Context, d formats.Deps, repo *domain.Repos
 			return nil, fmt.Errorf("blob store id %q not found", ref)
 		}
 	}
-	bs, err := d.Blobs.Get(ctx, "default")
-	if errors.Is(err, repository.ErrNotFound) {
-		return nil, fmt.Errorf("default blob store not found")
-	}
-	if err != nil {
-		return nil, fmt.Errorf("blob store: %w", err)
-	}
-	return bs, nil
+	return repository.DefaultBlobStore(ctx, d.Blobs)
 }
 
 // ResolveBlobStore returns the physical BlobStore, its DB id, and its DB name for repo.
@@ -727,12 +720,9 @@ func resolveBlobStoreRef(ctx context.Context, d formats.Deps, repo *domain.Repos
 		}
 	}
 	if bs == nil {
-		bs, err = d.Blobs.Get(ctx, "default")
+		bs, err = repository.DefaultBlobStore(ctx, d.Blobs)
 		if err != nil {
-			return "", "", fmt.Errorf("blob store: %w", err)
-		}
-		if bs == nil {
-			return "", "", fmt.Errorf("default blob store not found (seed blob_stores or assign repository.blobStoreId)")
+			return "", "", err
 		}
 	}
 

--- a/internal/repository/blobstore_default.go
+++ b/internal/repository/blobstore_default.go
@@ -1,0 +1,55 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// DefaultBlobStore returns the store to use for a repository that names none of
+// its own.
+//
+// The store called "default" is the one the schema seeds and the one every
+// installation starts with, so it stays the first choice. But nothing forces an
+// operator to keep it: deleting the seeded stores and creating a single "minio"
+// store is a perfectly ordinary setup, and it used to break every write that
+// went through a repository with no blob_store_id — uploads and Nexus
+// migrations alike failed with "default blob store not found" (#402). When
+// exactly one store exists there is no ambiguity about which one that is, so it
+// answers instead.
+//
+// With several stores configured and none named "default" there is a real
+// choice to make, and guessing would silently scatter blobs across stores. That
+// case stays an error, naming the stores so the operator can assign one.
+func DefaultBlobStore(ctx context.Context, blobs BlobStoreRepo) (*domain.BlobStore, error) {
+	bs, err := blobs.Get(ctx, "default")
+	if err == nil && bs != nil {
+		return bs, nil
+	}
+	if err != nil && !errors.Is(err, ErrNotFound) {
+		return nil, fmt.Errorf("blob store: %w", err)
+	}
+
+	all, listErr := blobs.List(ctx)
+	if listErr != nil {
+		return nil, fmt.Errorf("list blob stores: %w", listErr)
+	}
+	switch len(all) {
+	case 0:
+		return nil, fmt.Errorf("no blob store configured: create one, or assign repository.blobStoreId")
+	case 1:
+		store := all[0]
+		return &store, nil
+	default:
+		names := make([]string, 0, len(all))
+		for i := range all {
+			names = append(names, all[i].Name)
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("no blob store named %q and %d stores to choose from (%v): assign repository.blobStoreId",
+			"default", len(all), names)
+	}
+}

--- a/internal/repository/blobstore_default_test.go
+++ b/internal/repository/blobstore_default_test.go
@@ -1,0 +1,68 @@
+package repository_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func TestDefaultBlobStore_PrefersTheStoreNamedDefault(t *testing.T) {
+	blobs := testutil.NewBlobStoreRepo(
+		&domain.BlobStore{ID: "bs-minio", Name: "minio", Type: "s3"},
+		&domain.BlobStore{ID: "bs-default", Name: "default", Type: "local"},
+	)
+	bs, err := repository.DefaultBlobStore(context.Background(), blobs)
+	if err != nil {
+		t.Fatalf("DefaultBlobStore: %v", err)
+	}
+	if bs.Name != "default" {
+		t.Fatalf("picked %q, want the store named \"default\"", bs.Name)
+	}
+}
+
+// The reported shape of #402: the seeded stores are deleted and one store of
+// the operator's own is left. Every implicit write used to fail with
+// "default blob store not found".
+func TestDefaultBlobStore_FallsBackToTheOnlyStore(t *testing.T) {
+	blobs := testutil.NewBlobStoreRepo(&domain.BlobStore{ID: "bs-minio", Name: "minio", Type: "s3"})
+	bs, err := repository.DefaultBlobStore(context.Background(), blobs)
+	if err != nil {
+		t.Fatalf("DefaultBlobStore: %v", err)
+	}
+	if bs.ID != "bs-minio" {
+		t.Fatalf("picked %q, want the only configured store", bs.ID)
+	}
+}
+
+func TestDefaultBlobStore_SeveralStoresNoDefault_NamesThem(t *testing.T) {
+	blobs := testutil.NewBlobStoreRepo(
+		&domain.BlobStore{ID: "bs-minio", Name: "minio", Type: "s3"},
+		&domain.BlobStore{ID: "bs-cold", Name: "cold", Type: "s3"},
+	)
+	_, err := repository.DefaultBlobStore(context.Background(), blobs)
+	if err == nil {
+		t.Fatal("want an error when there is a real choice to make")
+	}
+	for _, want := range []string{"cold", "minio", "assign repository.blobStoreId"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q does not mention %q", err, want)
+		}
+	}
+}
+
+func TestDefaultBlobStore_NoStoresAtAll(t *testing.T) {
+	blobs := testutil.NewBlobStoreRepo()
+	// The mock seeds "default" when constructed empty, so drop it to model a
+	// database whose blob_stores table really is empty.
+	if err := blobs.Delete(context.Background(), "default"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	_, err := repository.DefaultBlobStore(context.Background(), blobs)
+	if err == nil || !strings.Contains(err.Error(), "no blob store configured") {
+		t.Fatalf("got %v, want a \"no blob store configured\" error", err)
+	}
+}

--- a/internal/repository/errors_test.go
+++ b/internal/repository/errors_test.go
@@ -1,0 +1,37 @@
+package repository_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/repository"
+)
+
+func TestUniqueViolationError_NamesTheFieldAndMatchesTheSentinel(t *testing.T) {
+	err := error(&repository.UniqueViolationError{Field: "email"})
+	if got := err.Error(); got != "email already exists" {
+		t.Fatalf("Error() = %q", got)
+	}
+	if !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatal("a UniqueViolationError must satisfy errors.Is(err, ErrAlreadyExists)")
+	}
+	if errors.Is(err, repository.ErrNotFound) {
+		t.Fatal("it must not match an unrelated sentinel")
+	}
+	// Callers wrap it on the way up; the sentinel has to survive that.
+	if !errors.Is(fmt.Errorf("create user: %w", err), repository.ErrAlreadyExists) {
+		t.Fatal("wrapping lost the sentinel")
+	}
+}
+
+func TestRequestNotPendingError_CarriesTheStatus(t *testing.T) {
+	err := error(&repository.RequestNotPendingError{Status: "approved"})
+	if got := err.Error(); got != "request is not pending (status: approved)" {
+		t.Fatalf("Error() = %q", got)
+	}
+	var target *repository.RequestNotPendingError
+	if !errors.As(fmt.Errorf("promote: %w", err), &target) || target.Status != "approved" {
+		t.Fatal("errors.As must recover the status a concurrent reviewer set")
+	}
+}

--- a/internal/service/promotion_service.go
+++ b/internal/service/promotion_service.go
@@ -602,18 +602,18 @@ func (s *PromotionService) resolveStore(ctx context.Context, blobStoreID *string
 	var bsMeta *domain.BlobStore
 	var err error
 	if implicit {
-		bsMeta, err = s.blobRepo.Get(ctx, "default")
+		bsMeta, err = repository.DefaultBlobStore(ctx, s.blobRepo)
+		if err != nil {
+			return nil, "", err
+		}
 	} else {
 		bsMeta, err = s.blobRepo.GetByID(ctx, *blobStoreID)
-	}
-	if errors.Is(err, repository.ErrNotFound) || (err == nil && bsMeta == nil) {
-		if implicit {
-			return nil, "", fmt.Errorf("default blob store not found (seed blob_stores or assign repository.blobStoreId)")
+		if errors.Is(err, repository.ErrNotFound) || (err == nil && bsMeta == nil) {
+			return nil, "", fmt.Errorf("blob store id %q not found", *blobStoreID)
 		}
-		return nil, "", fmt.Errorf("blob store id %q not found", *blobStoreID)
-	}
-	if err != nil {
-		return nil, "", fmt.Errorf("blob store: %w", err)
+		if err != nil {
+			return nil, "", fmt.Errorf("blob store: %w", err)
+		}
 	}
 	bs, err := s.blobResolver.Get(ctx, storage.BlobStoreDescriptor{
 		ID:     bsMeta.ID,

--- a/internal/service/promotion_service_defaultstore_test.go
+++ b/internal/service/promotion_service_defaultstore_test.go
@@ -68,18 +68,77 @@ func TestPromotionService_DefaultStoreRepos_PromoteRecordsRealStoreID(t *testing
 	}
 }
 
-// The "default blob store not found" diagnostic must actually be reachable:
-// the postgres repo reports a missing row as ErrNotFound, not (nil, nil), and
-// an err-first check would bury the actionable message under a bare
-// "not found" (the default row is deletable via the blobstore API when
-// nothing references it).
-func TestPromotionService_MissingDefaultStoreRow_NamesTheFix(t *testing.T) {
+// A repository with no blob_store_id used to hard-require a store literally
+// named "default". Deleting the seeded stores and running a single store of
+// one's own is an ordinary setup, and it broke every implicit write with
+// "default blob store not found" (#402). With one store configured there is
+// nothing to disambiguate, so it answers.
+func TestPromotionService_SingleNonDefaultStore_IsUsedImplicitly(t *testing.T) {
 	promoRepo := testutil.NewPromotionRepo()
 	compRepo := testutil.NewComponentRepo()
 	assetRepo := testutil.NewAssetRepo()
 	blobStore := testutil.NewBlobStore()
 	// Seeding a non-default row keeps the constructor from creating "default".
 	blobRepo := testutil.NewBlobStoreRepo(&domain.BlobStore{ID: "bs-other", Name: "other", Type: "local"})
+	repoRepo := testutil.NewRepoRepo()
+	svc, err := service.NewPromotionService(
+		promoRepo, compRepo, assetRepo, repoRepo, blobRepo, testutil.NewScanResultRepo(), testutil.NewFakeResolver(blobStore),
+	)
+	if err != nil {
+		t.Fatalf("NewPromotionService: %v", err)
+	}
+	ctx := context.Background()
+
+	repoRepo.Create(ctx, testutil.SimpleRepo("staging", "raw"))
+	repoRepo.Create(ctx, testutil.SimpleRepo("production", "raw"))
+	comp := &domain.Component{ID: "c1", Repository: "staging", Format: "raw", Group: "g", Name: "n", Version: "1"}
+	compRepo.AddComponent(comp)
+	blobKey := "staging:n-1.txt"
+	if err := blobStore.PutBytes(ctx, blobKey, []byte("abc")); err != nil {
+		t.Fatalf("PutBytes: %v", err)
+	}
+	assetRepo.Create(ctx, &domain.Asset{
+		ComponentID: comp.ID, Repository: "staging", Path: "n-1.txt",
+		BlobKey: blobKey, SizeBytes: 3, BlobStoreID: "bs-other",
+	})
+	rule := &domain.PromotionRule{Name: "auto", FromRepo: "staging", ToRepo: "production"}
+	if err := promoRepo.CreateRule(ctx, rule); err != nil {
+		t.Fatalf("CreateRule: %v", err)
+	}
+
+	reqs, err := svc.Promote(ctx, rule.ID, []string{comp.ID}, "user-1")
+	if err != nil || len(reqs) != 1 {
+		t.Fatalf("Promote: %v (%d requests)", err, len(reqs))
+	}
+	if reqs[0].Status != domain.PromotionCompleted {
+		t.Fatalf("status: got %s (%s), want completed", reqs[0].Status, reqs[0].Error)
+	}
+	copied, err := assetRepo.ListByRepoAndPath(ctx, "production", "")
+	if err != nil {
+		t.Fatalf("ListByRepoAndPath: %v", err)
+	}
+	if len(copied) == 0 {
+		t.Fatal("no asset was copied into production")
+	}
+	for _, a := range copied {
+		if a.BlobStoreID != "bs-other" {
+			t.Fatalf("copied asset blob_store_id: got %q, want the only configured store", a.BlobStoreID)
+		}
+	}
+}
+
+// Several stores and none named "default" is a genuine choice, and picking one
+// would scatter blobs at random. That case stays an error, and the message has
+// to name the way out rather than bury it under a bare "not found".
+func TestPromotionService_SeveralStoresNoDefault_NamesTheFix(t *testing.T) {
+	promoRepo := testutil.NewPromotionRepo()
+	compRepo := testutil.NewComponentRepo()
+	assetRepo := testutil.NewAssetRepo()
+	blobStore := testutil.NewBlobStore()
+	blobRepo := testutil.NewBlobStoreRepo(
+		&domain.BlobStore{ID: "bs-other", Name: "other", Type: "local"},
+		&domain.BlobStore{ID: "bs-minio", Name: "minio", Type: "s3"},
+	)
 	repoRepo := testutil.NewRepoRepo()
 	svc, err := service.NewPromotionService(
 		promoRepo, compRepo, assetRepo, repoRepo, blobRepo, testutil.NewScanResultRepo(), testutil.NewFakeResolver(blobStore),
@@ -105,7 +164,12 @@ func TestPromotionService_MissingDefaultStoreRow_NamesTheFix(t *testing.T) {
 	if reqs[0].Status != domain.PromotionFailed {
 		t.Fatalf("status: got %s, want failed", reqs[0].Status)
 	}
-	if !strings.Contains(reqs[0].Error, "default blob store not found") {
+	if !strings.Contains(reqs[0].Error, "assign repository.blobStoreId") {
 		t.Fatalf("error %q does not carry the actionable diagnostic", reqs[0].Error)
+	}
+	for _, name := range []string{"minio", "other"} {
+		if !strings.Contains(reqs[0].Error, name) {
+			t.Fatalf("error %q does not name the candidate store %q", reqs[0].Error, name)
+		}
 	}
 }


### PR DESCRIPTION
Closes #402

A repository that names no blob store of its own fell back to the store literally called `default`. That is the row the schema seeds, but nothing keeps an operator from deleting it — creating a single `minio` store and dropping the seeded local ones is an ordinary setup, and it broke every write that went through an unassigned repository:

- a manual upload to a `raw` hosted repo answered `{"error":"default blob store not found"}`;
- a Nexus migration created the repositories and users and then copied **no artifacts at all**, because the repositories it creates carry no `blob_store_id`. Assigning the store by hand fixed one repo, and the next migration recreated the problem.

## The fix

Resolution goes through a new `repository.DefaultBlobStore`:

1. the store named `default`, as before;
2. failing that, the only configured store — with one store there is nothing to disambiguate;
3. with several stores and no `default`, an error. That is a real choice, and guessing would scatter blobs across stores. The message now names the candidates and points at `repository.blobStoreId`, rather than reporting a store the operator never asked for as missing.

All three implicit-reference sites share the helper: `resolveBlobStoreObj` and `resolveBlobStoreRef` in `internal/formats/base` (the upload path) and `PromotionService.resolveStore`.

## Verified

New unit tests for each layer: the resolver itself (prefers `default`, falls back to the only store, names the candidates when ambiguous, and reports an empty `blob_stores` table distinctly), the upload path (`TestStoreArtifact_NoDefaultStore_UsesTheOnlyOne` stores the blob and records `bs-minio` on the asset; `TestStoreArtifact_SeveralStoresNoDefault_FailsWithGuidance`), and promotion. The pre-existing `TestPromotionService_MissingDefaultStoreRow_NamesTheFix` seeded exactly one non-default store and asserted the failure — that is precisely the case this PR fixes, so it is now split into the success case and a two-store ambiguity case.

`go build`, `go vet` and `golangci-lint` clean; `go test ./...` green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diVB5qCSUXhPkxXzJfF7D
