### PR TITLE
feat(blobstore): let an S3 endpoint's certificate go unverified

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -117,6 +117,9 @@ func cmdServe() *cobra.Command {
 			// Storage
 			if cfg.Storage.DefaultType == "s3" {
 				log.Info("storage", "type", "s3", "bucket", cfg.Storage.S3.Bucket, "endpoint", cfg.Storage.S3.Endpoint)
+				if cfg.Storage.S3.SkipTLSVerify {
+					log.Warn("storage.s3.skip_tls_verify is enabled — the S3 endpoint's certificate is NOT verified; use only with a private CA you cannot install into the trust store")
+				}
 			} else {
 				log.Info("storage", "type", "local", "path", cfg.Storage.Local.BasePath)
 			}
@@ -335,6 +338,7 @@ func desiredS3Config(s3 config.S3Config) map[string]any {
 		"access_key":       s3.AccessKeyID,
 		"secret_key":       s3.SecretAccessKey,
 		"force_path_style": s3.ForcePathStyle,
+		"skip_tls_verify":  s3.SkipTLSVerify,
 	}
 }
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -55,6 +55,7 @@ storage:
   #   access_key_id: ""
   #   secret_access_key: ""
   #   force_path_style: true
+  #   skip_tls_verify: false        # accept an unverifiable certificate (private CA); off by default
 
 auth:
   jwt_secret: "CHANGE_ME_AT_LEAST_32_CHARACTERS_LONG"   # from source / native install: set this (or NEXSPENCE_AUTH_JWT_SECRET) — server refuses to start with this placeholder unless allow_insecure_defaults=true. The Docker image and Helm chart auto-generate a unique secret when it is unset, so you don't set it there.

--- a/deploy/helm/nexspence/templates/configmap.yaml
+++ b/deploy/helm/nexspence/templates/configmap.yaml
@@ -23,5 +23,10 @@ data:
   NEXSPENCE_STORAGE_S3_ENDPOINT: {{ .Values.storage.s3.endpoint | quote }}
   NEXSPENCE_STORAGE_S3_BUCKET: {{ .Values.storage.s3.bucket | quote }}
   NEXSPENCE_STORAGE_S3_REGION: {{ .Values.storage.s3.region | quote }}
-  NEXSPENCE_STORAGE_S3_USE_SSL: {{ .Values.storage.s3.useSSL | quote }}
+  # Viper derives the env name from the config key, so these have to be spelled
+  # storage.s3.force_path_style / skip_tls_verify exactly. The chart used to set
+  # NEXSPENCE_STORAGE_S3_USE_SSL, which matches no key at all and was silently
+  # dropped, leaving MinIO installs without path-style addressing.
+  NEXSPENCE_STORAGE_S3_FORCE_PATH_STYLE: {{ .Values.storage.s3.forcePathStyle | quote }}
+  NEXSPENCE_STORAGE_S3_SKIP_TLS_VERIFY: {{ .Values.storage.s3.skipTLSVerify | quote }}
   {{- end }}

--- a/deploy/helm/nexspence/templates/secret.yaml
+++ b/deploy/helm/nexspence/templates/secret.yaml
@@ -28,6 +28,8 @@ stringData:
   NEXSPENCE_AUTH_JWT_SECRET: {{ $jwt | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.config.adminPassword | quote }}
   {{- if eq .Values.storage.type "s3" }}
-  NEXSPENCE_STORAGE_S3_ACCESS_KEY: {{ .Values.storage.s3.accessKey | quote }}
-  NEXSPENCE_STORAGE_S3_SECRET_KEY: {{ .Values.storage.s3.secretKey | quote }}
+  # storage.s3.access_key_id / secret_access_key — the shorter names the chart
+  # used before match no config key, so S3 credentials never reached the server.
+  NEXSPENCE_STORAGE_S3_ACCESS_KEY_ID: {{ .Values.storage.s3.accessKey | quote }}
+  NEXSPENCE_STORAGE_S3_SECRET_ACCESS_KEY: {{ .Values.storage.s3.secretKey | quote }}
   {{- end }}

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -84,7 +84,13 @@ storage:
     region: "us-east-1"
     accessKey: ""
     secretKey: ""
-    useSSL: true
+    # -- Path-style addressing (bucket in the path, not the hostname). Required
+    # by MinIO and most non-AWS S3 implementations.
+    forcePathStyle: true
+    # -- Accept the endpoint's TLS certificate without verifying it. For an
+    # on-prem S3 behind a private CA; the connection carries the credentials and
+    # every blob, so prefer trusting the CA.
+    skipTLSVerify: false
 
 service:
   type: ClusterIP

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -157,6 +157,7 @@ uses OSV.dev and works with nothing installed.
 | `storage.s3.bucket` | — | S3 bucket name (required when type=s3) |
 | `storage.s3.endpoint` | — | S3 endpoint URL (e.g. `http://minio:9000`) |
 | `storage.s3.force_path_style` | `true` | Required for MinIO / non-AWS S3 |
+| `storage.s3.skip_tls_verify` | `false` | Accept the endpoint's TLS certificate without verifying it. For an on-prem S3 behind a private CA whose root you cannot install into the container's trust store; the connection carries the credentials and every blob, so prefer trusting the CA. Per-blob-store stores set the same thing with `skip_tls_verify` in their config (System Admin → Blob Stores → *Skip TLS certificate verification*). |
 | `auth.jwt_secret` | — | JWT signing key. **From source / native install: set this (min 32 chars) before production.** The Docker image and Helm chart auto-generate a unique secret when it is unset. |
 | `auth.encryption_key` | — | Optional base64 32-byte key for replication credentials (decouples them from `jwt_secret`; existing rows are re-encrypted automatically at startup). Generate: `openssl rand -base64 32` |
 | `auth.jwt_expiry_hours` | `24` | JWT token lifetime |

--- a/frontend/src/pages/AdminPage.test.tsx
+++ b/frontend/src/pages/AdminPage.test.tsx
@@ -147,6 +147,24 @@ describe('AdminPage — Blob Stores tab', () => {
     expect(cfg?.secret_key).toBe('rotat3d')
   })
 
+  it('round-trips the skip-TLS-verify flag through the edit form', async () => {
+    let put: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/blobstores/:type/:name', async ({ request }) => {
+        put = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(s3Store)
+      }),
+    )
+    await openS3Edit()
+    const box = screen.getByLabelText(/Skip TLS certificate verification/i)
+    expect(box).not.toBeChecked() // the stored config has no flag
+    fireEvent.click(box)
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }))
+    await waitFor(() => expect(put).toBeTruthy())
+    const cfg = (put! as { config?: Record<string, unknown> }).config
+    expect(cfg?.skip_tls_verify).toBe(true)
+  })
+
   it('shows empty state', async () => {
     server.use(http.get('/service/rest/v1/blobstores', () => HttpResponse.json([])))
     renderAdmin('blobs')

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1604,6 +1604,7 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
   const [editEndpoint, setEditEndpoint]   = useState('')
   const [editAccessKey, setEditAccessKey] = useState('')
   const [editSecretKey, setEditSecretKey] = useState('')
+  const [editSkipTLS, setEditSkipTLS]     = useState(false)
   const [editPath, setEditPath]           = useState('')
   const [editErr, setEditErr]             = useState('')
   const delMut = useMutation({
@@ -1625,7 +1626,7 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
       // untouched field must omit it entirely — the server then keeps the stored one.
       const config: Record<string, unknown> = bs.type === 's3'
         ? { bucket: editBucket, region: editRegion, endpoint: editEndpoint,
-            access_key: editAccessKey,
+            access_key: editAccessKey, skip_tls_verify: editSkipTLS,
             ...(editSecretKey ? { secret_key: editSecretKey } : {}) }
         : { path: editPath }
       return nexusApi.updateBlobStore(bs.type, bs.name, { config, quotaBytes: bs.quotaBytes ?? null })
@@ -1671,6 +1672,7 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
     setEditEndpoint((cfg.endpoint as string) ?? '')
     setEditAccessKey((cfg.access_key as string) ?? '')
     setEditSecretKey('')
+    setEditSkipTLS(cfg.skip_tls_verify === true)
     setEditPath((cfg.path as string) ?? '')
     setEditErr('')
     setEditing(true)
@@ -1778,6 +1780,15 @@ function BlobStoreDetailModal({ name, blobStores: _blobStores, onClose }: { name
                     <label style={{ fontSize: 11, color: 'var(--holo-text-faint)', display: 'block', marginBottom: 3 }}>Endpoint</label>
                     <HoloInput value={editEndpoint} onChange={e => setEditEndpoint(e.target.value)} placeholder="leave empty for AWS S3" />
                   </div>
+                  <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, cursor: 'pointer', fontSize: 12, color: 'var(--holo-text)' }}>
+                    <input type="checkbox" checked={editSkipTLS} onChange={e => setEditSkipTLS(e.target.checked)} style={{ marginTop: 2 }} />
+                    <span>
+                      Skip TLS certificate verification
+                      <span style={{ display: 'block', color: 'var(--holo-text-faint)', fontSize: 11 }}>
+                        For an endpoint behind a private CA. Credentials and every blob travel over an unverified connection.
+                      </span>
+                    </span>
+                  </label>
                   <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
                     <div>
                       <label style={{ fontSize: 11, color: 'var(--holo-text-faint)', display: 'block', marginBottom: 3 }}>Access Key</label>
@@ -1911,6 +1922,7 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
   const [prefix, setPrefix] = useState('')
   const [accessKey, setAccessKey] = useState('')
   const [secretKey, setSecretKey] = useState('')
+  const [skipTLS, setSkipTLS] = useState(false)
   const [quotaGB, setQuotaGB] = useState('')
   const [err, setErr] = useState('')
   const [testResult, setTestResult] = useState<{ ok: boolean; error?: string } | null>(null)
@@ -1930,7 +1942,7 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
       const config: Record<string, unknown> = type === 'local'
         ? { path }
         : type === 's3'
-        ? { bucket, region, endpoint, prefix, access_key: accessKey, secret_key: secretKey }
+        ? { bucket, region, endpoint, prefix, access_key: accessKey, secret_key: secretKey, skip_tls_verify: skipTLS }
         : {}
       if (type === 'group') {
         config.fill_policy = groupFillPolicy
@@ -1957,7 +1969,7 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
     try {
       const cfg: Record<string, unknown> = type === 'local'
         ? { path }
-        : { bucket, region, endpoint, prefix, access_key: accessKey, secret_key: secretKey }
+        : { bucket, region, endpoint, prefix, access_key: accessKey, secret_key: secretKey, skip_tls_verify: skipTLS }
       const res = await nexusApi.testBlobStore(type === 'group' ? 'local' : type, cfg)
       if (seq !== testReqSeq.current) return // a field changed since this test started
       setTestResult(res.data)
@@ -2014,6 +2026,17 @@ function CreateBlobStoreModal({ blobStores, onClose }: { blobStores: BlobStore[]
               <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Endpoint (leave empty for AWS)</label>
               <HoloInput value={endpoint} onChange={e => { testReqSeq.current++; setTestResult(null); setEndpoint(e.target.value) }} placeholder="https://minio.example.com" />
             </div>
+            <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, cursor: 'pointer', fontSize: 12, color: 'var(--holo-text)' }}>
+              <input type="checkbox" checked={skipTLS}
+                onChange={e => { testReqSeq.current++; setTestResult(null); setSkipTLS(e.target.checked) }}
+                style={{ marginTop: 2 }} />
+              <span>
+                Skip TLS certificate verification
+                <span style={{ display: 'block', color: 'var(--holo-text-faint)', fontSize: 11 }}>
+                  For an endpoint behind a private CA. Credentials and every blob travel over an unverified connection.
+                </span>
+              </span>
+            </label>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
               <div>
                 <label style={{ fontSize: 12, fontWeight: 600, color: 'var(--holo-text-dim)', marginBottom: 4, display: 'block' }}>Access Key</label>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -171,6 +171,9 @@ type S3Config struct {
 	AccessKeyID     string `mapstructure:"access_key_id"`
 	SecretAccessKey string `mapstructure:"secret_access_key"`
 	ForcePathStyle  bool   `mapstructure:"force_path_style"`
+	// SkipTLSVerify disables certificate verification against the endpoint,
+	// for an on-prem S3 fronted by a private CA (#403). Off by default.
+	SkipTLSVerify bool `mapstructure:"skip_tls_verify"`
 }
 
 // AuthConfig holds JWT, bcrypt, anonymous-access, and token-expiry settings.
@@ -529,6 +532,7 @@ func Load(path string) (*Config, error) {
 	v.SetDefault("storage.s3.access_key_id", "")
 	v.SetDefault("storage.s3.secret_access_key", "")
 	v.SetDefault("storage.s3.force_path_style", false)
+	v.SetDefault("storage.s3.skip_tls_verify", false)
 	v.SetDefault("database.max_conns", 100)
 	v.SetDefault("database.min_conns", 5)
 	v.SetDefault("database.max_idle_sec", 300)

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -23,6 +23,7 @@ func NewBlobStoreFromConfig(ctx context.Context, cfg *nexspencecfg.Config) (Blob
 			AccessKeyID:     s3cfg.AccessKeyID,
 			SecretAccessKey: s3cfg.SecretAccessKey,
 			ForcePathStyle:  s3cfg.ForcePathStyle,
+			SkipTLSVerify:   s3cfg.SkipTLSVerify,
 		})
 	default: // "local" or empty
 		basePath := cfg.Storage.Local.BasePath

--- a/internal/storage/registry.go
+++ b/internal/storage/registry.go
@@ -143,6 +143,7 @@ func newFromDescriptor(ctx context.Context, desc BlobStoreDescriptor) (BlobStore
 		if bv, ok := desc.Config["force_path_style"].(bool); ok {
 			opts.ForcePathStyle = bv
 		}
+		opts.SkipTLSVerify = boolVal(desc.Config, "skip_tls_verify")
 		if opts.Bucket == "" {
 			return nil, fmt.Errorf("s3 blob store: bucket is required")
 		}
@@ -164,4 +165,21 @@ func strVal(m map[string]any, key string) string {
 	}
 	v, _ := m[key].(string)
 	return v
+}
+
+// boolVal reads a boolean config value. A store config round-trips through
+// JSONB, so a value the frontend sent as true can come back as the string
+// "true"; both spellings mean the same thing here.
+func boolVal(m map[string]any, key string) bool {
+	if m == nil {
+		return false
+	}
+	switch v := m[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	default:
+		return false
+	}
 }

--- a/internal/storage/s3.go
+++ b/internal/storage/s3.go
@@ -2,9 +2,11 @@ package storage
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
@@ -34,6 +36,13 @@ type S3Options struct {
 	AccessKeyID     string
 	SecretAccessKey string
 	ForcePathStyle  bool
+	// SkipTLSVerify turns off certificate verification against the endpoint.
+	// An on-prem MinIO or Ceph fronted by a private CA is the reason it exists
+	// (#403): without it the store cannot be created at all, and the operator's
+	// only alternative is to install the CA into the container's trust store.
+	// It is an explicit per-store opt-in and never a default — the connection
+	// it enables carries the credentials and every blob.
+	SkipTLSVerify bool
 }
 
 // NewS3BlobStore creates an S3BlobStore and validates connectivity by checking the bucket.
@@ -50,6 +59,10 @@ func NewS3BlobStore(ctx context.Context, opts S3Options) (*S3BlobStore, error) {
 		cfgOpts = append(cfgOpts, config.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(opts.AccessKeyID, opts.SecretAccessKey, ""),
 		))
+	}
+
+	if opts.SkipTLSVerify {
+		cfgOpts = append(cfgOpts, config.WithHTTPClient(unverifiedTLSClient()))
 	}
 
 	awsCfg, err := config.LoadDefaultConfig(ctx, cfgOpts...)
@@ -82,6 +95,18 @@ func NewS3BlobStore(ctx context.Context, opts S3Options) (*S3BlobStore, error) {
 		bucket:         opts.Bucket,
 		forcePathStyle: opts.ForcePathStyle,
 	}, nil
+}
+
+// unverifiedTLSClient is the process-wide default transport with certificate
+// verification switched off. It is cloned from http.DefaultTransport rather
+// than built from scratch so proxy settings, connection pooling and HTTP/2 keep
+// behaving the way every other client here does; only the trust decision
+// changes.
+func unverifiedTLSClient() *http.Client {
+	tr, _ := http.DefaultTransport.(*http.Transport)
+	tr = tr.Clone()
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // the point of the option: a per-store operator opt-in for a private CA (#403)
+	return &http.Client{Transport: tr}
 }
 
 // objectKey shards the blob key into a two-level prefix to avoid hot-spotting.

--- a/internal/storage/s3_tls_test.go
+++ b/internal/storage/s3_tls_test.go
@@ -1,0 +1,91 @@
+package storage_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/storage"
+)
+
+// tlsEndpoint starts an S3-shaped HTTPS server with a certificate signed by an
+// authority the client has never heard of — the shape of a MinIO behind a
+// private CA (#403).
+func tlsEndpoint(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestS3_UntrustedCertificate_FailsByDefault(t *testing.T) {
+	bs, err := storage.NewS3BlobStore(context.Background(), storage.S3Options{
+		Bucket: "b", Region: "us-east-1", Endpoint: tlsEndpoint(t),
+		AccessKeyID: "key", SecretAccessKey: "secret", ForcePathStyle: true,
+	})
+	require.NoError(t, err)
+
+	_, err = bs.Exists(context.Background(), "some-key")
+	require.Error(t, err, "an unverifiable certificate must not be accepted silently")
+	assert.Contains(t, strings.ToLower(err.Error()), "certificate")
+}
+
+// With the opt-in, the same endpoint answers: the request reaches the server
+// and comes back as an ordinary S3 answer rather than a TLS failure.
+func TestS3_SkipTLSVerify_ReachesTheEndpoint(t *testing.T) {
+	bs, err := storage.NewS3BlobStore(context.Background(), storage.S3Options{
+		Bucket: "b", Region: "us-east-1", Endpoint: tlsEndpoint(t),
+		AccessKeyID: "key", SecretAccessKey: "secret", ForcePathStyle: true,
+		SkipTLSVerify: true,
+	})
+	require.NoError(t, err)
+
+	exists, err := bs.Exists(context.Background(), "some-key")
+	require.NoError(t, err)
+	assert.True(t, exists, "the stub endpoint answers 200 to HeadObject")
+}
+
+// The store config round-trips through JSONB, so the flag has to survive both
+// the boolean the frontend sends and the string a hand-edited row can hold.
+func TestNewFromConfig_S3_SkipTLSVerifyIsRead(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value any
+	}{
+		{"bool", true},
+		{"string", "true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bs, err := storage.NewFromConfig(context.Background(), "s3", map[string]any{
+				"bucket":          "b",
+				"region":          "us-east-1",
+				"endpoint":        tlsEndpoint(t),
+				"access_key":      "key",
+				"secret_key":      "secret",
+				"skip_tls_verify": tc.value,
+			})
+			require.NoError(t, err)
+			exists, err := bs.Exists(context.Background(), "some-key")
+			require.NoError(t, err)
+			assert.True(t, exists)
+		})
+	}
+}
+
+func TestNewFromConfig_S3_SkipTLSVerifyDefaultsOff(t *testing.T) {
+	bs, err := storage.NewFromConfig(context.Background(), "s3", map[string]any{
+		"bucket": "b", "region": "us-east-1", "endpoint": tlsEndpoint(t),
+		"access_key": "key", "secret_key": "secret",
+	})
+	require.NoError(t, err)
+	_, err = bs.Exists(context.Background(), "some-key")
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "certificate")
+}

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -638,6 +638,7 @@ helm install nexspence deploy/helm/nexspence \
       <tr><td><code>storage.s3.endpoint</code></td><td>—</td><td>S3 endpoint URL (e.g. <code>http://minio:9000</code>)</td></tr>
       <tr><td><code>storage.s3.bucket</code></td><td>—</td><td>S3 bucket name (required when type=s3)</td></tr>
       <tr><td><code>storage.s3.force_path_style</code></td><td><code>true</code></td><td>Required for MinIO / non-AWS S3</td></tr>
+      <tr><td><code>storage.s3.skip_tls_verify</code></td><td><code>false</code></td><td>Accept an unverifiable TLS certificate — for an on-prem S3 behind a private CA. Blob stores created in the UI carry the same option per store.</td></tr>
       <tr><td><code>redis.enabled</code></td><td><code>false</code></td><td>Enable Redis (required for HA)</td></tr>
       <tr><td><code>redis.addr</code></td><td><code>localhost:6379</code></td><td>Redis address</td></tr>
       <tr><td><code>cleanup.default_schedule</code></td><td><code>0 2 * * *</code></td><td>Default cron for cleanup policies</td></tr>


### PR DESCRIPTION
Closes #403

Creating an S3 blob store against an on-prem MinIO or Ceph fronted by a private CA failed outright:

```
Connection failed: s3 head __health__: ... tls: failed to verify certificate:
x509: certificate is valid for ed9f01..., not minio.example.com
```

There was no way past it short of installing the CA into the container's trust store.

## What changed

- **Per-store**: `skip_tls_verify` in a blob store's config, surfaced in the UI as a *Skip TLS certificate verification* checkbox next to the endpoint field, in both the create and edit forms. `Registry.Invalidate` already runs on update, so toggling it takes effect without a restart.
- **Config-file store**: `storage.s3.skip_tls_verify`, off by default, with a startup warning when it is on — the same treatment `ldap.insecure_skip_verify` gets.

When set, the SDK is handed an `http.Client` whose transport is cloned from `http.DefaultTransport` with verification switched off, so proxy settings, connection pooling and HTTP/2 keep behaving as they do everywhere else and only the trust decision changes.

## Two Helm bugs found in the same corner

Both are S3-configuration wiring that never worked, and neither is visible to an operator — the values are simply ignored:

- The chart set `NEXSPENCE_STORAGE_S3_ACCESS_KEY` / `_SECRET_KEY`, but the config keys are `storage.s3.access_key_id` / `secret_access_key`. Viper derives the env name from the key, so it matched neither and the credentials in `values.yaml` never reached the server; the store fell back to whatever the AWS default credential chain found.
- It also set `NEXSPENCE_STORAGE_S3_USE_SSL`, which matches no config key at all, while `force_path_style` — the one MinIO needs — was never set.

Both are corrected, and `storage.s3.forcePathStyle` / `skipTLSVerify` are now chart values.

## Verified

`internal/storage/s3_tls_test.go` points a store at an `httptest.NewTLSServer` (a certificate signed by an authority the client has never heard of — the shape of the reported failure): the default rejects it with a certificate error, the opt-in reaches the endpoint and gets an ordinary S3 answer, and `NewFromConfig` reads the flag as both a JSON boolean and the string a hand-edited JSONB row can hold. A new `AdminPage` test round-trips the checkbox through the edit form. `helm template` renders the corrected env for an S3 install.

`go build`, `go vet`, `golangci-lint`, `tsc --noEmit` clean; `go test ./...` and the frontend suite green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diVB5qCSUXhPkxXzJfF7D
