### PR TITLE
feat(helm): expose the Docker subdomain connector

### DIFF
--- a/deploy/helm/nexspence/README.md
+++ b/deploy/helm/nexspence/README.md
@@ -129,22 +129,81 @@ helm install nexspence \
 
 ## S3 / MinIO Blob Store
 
-Set `config.storage.defaultType=s3` and provide bucket + endpoint. Use this
+Set `storage.type=s3` and provide bucket + endpoint. Use this
 for any multi-replica deployment — a single `ReadWriteOnce` PVC does not scale
 horizontally.
 
 ```bash
 helm install nexspence \
   deploy/helm/nexspence \
-  --set config.storage.defaultType=s3 \
-  --set config.storage.s3.endpoint="https://minio.example.com" \
-  --set config.storage.s3.bucket="nexspence-blobs" \
-  --set config.storage.s3.accessKey="minio" \
-  --set config.storage.s3.secretKey="minio123" \
+  --set storage.type=s3 \
+  --set storage.s3.endpoint="https://minio.example.com" \
+  --set storage.s3.bucket="nexspence-blobs" \
+  --set storage.s3.accessKey="minio" \
+  --set storage.s3.secretKey="minio123" \
   -f deploy/helm/nexspence/values-examples/nginx.yaml \
   --namespace nexspence \
   --create-namespace
 ```
+
+---
+
+## Docker Subdomain Connector
+
+Serves each Docker repository on its own hostname, so clients can
+`docker pull myrepo.example.com/alpine` instead of
+`docker pull nexspence.example.com:8081/repository/myrepo/alpine`. See
+[docs/docker-subdomain-connector.md](../../../docs/docker-subdomain-connector.md)
+for the full picture.
+
+```bash
+helm install nexspence \
+  deploy/helm/nexspence \
+  --set config.docker.subdomainConnector.enabled=true \
+  --set config.docker.subdomainConnector.baseDomain="nexspence.example.com" \
+  --namespace nexspence
+```
+
+Two things the chart cannot do for you:
+
+- **Wildcard DNS.** `*.nexspence.example.com` has to resolve to the ingress.
+- **The `Host` header.** The connector routes on it, so the ingress must pass
+  the client's original hostname through rather than rewriting it. Add a
+  wildcard host to `ingress.hosts` (and to the TLS certificate) — with nginx
+  the default `proxy_set_header Host $host` is already right; Traefik and Istio
+  preserve it too.
+
+```yaml
+ingress:
+  enabled: true
+  hosts:
+    - host: nexspence.example.com
+      paths: [{ path: /, pathType: Prefix }]
+    - host: "*.nexspence.example.com"
+      paths: [{ path: /, pathType: Prefix }]
+```
+
+### Hostname aliases
+
+When a DNS name does not match the repository behind it — a Nexus connector
+port being migrated, say — map it explicitly. Any domain works; the hostname
+does not have to sit under `baseDomain`:
+
+```yaml
+config:
+  docker:
+    subdomainConnector:
+      enabled: true
+      baseDomain: "nexspence.example.com"
+      aliases:
+        docker-hub-proxy.example.com: dockerhub-proxy
+        hub.nexspence.example.com: dockerhub-proxy
+```
+
+A YAML map has no environment-variable spelling, so setting any alias makes the
+chart mount a small config file over the image's `/app/config.yaml`. Every other
+setting still arrives as an environment variable, which viper reads last, so
+nothing else in the chart changes behaviour.
 
 ---
 

--- a/deploy/helm/nexspence/templates/configmap.yaml
+++ b/deploy/helm/nexspence/templates/configmap.yaml
@@ -17,6 +17,8 @@ data:
   NEXSPENCE_BOOTSTRAP_ADMIN_EMAIL: {{ .Values.config.adminEmail | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_FIRST_NAME: {{ .Values.config.adminFirstName | quote }}
   NEXSPENCE_METRICS_PUBLIC: {{ .Values.config.metricsPublic | quote }}
+  NEXSPENCE_DOCKER_SUBDOMAIN_CONNECTOR_ENABLED: {{ .Values.config.docker.subdomainConnector.enabled | quote }}
+  NEXSPENCE_DOCKER_SUBDOMAIN_CONNECTOR_BASE_DOMAIN: {{ .Values.config.docker.subdomainConnector.baseDomain | quote }}
   {{- if eq .Values.storage.type "local" }}
   NEXSPENCE_STORAGE_LOCAL_BASE_PATH: {{ .Values.storage.local.mountPath | quote }}
   {{- else if eq .Values.storage.type "s3" }}
@@ -25,3 +27,25 @@ data:
   NEXSPENCE_STORAGE_S3_REGION: {{ .Values.storage.s3.region | quote }}
   NEXSPENCE_STORAGE_S3_USE_SSL: {{ .Values.storage.s3.useSSL | quote }}
   {{- end }}
+{{- if .Values.config.docker.subdomainConnector.aliases }}
+---
+# A YAML map cannot be an environment variable, so subdomain-connector aliases
+# ride in as a config file mounted over the image's /app/config.yaml. Every
+# other setting still comes from the env above, which viper reads last and so
+# takes precedence over anything in here.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "nexspence.fullname" . }}-file
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nexspence.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    docker:
+      subdomain_connector:
+        aliases:
+          {{- range $host, $repo := .Values.config.docker.subdomainConnector.aliases }}
+          {{ $host | quote }}: {{ $repo | quote }}
+          {{- end }}
+{{- end }}

--- a/deploy/helm/nexspence/templates/deployment.yaml
+++ b/deploy/helm/nexspence/templates/deployment.yaml
@@ -112,6 +112,12 @@ spec:
               mountPath: /opt/trivy
               readOnly: true
             {{- end }}
+            {{- if .Values.config.docker.subdomainConnector.aliases }}
+            - name: config-file
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+              readOnly: true
+            {{- end }}
       volumes:
         # Writable scratch dirs (rootfs is read-only). The trivy cache lives at
         # /app/.cache (HOME=/app, TRIVY_CACHE_DIR=/app/.cache/trivy in the image).
@@ -119,6 +125,11 @@ spec:
           emptyDir: {}
         - name: cache
           emptyDir: {}
+        {{- if .Values.config.docker.subdomainConnector.aliases }}
+        - name: config-file
+          configMap:
+            name: {{ include "nexspence.fullname" . }}-file
+        {{- end }}
         {{- if eq .Values.storage.type "local" }}
         - name: blobs
           persistentVolumeClaim:

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -68,6 +68,25 @@ config:
   # the cluster network reaches the Service and a scrape token would just be one
   # more secret to rotate.
   metricsPublic: false
+  # -- Docker subdomain connector: serve each Docker repository on its own
+  # hostname, so clients can `docker pull myrepo.example.com/alpine` instead of
+  # `docker pull nexspence.example.com:8081/repository/myrepo/alpine`. Needs a
+  # wildcard DNS record for baseDomain and an ingress that passes the original
+  # Host header through — see docs/docker-subdomain-connector.md.
+  docker:
+    subdomainConnector:
+      enabled: false
+      # -- The domain the "<repo>.<baseDomain>" hostnames sit under. Optional
+      # when only aliases are used.
+      baseDomain: ""
+      # -- Hostname → repository name, for DNS names that do not match the
+      # repository (a Nexus connector port being migrated, say). Any domain
+      # works; the hostname does not have to sit under baseDomain. Setting any
+      # alias mounts a small config file into the container, because a YAML map
+      # cannot be expressed as an environment variable.
+      #   aliases:
+      #     docker-hub-proxy.example.com: dockerhub-proxy
+      aliases: {}
 
 # -- Blob storage: "local" or "s3"
 storage:

--- a/docs/docker-subdomain-connector.md
+++ b/docs/docker-subdomain-connector.md
@@ -50,6 +50,22 @@ Alias hostnames are matched case-insensitively, ignoring any port. Point the
 DNS record (or Istio/Ingress route) at Nexspence and pass the original `Host`
 header through, exactly as below — no repository rename needed.
 
+### 1b. Or with the Helm chart
+
+```yaml
+config:
+  docker:
+    subdomainConnector:
+      enabled: true
+      baseDomain: "nexspence.example.com"
+      aliases: {}   # optional, same meaning as above
+```
+
+The chart passes `enabled` and `baseDomain` as environment variables; setting
+any alias makes it mount a small config file, because a YAML map has no
+environment-variable spelling. Remember to add a wildcard host to
+`ingress.hosts` — see the chart README's *Docker Subdomain Connector* section.
+
 ### 2. Wildcard DNS
 
 Add a wildcard DNS A record pointing to your Nexspence server:


### PR DESCRIPTION
Closes #401

The Docker subdomain connector had no chart values at all, so the only way to turn it on under Kubernetes was to build a custom image or hand-edit the ConfigMap after install.

```yaml
config:
  docker:
    subdomainConnector:
      enabled: true
      baseDomain: "nexspence.example.com"
      aliases:
        docker-hub-proxy.example.com: dockerhub-proxy
```

`enabled` and `baseDomain` travel as environment variables like every other setting. Aliases cannot — a YAML map has no environment-variable spelling — so setting any alias renders a small config file and mounts it over the image's `/app/config.yaml`. Everything else still arrives as env, which viper reads last, so mounting the file changes nothing but the aliases; with no aliases set, no file and no volume are rendered at all.

The chart README gains the two halves the chart cannot supply for you: wildcard DNS for `baseDomain`, and a wildcard `ingress.hosts` entry that passes the client's original `Host` header through — the header the connector routes on.

**Also in here**: the README's S3 example named `config.storage.defaultType` / `config.storage.s3.*`. The chart reads `.Values.storage.*`, so every one of those `--set` flags was silently ignored and the install came up on local disk. Corrected to `storage.type` / `storage.s3.*`.

## Verified

`helm lint` clean. `helm template` with the connector on renders `NEXSPENCE_DOCKER_SUBDOMAIN_CONNECTOR_ENABLED` / `_BASE_DOMAIN` in the ConfigMap, and with an alias set also renders the `-file` ConfigMap, the `config-file` volume and its `subPath` mount; with no aliases neither appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diVB5qCSUXhPkxXzJfF7D
