### PR TITLE
feat(api,ui): browse public repositories without signing in

### DIFF
--- a/docs/security-rbac.md
+++ b/docs/security-rbac.md
@@ -389,6 +389,22 @@ browse trees, component and asset listings, artifact downloads, and anonymous
 tokens from the Docker token endpoint. Anonymous writes are never allowed by
 either switch.
 
+### Browsing without signing in
+
+The web UI follows the same two switches. A visitor with no session lands on
+Repositories, Browse and Search rather than a login wall, and sees exactly the
+repositories both switches agree on — an empty list when the instance-wide
+switch is off, or when no repository sets `allow_anonymous`. The sidebar offers
+a Sign in link in place of the user pill, and every other page (Users, Cleanup
+Policies, System Admin, Security, Audit Log) still redirects to `/login`.
+
+The endpoints behind those three pages accept an unauthenticated caller and let
+RBAC decide: repository list and get, the browse trees, component and asset
+reads, and search. A repository the caller may not see answers `404`, not
+`401` or `403`, so its name stays unguessable. Everything else — writes,
+deletes, `/api/v1/me`, tokens, scan results, and the whole admin surface —
+still requires a token.
+
 The Docker `/v2/` handshake itself is unconditional: an unauthenticated ping
 always answers `401` with a `Bearer` challenge pointing at `/v2/token`.
 Clients with credentials trade them there for a user token (this is the

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -39,10 +39,25 @@ describe('App', () => {
     })
   })
 
-  it('does not render the protected layout for an unauthenticated user (PrivateRoute guard)', async () => {
+  it('lets an unauthenticated visitor reach the repositories page', async () => {
     renderApp('/repositories')
-    // PrivateRoute redirects guests away from the Layout; the sidebar nav
-    // (e.g. "Cleanup Policies") must never appear.
+    // Browsing public repositories without signing in is the point of #404:
+    // the shell renders, and the sidebar offers a way in instead of a user pill.
+    expect((await screen.findAllByText('Browse')).length).toBeGreaterThan(0)
+    expect(screen.getByText('Not signed in')).toBeInTheDocument()
+  })
+
+  it('keeps an unauthenticated visitor out of the admin pages', async () => {
+    renderApp('/cleanup')
+    // PrivateRoute still guards everything that is not a public read, so the
+    // page itself never mounts — its <h1> is the thing to look for, not the
+    // sidebar label of the same name (which is admin-gated separately).
+    await Promise.resolve()
+    expect(screen.queryByRole('heading', { name: 'Cleanup Policies' })).not.toBeInTheDocument()
+  })
+
+  it('hides the system nav from an unauthenticated visitor', async () => {
+    renderApp('/repositories')
     await Promise.resolve()
     expect(screen.queryByText('Cleanup Policies')).not.toBeInTheDocument()
   })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,12 @@ function PrivateRoute({ children }: { children: React.ReactNode }) {
   return <>{children}</>
 }
 
+// Repositories, Browse, Search and Docs render for a signed-out visitor too:
+// the read endpoints behind them answer anonymously, and the server returns
+// only repositories with allow_anonymous (and only while
+// auth.anonymous_enabled is on), so a closed instance shows an empty list
+// instead of a login wall (#404). Everything else stays behind PrivateRoute.
+
 export default function App() {
   const init = useAuthStore(s => s.init)
   useEffect(() => { init() }, [init])
@@ -64,14 +70,7 @@ export default function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route path="/oidc/callback" element={<OIDCCallbackPage />} />
         <Route path="/saml/callback" element={<SAMLCallbackPage />} />
-        <Route
-          path="/"
-          element={
-            <PrivateRoute>
-              <Layout />
-            </PrivateRoute>
-          }
-        >
+        <Route path="/" element={<Layout />}>
           <Route index element={<Navigate to="/repositories" replace />} />
           <Route path="repositories" element={<RepositoriesPage />} />
           <Route
@@ -93,42 +92,42 @@ export default function App() {
           <Route
             path="users"
             element={
-              <ErrorBoundary><Suspense fallback={<PageSkeleton />}>
+              <PrivateRoute><ErrorBoundary><Suspense fallback={<PageSkeleton />}>
                 <UsersPage />
-              </Suspense></ErrorBoundary>
+              </Suspense></ErrorBoundary></PrivateRoute>
             }
           />
           <Route
             path="cleanup"
             element={
-              <ErrorBoundary><Suspense fallback={<PageSkeleton />}>
+              <PrivateRoute><ErrorBoundary><Suspense fallback={<PageSkeleton />}>
                 <CleanupPage />
-              </Suspense></ErrorBoundary>
+              </Suspense></ErrorBoundary></PrivateRoute>
             }
           />
           <Route
             path="admin"
             element={
-              <ErrorBoundary><Suspense fallback={<PageSkeleton />}>
+              <PrivateRoute><ErrorBoundary><Suspense fallback={<PageSkeleton />}>
                 <AdminPage />
-              </Suspense></ErrorBoundary>
+              </Suspense></ErrorBoundary></PrivateRoute>
             }
           />
           <Route path="migration" element={<Navigate to="/admin?tab=migration" replace />} />
           <Route
             path="security"
             element={
-              <ErrorBoundary><Suspense fallback={<PageSkeleton />}>
+              <PrivateRoute><ErrorBoundary><Suspense fallback={<PageSkeleton />}>
                 <SecurityPage />
-              </Suspense></ErrorBoundary>
+              </Suspense></ErrorBoundary></PrivateRoute>
             }
           />
           <Route
             path="audit"
             element={
-              <ErrorBoundary><Suspense fallback={<PageSkeleton />}>
+              <PrivateRoute><ErrorBoundary><Suspense fallback={<PageSkeleton />}>
                 <AuditPage />
-              </Suspense></ErrorBoundary>
+              </Suspense></ErrorBoundary></PrivateRoute>
             }
           />
           <Route path="monitoring" element={<Navigate to="/admin?tab=monitoring" replace />} />

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import { Outlet, NavLink } from 'react-router-dom'
 import {
   Home, Search, FolderOpen, Trash2,
   Settings, Shield, FileText, LogOut,
-  Key, Plus, X, Copy, Check,
+  Key, LogIn, Plus, X, Copy, Check,
   BookOpen, ChevronLeft, ChevronRight,
 } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
@@ -348,6 +348,21 @@ export default function Layout() {
             >
               <LogOut size={11} />
             </button>
+          </div>
+        )}
+        {/* A signed-out visitor browsing public repositories still needs a way
+            in — the pill would otherwise be missing entirely (#404). */}
+        {!user && (
+          <div className={styles.commandBar}>
+            <NavLink to="/login" className={styles.commandBarAvatar} title="Sign in">
+              <LogIn size={13} />
+            </NavLink>
+            <div className={styles.commandBarUser}>
+              <Truncated as="span" className={styles.commandBarUserName} text="Not signed in" />
+            </div>
+            <NavLink to="/login" className={styles.commandBarAction} title="Sign in">
+              <Key size={11} />
+            </NavLink>
           </div>
         )}
         <span className={styles.version}>Nexspence v{systemInfo?.version ?? '…'}</span>

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -441,6 +441,16 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 
 	// ── Authenticated endpoints (all valid users) ────────────
 	authed := r.Group("", authMW)
+	// Read endpoints that answer an unauthenticated caller too, marked
+	// publicRead below. Every one of them runs the request through RBACService,
+	// which serves an anonymous caller only for repositories carrying
+	// allow_anonymous, and only while the instance-wide auth.anonymous_enabled
+	// switch is on — so on a closed instance they behave exactly as they did
+	// behind authMW, answering with an empty list or a 404 rather than a 401.
+	// Browsing a public repository without signing in is what Nexus does, and
+	// what the web UI offers on top of this (#404). Writes, deletes and
+	// everything user-scoped stay on authed.
+	publicRead := r.Group("", handlers.OptionalAuth(userSvc, tokenSvc, loginGuard, log))
 	{
 		authed.GET("/service/rest/v1/status", func(c *gin.Context) {
 			c.JSON(http.StatusOK, gin.H{"status": "ok"})
@@ -455,27 +465,27 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		authed.PUT("/api/v1/me/change-password", userH.ChangePassword)
 
 		// ── Repositories (read) ───────────────────────────────
-		authed.GET("/service/rest/v1/repositories", repoH.List)
-		authed.GET("/service/rest/v1/repositories/:name", repoH.Get)
-		authed.GET("/api/v1/repositories", repoH.List)
+		publicRead.GET("/service/rest/v1/repositories", repoH.List)
+		publicRead.GET("/service/rest/v1/repositories/:name", repoH.Get)
+		publicRead.GET("/api/v1/repositories", repoH.List)
 		authed.GET("/api/v1/repositories/:name/quota", componentH.GetQuota)
 
 		// ── Browse ────────────────────────────────────────────
-		authed.GET("/api/v1/browse/repositories/:name/docker-tree", browseH.DockerTree)
-		authed.GET("/api/v1/browse/repositories/:name/oci-referrers", browseH.OCIReferrers)
-		authed.GET("/api/v1/browse/repositories/:name/raw-tree", browseH.RawTree)
-		authed.GET("/api/v1/browse/repositories/:name/path-tree", browseH.PathTree)
+		publicRead.GET("/api/v1/browse/repositories/:name/docker-tree", browseH.DockerTree)
+		publicRead.GET("/api/v1/browse/repositories/:name/oci-referrers", browseH.OCIReferrers)
+		publicRead.GET("/api/v1/browse/repositories/:name/raw-tree", browseH.RawTree)
+		publicRead.GET("/api/v1/browse/repositories/:name/path-tree", browseH.PathTree)
 		authed.DELETE("/api/v1/browse/repositories/:name/path", browseH.DeleteByPath)
 		authed.DELETE("/api/v1/browse/repositories/:name/docker-tag", browseH.DeleteDockerTag)
 		authed.DELETE("/api/v1/browse/repositories/:name/docker-image", browseH.DeleteDockerImage)
 
 		// ── Components & Assets (read + search) ───────────────
-		authed.GET("/service/rest/v1/components", componentH.List)
-		authed.GET("/service/rest/v1/components/:id", componentH.Get)
-		authed.GET("/service/rest/v1/assets", func(c *gin.Context) {
+		publicRead.GET("/service/rest/v1/components", componentH.List)
+		publicRead.GET("/service/rest/v1/components/:id", componentH.Get)
+		publicRead.GET("/service/rest/v1/assets", func(c *gin.Context) {
 			componentH.SearchAssets(c)
 		})
-		authed.GET("/service/rest/v1/assets/:id", func(c *gin.Context) {
+		publicRead.GET("/service/rest/v1/assets/:id", func(c *gin.Context) {
 			id := c.Param("id")
 			a, err := assetRepo.Get(c.Request.Context(), id)
 			if errors.Is(err, repository.ErrNotFound) {
@@ -514,9 +524,9 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		})
 
 		// ── Search ────────────────────────────────────────────
-		authed.GET("/service/rest/v1/search", componentH.Search)
-		authed.GET("/service/rest/v1/search/assets", componentH.SearchAssets)
-		authed.GET("/service/rest/v1/search/assets/download", componentH.SearchAssetsDownload)
+		publicRead.GET("/service/rest/v1/search", componentH.Search)
+		publicRead.GET("/service/rest/v1/search/assets", componentH.SearchAssets)
+		publicRead.GET("/service/rest/v1/search/assets/download", componentH.SearchAssetsDownload)
 
 		// ── Metrics (authenticated) ───────────────────────────
 		authed.GET("/api/v1/metrics", handlers.MetricsHandler(pool))

--- a/internal/integration/integration_test.go
+++ b/internal/integration/integration_test.go
@@ -82,6 +82,11 @@ func server(t *testing.T) *httptest.Server {
 		cfg.Bootstrap.AdminUsername = "admin"
 		cfg.Bootstrap.AdminPassword = "admin123"
 		cfg.Bootstrap.AdminEmail = "admin@test.local"
+		// Production's default. It is the instance-wide half of the anonymous
+		// switch; without it every allow_anonymous repository still refuses an
+		// unauthenticated read, and the public-read tests below would pass for
+		// the wrong reason.
+		cfg.Auth.AnonymousEnabled = true
 
 		log := logger.New("error", "json")
 		handler := api.NewRouter(context.Background(), cfg, pool, log, "integration-test")
@@ -301,4 +306,98 @@ func TestMetricsEndpoint(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&snap))
 	assert.Contains(t, snap, "requests_total")
 	assert.Contains(t, snap, "uptime_seconds")
+}
+
+// ── Anonymous browsing (#404) ─────────────────────────────────
+
+// anonReq issues a request with no Authorization header at all.
+func anonReq(t *testing.T, path string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, server(t).URL+path, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
+// Nexus lets a visitor browse public repositories without signing in, and the
+// read endpoints the web UI is built on refused an unauthenticated caller with
+// a 401 before this — so the UI had no choice but to gate everything behind a
+// login. They now run OptionalAuth and let RBAC decide, which means a
+// repository is visible anonymously only when it carries allow_anonymous.
+func TestAnonymousBrowse_SeesOnlyPublicRepositories(t *testing.T) {
+	token := login(t, "admin", "admin123")
+
+	for _, r := range []struct {
+		name string
+		anon bool
+	}{{"anon-public", true}, {"anon-private", false}} {
+		body := fmt.Sprintf(
+			`{"name":%q,"online":true,"allowAnonymous":%t,"storage":{"blobStoreName":"default","strictContentTypeValidation":false}}`,
+			r.name, r.anon)
+		resp := authReq(t, http.MethodPost, "/service/rest/v1/repositories/raw/hosted",
+			bytes.NewBufferString(body), token)
+		resp.Body.Close()
+		require.Equal(t, http.StatusCreated, resp.StatusCode, "create %s", r.name)
+		t.Cleanup(func() {
+			del := authReq(t, http.MethodDelete, "/service/rest/v1/repositories/"+r.name, nil, token)
+			del.Body.Close()
+		})
+	}
+
+	t.Run("list shows the public repo and hides the private one", func(t *testing.T) {
+		resp := anonReq(t, "/api/v1/repositories")
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var repos []map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&repos))
+		names := map[string]bool{}
+		for _, r := range repos {
+			names[fmt.Sprint(r["name"])] = true
+		}
+		assert.True(t, names["anon-public"], "public repo missing from the anonymous listing")
+		assert.False(t, names["anon-private"], "private repo leaked into the anonymous listing")
+	})
+
+	t.Run("get by name answers for the public repo only", func(t *testing.T) {
+		pub := anonReq(t, "/service/rest/v1/repositories/anon-public")
+		defer pub.Body.Close()
+		assert.Equal(t, http.StatusOK, pub.StatusCode)
+
+		// 404 rather than 401/403: the name stays unguessable, and the caller
+		// is never told to go and authenticate for something they cannot see.
+		priv := anonReq(t, "/service/rest/v1/repositories/anon-private")
+		defer priv.Body.Close()
+		assert.Equal(t, http.StatusNotFound, priv.StatusCode)
+	})
+
+	t.Run("browse and search answer anonymously", func(t *testing.T) {
+		tree := anonReq(t, "/api/v1/browse/repositories/anon-public/path-tree")
+		defer tree.Body.Close()
+		assert.Equal(t, http.StatusOK, tree.StatusCode)
+
+		search := anonReq(t, "/service/rest/v1/search?repository=anon-public")
+		defer search.Body.Close()
+		assert.Equal(t, http.StatusOK, search.StatusCode)
+
+		components := anonReq(t, "/service/rest/v1/components?repository=anon-public")
+		defer components.Body.Close()
+		assert.Equal(t, http.StatusOK, components.StatusCode)
+	})
+
+	// Everything that is not a public read still demands a token.
+	t.Run("writes and user-scoped endpoints still require auth", func(t *testing.T) {
+		for _, path := range []string{"/api/v1/me", "/api/v1/tokens", "/service/rest/v1/security/roles"} {
+			resp := anonReq(t, path)
+			resp.Body.Close()
+			assert.Equal(t, http.StatusUnauthorized, resp.StatusCode, "%s answered anonymously", path)
+		}
+		req, err := http.NewRequest(http.MethodDelete,
+			server(t).URL+"/api/v1/browse/repositories/anon-public/path?path=/x", nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode, "anonymous delete was not refused")
+	})
 }


### PR DESCRIPTION
Closes #404

Nexus lets a visitor browse public repositories in the web UI without an account. Here every read endpoint the UI is built on sat behind `authMW` and answered an unauthenticated caller with a `401`, so the UI had no choice but to gate the whole app behind a login — even on an instance whose repositories all carry `allow_anonymous`.

## Backend

These endpoints move from `authMW` to `OptionalAuth` and let `RBACService` decide:

- `GET /api/v1/repositories`, `GET /service/rest/v1/repositories`, `GET /service/rest/v1/repositories/:name`
- `GET /api/v1/browse/repositories/:name/{docker-tree,oci-referrers,raw-tree,path-tree}`
- `GET /service/rest/v1/components`, `/components/:id`, `/assets`, `/assets/:id`
- `GET /service/rest/v1/search`, `/search/assets`, `/search/assets/download`

This is the treatment the artifact endpoints have always had. It changes nothing on a closed instance: an anonymous caller is served only for repositories carrying `allow_anonymous`, and only while the instance-wide `auth.anonymous_enabled` is on, so the answer is an empty list or a `404` — never a `401` telling the caller to go and authenticate for something they cannot see. Every one of these handlers already ran its result through RBAC with a possibly-empty `userID`; #391/#416 closed the last four that did not.

Writes, deletes, `/api/v1/me`, tokens, scan results and the whole admin surface stay on `authed`.

## UI

`Layout` is no longer wrapped in `PrivateRoute` — the five admin pages (Users, Cleanup, Admin, Security, Audit) are wrapped individually instead. A signed-out visitor gets Repositories, Browse, Search and Docs, and a **Sign in** pill where the user pill would be. The System nav was already admin-gated, so it stays hidden.

## Verified

`TestAnonymousBrowse_SeesOnlyPublicRepositories` boots the real router over a real Postgres, creates one `allowAnonymous` repo and one private one, and checks that an unauthenticated caller: sees the public repo in the listing and not the private one; gets `200` on the public repo by name and `404` on the private one; gets `200` from path-tree, search and components; and still gets `401` from `/api/v1/me`, `/api/v1/tokens`, `/service/rest/v1/security/roles` and a browse `DELETE`. The harness now sets `cfg.Auth.AnonymousEnabled = true` (production's default) — without it the instance-wide switch would have made those assertions pass for the wrong reason.

Three new `App.test.tsx` cases cover the routing change. Full integration suite (22 tests) green against dockertest Postgres; `go build`, `go vet`, `golangci-lint`, `tsc --noEmit` clean; frontend suite 540 green; `go test ./...` green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diVB5qCSUXhPkxXzJfF7D
