### PR TITLE
fix(migration): settle a migration's record when its runner panics

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -173,11 +173,19 @@ func TestValidateToken_TamperedSignature(t *testing.T) {
 	s := newSvc()
 	token, err := s.GenerateToken("uid-12", "grace", []string{"viewer"})
 	require.NoError(t, err)
-	// flip the last character of the signature
+	// Flip a character in the middle of the signature. Not the last one: an
+	// HMAC-SHA256 signature is 32 bytes in 43 base64url characters, so the
+	// final character carries only 2 significant bits and the 16 characters
+	// sharing them all decode to the same bytes — a quarter of the tokens this
+	// test generates would have "tampered" into the identical signature and
+	// validated cleanly.
 	parts := strings.Split(token, ".")
 	require.Len(t, parts, 3)
-	last := parts[2]
-	swapped := last[:len(last)-1] + string(flipChar(last[len(last)-1]))
+	sig := parts[2]
+	require.Greater(t, len(sig), 1)
+	mid := len(sig) / 2
+	swapped := sig[:mid] + string(flipChar(sig[mid])) + sig[mid+1:]
+	require.NotEqual(t, sig, swapped)
 	tampered := parts[0] + "." + parts[1] + "." + swapped
 	_, err = s.ValidateToken(tampered)
 	assert.ErrorIs(t, err, auth.ErrInvalidToken)

--- a/internal/service/blob_store_migration_service.go
+++ b/internal/service/blob_store_migration_service.go
@@ -224,6 +224,20 @@ func (s *BlobStoreMigrationService) runMigration(ctx context.Context, m *domain.
 		delete(s.cancels, m.ID)
 		s.mu.Unlock()
 	}()
+	// Every ordinary exit below stamps a terminal status. A panic doesn't:
+	// safego.Go swallows it so the process survives, and the row would then
+	// say "running" forever — the repository stays locked out of a re-run by
+	// the active-migration check, and the operator sees a job that never
+	// finishes instead of one that failed. Closing it from a defer catches the
+	// early `return` when UpdateStatus itself fails, too.
+	defer func() {
+		cur, err := s.migrations.Get(context.Background(), m.ID)
+		if err != nil || cur == nil || (cur.Status != "pending" && cur.Status != "running") {
+			return
+		}
+		msg := "migration ended without finishing (panic recovered); see the server log for the stack"
+		_ = s.migrations.FinishMigration(context.Background(), m.ID, "failed", &msg)
+	}()
 
 	// Root span: the migration goroutine runs on context.Background(), cut
 	// loose from the HTTP request that started it (#302). The span hangs off

--- a/internal/service/blob_store_migration_service_test.go
+++ b/internal/service/blob_store_migration_service_test.go
@@ -308,6 +308,16 @@ func TestBlobStoreMigration_StartLosesInsertRace_ReportsConflict(t *testing.T) {
 func TestBlobStoreMigration_ConcurrentStarts_OnlyOneWins(t *testing.T) {
 	ctx := context.Background()
 
+	// The winning Start launches its runner immediately, and with no assets to
+	// copy that runner used to reach "done" before the loser's Start looked for
+	// an active migration — which made the loser's second migration correct
+	// behavior and the test fail for a reason it was not written to check.
+	// Holding the runner at its first asset query keeps the first migration
+	// "running" for as long as both goroutines are in flight.
+	assets := testutil.NewAssetRepo()
+	assets.MigrationListGate = make(chan struct{})
+	defer close(assets.MigrationListGate)
+
 	sourceID := "store-src-001"
 	bsID := sourceID
 	repo := &domain.Repository{
@@ -316,7 +326,7 @@ func TestBlobStoreMigration_ConcurrentStarts_OnlyOneWins(t *testing.T) {
 	}
 	migRepo := testutil.NewBlobStoreMigrationRepo()
 	svc := service.NewBlobStoreMigrationService(
-		migRepo, testutil.NewAssetRepo(), testutil.NewRepoRepo(repo),
+		migRepo, assets, testutil.NewRepoRepo(repo),
 		testutil.NewBlobStoreRepo(
 			&domain.BlobStore{ID: sourceID, Name: "source-store", Type: "local"},
 			&domain.BlobStore{ID: "store-tgt-a", Name: "target-a", Type: "local"},
@@ -355,5 +365,54 @@ func TestBlobStoreMigration_ConcurrentStarts_OnlyOneWins(t *testing.T) {
 	}
 	if created != 1 {
 		t.Fatalf("want exactly 1 migration created, got %d", created)
+	}
+}
+
+// panickingMigrationAssets blows up at the runner's first asset query — the
+// shape of any nil dereference or bad-shape panic inside a detached migration.
+type panickingMigrationAssets struct {
+	*testutil.AssetRepo
+}
+
+func (panickingMigrationAssets) ListForBlobStoreMigration(_ context.Context, _, _ string) ([]domain.MigrationAssetRow, error) {
+	panic("migration runner blew up")
+}
+
+// safego.Go keeps a panicking migration from taking the process down, but the
+// row it leaves behind said "running" forever: the repository stays locked out
+// of a re-run by the active-migration check, and the operator watches a job
+// that can never finish. The run has to close its own record on the way out.
+func TestBlobStoreMigration_RunnerPanics_MigrationIsMarkedFailed(t *testing.T) {
+	ctx := context.Background()
+
+	sourceID := "store-src-panic"
+	bsID := sourceID
+	repo := &domain.Repository{
+		ID: "repo-panic", Name: "panic-repo", Format: domain.RepoFormat("raw"),
+		Type: domain.TypeHosted, Online: true, BlobStoreID: &bsID,
+	}
+	svc := service.NewBlobStoreMigrationService(
+		testutil.NewBlobStoreMigrationRepo(),
+		panickingMigrationAssets{testutil.NewAssetRepo()},
+		testutil.NewRepoRepo(repo),
+		testutil.NewBlobStoreRepo(
+			&domain.BlobStore{ID: sourceID, Name: "source-store", Type: "local"},
+			&domain.BlobStore{ID: "store-tgt-panic", Name: "target-store", Type: "local"},
+		),
+		storage.NewRegistry(testutil.NewBlobStore()),
+	)
+
+	if _, err := svc.Start(ctx, "panic-repo", "store-tgt-panic"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	m := waitForMigration(t, svc, "panic-repo", "failed")
+	if m.ErrorMessage == nil || !strings.Contains(*m.ErrorMessage, "panic") {
+		t.Fatalf("error message %v does not say why the run ended", m.ErrorMessage)
+	}
+
+	// And the repository is free to try again.
+	if _, err := svc.Start(ctx, "panic-repo", "store-tgt-panic"); err != nil {
+		t.Fatalf("a failed migration must not block a re-run, got %v", err)
 	}
 }

--- a/internal/service/nexus_migration_service.go
+++ b/internal/service/nexus_migration_service.go
@@ -416,6 +416,23 @@ func (s *NexusMigrationService) run(ctx context.Context, jobID string) {
 		}
 		s.mu.Unlock()
 	}()
+	// Registered after the cleanup defer, so LIFO runs it first — the status
+	// is settled before anyone waiting on dones is released. Every ordinary
+	// exit below leaves a terminal status; a panic doesn't. safego.Go swallows
+	// it so the process survives, and the job would then say "running"
+	// forever: IsActive keeps a second run from starting and IsResumable
+	// refuses to relaunch it, so the operator is left with a job that can
+	// neither finish nor be retried. The early returns that only log (job load
+	// and SetStarted failures) left the same wedge.
+	defer func() {
+		bgCtx := context.Background()
+		cur, err := s.jobs.Get(bgCtx, jobID)
+		if err != nil || cur == nil || !cur.IsActive() {
+			return
+		}
+		s.finish(bgCtx, jobID, domain.MigrationError,
+			"migration ended without finishing (panic recovered); see the server log for the stack")
+	}()
 
 	// Progress and status are written on a background context: a paused or
 	// canceled run still has to record where it stopped.

--- a/internal/service/nexus_migration_service_test.go
+++ b/internal/service/nexus_migration_service_test.go
@@ -1516,3 +1516,48 @@ func TestNexusMigration_AssetListingUnavailable_Tolerated(t *testing.T) {
 	assert.Zero(t, done.ErrorCount)
 	assert.Equal(t, int64(1), done.DoneAssets)
 }
+
+// ── a panicking run must not wedge the job ───────────────────────────────────
+
+// panickingJobs blows up where the runner stamps the job started — the shape
+// of any nil dereference or bad-shape panic inside a detached migration.
+type panickingJobs struct {
+	*testutil.MigrationRepo
+}
+
+func (panickingJobs) SetStarted(_ context.Context, _ string, _ time.Time) error {
+	panic("migration runner blew up")
+}
+
+// safego.Go keeps a panicking run from taking the process down, but the job it
+// left behind said "running" forever — IsActive stops a second run from
+// starting and IsResumable refuses to relaunch it, so the operator holds a job
+// that can neither finish nor be retried. The run has to settle its own record
+// on the way out.
+func TestNexusMigration_RunPanics_JobIsMarkedError(t *testing.T) {
+	fake := &fakeNexus{settings: `[]`}
+	h := newMigHarness(t, fake)
+	h.svc = service.NewNexusMigrationService(service.NexusMigrationConfig{
+		Jobs:          panickingJobs{h.jobs},
+		Repos:         service.NewRepositoryService(h.repos, testutil.NewBlobStoreRepo(), h.blobs, testutil.NewCleanupPolicyRepo()),
+		Users:         h.users,
+		Roles:         h.roles,
+		Privileges:    h.privileges,
+		RoutingRules:  h.rules,
+		Deps:          formats.Deps{Repos: h.repos, Components: h.components, Assets: h.assets, BlobStore: h.blobs, BaseURL: "http://nexspence.test"},
+		JWTSecret:     "unit-test-secret",
+		Log:           zap.NewNop().Sugar(),
+		HTTPClientFor: func(time.Duration) *http.Client { return h.nexus.Client() },
+	})
+
+	job := &domain.MigrationJob{
+		SourceURL: h.nexus.URL, SourceUser: "admin",
+		Status: domain.MigrationPending, MigrateRepos: true,
+	}
+	require.NoError(t, h.svc.Create(context.Background(), job, "s3cret"))
+
+	settled := h.waitForStatus(t, job.ID, domain.MigrationError)
+	require.NotNil(t, settled.LastError)
+	assert.Contains(t, *settled.LastError, "panic")
+	assert.True(t, settled.IsResumable(), "a settled job must be retryable")
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -601,7 +601,11 @@ type AssetRepo struct {
 	// path does a single pass instead of looping.
 	ListStaleCalls int
 	MigrationRows  []domain.MigrationAssetRow
-	Err            error // when non-nil, ListByComponentID/ListByComponentIDs/SearchAssets/SumSizeByRepo return it (500-branch seam)
+	// MigrationListGate, when non-nil, holds ListForBlobStoreMigration until it
+	// is closed, parking a blob-store migration in the "running" state for as
+	// long as the test needs.
+	MigrationListGate chan struct{}
+	Err               error // when non-nil, ListByComponentID/ListByComponentIDs/SearchAssets/SumSizeByRepo return it (500-branch seam)
 	// DeleteErr, when non-nil, makes Delete fail while leaving the row in place —
 	// the seam for "the DB write failed after the bytes were already touched".
 	DeleteErr error
@@ -1165,6 +1169,13 @@ func (a *AssetRepo) ListRawAssetPaths(_ context.Context, repoName string) ([]str
 }
 
 func (a *AssetRepo) ListForBlobStoreMigration(_ context.Context, _, _ string) ([]domain.MigrationAssetRow, error) {
+	// A test that needs the run to still be in flight while it does something
+	// else closes this channel when it is ready to let the run proceed. The
+	// runner reaches this call right after stamping "running", so blocking
+	// here holds the migration in exactly the state a second starter must see.
+	if a.MigrationListGate != nil {
+		<-a.MigrationListGate
+	}
 	return a.MigrationRows, nil
 }
 


### PR DESCRIPTION
Follow-up to #390, closing the second finding from its review.

#390 wrapped the two detached migration goroutines in `safego.Go`, so a panic inside one no longer takes the process down. What it left behind was a row that says `running` forever:

- a **blob-store migration**'s repository stays locked out of a re-run by the active-migration check;
- a **Nexus job** is refused by `IsActive` (no second run) and `IsResumable` (no retry) alike — it can neither finish nor be retried, and the operator watches a progress bar that will never move.

A loud crash became a silently wedged job.

## The fix

Both runners settle their own record from a `defer` that fires only when the row is still non-terminal. Every ordinary exit path already stamps a terminal status, so the defer is a no-op on all of them; it catches the panic, and with it the two early returns that only logged (a failed `UpdateStatus`, a failed `SetStarted`) and wedged the job the same way. In the Nexus runner it is registered *after* the cleanup defer, so LIFO settles the status before anyone waiting on `dones` is released — which is what that defer's own comment already promised.

`TestBlobStoreMigration_RunnerPanics_MigrationIsMarkedFailed` and `TestNexusMigration_RunPanics_JobIsMarkedError` panic the runner through a repo stub, then assert the terminal status, an error message that says why, and — for the blob-store one — that a re-run is accepted afterwards.

## Two test-suite fixes found on the way

**`TestBlobStoreMigration_ConcurrentStarts_OnlyOneWins` raced the runner it started.** With no assets to copy, the winner's migration reached `done` before the loser's `Start` looked for an active one — so the second migration was correct behavior and the test failed for a reason it was not written to check. 3 failures in 40 runs on `main`. `AssetRepo` gains a gate that holds `ListForBlobStoreMigration`, parking the run in `running` for as long as both goroutines are in flight; 60 consecutive runs green.

**`TestValidateToken_TamperedSignature` flipped the last character of the signature.** An HMAC-SHA256 signature is 32 bytes in 43 base64url characters, so that character carries only 2 significant bits, and the 16 characters sharing them decode to identical bytes — a quarter of the tokens this test generates "tampered" into the same signature and validated cleanly. (It failed once during this session's batch verification.) It now flips a character in the middle.

`go build`, `go vet`, `golangci-lint` clean; `go test ./...` green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diVB5qCSUXhPkxXzJfF7D
