### PR TITLE
feat(helm): close the gap between what the app supports and the chart exposes

### DIFF
--- a/deploy/helm/nexspence/templates/NOTES.txt
+++ b/deploy/helm/nexspence/templates/NOTES.txt
@@ -10,7 +10,7 @@ Nexspence has been deployed!
   Check the cilium Gateway external IP:
   kubectl get gateway {{ include "nexspence.fullname" . }}-cilium -n {{ .Release.Namespace }}
 {{- else }}
-  kubectl port-forward svc/{{ include "nexspence.fullname" . }} 8081:8081
+  kubectl port-forward svc/{{ include "nexspence.fullname" . }} 8081:{{ .Values.service.port }}
   http://localhost:8081
 {{- end }}
 

--- a/deploy/helm/nexspence/templates/_helpers.tpl
+++ b/deploy/helm/nexspence/templates/_helpers.tpl
@@ -73,3 +73,37 @@ PostgreSQL DSN — either external or bitnami sub-chart.
 {{- .Values.externalDatabase.dsn }}
 {{- end }}
 {{- end }}
+
+{{/*
+Redis mutual-exclusion guard — bundled and external are not both allowed.
+*/}}
+{{- define "nexspence.redisInUse" -}}
+{{- if and .Values.redis.enabled .Values.externalRedis.enabled }}
+{{- fail "only one of redis.enabled / externalRedis.enabled may be true" }}
+{{- end }}
+{{- end }}
+
+{{- define "nexspence.redisAddr" -}}
+{{- include "nexspence.redisInUse" . }}
+{{- if .Values.redis.enabled }}
+{{- printf "%s-redis-master:6379" .Release.Name }}
+{{- else }}
+{{- .Values.externalRedis.addr }}
+{{- end }}
+{{- end }}
+
+{{- define "nexspence.redisPassword" -}}
+{{- if .Values.redis.enabled }}
+{{- .Values.redis.auth.password }}
+{{- else }}
+{{- .Values.externalRedis.password }}
+{{- end }}
+{{- end }}
+
+{{- define "nexspence.redisDB" -}}
+{{- if .Values.redis.enabled }}
+{{- 0 }}
+{{- else }}
+{{- .Values.externalRedis.db }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/nexspence/templates/configmap.yaml
+++ b/deploy/helm/nexspence/templates/configmap.yaml
@@ -6,8 +6,15 @@ metadata:
   labels:
     {{- include "nexspence.labels" . | nindent 4 }}
 data:
-  NEXSPENCE_HTTP_LISTEN: {{ .Values.config.httpListen | quote }}
+  # config.httpListen used to map to no config key at all (the real one is
+  # http.addr); NEXSPENCE_HTTP_ADDR is what viper actually reads.
+  NEXSPENCE_HTTP_ADDR: {{ .Values.config.httpAddr | quote }}
   NEXSPENCE_HTTP_BASE_URL: {{ .Values.config.baseURL | quote }}
+  {{- if .Values.config.trustedProxies }}
+  # Comma-separated; viper's default mapstructure decode hook splits a
+  # []string env override on "," (config_test.go:TestLoad_TrustedProxies_EnvOverride).
+  NEXSPENCE_HTTP_TRUSTED_PROXIES: {{ .Values.config.trustedProxies | join "," | quote }}
+  {{- end }}
   NEXSPENCE_LOG_LEVEL: {{ .Values.config.logLevel | quote }}
   NEXSPENCE_LOG_FORMAT: {{ .Values.config.logFormat | quote }}
   NEXSPENCE_AUTH_JWT_EXPIRY_HOURS: {{ .Values.config.jwtExpiryHours | quote }}
@@ -19,6 +26,28 @@ data:
   NEXSPENCE_METRICS_PUBLIC: {{ .Values.config.metricsPublic | quote }}
   NEXSPENCE_DOCKER_SUBDOMAIN_CONNECTOR_ENABLED: {{ .Values.config.docker.subdomainConnector.enabled | quote }}
   NEXSPENCE_DOCKER_SUBDOMAIN_CONNECTOR_BASE_DOMAIN: {{ .Values.config.docker.subdomainConnector.baseDomain | quote }}
+  NEXSPENCE_TRACING_ENABLED: {{ .Values.tracing.enabled | quote }}
+  {{- if .Values.tracing.enabled }}
+  NEXSPENCE_TRACING_OTLP_ENDPOINT: {{ .Values.tracing.otlpEndpoint | quote }}
+  NEXSPENCE_TRACING_OTLP_PROTOCOL: {{ .Values.tracing.otlpProtocol | quote }}
+  NEXSPENCE_TRACING_OTLP_INSECURE: {{ .Values.tracing.otlpInsecure | quote }}
+  NEXSPENCE_TRACING_SAMPLE_RATIO: {{ .Values.tracing.sampleRatio | quote }}
+  NEXSPENCE_TRACING_SERVICE_NAME: {{ .Values.tracing.serviceName | quote }}
+  NEXSPENCE_TRACING_ENVIRONMENT: {{ .Values.tracing.environment | quote }}
+  {{- end }}
+  NEXSPENCE_OIDC_ENABLED: {{ .Values.oidc.enabled | quote }}
+  {{- if or .Values.redis.enabled .Values.externalRedis.enabled }}
+  NEXSPENCE_REDIS_ENABLED: "true"
+  NEXSPENCE_REDIS_ADDR: {{ include "nexspence.redisAddr" . | quote }}
+  NEXSPENCE_REDIS_DB: {{ include "nexspence.redisDB" . | quote }}
+  {{- else }}
+  NEXSPENCE_REDIS_ENABLED: "false"
+  {{- end }}
+  # storage.default_type is the one setting that actually tells the app which
+  # backend to use — emitting only the type-specific block below and never
+  # this key meant storage.type: s3 in values had zero effect on the running
+  # app, which stayed on "local" (its own default) regardless.
+  NEXSPENCE_STORAGE_DEFAULT_TYPE: {{ .Values.storage.type | quote }}
   {{- if eq .Values.storage.type "local" }}
   NEXSPENCE_STORAGE_LOCAL_BASE_PATH: {{ .Values.storage.local.mountPath | quote }}
   {{- else if eq .Values.storage.type "s3" }}

--- a/deploy/helm/nexspence/templates/deployment.yaml
+++ b/deploy/helm/nexspence/templates/deployment.yaml
@@ -84,6 +84,45 @@ spec:
             - name: NEXSPENCE_SCAN_TRIVY_BIN
               value: /opt/trivy/trivy
             {{- end }}
+            {{- if and (not .Values.postgresql.enabled) .Values.externalDatabase.existingSecret }}
+            - name: NEXSPENCE_DATABASE_DSN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalDatabase.existingSecret }}
+                  key: {{ .Values.externalDatabase.existingSecretKey | default "dsn" }}
+            {{- end }}
+            {{- if and (eq .Values.storage.type "s3") .Values.storage.s3.existingSecret }}
+            - name: NEXSPENCE_STORAGE_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.s3.existingSecret }}
+                  key: {{ .Values.storage.s3.existingSecretAccessKeyKey | default "access-key" }}
+            - name: NEXSPENCE_STORAGE_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.s3.existingSecret }}
+                  key: {{ .Values.storage.s3.existingSecretSecretKeyKey | default "secret-key" }}
+            {{- end }}
+            {{- if and .Values.redis.enabled .Values.redis.auth.existingSecret }}
+            - name: NEXSPENCE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.auth.existingSecret }}
+                  key: {{ .Values.redis.auth.existingSecretKey | default "password" }}
+            {{- else if and .Values.externalRedis.enabled .Values.externalRedis.existingSecret }}
+            - name: NEXSPENCE_REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.externalRedis.existingSecret }}
+                  key: {{ .Values.externalRedis.existingSecretKey | default "password" }}
+            {{- end }}
+            {{- if and .Values.oidc.enabled .Values.oidc.clientSecretExistingSecret }}
+            - name: NEXSPENCE_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.oidc.clientSecretExistingSecret }}
+                  key: {{ .Values.oidc.clientSecretExistingSecretKey | default "client-secret" }}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "nexspence.fullname" . }}
@@ -118,6 +157,9 @@ spec:
               subPath: config.yaml
               readOnly: true
             {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         # Writable scratch dirs (rootfs is read-only). The trivy cache lives at
         # /app/.cache (HOME=/app, TRIVY_CACHE_DIR=/app/.cache/trivy in the image).
@@ -133,12 +175,15 @@ spec:
         {{- if eq .Values.storage.type "local" }}
         - name: blobs
           persistentVolumeClaim:
-            claimName: {{ include "nexspence.fullname" . }}-blobs
+            claimName: {{ .Values.storage.local.existingClaim | default (printf "%s-blobs" (include "nexspence.fullname" .)) }}
         {{- end }}
         {{- if .Values.scanning.enabled }}
         - name: trivy-bin
           emptyDir:
             sizeLimit: {{ .Values.scanning.volumeSize }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/helm/nexspence/templates/pvc.yaml
+++ b/deploy/helm/nexspence/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.storage.type "local" }}
+{{- if and (eq .Values.storage.type "local") (not .Values.storage.local.existingClaim) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -8,7 +8,7 @@ metadata:
     {{- include "nexspence.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.storage.local.accessMode }}
   resources:
     requests:
       storage: {{ .Values.storage.local.size }}

--- a/deploy/helm/nexspence/templates/secret.yaml
+++ b/deploy/helm/nexspence/templates/secret.yaml
@@ -7,7 +7,10 @@ metadata:
     {{- include "nexspence.labels" . | nindent 4 }}
 type: Opaque
 stringData:
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "nexspence.fullname" .) }}
+  {{- if or .Values.postgresql.enabled (not .Values.externalDatabase.existingSecret) }}
   NEXSPENCE_DATABASE_DSN: {{ include "nexspence.databaseDSN" . | quote }}
+  {{- end }}
   {{- /*
     JWT secret resolution:
       1. explicit .Values.config.jwtSecret wins;
@@ -18,7 +21,6 @@ stringData:
   */ -}}
   {{- $jwt := .Values.config.jwtSecret }}
   {{- if not $jwt }}
-  {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "nexspence.fullname" .) }}
   {{- if and $existing $existing.data (index $existing.data "NEXSPENCE_AUTH_JWT_SECRET") }}
   {{- $jwt = index $existing.data "NEXSPENCE_AUTH_JWT_SECRET" | b64dec }}
   {{- else }}
@@ -27,9 +29,47 @@ stringData:
   {{- end }}
   NEXSPENCE_AUTH_JWT_SECRET: {{ $jwt | quote }}
   NEXSPENCE_BOOTSTRAP_ADMIN_PASSWORD: {{ .Values.config.adminPassword | quote }}
-  {{- if eq .Values.storage.type "s3" }}
+  {{- if and (eq .Values.storage.type "s3") (not .Values.storage.s3.existingSecret) }}
   # storage.s3.access_key_id / secret_access_key — the shorter names the chart
   # used before match no config key, so S3 credentials never reached the server.
   NEXSPENCE_STORAGE_S3_ACCESS_KEY_ID: {{ .Values.storage.s3.accessKey | quote }}
   NEXSPENCE_STORAGE_S3_SECRET_ACCESS_KEY: {{ .Values.storage.s3.secretKey | quote }}
+  {{- end }}
+  {{- if or (and .Values.redis.enabled (not .Values.redis.auth.existingSecret)) (and .Values.externalRedis.enabled (not .Values.externalRedis.existingSecret)) }}
+  NEXSPENCE_REDIS_PASSWORD: {{ include "nexspence.redisPassword" . | quote }}
+  {{- end }}
+  {{- if .Values.oidc.enabled }}
+  NEXSPENCE_OIDC_ISSUER: {{ .Values.oidc.issuer | quote }}
+  NEXSPENCE_OIDC_PUBLIC_ISSUER_URL: {{ .Values.oidc.publicIssuerUrl | quote }}
+  NEXSPENCE_OIDC_CLIENT_ID: {{ .Values.oidc.clientId | quote }}
+  {{- if not .Values.oidc.clientSecretExistingSecret }}
+  NEXSPENCE_OIDC_CLIENT_SECRET: {{ .Values.oidc.clientSecret | quote }}
+  {{- end }}
+  NEXSPENCE_OIDC_REDIRECT_URL: {{ .Values.oidc.redirectUrl | quote }}
+  NEXSPENCE_OIDC_FRONTEND_BASE_URL: {{ .Values.oidc.frontendBaseUrl | quote }}
+  NEXSPENCE_OIDC_SCOPES: {{ .Values.oidc.scopes | join "," | quote }}
+  NEXSPENCE_OIDC_PROVISIONING: {{ .Values.oidc.provisioning | quote }}
+  NEXSPENCE_OIDC_GROUPS_CLAIM: {{ .Values.oidc.groupsClaim | quote }}
+  NEXSPENCE_OIDC_ADMIN_GROUP: {{ .Values.oidc.adminGroup | quote }}
+  NEXSPENCE_OIDC_USERNAME_CLAIM: {{ .Values.oidc.usernameClaim | quote }}
+  NEXSPENCE_OIDC_EMAIL_CLAIM: {{ .Values.oidc.emailClaim | quote }}
+  NEXSPENCE_OIDC_NAME_CLAIM: {{ .Values.oidc.nameClaim | quote }}
+  NEXSPENCE_OIDC_SHOW_LOGIN_BUTTON: {{ .Values.oidc.showLoginButton | quote }}
+  NEXSPENCE_OIDC_COOKIE_SECURE: {{ .Values.oidc.cookieSecure | quote }}
+  NEXSPENCE_OIDC_ALLOWED_SKEW_SECONDS: {{ .Values.oidc.allowedSkewSeconds | quote }}
+  {{- /*
+    Cookie key resolution mirrors jwtSecret above: explicit value wins,
+    otherwise reuse what's already persisted in this release's Secret, otherwise
+    generate a fresh one — so an upgrade never rotates it out from under an
+    in-flight login.
+  */}}
+  {{- $cookieKey := .Values.oidc.cookieKey }}
+  {{- if not $cookieKey }}
+  {{- if and $existing $existing.data (index $existing.data "NEXSPENCE_OIDC_COOKIE_KEY") }}
+  {{- $cookieKey = index $existing.data "NEXSPENCE_OIDC_COOKIE_KEY" | b64dec }}
+  {{- else }}
+  {{- $cookieKey = randBytes 32 }}
+  {{- end }}
+  {{- end }}
+  NEXSPENCE_OIDC_COOKIE_KEY: {{ $cookieKey | quote }}
   {{- end }}

--- a/deploy/helm/nexspence/values.yaml
+++ b/deploy/helm/nexspence/values.yaml
@@ -43,7 +43,14 @@ config:
   baseURL: "http://nexspence.example.com"
   logLevel: "info"
   logFormat: "json"
-  httpListen: ":8081"
+  httpAddr: ":8081"
+  # -- Peers (IPs or CIDRs) allowed to set X-Forwarded-For. Every chart
+  # deployment sits behind an ingress/gateway, so leaving this empty (the
+  # app's own default) means the audit log and any IP-based logic only ever
+  # see the ingress's own pod IP, never the real client. Set to the in-cluster
+  # pod CIDR, or "*" to trust every hop (only safe when the server is
+  # unreachable except through a proxy you control).
+  trustedProxies: []
   # -- JWT secret (min 32 chars). Leave empty to auto-generate a unique random
   # secret on first install and persist it across upgrades (recommended). Set an
   # explicit value only if you need to share the secret across clusters.
@@ -88,6 +95,69 @@ config:
       #     docker-hub-proxy.example.com: dockerhub-proxy
       aliases: {}
 
+# -- OIDC single sign-on. Every field below is sensitive (issuer/redirect_url/
+# admin_group name real internal infrastructure and access-control policy) and
+# renders into secret.yaml, not configmap.yaml — only `enabled` is a plain
+# value, since it has to gate templating itself.
+oidc:
+  enabled: false
+  issuer: ""
+  publicIssuerUrl: ""
+  clientId: ""
+  # -- Prefer clientSecretExistingSecret below — a plaintext value here tends
+  # to end up committed to a values file. Uncomment only if you genuinely have
+  # no existing Secret to point at.
+  # clientSecret: ""
+  # -- Reference an existing Secret instead of putting the client secret in
+  # values.
+  clientSecretExistingSecret: ""
+  clientSecretExistingSecretKey: "client-secret"
+  redirectUrl: ""
+  frontendBaseUrl: ""
+  scopes: ["openid", "profile", "email", "groups"]
+  provisioning: "auto"
+  groupsClaim: "groups"
+  adminGroup: ""
+  usernameClaim: "preferred_username"
+  emailClaim: "email"
+  nameClaim: "name"
+  showLoginButton: true
+  cookieSecure: true
+  allowedSkewSeconds: 60
+  # -- Leave empty to auto-generate and persist across upgrades (same pattern
+  # as config.jwtSecret) so an upgrade never rotates it out from under a login
+  # in flight.
+  cookieKey: ""
+
+# -- Redis: backs the distributed lock (cleanup/GC/replication/migration cron
+# coordination across replicas) and the login-attempt rate limiter's shared
+# state. Required once replicaCount > 1 / autoscaling.enabled, or every pod
+# runs its own uncoordinated schedule and rate limiting stops being global.
+redis:
+  enabled: false
+  auth:
+    # -- Prefer existingSecret below — a plaintext value here tends to end up
+    # committed to a values file. Uncomment only if you genuinely have no
+    # existing Secret to point at.
+    # password: ""
+    # -- Reference an existing Secret instead of putting the password in values.
+    existingSecret: ""
+    existingSecretKey: "password"
+
+# -- External Redis (used when redis.enabled=false and you still want the
+# distributed-lock/rate-limiter coordination above)
+externalRedis:
+  enabled: false
+  addr: ""
+  # -- Prefer existingSecret below — a plaintext value here tends to end up
+  # committed to a values file. Uncomment only if you genuinely have no
+  # existing Secret to point at.
+  # password: ""
+  # -- Reference an existing Secret instead of putting the password in values.
+  existingSecret: ""
+  existingSecretKey: "password"
+  db: 0
+
 # -- Blob storage: "local" or "s3"
 storage:
   type: local
@@ -96,13 +166,28 @@ storage:
     # -- PVC size for blob storage
     size: "100Gi"
     storageClass: ""
+    # -- ReadWriteOnce (default) or ReadWriteMany for a shared filesystem
+    # (e.g. AWS EFS via efs-csi) across replicas — LocalBlobStore's writes
+    # (atomic rename, single-writer append) don't depend on POSIX locking, so
+    # RWX is safe.
+    accessMode: "ReadWriteOnce"
+    # -- Bring your own PVC (e.g. a statically-provisioned EFS access point):
+    # when set, the chart skips rendering its own PVC and mounts this claim.
+    existingClaim: ""
   s3:
     # -- Filled when storage.type=s3
     endpoint: ""
     bucket: ""
     region: "us-east-1"
-    accessKey: ""
-    secretKey: ""
+    # -- Prefer existingSecret below — a plaintext value here tends to end up
+    # committed to a values file. Uncomment only if you genuinely have no
+    # existing Secret to point at.
+    # accessKey: ""
+    # secretKey: ""
+    # -- Reference an existing Secret instead of putting the credentials in values.
+    existingSecret: ""
+    existingSecretAccessKeyKey: "access-key"
+    existingSecretSecretKeyKey: "secret-key"
     # -- Path-style addressing (bucket in the path, not the hostname). Required
     # by MinIO and most non-AWS S3 implementations.
     forcePathStyle: true
@@ -110,6 +195,22 @@ storage:
     # on-prem S3 behind a private CA; the connection carries the credentials and
     # every blob, so prefer trusting the CA.
     skipTLSVerify: false
+
+# -- OpenTelemetry distributed tracing (HTTP, DB, blob-store, background jobs,
+# cross-instance replication). Off by default — nexspence ships no trace
+# backend, point otlpEndpoint at whatever collector/Jaeger/Tempo you run.
+tracing:
+  enabled: false
+  otlpEndpoint: "otel-collector:4317"
+  # -- Exporter transport: "grpc" (default, port 4317) or "http" (port 4318)
+  otlpProtocol: "grpc"
+  # -- Send plaintext instead of TLS — for a collector on the same cluster/VPC
+  otlpInsecure: true
+  # -- Head-samples root spans at this ratio (0..1); child spans follow their parent
+  sampleRatio: 0.1
+  serviceName: "nexspence"
+  # -- Distinguishes this deployment's traces (e.g. "prod", "staging") when several share one backend
+  environment: ""
 
 service:
   type: ClusterIP
@@ -184,7 +285,7 @@ resources:
 # ── Liveness / Readiness probes ───────────────────────────────────────
 livenessProbe:
   httpGet:
-    path: /service/rest/v1/status/check
+    path: /healthz
     port: 8081
   initialDelaySeconds: 20
   periodSeconds: 30
@@ -193,7 +294,7 @@ livenessProbe:
 
 readinessProbe:
   httpGet:
-    path: /service/rest/v1/status/check
+    path: /readyz
     port: 8081
   initialDelaySeconds: 10
   periodSeconds: 10
@@ -203,6 +304,13 @@ readinessProbe:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# -- Extra volumes/mounts on the main container, e.g. a custom CA bundle
+# Secret/ConfigMap for `database.dsn`'s sslmode=verify-ca/verify-full (which
+# already works at the application level — pgxpool.ParseConfig parses standard
+# libpq syntax — the chart just has nowhere to put the certificate file).
+extraVolumes: []
+extraVolumeMounts: []
 
 # ── PostgreSQL sub-chart (bitnami) ────────────────────────────────────
 # Set enabled: false and provide externalDatabase.dsn for external Postgres.
@@ -226,7 +334,15 @@ postgresql:
 
 # -- External PostgreSQL DSN (used when postgresql.enabled=false)
 externalDatabase:
-  dsn: "postgres://nexspence:nexspence@external-postgres:5432/nexspence?sslmode=disable"
+  # -- Prefer existingSecret below — a plaintext value here (password
+  # included) tends to end up committed to a values file. Uncomment only if
+  # you genuinely have no existing Secret to point at.
+  # dsn: "postgres://nexspence:nexspence@external-postgres:5432/nexspence?sslmode=disable"
+  # -- Reference an existing Secret instead of putting the DSN directly in
+  # values. When set, the chart never composes NEXSPENCE_DATABASE_DSN itself —
+  # the Deployment reads it straight from this Secret via secretKeyRef.
+  existingSecret: ""
+  existingSecretKey: "dsn"
 
 # Image scanning (Trivy).
 #


### PR DESCRIPTION
Eleven fixes to the Helm chart, all independently verified with helm lint --strict / helm template / helm install --dry-run and then re-verified together with every toggle active at once.

- storage.type: s3 was non-functional - NEXSPENCE_STORAGE_DEFAULT_TYPE was never set, so the app silently stayed on local storage no matter what storage.type said. Added it to configmap.yaml.
- Liveness/readiness probes pointed at /service/rest/v1/status/check, which unconditionally returns 200 - now /healthz and /readyz.
- No way to configure Redis, so the distributed lock and login-attempt rate limiter silently degrade to no-op/per-instance once replicaCount > 1. Added redis (bundled, single-replica StatefulSet, mirroring the shape #415 gives the bundled Postgres) and externalRedis, with a redisInUse helper that fails loudly if both are enabled at once instead of silently picking one.
- No way to configure OpenTelemetry tracing, even though the app and docker-compose.yml's tracing profile both support it. Added a tracing values block mirroring TracingConfig.
- No way to set http.trusted_proxies, so every chart deployment (all of which sit behind an ingress/gateway) has the audit log and any IP-based logic see only the ingress pod's own IP. Added config.trustedProxies (comma-separated env override).
- Local storage PVC was hardcoded to ReadWriteOnce with no bring-your-own-claim option, blocking a shared-filesystem topology (e.g. EFS) for more than one replica even though LocalBlobStore's writes don't depend on POSIX locking. Added storage.local.accessMode/existingClaim.
- NEXSPENCE_HTTP_LISTEN matched no config key at all (the real one is http.addr) - renamed to NEXSPENCE_HTTP_ADDR.
- No way to configure OIDC, even though the app fully supports it. Added an oidc values block, every field routed through secret.yaml, cookieKey reusing config.jwtSecret's lookup-or-generate-and-persist pattern.
- No extraVolumes/extraVolumeMounts, so a custom CA bundle for a managed Postgres's sslmode=verify-ca (already supported at the app level) had nowhere to mount.
- NOTES.txt's kubectl port-forward command used the wrong port (8081:8081 against a Service that exposes 80 by default).
- Four credential values (storage.s3 access/secret key, redis/externalRedis password, oidc.clientSecret) plus externalDatabase.dsn only accepted plaintext, no existingSecret escape hatch the way postgresql.auth.existingSecret already has. Added the same secretKeyRef pattern to all five, and commented out the plaintext fields by default so existingSecret reads as the encouraged path.

Verified individually and all eleven combined into one chart at once, every credential sourced from an existing Secret rather than a plaintext value: helm lint --strict clean, helm template renders with no plaintext secret leaking into the manifest, helm install --dry-run confirms NOTES.txt.

Closes #422