### PR TITLE
fix(repositories): apply routingRuleId on update instead of dropping it

### DIFF
--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -1008,7 +1008,10 @@ function EditRepoModal({
         updateBody.blobStoreId = blobStoreId
       }
       if (repo.type === 'group') {
-        updateBody.routingRuleId = routingRuleId || null
+        // Empty string, not null: the API reads an absent field as "unchanged"
+        // and an empty one as "detach" (same convention as blobStoreId), so a
+        // null here would silently leave the old rule attached.
+        updateBody.routingRuleId = routingRuleId || ''
         // Preserve any other formatConfig entries (e.g. writable_member) the API set.
         const { proxy_password_set: _drop, ...rest } = (repo.formatConfig ?? {}) as Record<string, unknown>
         void _drop

--- a/internal/service/repository_service.go
+++ b/internal/service/repository_service.go
@@ -202,6 +202,23 @@ func (s *RepositoryService) Update(ctx context.Context, name string, updates *do
 			r.BlobStoreID = &bs.ID
 		}
 	}
+	// Create accepts routingRuleId and Update used to drop it on the floor, so a
+	// routing rule could be attached when the repository was made and never
+	// changed or detached again — the API answered 200 and the UI reported a
+	// saved repository while the row kept whatever it started with. A routing
+	// rule is a BLOCK control, so silently not attaching one is the direction
+	// that matters. Same convention as blobStoreId above: an absent field means
+	// unchanged, an empty string detaches.
+	if updates.RoutingRuleID != nil {
+		id := strings.TrimSpace(*updates.RoutingRuleID)
+		if id == "" {
+			r.RoutingRuleID = nil
+		} else {
+			// Existence is left to the routing_rule_id foreign key, the way
+			// Create already leaves it.
+			r.RoutingRuleID = &id
+		}
+	}
 	r.AllowAnonymous = updates.AllowAnonymous
 
 	if err := s.validateCleanupPolicies(ctx, r.Format, r.CleanupPolicyIDs); err != nil {

--- a/internal/service/repository_service_routing_test.go
+++ b/internal/service/repository_service_routing_test.go
@@ -1,0 +1,91 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func routingSvc(repos *testutil.RepoRepo) *service.RepositoryService {
+	return service.NewRepositoryService(
+		repos, testutil.NewBlobStoreRepo(), testutil.NewBlobStore(), testutil.NewCleanupPolicyRepo(),
+	)
+}
+
+func existingRepo(t *testing.T, repos *testutil.RepoRepo, svc *service.RepositoryService, rule *string) *domain.Repository {
+	t.Helper()
+	r := &domain.Repository{
+		Name: "r1", Format: domain.FormatRaw, Type: domain.TypeHosted, RoutingRuleID: rule,
+	}
+	if err := svc.Create(context.Background(), r); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	return r
+}
+
+// Create accepted routingRuleId and Update dropped it, so a routing rule could
+// be attached when the repository was made and never changed afterwards. The
+// API answered 200 and the UI reported a saved repository while the row kept
+// whatever it started with — and a routing rule is a BLOCK control, so the
+// direction that matters is the one where nothing gets attached.
+func TestRepositoryService_Update_AttachesRoutingRule(t *testing.T) {
+	repos := testutil.NewRepoRepo()
+	svc := routingSvc(repos)
+	existingRepo(t, repos, svc, nil)
+
+	const ruleID = "b60ff2a3-17cc-4065-9726-bf8fcb52b974"
+	updated, err := svc.Update(context.Background(), "r1", &domain.Repository{
+		Online: true, RoutingRuleID: strPtr(ruleID),
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.RoutingRuleID == nil || *updated.RoutingRuleID != ruleID {
+		t.Fatalf("routing rule after update: %v, want %q", updated.RoutingRuleID, ruleID)
+	}
+	// And it is on the stored row, not only on the returned copy.
+	stored, err := repos.Get(context.Background(), "r1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if stored.RoutingRuleID == nil || *stored.RoutingRuleID != ruleID {
+		t.Fatalf("stored routing rule: %v, want %q", stored.RoutingRuleID, ruleID)
+	}
+}
+
+// Same convention as blobStoreId: an empty string detaches.
+func TestRepositoryService_Update_DetachesRoutingRuleOnEmptyString(t *testing.T) {
+	repos := testutil.NewRepoRepo()
+	svc := routingSvc(repos)
+	existingRepo(t, repos, svc, strPtr("b60ff2a3-17cc-4065-9726-bf8fcb52b974"))
+
+	updated, err := svc.Update(context.Background(), "r1", &domain.Repository{
+		Online: true, RoutingRuleID: strPtr(""),
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.RoutingRuleID != nil {
+		t.Fatalf("routing rule after detach: %v, want nil", *updated.RoutingRuleID)
+	}
+}
+
+// An absent field means "unchanged" — an update that only toggles `online`
+// must not quietly detach the rule.
+func TestRepositoryService_Update_KeepsRoutingRuleWhenFieldOmitted(t *testing.T) {
+	repos := testutil.NewRepoRepo()
+	svc := routingSvc(repos)
+	const ruleID = "b60ff2a3-17cc-4065-9726-bf8fcb52b974"
+	existingRepo(t, repos, svc, strPtr(ruleID))
+
+	updated, err := svc.Update(context.Background(), "r1", &domain.Repository{Online: true})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.RoutingRuleID == nil || *updated.RoutingRuleID != ruleID {
+		t.Fatalf("routing rule after unrelated update: %v, want %q", updated.RoutingRuleID, ruleID)
+	}
+}


### PR DESCRIPTION
`POST /service/rest/v1/repositories/:format/:type` accepts `routingRuleId`, but `RepositoryService.Update` never copied it onto the loaded row. A routing rule could therefore be attached when a repository was created and **never changed or detached again**: the API answered `200`, the UI reported a saved repository, and the row kept whatever it started with.

A routing rule is a BLOCK control. The direction that matters is the one where an operator attaches one to an existing repository, is told it worked, and nothing is blocked.

Reproduced against `v2.6.0` before the fix:

```
$ curl -X PUT .../repositories/npm/proxy/chk-proxy -d '{..., "routingRuleId":"ee8a7907-..."}'
attach: 200
$ curl .../repositories/chk-proxy
routingRuleId = None
```

## The fix

`Update` follows the same convention `blobStoreId` already uses one block above: an absent field means unchanged, an empty string detaches. Existence is left to the `routing_rule_id` foreign key, the way `Create` leaves it.

The repository edit modal sent `routingRuleId: null` to detach, which under that convention reads as "unchanged" — it now sends an empty string.

## Verified

Three unit tests: attach on update (reaches the stored row, not just the returned copy), detach on empty string, and unchanged when the field is omitted — so an update that only toggles `online` cannot quietly drop the rule. The first two fail on `main` with exactly the old behaviour (`<nil>` after attach, the old id after detach).

End-to-end, this surfaced while reviewing [terraform-provider-nexspence#4](https://github.com/nexspence/terraform-provider-nexspence/pull/4) as a hard Terraform failure on any plan attaching a rule to an existing repository:

```
Error: Provider produced inconsistent result after apply
  .routing_rule_id: was cty.StringVal("b60ff2a3-..."), but now null.
  This is a bug in the provider, which should be reported in the provider's own issue tracker.
```

— the message blames the provider, which is not where the bug is. That acceptance test fails against `v2.6.0` and passes against a server built from this branch; the provider's full acceptance suite is green against it too.

`go build`, `go vet`, `golangci-lint`, `tsc --noEmit` clean; `go test ./...` and the frontend suite green apart from the pre-existing sandbox-only `TestWebhookHandler_Test_200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017diVB5qCSUXhPkxXzJfF7D
