### PR TITLE
fix(ui): let a signed-out visitor actually browse public repositories (#427)

### DIFF
--- a/docs/security-rbac.md
+++ b/docs/security-rbac.md
@@ -405,6 +405,12 @@ reads, and search. A repository the caller may not see answers `404`, not
 deletes, `/api/v1/me`, tokens, scan results, and the whole admin surface —
 still requires a token.
 
+The UI asks for that signed-in-only data (blob-store names, repository quota,
+the caller's privileges, scan results) only while a session exists, and offers
+promotion and bulk selection only then. A `401` is treated as an expired
+session — clearing it and returning to `/login` — only when the request
+carried a token; a visitor who never had one is left on the page.
+
 The Docker `/v2/` handshake itself is unconditional: an unauthenticated ping
 always answers `401` with a `Bearer` challenge pointing at `/v2/token`.
 Clients with credentials trade them there for a user token (this is the

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -106,7 +106,8 @@ describe('apiClient request interceptor', () => {
 })
 
 describe('apiClient response interceptor', () => {
-  it('redirects to /login on 401 from a non-login endpoint', async () => {
+  it('redirects to /login when a presented token is refused with 401', async () => {
+    localStorage.setItem('nexspence_token', 'expired-token')
     server.use(
       http.get('/api/v1/protected', () =>
         HttpResponse.json({ error: 'unauthorized' }, { status: 401 })
@@ -119,6 +120,21 @@ describe('apiClient response interceptor', () => {
     }
     // The interceptor sets window.location.href = '/login'
     expect(window.location.href).toBe('/login')
+  })
+
+  // A signed-out visitor browsing public repositories (#404) meets 401s from
+  // the signed-in-only endpoints; none of them is a session to lose.
+  it('leaves a signed-out visitor where they are on 401 (no token presented)', async () => {
+    let authHeader: string | null = 'unset'
+    server.use(
+      http.get('/api/v1/protected-anon', ({ request }) => {
+        authHeader = request.headers.get('Authorization')
+        return HttpResponse.json({ error: 'unauthorized' }, { status: 401 })
+      })
+    )
+    await expect(apiClient.get('/api/v1/protected-anon')).rejects.toBeDefined()
+    expect(authHeader).toBeNull()
+    expect(window.location.href).toBe('http://localhost/')
   })
 
   it('clears nexspence_token from localStorage on 401 from non-login endpoint', async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -32,13 +32,19 @@ apiClient.interceptors.request.use((config) => {
   return config
 })
 
-// Redirect to login on 401, but NOT when the 401 comes from the login endpoint itself
-// (otherwise the error never reaches the form and "nothing happens").
+// A 401 means "sign in" only when the request carried a token that the server
+// refused — the session expired or was revoked — so clear it and go to /login.
+// A signed-out visitor browsing public repositories (#404) has no session to
+// lose: a 401 there is just a resource they cannot read, and bouncing them to
+// the login wall would undo the anonymous UI. NOT when the 401 comes from the
+// login endpoint itself (otherwise the error never reaches the form and
+// "nothing happens").
 apiClient.interceptors.response.use(
   (r) => r,
   (err) => {
     const url: string = err.config?.url ?? ''
-    if (err.response?.status === 401 && !url.endsWith('/login')) {
+    const presentedToken = Boolean(err.config?.headers?.Authorization)
+    if (err.response?.status === 401 && presentedToken && !url.endsWith('/login')) {
       localStorage.removeItem('nexspence_token')
       window.location.href = '/login'
     }

--- a/frontend/src/pages/BrowsePage.test.tsx
+++ b/frontend/src/pages/BrowsePage.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { http, HttpResponse } from 'msw'
 import { QueryClient } from '@tanstack/react-query'
 import BrowsePage from './BrowsePage'
-import { renderWithProviders, seedAuthAsAdmin } from '@/test/renderUtils'
+import { renderWithProviders, seedAuthAsAdmin, seedAuthAsGuest } from '@/test/renderUtils'
 import { server } from '@/test/msw/server'
 import { fixtures } from '@/test/fixtures'
 import { useAuthStore } from '@/store/authStore'
@@ -874,5 +874,47 @@ describe('BrowsePage — non-admin', () => {
     renderBrowse('?repo=maven-hosted')
     await screen.findByText('pkg-a')
     expect(screen.queryByTitle('Delete')).not.toBeInTheDocument()
+  })
+})
+
+// A visitor with no session may browse public repositories (#404). The
+// privilege lookup, promotion and scan results are signed-in surfaces: they
+// are neither requested nor offered, so the page renders without a single
+// 401 — the response interceptor of the time turned the first one into a
+// redirect to /login.
+describe('BrowsePage — signed-out visitor', () => {
+  beforeEach(() => {
+    seedAuthAsGuest()
+    window.location.href = 'http://localhost/'
+  })
+
+  it('browses a public repository without privileges, selection or promote', async () => {
+    const user = userEvent.setup()
+    let privilegeHits = 0
+    server.use(
+      http.get('/api/v1/me/privileges', () => {
+        privilegeHits++
+        return HttpResponse.json({ error: 'authentication required' }, { status: 401 })
+      }),
+      http.get('/service/rest/v1/components', () =>
+        HttpResponse.json({
+          items: [
+            { id: 'c1', name: 'pkg-a', group: 'com.example', version: '1.0', format: 'maven2', assets: [{ id: 'a1', path: 'com/example/pkg-a/1.0/pkg-a.jar', fileSize: 2048, contentType: 'application/java-archive' }] },
+          ],
+          continuationToken: null,
+        }),
+      ),
+    )
+    renderBrowse()
+    await screen.findByText('Choose a repository above')
+    await user.click(screen.getByRole('button', { name: /Select repository/ }))
+    await user.click((await screen.findAllByText('maven-hosted'))[0])
+    expect(await screen.findByText('pkg-a')).toBeInTheDocument()
+    await new Promise((r) => setTimeout(r, 50))
+    expect(privilegeHits).toBe(0)
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Promote/)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Upload/ })).not.toBeInTheDocument()
+    expect(window.location.href).toBe('http://localhost/')
   })
 })

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -199,6 +199,9 @@ function fmtElapsed(s: number): string {
 }
 
 function ScanBadgeRow({ componentId }: { componentId: string }) {
+  // Scan results stay behind the auth middleware (#404): a signed-out visitor
+  // gets no badge rather than a 401 per selected component.
+  const signedIn = useAuthStore((st) => st.token !== null)
   const queryClient = useQueryClient()
   const queryKey = ['scanResult', componentId]
   const [mutationError, setMutationError] = useState<string | null>(null)
@@ -213,6 +216,7 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
         .then((r) => (r.data as ScanResult | null) ?? null)
         .catch((e) => (e.response?.status === 404 ? null : Promise.reject(e))),
     retry: false,
+    enabled: signedIn,
   })
 
   // The scanned component id travels with the mutation instead of being read
@@ -256,6 +260,8 @@ function ScanBadgeRow({ componentId }: { componentId: string }) {
   const findings = scanResult?.findings ?? []
   const filtered =
     sevFilter === 'ALL' ? findings : findings.filter((f) => f.severity?.toUpperCase() === sevFilter)
+
+  if (!signedIn) return null
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8, padding: '10px 0 0' }}>
@@ -1172,11 +1178,17 @@ export default function BrowsePage() {
   const limit = 25
 
   const { isAdmin } = useAuthStore()
+  const signedIn = useAuthStore((st) => st.token !== null)
   const queryClient = useQueryClient()
 
+  // Privileges, promotion and scan results are signed-in surfaces; the browse
+  // trees and listings answer a visitor on their own (#404). Without a session
+  // the privilege query is skipped and the promote / select affordances are
+  // not rendered, so a public repository browses without a single 401.
   const { data: myPrivs = [] } = useQuery<Privilege[]>({
     queryKey: ['me-privileges'],
     queryFn: () => nexspenceApi.myPrivileges(),
+    enabled: signedIn,
   })
 
   const canDeleteRepo = isAdmin() || myPrivs.some(p =>
@@ -1489,7 +1501,7 @@ export default function BrowsePage() {
                     <PanelBtn onClick={() => setUsageTarget({ format: dockerDetail.format, name: dockerDetail.name })}>
                       <BookOpen size={13} /> Example Usage
                     </PanelBtn>
-                    <PanelBtn onClick={async () => {
+                    {signedIn && <PanelBtn onClick={async () => {
                       try {
                         const res = await apiClient.get(`/api/v1/components/${dockerSelection.componentId}/promotion-rules`)
                         if (res.data.length === 0) { alert('No promotion rules defined for this repository.'); return }
@@ -1506,7 +1518,7 @@ export default function BrowsePage() {
                       setPromoteModalOpen(true)
                     }}>
                       Promote
-                    </PanelBtn>
+                    </PanelBtn>}
                   </div>
                   <TagEditor
                     key={dockerSelection.componentId}
@@ -1617,7 +1629,7 @@ export default function BrowsePage() {
                       <PanelBtn onClick={() => setUsageTarget({ format: selectedRepo?.format ?? 'raw', name: node.label })}>
                         <BookOpen size={13} /> Usage
                       </PanelBtn>
-                      {node.componentId && (
+                      {signedIn && node.componentId && (
                         <PanelBtn onClick={async () => {
                           try {
                             const res = await apiClient.get(`/api/v1/components/${node.componentId}/promotion-rules`)
@@ -1660,7 +1672,7 @@ export default function BrowsePage() {
         </div>
       ) : (
         <>
-          {selectedComponentIDs.size > 0 && (
+          {signedIn && selectedComponentIDs.size > 0 && (
             <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 12px', background: 'rgba(59,130,246,0.1)', borderRadius: 8, marginBottom: 8, border: '1px solid rgba(59,130,246,0.3)' }}>
               <span style={{ fontSize: 13, color: '#93c5fd' }}>{selectedComponentIDs.size} selected</span>
               <HoloButton variant="primary" onClick={async () => {
@@ -1727,7 +1739,7 @@ export default function BrowsePage() {
                   }}
                 >
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                    <input
+                    {signedIn && <input
                       type="checkbox"
                       checked={selectedComponentIDs.has(c.id)}
                       onChange={e => {
@@ -1737,7 +1749,7 @@ export default function BrowsePage() {
                         setSelectedComponentIDs(next)
                       }}
                       style={{ cursor: 'pointer', accentColor: '#3b82f6' }}
-                    />
+                    />}
                   </div>
                   <Truncated text={c.name} style={{ fontWeight: 600, color: 'var(--holo-text)' }} />
                   <Truncated text={c.group || '—'} style={S.muted} />

--- a/frontend/src/pages/RepositoriesPage.test.tsx
+++ b/frontend/src/pages/RepositoriesPage.test.tsx
@@ -916,3 +916,58 @@ describe('RepositoriesPage', () => {
     expect(screen.getByText('oci')).toBeInTheDocument()
   })
 })
+
+// A visitor with no session lands on this page too (#404). The list answers
+// them, but blob-store names and per-repository quota still sit behind the
+// auth middleware — so those must not even be asked for: with the response
+// interceptor of the time, the first 401 sent the visitor to /login.
+describe('RepositoriesPage — signed-out visitor', () => {
+  beforeEach(() => {
+    seedAuthAsGuest()
+    window.location.href = 'http://localhost/'
+  })
+
+  it('lists public repositories without asking for signed-in data or leaving the page', async () => {
+    const hits = { blobstores: 0, quota: 0 }
+    server.use(
+      http.get('/service/rest/v1/repositories', () => HttpResponse.json(repoList)),
+      http.get('/service/rest/v1/blobstores', () => {
+        hits.blobstores++
+        return HttpResponse.json({ error: 'authentication required' }, { status: 401 })
+      }),
+      http.get('/api/v1/repositories/:name/quota', () => {
+        hits.quota++
+        return HttpResponse.json({ error: 'authentication required' }, { status: 401 })
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    expect(await screen.findByText('maven-hosted')).toBeInTheDocument()
+    expect(screen.getByText('npm-proxy')).toBeInTheDocument()
+    expect(screen.getByText('docker-group')).toBeInTheDocument()
+    // Give any stray query a tick to fire before asserting it never did.
+    await new Promise((r) => setTimeout(r, 50))
+    expect(hits).toEqual({ blobstores: 0, quota: 0 })
+    expect(window.location.href).toBe('http://localhost/')
+    expect(screen.queryByRole('button', { name: /New Repository/i })).not.toBeInTheDocument()
+  })
+
+  it('fetches blob-store names and quota once signed in', async () => {
+    seedAuthAsAdmin()
+    const hits = { blobstores: 0, quota: 0 }
+    server.use(
+      http.get('/service/rest/v1/repositories', () => HttpResponse.json(repoList)),
+      http.get('/service/rest/v1/blobstores', () => {
+        hits.blobstores++
+        return HttpResponse.json(blobStores)
+      }),
+      http.get('/api/v1/repositories/:name/quota', () => {
+        hits.quota++
+        return HttpResponse.json({ usedBytes: 1, quotaBytes: 2, percentUsed: 50 })
+      }),
+    )
+    renderWithProviders(<RepositoriesPage />)
+    expect(await screen.findByText('maven-hosted')).toBeInTheDocument()
+    await waitFor(() => expect(hits.blobstores).toBeGreaterThan(0))
+    await waitFor(() => expect(hits.quota).toBe(repoList.length))
+  })
+})

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -83,6 +83,7 @@ export default function RepositoriesPage() {
   const qc = useQueryClient()
   const navigate = useNavigate()
   const isAdmin = useAuthStore(s => s.isAdmin())
+  const signedIn = useAuthStore(s => s.token !== null)
   const [filter, setFilter] = useState('')
   const [formatFilter, setFormatFilter] = useState('')
   const [showCreate, setShowCreate] = useState(false)
@@ -96,9 +97,13 @@ export default function RepositoriesPage() {
         .then(r => r.data),
   })
 
+  // Blob-store names and per-repository quota sit behind the auth middleware,
+  // while the list itself answers a signed-out visitor (#404). Ask for them
+  // only with a session — otherwise every row would cost a 401.
   const { data: blobStores = [] } = useQuery<BlobStoreLite[]>({
     queryKey: ['blobstores'],
     queryFn: () => nexusApi.listBlobStores().then(r => r.data),
+    enabled: signedIn,
   })
   const storeNameById = new Map(blobStores.map(b => [b.id, b.name]))
 
@@ -285,10 +290,12 @@ function RepoRow({
   onToggleOnline: (online: boolean) => void
   onExport: () => void
 }) {
+  const signedIn = useAuthStore(s => s.token !== null)
   const { data: quota } = useQuery({
     queryKey: ['repoQuota', repo.name],
     queryFn: () => nexspenceApi.getRepositoryQuota(repo.name).then(r => r.data),
     staleTime: 30_000,
+    enabled: signedIn,
   })
   const pct = quota?.percentUsed ?? null
 


### PR DESCRIPTION
Closes #427.

The signed-out UI from #404 / #420 never got to render: `RepositoriesPage` queried `GET /service/rest/v1/blobstores` and `GET /api/v1/repositories/:name/quota` unconditionally, `BrowsePage` did the same with `GET /api/v1/me/privileges` (and `…/scan` per selected image), and all of those correctly stay in the `authed` group — so a visitor collected a `401` per row, and the response interceptor turned the first one into `window.location = '/login'`. On a 12-repository instance that is thirteen `401`s and a login wall; with the unconditional blobstores query it happens even on an empty instance.

## Change

- **Interceptor** (`client.ts`): a `401` is an expired session — clear the token, go to `/login` — only when the request actually carried a token. A visitor who never had one is left on the page; that is the whole premise of #404, and the pages already tolerate the missing data.
- **RepositoriesPage**: blobstores and quota queries run only with a session. Store names and usage are operator data, not visitor data.
- **BrowsePage**: the privilege query and the scan badge run only with a session; the Promote buttons and the bulk-select checkboxes (all of which lead to `authed` endpoints) are rendered only with one. Upload and delete were already gated on privileges, which a visitor has none of.
- `docs/security-rbac.md` gains a paragraph under "Browsing without signing in" saying which data the UI asks for only with a session and when a `401` means "sign in".

Nothing changes for a signed-in user: every gated query has `enabled: true` the moment a token exists, and the redirect-on-refused-token path is unchanged.

## Tests

- `client.test.ts`: the existing "redirects on 401" test now presents a token (which is what it meant); a new case sends no token, gets a `401`, and asserts the location is untouched and no `Authorization` header went out.
- `RepositoriesPage.test.tsx`: a guest render lists the repositories while the blobstores and quota handlers answer `401` and count hits — both stay at zero, the location stays put, the admin-only "New Repository" button is absent. A signed-in render asserts the same handlers are hit (blobstores once, quota once per repository).
- `BrowsePage.test.tsx`: a guest selects a repository and sees its components with the privilege handler answering `401` — zero hits, no checkbox, no Promote, no Upload, location unchanged.

Run against the unfixed code, exactly the three guest cases fail and the two signed-in cases pass. Verified in a real browser against a live instance: a signed-out visitor now gets the repository list, Browse and Search; the network tab shows no `401`.
