### PR TITLE
feat(cran): add R/CRAN as a new repository format

### DIFF
--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -32,7 +32,8 @@ CREATE TABLE repositories (
     name            TEXT NOT NULL UNIQUE,
     format          TEXT NOT NULL CHECK (format IN (
                         'maven2', 'npm', 'docker', 'oci', 'pypi',
-                        'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan', 'conda', 'terraform'
+                        'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan', 'conda', 'terraform',
+                        'rubygems', 'cran'
                     )),
     type            TEXT NOT NULL CHECK (type IN ('hosted', 'proxy', 'group')),
     blob_store_id   UUID REFERENCES blob_stores(id),

--- a/frontend/src/pages/BrowsePage.tsx
+++ b/frontend/src/pages/BrowsePage.tsx
@@ -678,6 +678,7 @@ const FORMAT_COLORS: Record<string, string> = {
   raw: '#6b7280',
   apt: '#f59e0b',
   yum: '#10b981',
+  cran: '#276dc3',
 }
 
 // Colors for the artifact-type labels the registry browse tree reports. A media

--- a/frontend/src/pages/CleanupPage.tsx
+++ b/frontend/src/pages/CleanupPage.tsx
@@ -44,12 +44,13 @@ interface PolicyForm {
   scopePath: string
 }
 
-const FORMATS = ['*', 'maven2', 'npm', 'docker', 'oci', 'pypi', 'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan']
+const FORMATS = ['*', 'maven2', 'npm', 'docker', 'oci', 'pypi', 'go', 'nuget', 'helm', 'raw', 'apt', 'yum', 'cargo', 'conan', 'cran']
 
 const FORMAT_COLOR: Record<string, string> = {
   maven2: '#f97316', npm: '#ef4444', docker: '#3b82f6', oci: '#5b8def', pypi: '#a78bfa',
   go: '#06b6d4', nuget: '#8b5cf6', helm: '#0ea5e9', raw: '#6b7280',
   apt: '#f59e0b', yum: '#10b981', cargo: '#fb923c', conan: '#94a3b8',
+  cran: '#276dc3',
   '*': '#6b7280',
 }
 

--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -71,6 +71,7 @@ const FORMAT_COLORS: Record<string, string> = {
   conda:     '#44b765',
   rubygems:  '#e9573f',
   terraform: '#7b42bc',
+  cran:      '#276dc3',
 }
 
 const TYPE_LABELS: Record<string, string> = {
@@ -159,7 +160,7 @@ export default function RepositoriesPage() {
         <Select
           options={[
             { value: '', label: 'All formats' },
-            ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform','rubygems'].map(f => ({ value: f, label: f })),
+            ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform','rubygems','cran'].map(f => ({ value: f, label: f })),
           ]}
           value={formatFilter}
           onChange={setFormatFilter}
@@ -399,6 +400,7 @@ const PROXY_DEFAULTS: Record<string, string> = {
   conda:     'https://conda.anaconda.org/conda-forge/',
   rubygems:  'https://rubygems.org/',
   terraform: 'https://registry.terraform.io/',
+  cran:      'https://cran.r-project.org/',
 }
 
 /** Sets a trimmed value on cfg, or removes the key entirely when the field was cleared. */
@@ -541,7 +543,7 @@ function CreateRepoModal({ onClose, onCreated }: {
       <div className={styles.formRow}>
         <label style={LABEL_STYLE}>Format</label>
         <Select
-          options={['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform','rubygems'].map(f => ({ value: f, label: f }))}
+          options={['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cargo','conan','conda','terraform','rubygems','cran'].map(f => ({ value: f, label: f }))}
           value={form.format}
           onChange={handleFormatChange}
         />

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -94,6 +94,7 @@ const S = {
 const FORMAT_COLORS: Record<string, string> = {
   maven2: '#f97316', npm: '#ef4444', docker: '#3b82f6', oci: '#5b8def', pypi: '#a78bfa',
   go: '#06b6d4', nuget: '#8b5cf6', helm: '#0ea5e9', raw: '#6b7280', apt: '#f59e0b', yum: '#10b981',
+  cran: '#276dc3',
 }
 
 function fmtSize(b: number | undefined) {
@@ -296,7 +297,7 @@ export default function SearchPage() {
             <Select
               options={[
                 { value: '', label: 'any' },
-                ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum'].map(f => ({ value: f, label: f })),
+                ...['maven2','npm','docker','oci','pypi','go','nuget','helm','raw','apt','yum','cran'].map(f => ({ value: f, label: f })),
               ]}
               value={filters.format}
               onChange={v => setFilters(f => ({ ...f, format: v }))}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -29,6 +29,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/formats/cargo"
 	"github.com/nexspence-oss/nexspence/internal/formats/conan"
 	"github.com/nexspence-oss/nexspence/internal/formats/conda"
+	"github.com/nexspence-oss/nexspence/internal/formats/cran"
 	"github.com/nexspence-oss/nexspence/internal/formats/gomod"
 	"github.com/nexspence-oss/nexspence/internal/formats/group"
 	"github.com/nexspence-oss/nexspence/internal/formats/helm"
@@ -284,6 +285,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		"apt":       apt.New(formatDeps),
 		"terraform": terraform.New(formatDeps),
 		"rubygems":  rubygems.New(formatDeps),
+		"cran":      cran.New(formatDeps),
 		"yum":       yum.New(formatDeps),
 		"docker":    oci.New(formatDeps),
 	}

--- a/internal/db/migrations/031_format_cran.sql
+++ b/internal/db/migrations/031_format_cran.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_format_check;
+ALTER TABLE repositories ADD CONSTRAINT repositories_format_check CHECK (format IN (
+    'maven2','npm','docker','oci','pypi','go','nuget','helm','raw',
+    'apt','yum','cargo','conan','conda','terraform','rubygems','cran'
+));
+
+-- +goose Down
+ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_format_check;
+ALTER TABLE repositories ADD CONSTRAINT repositories_format_check CHECK (format IN (
+    'maven2','npm','docker','oci','pypi','go','nuget','helm','raw',
+    'apt','yum','cargo','conan','conda','terraform','rubygems'
+));

--- a/internal/domain/site_formats_test.go
+++ b/internal/domain/site_formats_test.go
@@ -85,6 +85,7 @@ func TestSiteFormatTableListsEveryFormat(t *testing.T) {
 		domain.FormatConda:     "Conda",
 		domain.FormatTerraform: "Terraform",
 		domain.FormatRubyGems:  "RubyGems",
+		domain.FormatCRAN:      "CRAN",
 	}
 	for _, f := range domain.AllFormats {
 		label, ok := labels[f]

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -34,6 +34,7 @@ const (
 	FormatConda     RepoFormat = "conda"
 	FormatTerraform RepoFormat = "terraform"
 	FormatRubyGems  RepoFormat = "rubygems"
+	FormatCRAN      RepoFormat = "cran"
 
 	TypeHosted RepoType = "hosted"
 	TypeProxy  RepoType = "proxy"
@@ -60,6 +61,7 @@ var AllFormats = []RepoFormat{
 	FormatConda,
 	FormatTerraform,
 	FormatRubyGems,
+	FormatCRAN,
 }
 
 // IsOCIRegistry reports whether a repository of this format speaks the OCI

--- a/internal/formats/cran/cran_proxy_test.go
+++ b/internal/formats/cran/cran_proxy_test.go
@@ -1,0 +1,140 @@
+package cran_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/cran"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// useUnguardedUpstream swaps the SSRF-guarded upstream client for a plain one so
+// cache-miss fetches can reach the loopback httptest server used as a fake mirror.
+func useUnguardedUpstream(t *testing.T) {
+	t.Helper()
+	orig := repoproxy.UpstreamClient
+	repoproxy.UpstreamClient = &http.Client{}
+	t.Cleanup(func() { repoproxy.UpstreamClient = orig })
+}
+
+// setupProxy wires a cran proxy repo pointed at upstream and returns the engine
+// plus the component/asset mocks so tests can inspect what was cached.
+func setupProxy(t *testing.T, name, upstream string) (*gin.Engine, *testutil.ComponentRepo, *testutil.AssetRepo) {
+	t.Helper()
+	repo := testutil.SimpleRepo(name, "cran")
+	repo.Type = domain.TypeProxy
+	repo.ProxyConfig = map[string]any{"remote_url": upstream}
+
+	comps := testutil.NewComponentRepo()
+	assets := testutil.NewAssetRepo()
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     assets,
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := cran.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r, comps, assets
+}
+
+func getProxy(t *testing.T, r *gin.Engine, url string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+	return w
+}
+
+// A cached tarball must land on a component named after the package, with the
+// version parsed out of the filename — same coordinates a hosted upload gets.
+func TestCRANProxy_CachedTarball_HasPackageCoordinates(t *testing.T) {
+	useUnguardedUpstream(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("tarball-bytes"))
+	}))
+	defer upstream.Close()
+
+	r, comps, _ := setupProxy(t, "cran-proxy", upstream.URL)
+
+	w := getProxy(t, r, "/repository/cran-proxy/src/contrib/dplyr_1.1.4.tar.gz")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	page, err := comps.List(t.Context(), "cran-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "dplyr", page.Items[0].Name)
+	assert.Equal(t, "1.1.4", page.Items[0].Version)
+}
+
+// The PACKAGES index is not a package: it gets its own component keyed by
+// path, so it stays individually browsable and deletable.
+func TestCRANProxy_CachedPackagesIndex_IsPerPathComponent(t *testing.T) {
+	useUnguardedUpstream(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("Package: dplyr\nVersion: 1.1.4\n"))
+	}))
+	defer upstream.Close()
+
+	r, comps, _ := setupProxy(t, "cran-proxy", upstream.URL)
+
+	require.Equal(t, http.StatusOK, getProxy(t, r, "/repository/cran-proxy/src/contrib/PACKAGES").Code)
+
+	page, err := comps.List(t.Context(), "cran-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+	assert.Equal(t, "src/contrib/PACKAGES", page.Items[0].Name)
+	assert.Equal(t, "metadata", page.Items[0].Version)
+}
+
+// Every cached asset must be reachable from the component that owns it —
+// this is what the browse row needs in order to delete it.
+func TestCRANProxy_CachedAsset_LinkedToComponent(t *testing.T) {
+	useUnguardedUpstream(t)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("tarball-bytes"))
+	}))
+	defer upstream.Close()
+
+	r, comps, assets := setupProxy(t, "cran-proxy", upstream.URL)
+	require.Equal(t, http.StatusOK,
+		getProxy(t, r, "/repository/cran-proxy/src/contrib/ggplot2_3.5.0.tar.gz").Code)
+
+	page, err := comps.List(t.Context(), "cran-proxy", 100, 0)
+	require.NoError(t, err)
+	require.Len(t, page.Items, 1)
+
+	owned, err := assets.ListByComponentID(t.Context(), page.Items[0].ID)
+	require.NoError(t, err)
+	require.Len(t, owned, 1)
+	assert.Equal(t, "/src/contrib/ggplot2_3.5.0.tar.gz", owned[0].Path)
+}
+
+// A proxy repo with no repository record at all (unresolvable) falls through
+// to the hosted path, same as apt/every other format handler.
+func TestCRANProxy_UnknownRepo_FallsThroughToHosted(t *testing.T) {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := cran.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+
+	w := getProxy(t, r, "/repository/does-not-exist/src/contrib/PACKAGES")
+	assert.Equal(t, http.StatusOK, w.Code, "hosted path serves an empty index for an unknown repo rather than erroring")
+}

--- a/internal/formats/cran/groupindex.go
+++ b/internal/formats/cran/groupindex.go
@@ -1,0 +1,81 @@
+package cran
+
+// Group index merging: PACKAGES answers 200-empty for members without any
+// package, shadowing later members under first-non-404 fan-out — same problem
+// apt/#99 solved. Stanzas are unioned, deduped by Package+Version.
+//
+// Unlike apt, CRAN has no Release-equivalent document that describes other
+// index documents (no cross-file checksums to keep consistent), so this only
+// implements formats.GroupIndexMerger — not GroupIndexDependentMerger.
+
+import (
+	"strings"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+)
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger. The .gz flavor
+// fans out on the PLAIN document — members serve plain text, the merger
+// gzips the merged result.
+func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
+	if strings.HasSuffix(p, "/PACKAGES") || strings.HasSuffix(p, "/PACKAGES.gz") {
+		return strings.TrimSuffix(p, ".gz"), true
+	}
+	return "", false
+}
+
+// MergeGroupIndex implements formats.GroupIndexMerger.
+func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	plain := mergePackages(parts)
+	if strings.HasSuffix(p, ".gz") {
+		return gzipBytes(plain), "application/x-gzip", nil
+	}
+	return plain, "text/plain; charset=utf-8", nil
+}
+
+// mergePackages unions the members' stanzas, deduped by Package+Version (first
+// member wins) — CRAN has no Filename: field like apt to dedup by instead.
+func mergePackages(parts []formats.GroupIndexPart) []byte {
+	var stanzas []string
+	seen := map[string]bool{}
+	for _, part := range parts {
+		for _, stanza := range strings.Split(strings.TrimSpace(string(part.Body)), "\n\n") {
+			stanza = strings.TrimSpace(stanza)
+			if stanza == "" {
+				continue
+			}
+			key := stanzaKey(stanza)
+			if key != "" && seen[key] {
+				continue // first member wins per Package+Version
+			}
+			if key != "" {
+				seen[key] = true
+			}
+			stanzas = append(stanzas, stanza)
+		}
+	}
+
+	var sb strings.Builder
+	for _, s := range stanzas {
+		sb.WriteString(s)
+		sb.WriteString("\n\n")
+	}
+	return []byte(sb.String())
+}
+
+// stanzaKey extracts "Package|Version" as the dedup key.
+func stanzaKey(stanza string) string {
+	var pkg, ver string
+	for _, line := range strings.Split(stanza, "\n") {
+		if v, found := strings.CutPrefix(line, "Package:"); found {
+			pkg = strings.TrimSpace(v)
+		}
+		if v, found := strings.CutPrefix(line, "Version:"); found {
+			ver = strings.TrimSpace(v)
+		}
+	}
+	if pkg == "" {
+		return ""
+	}
+	return pkg + "|" + ver
+}

--- a/internal/formats/cran/groupindex.go
+++ b/internal/formats/cran/groupindex.go
@@ -9,23 +9,48 @@ package cran
 // implements formats.GroupIndexMerger — not GroupIndexDependentMerger.
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/nexspence-oss/nexspence/internal/formats"
 )
 
-// GroupIndexSourcePath implements formats.GroupIndexMerger. The .gz flavor
-// fans out on the PLAIN document — members serve plain text, the merger
-// gzips the merged result.
+// errRDSUnsupported is returned by MergeGroupIndex for PACKAGES.rds: it is a
+// binary R serialization format, not text stanzas, so there is no merged
+// document to produce.
+var errRDSUnsupported = errors.New("cran: PACKAGES.rds is a binary format the group cannot merge; client falls back to PACKAGES.gz")
+
+// GroupIndexSourcePath implements formats.GroupIndexMerger. The .gz and .rds
+// flavors both fan out on the PLAIN document — members serve plain text, the
+// merger gzips the merged result for .gz and refuses to produce one for .rds
+// (see MergeGroupIndex).
+//
+// PACKAGES.rds must be claimed here even though the group can't answer it: R
+// requests it before PACKAGES.gz/PACKAGES (utils::available.packages), so
+// left unclaimed it would fall to first-non-404 fan-out — a hosted member
+// answers 405 there, but a proxy member relays its upstream's real
+// PACKAGES.rds, silently shadowing every hosted-only package (the exact
+// shadowing #99's merger exists to prevent, just one level up the R client's
+// own fallback chain).
 func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
 	if strings.HasSuffix(p, "/PACKAGES") || strings.HasSuffix(p, "/PACKAGES.gz") {
 		return strings.TrimSuffix(p, ".gz"), true
+	}
+	if strings.HasSuffix(p, "/PACKAGES.rds") {
+		return strings.TrimSuffix(p, ".rds"), true
 	}
 	return "", false
 }
 
 // MergeGroupIndex implements formats.GroupIndexMerger.
 func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
+	if strings.HasSuffix(p, ".rds") {
+		// Refusing degrades to the first member's plain-text body (see
+		// group.Handler.serveMergedIndex) — not valid RDS either, but R's own
+		// readRDS/available.packages fallback treats a read error exactly like a
+		// failed download and retries PACKAGES.gz, which merges correctly.
+		return nil, "", errRDSUnsupported
+	}
 	plain := mergePackages(parts)
 	if strings.HasSuffix(p, ".gz") {
 		return gzipBytes(plain), "application/x-gzip", nil

--- a/internal/formats/cran/groupindex_test.go
+++ b/internal/formats/cran/groupindex_test.go
@@ -1,0 +1,95 @@
+package cran_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/cran"
+)
+
+const (
+	stanzaDplyr   = "Package: dplyr\nVersion: 1.1.4\n"
+	stanzaGgplot2 = "Package: ggplot2\nVersion: 3.5.0\n"
+)
+
+func TestCRAN_GroupIndexSourcePath(t *testing.T) {
+	h := cran.New(formats.Deps{})
+
+	src, ok := h.GroupIndexSourcePath("/src/contrib/PACKAGES")
+	require.True(t, ok)
+	assert.Equal(t, "/src/contrib/PACKAGES", src)
+
+	// .gz fans out on the PLAIN document; the merger gzips the result.
+	src, ok = h.GroupIndexSourcePath("/src/contrib/PACKAGES.gz")
+	require.True(t, ok)
+	assert.Equal(t, "/src/contrib/PACKAGES", src)
+
+	_, ok = h.GroupIndexSourcePath("/src/contrib/dplyr_1.1.4.tar.gz")
+	assert.False(t, ok, "package downloads keep first-non-404")
+}
+
+func TestCRAN_MergeGroupIndex_UnionsStanzas(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(stanzaDplyr + "\n")},
+		{Member: "m2", Body: []byte(stanzaDplyr + "\n" + stanzaGgplot2 + "\n")}, // dplyr duplicated
+	}
+
+	body, ct, err := h.MergeGroupIndex("g", "/src/contrib/PACKAGES", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "text/plain")
+	out := string(body)
+	assert.Contains(t, out, "Package: dplyr")
+	assert.Contains(t, out, "Package: ggplot2")
+	assert.Equal(t, 1, bytes.Count(body, []byte("Package: dplyr")), "dedup by Package+Version")
+}
+
+func TestCRAN_MergeGroupIndex_GzipOutput(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{{Member: "m1", Body: []byte(stanzaDplyr + "\n")}}
+
+	body, ct, err := h.MergeGroupIndex("g", "/src/contrib/PACKAGES.gz", parts)
+	require.NoError(t, err)
+	assert.Contains(t, ct, "gzip")
+
+	zr, err := gzip.NewReader(bytes.NewReader(body))
+	require.NoError(t, err)
+	plain, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	assert.Contains(t, string(plain), "Package: dplyr")
+}
+
+func TestCRAN_MergeGroupIndex_EmptyMemberContributesNothing(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte("")},
+		{Member: "m2", Body: []byte(stanzaDplyr + "\n")},
+	}
+
+	body, _, err := h.MergeGroupIndex("g", "/src/contrib/PACKAGES", parts)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Package: dplyr")
+}
+
+func TestCRAN_MergeGroupIndex_DedupPrefersFirstMember(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	// Same Package+Version from two members with different bodies (simulated
+	// via a distinguishing extra field) — first member's stanza must win.
+	first := "Package: dplyr\nVersion: 1.1.4\nX-Source: m1\n"
+	second := "Package: dplyr\nVersion: 1.1.4\nX-Source: m2\n"
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(first + "\n")},
+		{Member: "m2", Body: []byte(second + "\n")},
+	}
+
+	body, _, err := h.MergeGroupIndex("g", "/src/contrib/PACKAGES", parts)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "X-Source: m1")
+	assert.NotContains(t, string(body), "X-Source: m2")
+}

--- a/internal/formats/cran/groupindex_test.go
+++ b/internal/formats/cran/groupindex_test.go
@@ -32,6 +32,21 @@ func TestCRAN_GroupIndexSourcePath(t *testing.T) {
 
 	_, ok = h.GroupIndexSourcePath("/src/contrib/dplyr_1.1.4.tar.gz")
 	assert.False(t, ok, "package downloads keep first-non-404")
+
+	// .rds must be claimed too, even though the group can't answer it — R asks
+	// for it before .gz/plain, so left unclaimed a proxy member would shadow
+	// the merge under first-non-404 fan-out (see MergeGroupIndex).
+	src, ok = h.GroupIndexSourcePath("/src/contrib/PACKAGES.rds")
+	require.True(t, ok)
+	assert.Equal(t, "/src/contrib/PACKAGES", src)
+}
+
+func TestCRAN_MergeGroupIndex_RefusesRDS(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	parts := []formats.GroupIndexPart{{Member: "m1", Body: []byte(stanzaDplyr + "\n")}}
+
+	_, _, err := h.MergeGroupIndex("g", "/src/contrib/PACKAGES.rds", parts)
+	assert.Error(t, err, "no valid RDS can be produced from merged stanzas")
 }
 
 func TestCRAN_MergeGroupIndex_UnionsStanzas(t *testing.T) {

--- a/internal/formats/cran/groupindex_test.go
+++ b/internal/formats/cran/groupindex_test.go
@@ -77,6 +77,21 @@ func TestCRAN_MergeGroupIndex_EmptyMemberContributesNothing(t *testing.T) {
 	assert.Contains(t, string(body), "Package: dplyr")
 }
 
+// A stanza with no Package: line has no dedup key — it can't collide with
+// anything, so it passes through unioned rather than being dropped.
+func TestCRAN_MergeGroupIndex_StanzaWithoutPackageLinePassesThrough(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	malformed := "Version: 1.1.4\nNote: no Package line\n"
+	parts := []formats.GroupIndexPart{
+		{Member: "m1", Body: []byte(malformed + "\n" + stanzaDplyr + "\n")},
+	}
+
+	body, _, err := h.MergeGroupIndex("g", "/src/contrib/PACKAGES", parts)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "Note: no Package line")
+	assert.Contains(t, string(body), "Package: dplyr")
+}
+
 func TestCRAN_MergeGroupIndex_DedupPrefersFirstMember(t *testing.T) {
 	h := cran.New(formats.Deps{})
 	// Same Package+Version from two members with different bodies (simulated

--- a/internal/formats/cran/handler.go
+++ b/internal/formats/cran/handler.go
@@ -100,6 +100,13 @@ func (h *Handler) serveHosted(c *gin.Context, repoName, p string) {
 		}
 		c.Status(http.StatusNoContent)
 
+	// A GET this repository doesn't keep an index or tarball for (e.g.
+	// PACKAGES.rds, which nexspence never generates) is a missing resource, not
+	// a bad method — and a group of hosted members fanning out on it can only
+	// skip to the next member on 404, never on 405.
+	case c.Request.Method == http.MethodGet:
+		c.Status(http.StatusNotFound)
+
 	default:
 		c.Status(http.StatusMethodNotAllowed)
 	}

--- a/internal/formats/cran/handler.go
+++ b/internal/formats/cran/handler.go
@@ -1,0 +1,246 @@
+// Package cran implements the CRAN (Comprehensive R Archive Network)
+// repository protocol for R source packages.
+//
+// Layout under /repository/:repoName/:
+//
+//	GET    /src/contrib/PACKAGES[.gz]        → packages index
+//	GET    /src/contrib/:pkg_version.tar.gz  → package download
+//	PUT    /src/contrib/:pkg_version.tar.gz  → upload package
+//	POST   /src/contrib/:pkg_version.tar.gz  → upload package (Nexus-compatible verb)
+//	DELETE /src/contrib/:pkg_version.tar.gz  → delete package
+//
+// Binary packages (Windows .zip, macOS .tgz under bin/windows|macosx/contrib/)
+// are out of scope for this first version.
+package cran
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/base"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
+)
+
+// Handler serves the CRAN repository protocol.
+type Handler struct{ deps formats.Deps }
+
+// New creates a CRAN format Handler with the given dependencies.
+func New(deps formats.Deps) *Handler { return &Handler{deps: deps} }
+
+// Name returns the format identifier.
+func (h *Handler) Name() string { return "cran" }
+
+func (h *Handler) ServeHTTP(c *gin.Context) {
+	p := normPath(c.Param("path"))
+	repoName := c.Param("repoName")
+
+	repo, _ := h.deps.Repos.Get(c.Request.Context(), repoName)
+
+	// Proxy: block uploads/deletes, pass reads through to upstream (e.g. cran.r-project.org)
+	if repo != nil && repo.Type == domain.TypeProxy {
+		if repoproxy.RejectMutation(c, repo) {
+			return
+		}
+		ct := "application/octet-stream"
+		if strings.Contains(p, "/PACKAGES") {
+			ct = "text/plain"
+		}
+		// Package tarballs are immutable (name+version is permanent by CRAN
+		// convention, like npm); PACKAGES/PACKAGES.gz are mutable metadata that
+		// change whenever the upstream repo gains a new package, so they're
+		// revalidated on a TTL.
+		var maxAge time.Duration
+		if !strings.HasSuffix(p, ".tar.gz") {
+			maxAge = repoproxy.MetadataMaxAge(repo)
+		}
+		if err := repoproxy.ServeGET(c, h.deps, repo, p, "", proxyCoords(p), ct, maxAge); err != nil {
+			c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		}
+		return
+	}
+
+	h.serveHosted(c, repoName, p)
+}
+
+// serveHosted routes the hosted (non-proxy) surface of the CRAN protocol.
+func (h *Handler) serveHosted(c *gin.Context, repoName, p string) {
+	switch {
+	// Packages index (plain or gzip)
+	case c.Request.Method == http.MethodGet && (strings.HasSuffix(p, "/PACKAGES") || strings.HasSuffix(p, "/PACKAGES.gz")):
+		h.servePackagesIndex(c, repoName, p)
+
+	// Download package tarball
+	case (c.Request.Method == http.MethodGet || c.Request.Method == http.MethodHead) && strings.HasSuffix(p, ".tar.gz"):
+		h.serveFile(c, repoName, p)
+
+	// Upload: PUT/POST to a .tar.gz path, or a root-level upload (R clients and
+	// `curl --upload-file pkg.tar.gz .../repository/<repo>/` upload to the
+	// repository root rather than an explicit src/contrib path). POST also
+	// accepts multipart/form-data with a "file"/"package" field (Nexus-compatible).
+	case (c.Request.Method == http.MethodPut || c.Request.Method == http.MethodPost) &&
+		(p == "/" || strings.HasSuffix(p, ".tar.gz")):
+		h.handleUpload(c, repoName, p)
+
+	// Delete package tarball
+	case c.Request.Method == http.MethodDelete && strings.HasSuffix(p, ".tar.gz"):
+		if err := base.DeleteArtifact(c.Request.Context(), h.deps, repoName, p); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusNoContent)
+
+	default:
+		c.Status(http.StatusMethodNotAllowed)
+	}
+}
+
+// buildPackagesIndex generates the PACKAGES index from every stored .tar.gz.
+//
+// DESCRIPTION is not parsed out of the tarball in this first version —
+// Depends/Imports/License are left generic rather than fabricated, since a
+// wrong dependency line is worse than an absent one.
+func (h *Handler) buildPackagesIndex(ctx context.Context, repoName string) ([]byte, error) {
+	page, err := h.deps.Components.Search(ctx, domain.SearchParams{
+		Repository: repoName, Limit: 1000,
+	})
+	if err != nil {
+		return nil, err
+	}
+	assetPage, err := h.deps.Assets.List(ctx, repoName, 1000, 0)
+	if err != nil {
+		return nil, err
+	}
+	compMap := map[string]*domain.Component{}
+	for i := range page.Items {
+		compMap[page.Items[i].ID] = &page.Items[i]
+	}
+
+	var sb strings.Builder
+	for _, a := range assetPage.Items {
+		if !strings.HasSuffix(a.Path, ".tar.gz") {
+			continue
+		}
+		comp := compMap[a.ComponentID]
+		if comp == nil {
+			continue
+		}
+		fmt.Fprintf(&sb, "Package: %s\n", comp.Name)
+		fmt.Fprintf(&sb, "Version: %s\n", comp.Version)
+		sb.WriteString("\n")
+	}
+	return []byte(sb.String()), nil
+}
+
+func (h *Handler) servePackagesIndex(c *gin.Context, repoName, p string) {
+	data, err := h.buildPackagesIndex(c.Request.Context(), repoName)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	if strings.HasSuffix(p, ".gz") {
+		c.Data(http.StatusOK, "application/x-gzip", gzipBytes(data))
+		return
+	}
+	c.Data(http.StatusOK, "text/plain; charset=utf-8", data)
+}
+
+func gzipBytes(plain []byte) []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	_, _ = gw.Write(plain)
+	_ = gw.Close()
+	return buf.Bytes()
+}
+
+// cranCoords parses the CRAN "name_version.tar.gz" filename convention. R
+// package names never contain underscores (they use dots), so the first
+// underscore unambiguously separates name from version — unlike Debian's
+// "name_version_arch.deb", there's no third field to account for.
+func cranCoords(filename string) (pkgName, version string) {
+	stem := strings.TrimSuffix(filename, ".tar.gz")
+	if idx := strings.Index(stem, "_"); idx > 0 {
+		return stem[:idx], stem[idx+1:]
+	}
+	return filename, "0.0.0"
+}
+
+// proxyCoords derives component coordinates for a file cached from upstream.
+// Packages get real name/version coordinates so they browse like hosted ones;
+// the PACKAGES index is keyed by its path, since it's a single document
+// rather than a version of a package.
+func proxyCoords(p string) base.Coords {
+	if strings.HasSuffix(p, ".tar.gz") {
+		name, version := cranCoords(path.Base(p))
+		return base.Coords{Name: name, Version: version}
+	}
+	return base.Coords{Name: strings.TrimPrefix(p, "/"), Version: "metadata"}
+}
+
+func (h *Handler) handleUpload(c *gin.Context, repoName, p string) {
+	filename := path.Base(p)
+	body := io.Reader(c.Request.Body)
+	size := c.Request.ContentLength
+
+	// Nexus-style root POST: the tarball arrives as a multipart file field
+	// ("file" or "package") and the filename comes from the part, not the path.
+	if !strings.HasSuffix(filename, ".tar.gz") {
+		f, fh, err := c.Request.FormFile("file")
+		if err != nil {
+			f, fh, err = c.Request.FormFile("package")
+		}
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "expected a *.tar.gz path or a multipart 'file' field"})
+			return
+		}
+		defer func() { _ = f.Close() }()
+		filename, body, size = fh.Filename, f, fh.Size
+	}
+
+	pkgName, version := cranCoords(filename)
+
+	// Normalize root-level uploads into the canonical src/contrib layout so the
+	// PACKAGES index (which lists /src/contrib/ assets) still finds them.
+	storePath := p
+	if !strings.HasPrefix(storePath, "/src/contrib/") {
+		storePath = "/src/contrib/" + filename
+	}
+
+	coords := base.Coords{Name: pkgName, Version: version}
+	if _, err := base.StoreArtifact(c.Request.Context(), h.deps,
+		repoName, storePath, "application/x-gzip",
+		coords, body, size); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusCreated)
+}
+
+func (h *Handler) serveFile(c *gin.Context, repoName, p string) {
+	rc, asset, err := base.FetchArtifact(c.Request.Context(), h.deps, repoName, p)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+	defer func() { _ = rc.Close() }()
+	if c.Request.Method == http.MethodHead {
+		c.Header("Content-Length", fmt.Sprintf("%d", asset.SizeBytes))
+		c.Status(http.StatusOK)
+		return
+	}
+	c.DataFromReader(http.StatusOK, asset.SizeBytes, asset.ContentType, rc, nil)
+}
+
+func normPath(p string) string {
+	return path.Clean("/" + strings.TrimPrefix(p, "/"))
+}

--- a/internal/formats/cran/handler_test.go
+++ b/internal/formats/cran/handler_test.go
@@ -1,0 +1,232 @@
+package cran_test
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/cran"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+func init() { gin.SetMode(gin.TestMode) }
+
+func setup(repo *domain.Repository) *gin.Engine {
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := cran.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+	return r
+}
+
+func putPkg(r *gin.Engine, repoName, path, content string) int {
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+path,
+		strings.NewReader(content))
+	req.ContentLength = int64(len(content))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestCRAN_UploadAndDownload(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putPkg(r, "rpkgs", "/src/contrib/dplyr_1.1.4.tar.gz", "pkg-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs/src/contrib/dplyr_1.1.4.tar.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "pkg-bytes", w.Body.String())
+}
+
+func TestCRAN_RootUpload_NormalizesToSrcContrib(t *testing.T) {
+	// Regression for the apt #46 pattern: a root-level PUT must not 405.
+	repo := testutil.SimpleRepo("rpkgs-root", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putPkg(r, "rpkgs-root", "/ggplot2_3.5.0.tar.gz", "gg-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs-root/src/contrib/ggplot2_3.5.0.tar.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "gg-bytes", w.Body.String())
+
+	req = httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs-root/src/contrib/PACKAGES", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "ggplot2")
+}
+
+func TestCRAN_PackagesIndex_Empty(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs2", "cran")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs2/src/contrib/PACKAGES", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "", w.Body.String())
+}
+
+func TestCRAN_PackagesIndex_ShowsPackage(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs3", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putPkg(r, "rpkgs3", "/src/contrib/jsonlite_1.8.8.tar.gz", "json-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs3/src/contrib/PACKAGES", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Package: jsonlite")
+	assert.Contains(t, w.Body.String(), "Version: 1.8.8")
+}
+
+func TestCRAN_PackagesIndexGz(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs-gz", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putPkg(r, "rpkgs-gz", "/src/contrib/xml2_1.3.6.tar.gz", "xml-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs-gz/src/contrib/PACKAGES.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/x-gzip", w.Header().Get("Content-Type"))
+}
+
+func TestCRAN_Delete(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs4", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putPkg(r, "rpkgs4", "/src/contrib/stringr_1.5.1.tar.gz", "str-bytes"))
+
+	req := httptest.NewRequest(http.MethodDelete,
+		"/repository/rpkgs4/src/contrib/stringr_1.5.1.tar.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func TestCRAN_GetNotFound(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs5", "cran")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs5/src/contrib/missing_1.0.tar.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCRAN_ProxyRejectMutation(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs6", "cran")
+	repo.Type = domain.TypeProxy
+
+	r := setup(repo)
+	code := putPkg(r, "rpkgs6", "/src/contrib/pkg_1.0.tar.gz", "data")
+	assert.Equal(t, http.StatusMethodNotAllowed, code)
+}
+
+// postPkg uploads a tarball via POST to an explicit path (body = raw bytes).
+func postPkg(r *gin.Engine, repoName, path, content string) int {
+	req := httptest.NewRequest(http.MethodPost, "/repository/"+repoName+path,
+		strings.NewReader(content))
+	req.Header.Set("Content-Type", "application/x-gzip")
+	req.ContentLength = int64(len(content))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+// postPkgMultipart uploads a tarball via Nexus-style POST to the repo root
+// (multipart/form-data with a "file" field carrying the filename).
+func postPkgMultipart(r *gin.Engine, repoName, filename, content string) int {
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, _ := mw.CreateFormFile("file", filename)
+	_, _ = part.Write([]byte(content))
+	_ = mw.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/repository/"+repoName+"/", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestCRAN_PostPath_Upload(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs-post", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		postPkg(r, "rpkgs-post", "/purrr_1.0.2.tar.gz", "purrr-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs-post/src/contrib/purrr_1.0.2.tar.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "purrr-bytes", w.Body.String())
+}
+
+func TestCRAN_PostRootMultipart_Upload(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs-mp", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		postPkgMultipart(r, "rpkgs-mp", "tibble_3.2.1.tar.gz", "tibble-bytes"))
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/repository/rpkgs-mp/src/contrib/tibble_3.2.1.tar.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "tibble-bytes", w.Body.String())
+}
+
+func TestCRAN_Name(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	assert.Equal(t, "cran", h.Name())
+}
+
+func TestCRAN_MethodNotAllowed(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs7", "cran")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodPatch, "/repository/rpkgs7/src/contrib/PACKAGES", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}

--- a/internal/formats/cran/handler_test.go
+++ b/internal/formats/cran/handler_test.go
@@ -2,6 +2,7 @@ package cran_test
 
 import (
 	"bytes"
+	"errors"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -229,4 +230,73 @@ func TestCRAN_MethodNotAllowed(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestCRAN_HeadReturnsContentLengthNoBody(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs8", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putPkg(r, "rpkgs8", "/src/contrib/vctrs_0.6.5.tar.gz", "vctrs-bytes"))
+
+	req := httptest.NewRequest(http.MethodHead, "/repository/rpkgs8/src/contrib/vctrs_0.6.5.tar.gz", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "11", w.Header().Get("Content-Length"))
+	assert.Empty(t, w.Body.String(), "HEAD must not return a body")
+}
+
+// A filename without an underscore has no parseable version — cranCoords
+// falls back to the whole filename as the name and a placeholder version,
+// same convention apt's debCoords uses for non-conforming names.
+func TestCRAN_UploadWithoutUnderscore_FallsBackToPlaceholderVersion(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs9", "cran")
+	r := setup(repo)
+
+	require.Equal(t, http.StatusCreated,
+		putPkg(r, "rpkgs9", "/src/contrib/nounderscore.tar.gz", "data"))
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/rpkgs9/src/contrib/PACKAGES", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "Package: nounderscore.tar.gz")
+	assert.Contains(t, w.Body.String(), "Version: 0.0.0")
+}
+
+// A root-level POST/PUT that is neither a .tar.gz-suffixed path nor valid
+// multipart form data has nothing to derive a filename from.
+func TestCRAN_RootUpload_NeitherTarballNorMultipart_BadRequest(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs10", "cran")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodPut, "/repository/rpkgs10/", strings.NewReader("not-multipart"))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// A backend failure while building the index must surface as a 500, not a
+// silently empty or corrupted PACKAGES document.
+func TestCRAN_PackagesIndex_BackendError(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs11", "cran")
+	comps := testutil.NewComponentRepo()
+	comps.Err = errors.New("search backend unavailable")
+	d := formats.Deps{
+		Repos:      testutil.NewRepoRepo(repo),
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: comps,
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	h := cran.New(d)
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) { h.ServeHTTP(c) })
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/rpkgs11/src/contrib/PACKAGES", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/internal/formats/cran/handler_test.go
+++ b/internal/formats/cran/handler_test.go
@@ -232,6 +232,16 @@ func TestCRAN_MethodNotAllowed(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
 }
 
+func TestCRAN_GetUnsupportedIndex_NotFound(t *testing.T) {
+	repo := testutil.SimpleRepo("rpkgs9", "cran")
+	r := setup(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/repository/rpkgs9/src/contrib/PACKAGES.rds", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestCRAN_HeadReturnsContentLengthNoBody(t *testing.T) {
 	repo := testutil.SimpleRepo("rpkgs8", "cran")
 	r := setup(repo)

--- a/internal/formats/group/merge_cran_test.go
+++ b/internal/formats/group/merge_cran_test.go
@@ -1,0 +1,119 @@
+package group_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/formats"
+	"github.com/nexspence-oss/nexspence/internal/formats/cran"
+	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// buildCranGroupEngine wires real cran handlers for members and a group over them.
+func buildCranGroupEngine(t *testing.T, groupName string, memberNames ...string) *gin.Engine {
+	t.Helper()
+
+	repos := make([]*domain.Repository, 0, len(memberNames)+1)
+	ms := make([]interface{}, len(memberNames))
+	for i, name := range memberNames {
+		repos = append(repos, testutil.SimpleRepo(name, "cran"))
+		ms[i] = name
+	}
+	repos = append(repos, &domain.Repository{
+		ID: "repo-" + groupName, Name: groupName, Format: "cran",
+		Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": ms},
+	})
+
+	repoRepo := testutil.NewRepoRepo(repos...)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	cranH := cran.New(d)
+	groupH := group.New(d, map[string]formats.FormatHandler{"cran": cranH})
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		cranH.ServeHTTP(c)
+	})
+	return r
+}
+
+func putPkg(t *testing.T, r *gin.Engine, repoName, filename string) {
+	t.Helper()
+	body := "pkg-payload-" + filename
+	req := httptest.NewRequest(http.MethodPut, "/repository/"+repoName+"/src/contrib/"+filename, strings.NewReader(body))
+	req.ContentLength = int64(len(body))
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Contains(t, []int{http.StatusCreated, http.StatusOK}, w.Code, "upload %s: %s", filename, w.Body.String())
+}
+
+// A group's PACKAGES must union every member's packages — first-non-404
+// fan-out would shadow every member after the first one that answers.
+func TestGroupMerge_CranPackagesUnionsMembers(t *testing.T) {
+	r := buildCranGroupEngine(t, "rg", "rd1", "rd2")
+	putPkg(t, r, "rd1", "dplyr_1.1.4.tar.gz")
+	putPkg(t, r, "rd2", "ggplot2_3.5.0.tar.gz")
+
+	w := get(r, "/repository/rg/src/contrib/PACKAGES")
+	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
+	body := w.Body.String()
+	assert.Contains(t, body, "Package: dplyr")
+	assert.Contains(t, body, "Package: ggplot2")
+
+	// Both members' packages are reachable through the group.
+	dplyr := get(r, "/repository/rg/src/contrib/dplyr_1.1.4.tar.gz")
+	assert.Equal(t, http.StatusOK, dplyr.Code)
+	ggplot2 := get(r, "/repository/rg/src/contrib/ggplot2_3.5.0.tar.gz")
+	assert.Equal(t, http.StatusOK, ggplot2.Code)
+}
+
+// The gzip flavor has to be the same document as the plain one, not a
+// separately merged one.
+func TestGroupMerge_CranPackagesGzUnzipsToPlain(t *testing.T) {
+	r := buildCranGroupEngine(t, "rg2", "rh1", "rh2")
+	putPkg(t, r, "rh1", "dplyr_1.1.4.tar.gz")
+	putPkg(t, r, "rh2", "stringr_1.5.1.tar.gz")
+
+	plain := get(r, "/repository/rg2/src/contrib/PACKAGES").Body.Bytes()
+	gz := get(r, "/repository/rg2/src/contrib/PACKAGES.gz").Body.Bytes()
+
+	zr, err := gzip.NewReader(bytes.NewReader(gz))
+	require.NoError(t, err)
+	unzipped, err := io.ReadAll(zr)
+	require.NoError(t, err)
+	assert.Equal(t, string(plain), string(unzipped))
+}
+
+// A one-member group is that member: its PACKAGES must match the member's own.
+func TestGroupMerge_CranSingleMemberMatchesMember(t *testing.T) {
+	r := buildCranGroupEngine(t, "rg3", "ri1")
+	putPkg(t, r, "ri1", "dplyr_1.1.4.tar.gz")
+
+	direct := get(r, "/repository/ri1/src/contrib/PACKAGES")
+	viaGroup := get(r, "/repository/rg3/src/contrib/PACKAGES")
+	require.Equal(t, http.StatusOK, viaGroup.Code)
+	assert.Equal(t, direct.Body.String(), viaGroup.Body.String())
+}

--- a/internal/formats/group/merge_cran_test.go
+++ b/internal/formats/group/merge_cran_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/nexspence-oss/nexspence/internal/formats"
 	"github.com/nexspence-oss/nexspence/internal/formats/cran"
 	"github.com/nexspence-oss/nexspence/internal/formats/group"
+	"github.com/nexspence-oss/nexspence/internal/formats/repoproxy"
 	"github.com/nexspence-oss/nexspence/internal/testutil"
 )
 
@@ -105,6 +106,76 @@ func TestGroupMerge_CranPackagesGzUnzipsToPlain(t *testing.T) {
 	unzipped, err := io.ReadAll(zr)
 	require.NoError(t, err)
 	assert.Equal(t, string(plain), string(unzipped))
+}
+
+// A group with a proxy member must never relay the proxy's real upstream
+// PACKAGES.rds: an R client reads that document before PACKAGES.gz/PACKAGES
+// (utils::available.packages), and a real, parseable .rds from upstream would
+// let R stop right there — silently hiding every hosted-only package forever,
+// not just until the next request. Regression for the review on PR #430.
+func TestGroupMerge_CranNeverRelaysProxyRDS(t *testing.T) {
+	orig := repoproxy.UpstreamClient
+	repoproxy.UpstreamClient = &http.Client{}
+	t.Cleanup(func() { repoproxy.UpstreamClient = orig })
+
+	const rdsMarker = "REAL-UPSTREAM-RDS-BINARY"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/PACKAGES.rds") {
+			_, _ = w.Write([]byte(rdsMarker))
+			return
+		}
+		_, _ = w.Write([]byte("Package: upstreamonly\nVersion: 1.0\n"))
+	}))
+	defer upstream.Close()
+
+	hosted := testutil.SimpleRepo("rj-hosted", "cran")
+	proxy := testutil.SimpleRepo("rj-proxy", "cran")
+	proxy.Type = domain.TypeProxy
+	proxy.ProxyConfig = map[string]any{"remote_url": upstream.URL}
+
+	// Proxy listed ahead of hosted: this is the actual failure mode, not just
+	// any order — before this fix, a hosted member answering first with its own
+	// 405 would (by accident) stop the old first-non-404 fan-out before proxy
+	// ever got a turn. With proxy first, its 200 wins the old fan-out outright.
+	groupDef := &domain.Repository{
+		ID: "repo-rj", Name: "rj", Format: "cran",
+		Type: domain.TypeGroup, Online: true,
+		FormatConfig: map[string]any{"member_names": []interface{}{"rj-proxy", "rj-hosted"}},
+	}
+
+	repoRepo := testutil.NewRepoRepo(hosted, proxy, groupDef)
+	d := formats.Deps{
+		Repos:      repoRepo,
+		Blobs:      testutil.NewBlobStoreRepo(),
+		Components: testutil.NewComponentRepo(),
+		Assets:     testutil.NewAssetRepo(),
+		BlobStore:  testutil.NewBlobStore(),
+		BaseURL:    "http://localhost:8080",
+	}
+	cranH := cran.New(d)
+	groupH := group.New(d, map[string]formats.FormatHandler{"cran": cranH})
+
+	r := gin.New()
+	r.Any("/repository/:repoName/*path", func(c *gin.Context) {
+		repo, _ := repoRepo.Get(c.Request.Context(), c.Param("repoName"))
+		if repo != nil && repo.Type == domain.TypeGroup {
+			groupH.ServeHTTP(c)
+			return
+		}
+		cranH.ServeHTTP(c)
+	})
+
+	putPkg(t, r, "rj-hosted", "onlyhosted_2.0.tar.gz")
+
+	rds := get(r, "/repository/rj/src/contrib/PACKAGES.rds")
+	assert.NotContains(t, rds.Body.String(), rdsMarker,
+		"the group must never answer with the proxy's real upstream .rds — R would parse it successfully and never fall back to the merged PACKAGES.gz")
+
+	// The properly mergeable flavors are unaffected: both members still show up.
+	plain := get(r, "/repository/rj/src/contrib/PACKAGES")
+	require.Equal(t, http.StatusOK, plain.Code)
+	assert.Contains(t, plain.Body.String(), "Package: onlyhosted")
+	assert.Contains(t, plain.Body.String(), "Package: upstreamonly")
 }
 
 // A one-member group is that member: its PACKAGES must match the member's own.

--- a/internal/integration/proxy_formats_test.go
+++ b/internal/integration/proxy_formats_test.go
@@ -78,6 +78,26 @@ func TestProxyApt_RealShape(t *testing.T) {
 	assert.Equal(t, "deb-bytes", fetchOK(t, "/repository/apt-real/pool/main/h/hello/hello_2.10-3_amd64.deb"))
 }
 
+// ── cran (cran.r-project.org shape) ──────────────────────────────
+
+func TestProxyCRAN_RealShape(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/src/contrib/PACKAGES":
+			fmt.Fprint(w, "Package: dplyr\nVersion: 1.1.4\n")
+		case "/src/contrib/dplyr_1.1.4.tar.gz":
+			fmt.Fprint(w, "cran-bytes")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer up.Close()
+	createProxyRepo(t, "cran", "cran-real", up.URL)
+
+	assert.Contains(t, fetchOK(t, "/repository/cran-real/src/contrib/PACKAGES"), "Package: dplyr")
+	assert.Equal(t, "cran-bytes", fetchOK(t, "/repository/cran-real/src/contrib/dplyr_1.1.4.tar.gz"))
+}
+
 // ── yum (EPEL shape) ─────────────────────────────────────────────
 
 func TestProxyYum_RealShape(t *testing.T) {

--- a/website/docs/index.html
+++ b/website/docs/index.html
@@ -1713,7 +1713,7 @@ export NEXSPENCE_OIDC_CLIENT_SECRET="..."</div></div>
       </section>
       <section id="sec-formats" class="doc-section" hidden>
   <div class="doc-section-title" data-i18n="fmt.title">Supported Formats</div>
-  <div class="doc-section-sub" data-i18n="fmt.sub">16 artifact formats — each supports Hosted, Proxy, and Group repository types.</div>
+  <div class="doc-section-sub" data-i18n="fmt.sub">17 artifact formats — each supports Hosted, Proxy, and Group repository types.</div>
   <table class="doc-table">
     <thead><tr><th>Format</th><th>Protocol</th><th>Hosted</th><th>Proxy</th><th>Group</th></tr></thead>
     <tbody>
@@ -1733,6 +1733,7 @@ export NEXSPENCE_OIDC_CLIENT_SECRET="..."</div></div>
       <tr><td>Conda</td><td>conda index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>Terraform</td><td>Registry protocol v1</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
       <tr><td>RubyGems</td><td>Compact index</td><td class="y">✓</td><td class="y">✓</td><td>—</td></tr>
+      <tr><td>CRAN</td><td>PACKAGES index</td><td class="y">✓</td><td class="y">✓</td><td class="y">✓</td></tr>
     </tbody>
   </table>
       </section>
@@ -2129,7 +2130,7 @@ const TRANSLATIONS={
     'sb.native-install':'Native Install',
     'crumb.native-install':'native install',
     'fmt.title':'Supported Formats',
-    'fmt.sub':'16 artifact formats — each supports Hosted, Proxy, and Group repository types.',
+    'fmt.sub':'17 artifact formats — each supports Hosted, Proxy, and Group repository types.',
     'api.title':'API Reference','api.sub':'Nexspence exposes two API surfaces.',
     'api.auth.title':'Authentication',
     'api.auth.desc':'JWT Bearer token (from <code>POST /api/v1/auth/login</code>), API tokens (<code>nxs_*</code> prefix via Bearer or Basic password), or HTTP Basic with username + password.',
@@ -2507,7 +2508,7 @@ const TRANSLATIONS={
     'sb.native-install':'Нативная установка',
     'crumb.native-install':'нативная установка',
     'fmt.title':'Поддерживаемые форматы',
-    'fmt.sub':'16 форматов артефактов — каждый поддерживает типы Hosted, Proxy и Group.',
+    'fmt.sub':'17 форматов артефактов — каждый поддерживает типы Hosted, Proxy и Group.',
     'api.title':'Справочник API',
     'api.sub':'Nexspence предоставляет два API-интерфейса.',
     'api.auth.title':'Аутентификация',


### PR DESCRIPTION
Closes #429

## Summary

Add **R / CRAN** as a new repository format — hosted, proxy, and group — following the same protocol shape already implemented for APT (a generated-on-the-fly `PACKAGES` text index plus flat package files), since CRAN's own protocol is structurally the simplest of the formats not yet supported.

## Motivation

Nexspence already covers the npm/PyPI/Maven-equivalent formats for most language ecosystems, but has no repository format for R, CRAN's own language. Both Sonatype Nexus and JFrog Artifactory support CRAN, and Nexspence advertises Nexus API compatibility, so this is a conspicuous gap in the current format catalog.

CRAN's real protocol is deliberately simple:
- An index of plain-text stanzas (`src/contrib/PACKAGES`, key:value fields separated by blank lines — the same shape as Debian's `Packages` file).
- Source packages as flat tarballs, named `{package}_{version}.tar.gz`, served at `src/contrib/`.
- No signing of the index, and no meta-document describing other index documents (unlike APT's `Release`, which carries checksums of every `Packages` file it vouches for).

## Design

New package `internal/formats/cran/`, mirroring `internal/formats/apt/`'s existing pattern:

- `handler.go` — `ServeHTTP` dispatches proxy vs. hosted exactly like `apt.Handler.ServeHTTP`. `buildPackagesIndex` generates `PACKAGES`/`PACKAGES.gz` on-demand from stored assets (no index file is ever persisted, same as APT) — `Package:`/`Version:` stanzas per `.tar.gz` asset found. Upload accepts `PUT`/`POST` to a `.tar.gz` path or the repo root (normalized into `src/contrib/`, matching APT's pool-normalization for root-level uploads), plus Nexus-compatible multipart POST. Package name/version are parsed from the filename's first underscore (`cranCoords`) — simpler than APT's `debCoords`, since R package names never contain underscores, so there's no third field (architecture) to account for.
- `groupindex.go` — implements `formats.GroupIndexMerger` only, **not** `GroupIndexDependentMerger`: CRAN has no `Release`-equivalent, so there's no cross-file checksum document to keep consistent across a group's members. Stanzas are unioned across members, deduped by `Package:`+`Version:` (APT dedups by `Filename:`, which CRAN's format doesn't have).
- Wiring: new `domain.FormatCRAN`, a `repositories_format_check` migration, and a `formatRegistry["cran"]` entry in the router — no changes needed anywhere else (RBAC and the OSV.dev vulnerability-scan switch have no format-specific branches to extend; CRAN correctly falls through to the existing "vulnerability scanning is not supported for format %q" error, since OSV.dev has no CRAN ecosystem).

## Verified

Implemented and verified end-to-end against a real local stack (`docker compose up -d --build`) before opening this PR:
- Hosted repo: uploaded a real, valid minimal R source package and installed it with a genuine `R` client (`r-base` Docker image) via `install.packages(repos=...)` — full build/install cycle succeeded, then `library()`+function call confirmed the installed package actually runs.
- Group repo: two hosted members with different packages, confirmed `PACKAGES` through the group is the real union of both (not first-member-wins), and both members' tarballs are individually downloadable through the group URL.
- Proxy repo: pointed at the real `https://cran.r-project.org/`, fetched the real (multi-MB) `PACKAGES` index unmodified, and downloaded a real package tarball (`praise_1.0.0.tar.gz`) through the proxy cache — registered with correct `name`/`version` component coordinates, cache-hit on a second request.
- Frontend: format selector, proxy-URL default (`https://cran.r-project.org/`), and badge color wired in the repositories/browse/search/cleanup pages; verified in a real Chrome session (Playwright) with no console errors.
- `go build`/`go vet`/`go test ./...` green, including new unit tests for the handler and group-merge logic mirroring APT's own test coverage.

## Out of scope (this PR)

- **Binary packages** (Windows `.zip`, macOS `.tgz` under `bin/windows|macosx/contrib/`) — source packages only for this first version.
- **Parsing `DESCRIPTION`** out of the uploaded tarball for real `Depends:`/`Imports:`/`License:` metadata — the generated index currently derives only `Package:`/`Version:` from the filename, same minimal-metadata approach APT already takes with `.deb` filenames.
- **Signing the index** — CRAN has no standard equivalent to APT's `Release`/detached-signature scheme.
