### PR TITLE
fix(api): answer a duplicate name with a conflict, not with the driver's text (#432)

### DIFF
--- a/internal/api/handlers/blobstores.go
+++ b/internal/api/handlers/blobstores.go
@@ -214,6 +214,9 @@ func (h *BlobStoreHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.repo.Create(c.Request.Context(), &bs); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/content_selectors.go
+++ b/internal/api/handlers/content_selectors.go
@@ -55,6 +55,9 @@ func (h *ContentSelectorHandler) Create(c *gin.Context) {
 		return
 	}
 	if err := h.svc.Create(c.Request.Context(), &s); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -70,6 +73,9 @@ func (h *ContentSelectorHandler) Update(c *gin.Context) {
 	}
 	s.ID = c.Param("id")
 	if err := h.svc.Update(c.Request.Context(), &s); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/duplicate_name_test.go
+++ b/internal/api/handlers/duplicate_name_test.go
@@ -1,0 +1,130 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/nexspence-oss/nexspence/internal/api/handlers"
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/service"
+	"github.com/nexspence-oss/nexspence/internal/testutil"
+)
+
+// A duplicate name is a conflict the caller can act on, so every catalog
+// resource answers it as one — with a message of its own rather than the
+// driver's, whose text names the constraint and the table behind it.
+//
+// The repositories translate the unique violation (see translateNameUnique in
+// internal/repository/postgres); these tests start from that translated error,
+// which is what a handler actually sees.
+
+var duplicateName error = &repository.UniqueViolationError{Field: "name"}
+
+// assertNameConflict asserts a 409 whose body says only that the name is taken.
+func assertNameConflict(t *testing.T, code int, body []byte) {
+	t.Helper()
+	require.Equal(t, http.StatusConflict, code, "body=%s", body)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, "name already exists", got["error"])
+	assert.NotContains(t, got["error"], "SQLSTATE")
+	assert.NotContains(t, got["error"], "constraint")
+}
+
+func TestRoleHandler_Create_DuplicateName_409(t *testing.T) {
+	r, roles, _ := mountRoles(t)
+	roles.Err = duplicateName
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/security/roles",
+		map[string]any{"name": "dev"})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestRoleHandler_Update_DuplicateName_409(t *testing.T) {
+	r, roles, _ := mountRoles(t)
+	ro := &domain.Role{Name: "ops"}
+	require.NoError(t, roles.Create(testContext(), ro))
+	roles.Err = duplicateName
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/security/roles/"+ro.ID,
+		map[string]any{"name": "dev"})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestPrivilegeHandler_Create_DuplicateName_409(t *testing.T) {
+	repo := testutil.NewPrivilegeRepo()
+	h := handlers.NewPrivilegeHandler(repo, testutil.NewRoleRepo())
+	r := gin.New()
+	r.POST("/privileges", h.Create)
+	repo.Err = duplicateName
+	rec := do(t, r, http.MethodPost, "/privileges",
+		map[string]any{"name": "read-all", "type": "repository-view"})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestPrivilegeHandler_Update_DuplicateName_409(t *testing.T) {
+	repo := testutil.NewPrivilegeRepo()
+	h := handlers.NewPrivilegeHandler(repo, testutil.NewRoleRepo())
+	r := gin.New()
+	r.PUT("/privileges/:id", h.Update)
+	repo.Err = duplicateName
+	rec := do(t, r, http.MethodPut, "/privileges/p1",
+		map[string]any{"name": "read-all", "type": "repository-view"})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestBlobStoreHandler_Create_DuplicateName_409(t *testing.T) {
+	r, blobRepo, _, _, _ := mountBlobStores(t)
+	blobRepo.Err = duplicateName
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/blobstores/local",
+		map[string]any{"name": "default"})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestContentSelectorHandler_Create_DuplicateName_409(t *testing.T) {
+	r, repo := buildSelectorRouter(t)
+	repo.Err = duplicateName
+	rec := do(t, r, http.MethodPost, "/cs",
+		map[string]any{"name": "mvn", "expression": `format == "maven2"`})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestContentSelectorHandler_Update_DuplicateName_409(t *testing.T) {
+	r, repo := buildSelectorRouter(t)
+	repo.Err = duplicateName
+	rec := do(t, r, http.MethodPut, "/cs/cs-1",
+		map[string]any{"name": "mvn", "expression": `format == "maven2"`})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestRoutingRuleHandler_Create_DuplicateName_409(t *testing.T) {
+	r, repo := mountRoutingRules(t)
+	repo.Err = duplicateName
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/routing-rules",
+		map[string]any{"name": "block-npm", "mode": "BLOCK", "matchers": []string{".*"}})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+func TestRoutingRuleHandler_Update_DuplicateName_409(t *testing.T) {
+	r, repo := mountRoutingRules(t)
+	rule := &domain.RoutingRule{Name: "allow-all", Mode: "ALLOW", Matchers: []string{".*"}}
+	require.NoError(t, repo.Create(testContext(), rule))
+	repo.Err = duplicateName
+	rec := do(t, r, http.MethodPut, "/service/rest/v1/routing-rules/"+rule.ID,
+		map[string]any{"name": "block-npm", "mode": "BLOCK", "matchers": []string{".*"}})
+	assertNameConflict(t, rec.Code, rec.Body.Bytes())
+}
+
+// A failure that is not a conflict keeps its old status: the 409 is reserved
+// for the one case a caller can fix by choosing another name.
+func TestRoleHandler_Create_OtherRepoError_Still500(t *testing.T) {
+	r, roles, _ := mountRoles(t)
+	roles.Err = service.ErrNotFound
+	rec := do(t, r, http.MethodPost, "/service/rest/v1/security/roles",
+		map[string]any{"name": "dev"})
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}

--- a/internal/api/handlers/errors.go
+++ b/internal/api/handlers/errors.go
@@ -2,7 +2,11 @@ package handlers
 
 import (
 	"errors"
+	"net/http"
 
+	"github.com/gin-gonic/gin"
+
+	"github.com/nexspence-oss/nexspence/internal/repository"
 	"github.com/nexspence-oss/nexspence/internal/service"
 )
 
@@ -10,8 +14,23 @@ func isNotFound(err error) bool {
 	return errors.Is(err, service.ErrNotFound)
 }
 
+// isAlreadyExists covers both sentinels: a service that phrases the conflict
+// itself, and a repository conflict a service passes straight through.
 func isAlreadyExists(err error) bool {
-	return errors.Is(err, service.ErrAlreadyExists)
+	return errors.Is(err, service.ErrAlreadyExists) || errors.Is(err, repository.ErrAlreadyExists)
+}
+
+// conflictOnDuplicateName answers 409 when err is a duplicate-name conflict and
+// reports whether it did, so a handler can `if conflictOnDuplicateName(...) {
+// return }` ahead of its own error mapping. The message is fixed rather than
+// taken from err: the driver's own text names the constraint and the table
+// behind it, which is not the caller's business.
+func conflictOnDuplicateName(c *gin.Context, err error) bool {
+	if !isAlreadyExists(err) {
+		return false
+	}
+	c.JSON(http.StatusConflict, gin.H{"error": "name already exists"})
+	return true
 }
 
 func isInvalidInput(err error) bool {

--- a/internal/api/handlers/metrics.go
+++ b/internal/api/handlers/metrics.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/nexspence-oss/nexspence/internal/logger"
 	"github.com/nexspence-oss/nexspence/internal/metrics"
 )
 
@@ -65,7 +66,12 @@ type RepoMetric struct {
 }
 
 // ReposHandler serves GET /api/v1/metrics/repos — top 10 repos by downloads.
-func ReposHandler(pool *pgxpool.Pool) gin.HandlerFunc {
+//
+// A query failure is logged and answered with a fixed message, the way
+// MetricsHandler above deliberately keeps its own query error off the wire: the
+// driver's text names tables and columns, which a metrics reader has no need
+// for and no way to act on.
+func ReposHandler(pool *pgxpool.Pool, log logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		rows, err := pool.Query(c.Request.Context(), `
 			SELECT r.name, r.format, r.type,
@@ -78,7 +84,8 @@ func ReposHandler(pool *pgxpool.Pool) gin.HandlerFunc {
 			LIMIT 10
 		`)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Errorw("per-repository metrics query failed", "err", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "could not read repository metrics"})
 			return
 		}
 		defer rows.Close()
@@ -93,7 +100,8 @@ func ReposHandler(pool *pgxpool.Pool) gin.HandlerFunc {
 		}
 		rows.Close()
 		if err := rows.Err(); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			log.Errorw("per-repository metrics query failed", "err", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "could not read repository metrics"})
 			return
 		}
 		c.JSON(http.StatusOK, result)

--- a/internal/api/handlers/privileges.go
+++ b/internal/api/handlers/privileges.go
@@ -64,6 +64,9 @@ func (h *PrivilegeHandler) Create(c *gin.Context) {
 		return
 	}
 	if err := h.repo.Create(c.Request.Context(), &p); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -79,6 +82,9 @@ func (h *PrivilegeHandler) Update(c *gin.Context) {
 	}
 	p.ID = c.Param("id")
 	if err := h.repo.Update(c.Request.Context(), &p); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/roles.go
+++ b/internal/api/handlers/roles.go
@@ -46,6 +46,9 @@ func (h *RoleHandler) Create(c *gin.Context) {
 	}
 	ro.Source = "default"
 	if err := h.roles.Create(c.Request.Context(), &ro); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
@@ -67,6 +70,9 @@ func (h *RoleHandler) Update(c *gin.Context) {
 	}
 	ro.ID = c.Param("id")
 	if err := h.roles.Update(c.Request.Context(), &ro); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/handlers/routing_rules.go
+++ b/internal/api/handlers/routing_rules.go
@@ -59,6 +59,9 @@ func (h *RoutingRuleHandler) Create(c *gin.Context) {
 		r.Matchers = []string{}
 	}
 	if err := h.svc.Create(c.Request.Context(), &r); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
@@ -77,6 +80,9 @@ func (h *RoutingRuleHandler) Update(c *gin.Context) {
 		r.Matchers = []string{}
 	}
 	if err := h.svc.Update(c.Request.Context(), &r); err != nil {
+		if conflictOnDuplicateName(c, err) {
+			return
+		}
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -531,7 +531,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, pool *pgxpool.Pool, log 
 		// ── Metrics (authenticated) ───────────────────────────
 		authed.GET("/api/v1/metrics", handlers.MetricsHandler(pool))
 		authed.GET("/api/v1/metrics/history", handlers.HistoryHandler())
-		authed.GET("/api/v1/metrics/repos", handlers.ReposHandler(pool))
+		authed.GET("/api/v1/metrics/repos", handlers.ReposHandler(pool, log))
 
 		// ── API tokens (current user) ─────────────────────────
 		authed.GET("/api/v1/tokens", tokenH.List)

--- a/internal/repository/postgres/blobstore_repo.go
+++ b/internal/repository/postgres/blobstore_repo.go
@@ -65,12 +65,12 @@ func (r *blobStoreRepo) GetByID(ctx context.Context, id string) (*domain.BlobSto
 
 func (r *blobStoreRepo) Create(ctx context.Context, b *domain.BlobStore) error {
 	cfg, _ := json.Marshal(b.Config)
-	return r.db.QueryRow(ctx, `
+	return translateNameUnique(r.db.QueryRow(ctx, `
 		INSERT INTO blob_stores (name, type, config, quota_bytes)
 		VALUES ($1,$2,$3,$4)
 		RETURNING id, created_at, updated_at`,
 		b.Name, b.Type, cfg, b.QuotaBytes,
-	).Scan(&b.ID, &b.CreatedAt, &b.UpdatedAt)
+	).Scan(&b.ID, &b.CreatedAt, &b.UpdatedAt))
 }
 
 func (r *blobStoreRepo) Update(ctx context.Context, b *domain.BlobStore) error {

--- a/internal/repository/postgres/content_selector_repo.go
+++ b/internal/repository/postgres/content_selector_repo.go
@@ -91,7 +91,7 @@ func (r *ContentSelectorRepo) Update(ctx context.Context, s *domain.ContentSelec
 		 WHERE id=$4`,
 		s.Name, s.Description, s.Expression, s.ID)
 	if err != nil {
-		if conflict := translateNameUnique(err); conflict != err {
+		if conflict, ok := nameConflict(err); ok {
 			return conflict
 		}
 		return fmt.Errorf("content_selectors update: %w", err)

--- a/internal/repository/postgres/content_selector_repo.go
+++ b/internal/repository/postgres/content_selector_repo.go
@@ -75,12 +75,12 @@ func (r *ContentSelectorRepo) GetByName(ctx context.Context, name string) (*doma
 
 // Create inserts a new content selector and populates its generated fields.
 func (r *ContentSelectorRepo) Create(ctx context.Context, s *domain.ContentSelector) error {
-	return r.pool.QueryRow(ctx,
+	return translateNameUnique(r.pool.QueryRow(ctx,
 		`INSERT INTO content_selectors (name, description, expression)
 		 VALUES ($1, $2, $3)
 		 RETURNING id, created_at, updated_at`,
 		s.Name, s.Description, s.Expression).
-		Scan(&s.ID, &s.CreatedAt, &s.UpdatedAt)
+		Scan(&s.ID, &s.CreatedAt, &s.UpdatedAt))
 }
 
 // Update overwrites the content selector identified by s.ID.
@@ -91,6 +91,9 @@ func (r *ContentSelectorRepo) Update(ctx context.Context, s *domain.ContentSelec
 		 WHERE id=$4`,
 		s.Name, s.Description, s.Expression, s.ID)
 	if err != nil {
+		if conflict := translateNameUnique(err); conflict != err {
+			return conflict
+		}
 		return fmt.Errorf("content_selectors update: %w", err)
 	}
 	if tag.RowsAffected() == 0 {

--- a/internal/repository/postgres/errors.go
+++ b/internal/repository/postgres/errors.go
@@ -28,16 +28,28 @@ func uniqueViolation(err error) (constraint string, ok bool) {
 // `name TEXT NOT NULL UNIQUE` column: "<table>_name_key".
 const nameConstraintSuffix = "_name_key"
 
+// nameConflict reports whether err is a unique-violation on a catalog table's
+// name column and, if so, returns it as repository.ErrAlreadyExists naming that
+// field. A violation of any other constraint is not one — it would be reported
+// as a name conflict it is not. Callers that only want the translation use
+// translateNameUnique; callers that must know whether one happened (to keep the
+// conflict out of a context wrap) ask here.
+func nameConflict(err error) (*repository.UniqueViolationError, bool) {
+	constraint, ok := uniqueViolation(err)
+	if !ok || !strings.HasSuffix(constraint, nameConstraintSuffix) {
+		return nil, false
+	}
+	return &repository.UniqueViolationError{Field: "name"}, true
+}
+
 // translateNameUnique converts a unique-violation on a catalog table's name
 // column into repository.ErrAlreadyExists naming that field, so a duplicate
 // name answers as the conflict it is instead of leaking the constraint name,
-// table name and SQLSTATE of the raw driver error. A violation of any other
-// constraint passes through untouched rather than being reported as a name
-// conflict it is not.
+// table name and SQLSTATE of the raw driver error. Any other error passes
+// through untouched.
 func translateNameUnique(err error) error {
-	constraint, ok := uniqueViolation(err)
-	if !ok || !strings.HasSuffix(constraint, nameConstraintSuffix) {
-		return err
+	if conflict, ok := nameConflict(err); ok {
+		return conflict
 	}
-	return &repository.UniqueViolationError{Field: "name"}
+	return err
 }

--- a/internal/repository/postgres/errors.go
+++ b/internal/repository/postgres/errors.go
@@ -2,8 +2,11 @@ package postgres
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/nexspence-oss/nexspence/internal/repository"
 )
 
 // pgerrUniqueViolation is Postgres' SQLSTATE for a unique-constraint violation.
@@ -19,4 +22,22 @@ func uniqueViolation(err error) (constraint string, ok bool) {
 		return "", false
 	}
 	return pgErr.ConstraintName, true
+}
+
+// nameConstraintSuffix is how Postgres names the implicit constraint behind a
+// `name TEXT NOT NULL UNIQUE` column: "<table>_name_key".
+const nameConstraintSuffix = "_name_key"
+
+// translateNameUnique converts a unique-violation on a catalog table's name
+// column into repository.ErrAlreadyExists naming that field, so a duplicate
+// name answers as the conflict it is instead of leaking the constraint name,
+// table name and SQLSTATE of the raw driver error. A violation of any other
+// constraint passes through untouched rather than being reported as a name
+// conflict it is not.
+func translateNameUnique(err error) error {
+	constraint, ok := uniqueViolation(err)
+	if !ok || !strings.HasSuffix(constraint, nameConstraintSuffix) {
+		return err
+	}
+	return &repository.UniqueViolationError{Field: "name"}
 }

--- a/internal/repository/postgres/name_conflict_integration_test.go
+++ b/internal/repository/postgres/name_conflict_integration_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+	"github.com/nexspence-oss/nexspence/internal/repository"
+	"github.com/nexspence-oss/nexspence/internal/testutil/pgtest"
+)
+
+// Every catalog table whose name column is unique reports a duplicate as
+// repository.ErrAlreadyExists naming that field, the way user_repo already
+// did — instead of handing the caller Postgres' own text, which carries the
+// constraint name, the table behind it and the SQLSTATE.
+//
+// Both halves are exercised per table: a second Create under a taken name, and
+// an Update that renames a row onto one.
+
+// assertNameConflict fails unless err is an ErrAlreadyExists naming "name".
+func assertNameConflict(t *testing.T, what string, err error) {
+	t.Helper()
+	if !errors.Is(err, repository.ErrAlreadyExists) {
+		t.Fatalf("%s: want ErrAlreadyExists, got %v", what, err)
+	}
+	var uv *repository.UniqueViolationError
+	if !errors.As(err, &uv) {
+		t.Fatalf("%s: want a UniqueViolationError, got %T", what, err)
+	}
+	if uv.Field != "name" {
+		t.Fatalf("%s: want field %q, got %q", what, "name", uv.Field)
+	}
+}
+
+func TestBlobStoreRepo_Create_DuplicateName_IsConflict(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "blob_stores")
+	ctx := context.Background()
+	repo := NewBlobStoreRepo(pool)
+
+	first := makeLocalBS("conflict_bs")
+	if err := repo.Create(ctx, first); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	assertNameConflict(t, "second Create", repo.Create(ctx, makeLocalBS("conflict_bs")))
+}
+
+func TestRoleRepo_DuplicateName_IsConflict(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "roles", "privileges", "content_selectors")
+	ctx := context.Background()
+	repo := NewRoleRepo(pool)
+
+	taken := makeRole("conflict_role_taken", "local")
+	if err := repo.Create(ctx, taken); err != nil {
+		t.Fatalf("Create taken: %v", err)
+	}
+	assertNameConflict(t, "second Create", repo.Create(ctx, makeRole("conflict_role_taken", "local")))
+
+	other := makeRole("conflict_role_other", "local")
+	if err := repo.Create(ctx, other); err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+	other.Name = taken.Name
+	assertNameConflict(t, "Update onto a taken name", repo.Update(ctx, other))
+}
+
+func TestPrivilegeRepo_DuplicateName_IsConflict(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "roles", "privileges", "content_selectors")
+	ctx := context.Background()
+	repo := NewPrivilegeRepo(pool)
+
+	taken := makePriv("conflict_priv_taken", nil)
+	if err := repo.Create(ctx, taken); err != nil {
+		t.Fatalf("Create taken: %v", err)
+	}
+	assertNameConflict(t, "second Create", repo.Create(ctx, makePriv("conflict_priv_taken", nil)))
+
+	other := makePriv("conflict_priv_other", nil)
+	if err := repo.Create(ctx, other); err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+	other.Name = taken.Name
+	assertNameConflict(t, "Update onto a taken name", repo.Update(ctx, other))
+}
+
+func TestContentSelectorRepo_DuplicateName_IsConflict(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "roles", "privileges", "content_selectors")
+	ctx := context.Background()
+	repo := NewContentSelectorRepo(pool)
+
+	taken := &domain.ContentSelector{Name: "conflict_cs_taken", Expression: `format == "maven2"`}
+	if err := repo.Create(ctx, taken); err != nil {
+		t.Fatalf("Create taken: %v", err)
+	}
+	dup := &domain.ContentSelector{Name: "conflict_cs_taken", Expression: `format == "npm"`}
+	assertNameConflict(t, "second Create", repo.Create(ctx, dup))
+
+	other := &domain.ContentSelector{Name: "conflict_cs_other", Expression: `format == "npm"`}
+	if err := repo.Create(ctx, other); err != nil {
+		t.Fatalf("Create other: %v", err)
+	}
+	other.Name = taken.Name
+	assertNameConflict(t, "Update onto a taken name", repo.Update(ctx, other))
+}
+
+func TestRoutingRuleRepo_DuplicateName_IsConflict(t *testing.T) {
+	pool := pgtest.Pool(t)
+	pgtest.Truncate(t, pool, "routing_rules")
+	ctx := context.Background()
+	repo := NewRoutingRuleRepo(pool)
+
+	taken := newRR("conflict_rr_taken", "", "BLOCK", []string{".*"})
+	insertRR(t, ctx, repo, taken)
+	dup := newRR("conflict_rr_taken", "", "BLOCK", []string{".*"})
+	assertNameConflict(t, "second Create", repo.Create(ctx, dup))
+
+	other := newRR("conflict_rr_other", "", "BLOCK", []string{".*"})
+	insertRR(t, ctx, repo, other)
+	other.Name = taken.Name
+	assertNameConflict(t, "Update onto a taken name", repo.Update(ctx, other))
+}

--- a/internal/repository/postgres/name_conflict_integration_test.go
+++ b/internal/repository/postgres/name_conflict_integration_test.go
@@ -74,13 +74,16 @@ func TestPrivilegeRepo_DuplicateName_IsConflict(t *testing.T) {
 	ctx := context.Background()
 	repo := NewPrivilegeRepo(pool)
 
-	taken := makePriv("conflict_priv_taken", nil)
+	// Migration 007 requires a selector for this privilege type.
+	cs := makeCS(t, ctx, "conflict_priv_cs", `true`)
+
+	taken := makePriv("conflict_priv_taken", &cs.ID)
 	if err := repo.Create(ctx, taken); err != nil {
 		t.Fatalf("Create taken: %v", err)
 	}
-	assertNameConflict(t, "second Create", repo.Create(ctx, makePriv("conflict_priv_taken", nil)))
+	assertNameConflict(t, "second Create", repo.Create(ctx, makePriv("conflict_priv_taken", &cs.ID)))
 
-	other := makePriv("conflict_priv_other", nil)
+	other := makePriv("conflict_priv_other", &cs.ID)
 	if err := repo.Create(ctx, other); err != nil {
 		t.Fatalf("Create other: %v", err)
 	}

--- a/internal/repository/postgres/privilege_repo.go
+++ b/internal/repository/postgres/privilege_repo.go
@@ -65,12 +65,12 @@ func (r *privilegeRepo) Create(ctx context.Context, p *domain.Privilege) error {
 	if err != nil {
 		return err
 	}
-	return r.db.QueryRow(ctx, `
+	return translateNameUnique(r.db.QueryRow(ctx, `
 		INSERT INTO privileges (name, description, type, attrs, content_selector_id)
 		VALUES ($1, $2, $3, $4, $5)
 		RETURNING id, created_at`,
 		p.Name, p.Description, string(p.Type), attrsJSON, p.ContentSelectorID,
-	).Scan(&p.ID, &p.CreatedAt)
+	).Scan(&p.ID, &p.CreatedAt))
 }
 
 func (r *privilegeRepo) Update(ctx context.Context, p *domain.Privilege) error {
@@ -83,7 +83,7 @@ func (r *privilegeRepo) Update(ctx context.Context, p *domain.Privilege) error {
 		WHERE id=$6`,
 		p.Name, p.Description, string(p.Type), attrsJSON, p.ContentSelectorID, p.ID,
 	)
-	return err
+	return translateNameUnique(err)
 }
 
 func (r *privilegeRepo) Delete(ctx context.Context, id string) error {

--- a/internal/repository/postgres/role_repo.go
+++ b/internal/repository/postgres/role_repo.go
@@ -72,12 +72,12 @@ func (r *roleRepo) GetByName(ctx context.Context, name string) (*domain.Role, er
 }
 
 func (r *roleRepo) Create(ctx context.Context, ro *domain.Role) error {
-	return r.db.QueryRow(ctx, `
+	return translateNameUnique(r.db.QueryRow(ctx, `
 		INSERT INTO roles (name, description, source, builtin)
 		VALUES ($1, $2, $3, $4)
 		RETURNING id, created_at, updated_at`,
 		ro.Name, ro.Description, ro.Source, ro.ReadOnly,
-	).Scan(&ro.ID, &ro.CreatedAt, &ro.UpdatedAt)
+	).Scan(&ro.ID, &ro.CreatedAt, &ro.UpdatedAt))
 }
 
 func (r *roleRepo) Update(ctx context.Context, ro *domain.Role) error {
@@ -86,7 +86,7 @@ func (r *roleRepo) Update(ctx context.Context, ro *domain.Role) error {
 		WHERE id=$3`,
 		ro.Name, ro.Description, ro.ID,
 	)
-	return err
+	return translateNameUnique(err)
 }
 
 func (r *roleRepo) Delete(ctx context.Context, id string) error {

--- a/internal/repository/postgres/routing_rule_repo.go
+++ b/internal/repository/postgres/routing_rule_repo.go
@@ -93,7 +93,7 @@ func (r *RoutingRuleRepo) Update(ctx context.Context, rr *domain.RoutingRule) er
 		 WHERE id=$5`,
 		rr.Name, rr.Description, rr.Mode, rr.Matchers, rr.ID)
 	if err != nil {
-		if conflict := translateNameUnique(err); conflict != err {
+		if conflict, ok := nameConflict(err); ok {
 			return conflict
 		}
 		return fmt.Errorf("routing_rules update: %w", err)

--- a/internal/repository/postgres/routing_rule_repo.go
+++ b/internal/repository/postgres/routing_rule_repo.go
@@ -77,12 +77,12 @@ func (r *RoutingRuleRepo) GetByName(ctx context.Context, name string) (*domain.R
 
 // Create inserts a new routing rule and populates its generated fields.
 func (r *RoutingRuleRepo) Create(ctx context.Context, rr *domain.RoutingRule) error {
-	return r.pool.QueryRow(ctx,
+	return translateNameUnique(r.pool.QueryRow(ctx,
 		`INSERT INTO routing_rules (name, description, mode, matchers)
 		 VALUES ($1, $2, $3, $4)
 		 RETURNING id, created_at, updated_at`,
 		rr.Name, rr.Description, rr.Mode, rr.Matchers).
-		Scan(&rr.ID, &rr.CreatedAt, &rr.UpdatedAt)
+		Scan(&rr.ID, &rr.CreatedAt, &rr.UpdatedAt))
 }
 
 // Update overwrites the routing rule identified by rr.ID.
@@ -93,6 +93,9 @@ func (r *RoutingRuleRepo) Update(ctx context.Context, rr *domain.RoutingRule) er
 		 WHERE id=$5`,
 		rr.Name, rr.Description, rr.Mode, rr.Matchers, rr.ID)
 	if err != nil {
+		if conflict := translateNameUnique(err); conflict != err {
+			return conflict
+		}
 		return fmt.Errorf("routing_rules update: %w", err)
 	}
 	if tag.RowsAffected() == 0 {

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -174,6 +174,9 @@ type BlobStoreRepo struct {
 	// this repo shares a database with. Without it a recompute finds no assets
 	// and zeroes every store, exactly as the SQL would against an empty table.
 	assets *AssetRepo
+	// Err, when non-nil, is what Create returns — a blob store's name is its
+	// key here and in postgres, where Update cannot rename one.
+	Err error
 }
 
 func NewBlobStoreRepo(stores ...*domain.BlobStore) *BlobStoreRepo {
@@ -225,6 +228,9 @@ func (b *BlobStoreRepo) GetByID(_ context.Context, id string) (*domain.BlobStore
 func (b *BlobStoreRepo) Create(_ context.Context, s *domain.BlobStore) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.Err != nil {
+		return b.Err
+	}
 	b.stores[s.Name] = s
 	return nil
 }
@@ -1843,6 +1849,7 @@ type ContentSelectorRepo struct {
 	mu                sync.Mutex
 	selectors         map[string]*domain.ContentSelector
 	nextID            int
+	Err               error               // when non-nil, Create and Update return this error
 	PrivilegeSelector map[string]string   // privilegeName → selectorID
 	UserSelectors     map[string][]string // userID → []selectorID
 }
@@ -1887,6 +1894,9 @@ func (r *ContentSelectorRepo) GetByName(_ context.Context, name string) (*domain
 func (r *ContentSelectorRepo) Create(_ context.Context, s *domain.ContentSelector) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.Err != nil {
+		return r.Err
+	}
 	r.nextID++
 	s.ID = fmt.Sprintf("cs-%d", r.nextID)
 	cp := *s
@@ -1896,6 +1906,9 @@ func (r *ContentSelectorRepo) Create(_ context.Context, s *domain.ContentSelecto
 func (r *ContentSelectorRepo) Update(_ context.Context, s *domain.ContentSelector) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	if r.Err != nil {
+		return r.Err
+	}
 	cp := *s
 	r.selectors[s.ID] = &cp
 	return nil


### PR DESCRIPTION
Closes #432.

`user_repo.go` already wrapped a unique violation into `repository.UniqueViolationError`, so a duplicate username never reached the caller as raw driver text. Five sibling catalog resources never got the same treatment: a duplicate-name `POST`/`PUT` on a role, privilege, blob store, content selector or routing rule answered `500`/`400` carrying `duplicate key value violates unique constraint "roles_name_key" (SQLSTATE 23505)` — the constraint name, the table behind it, and the SQLSTATE.

## What changed

- **`translateNameUnique()`** in `internal/repository/postgres/errors.go`, on top of the existing `uniqueViolation()` helper. All five tables have exactly one unique constraint, on `name`, so recognizing it by the constraint's `_name_key` suffix is enough — no per-constraint mapping table as in `user_repo.go`'s two-field case. A violation of any other constraint passes through untouched rather than being reported as a name conflict it is not.
- Wired into `Create`/`Update` of `blobstore_repo`, `role_repo`, `privilege_repo`, `content_selector_repo`, `routing_rule_repo`. For content selectors and routing rules the translation happens **before** the `fmt.Errorf("… update: %w", …)` context wrap, so the conflict reaches the caller as itself rather than as a wrapped internal failure. A blob store's `Update` takes no new name (the name is how the row is found), so only its `Create` can conflict.
- **`isAlreadyExists()`** now covers `repository.ErrAlreadyExists` as well as `service.ErrAlreadyExists` — content selectors and routing rules reach their handler through a service that passes repository errors straight through — and a new `conflictOnDuplicateName()` answers `409 {"error":"name already exists"}`. The message is fixed rather than taken from the error, so no wrapping can put table names back on the wire.
- **`ReposHandler`** (`/api/v1/metrics/repos`) returned its query error verbatim, unlike `MetricsHandler` two functions above it in the same file, which deliberately discards its own. It now logs the failure and answers `could not read repository metrics`.

## Tests

- `internal/api/handlers/duplicate_name_test.go` — all five resources, `Create` and `Update` where each can conflict, asserting `409` and a body that names neither the constraint nor the SQLSTATE; plus one test that a non-conflict repository failure still answers `500`.
- `internal/repository/postgres/name_conflict_integration_test.go` — against a real Postgres: a duplicate `Create` and a rename-onto-a-taken-name `Update` per table both assert `errors.Is(err, repository.ErrAlreadyExists)` and `Field == "name"`.

`go build`, `go vet` and `go test ./internal/...` are green locally (the only failure is the sandbox-only `TestWebhookHandler_Test_200`, which needs outbound network). The integration tests need Docker, so they are verified by CI here rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M9JBj5URUNx6RrESf7VSrs