### PR TITLE
fix(cran): fail a group's PACKAGES.rds honestly instead of relaying a member

### DIFF
--- a/internal/formats/cran/groupindex.go
+++ b/internal/formats/cran/groupindex.go
@@ -45,10 +45,13 @@ func (h *Handler) GroupIndexSourcePath(p string) (string, bool) {
 // MergeGroupIndex implements formats.GroupIndexMerger.
 func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) ([]byte, string, error) {
 	if strings.HasSuffix(p, ".rds") {
-		// Refusing degrades to the first member's plain-text body (see
-		// group.Handler.serveMergedIndex) — not valid RDS either, but R's own
-		// readRDS/available.packages fallback treats a read error exactly like a
-		// failed download and retries PACKAGES.gz, which merges correctly.
+		// Refusing takes GroupIndexStrictMerger's isStrict branch below (a
+		// short 502) instead of degrading to a member's document: against a
+		// real proxy member that document is upstream's whole index — tens of
+		// MB a client downloads, discards because it's not valid RDS, then
+		// re-fetches anyway once it retries PACKAGES.gz. A 502 costs it
+		// nothing and R's fallback treats a failed download exactly like a
+		// failed readRDS, so the retry to PACKAGES.gz is unchanged.
 		return nil, "", errRDSUnsupported
 	}
 	plain := mergePackages(parts)
@@ -56,6 +59,18 @@ func (h *Handler) MergeGroupIndex(_, p string, parts []formats.GroupIndexPart) (
 		return gzipBytes(plain), "application/x-gzip", nil
 	}
 	return plain, "text/plain; charset=utf-8", nil
+}
+
+// GroupIndexMemberFailureIsFatal implements formats.GroupIndexStrictMerger.
+// Always false: a member's non-2xx source answer is still just "nothing to
+// contribute" and gets skipped exactly as GroupIndexMerger's default
+// behavior already does. Implementing this interface at all is what routes
+// MergeGroupIndex's PACKAGES.rds refusal above through the group layer's
+// isStrict branch (an honest 502) instead of its default degrade-to-first-
+// member's-document behavior — the two failure modes are independent, and
+// this format only needs to opt into the second one.
+func (h *Handler) GroupIndexMemberFailureIsFatal(_ string, _ int) bool {
+	return false
 }
 
 // mergePackages unions the members' stanzas, deduped by Package+Version (first

--- a/internal/formats/cran/groupindex_test.go
+++ b/internal/formats/cran/groupindex_test.go
@@ -49,6 +49,19 @@ func TestCRAN_MergeGroupIndex_RefusesRDS(t *testing.T) {
 	assert.Error(t, err, "no valid RDS can be produced from merged stanzas")
 }
 
+// The interface itself must be implemented — that's what routes the refusal
+// above through the group layer's isStrict branch (a 502) instead of its
+// default degrade-to-first-member's-document behavior. What the callback
+// answers must stay false, though: a member's non-2xx source answer is still
+// just "nothing to contribute", not a reason to fail the whole group.
+func TestCRAN_ImplementsGroupIndexStrictMerger(t *testing.T) {
+	h := cran.New(formats.Deps{})
+	strict, ok := any(h).(formats.GroupIndexStrictMerger)
+	require.True(t, ok, "cran.Handler must implement formats.GroupIndexStrictMerger")
+	assert.False(t, strict.GroupIndexMemberFailureIsFatal("/src/contrib/PACKAGES", 502))
+	assert.False(t, strict.GroupIndexMemberFailureIsFatal("/src/contrib/PACKAGES", 404))
+}
+
 func TestCRAN_MergeGroupIndex_UnionsStanzas(t *testing.T) {
 	h := cran.New(formats.Deps{})
 	parts := []formats.GroupIndexPart{

--- a/internal/formats/group/merge_cran_test.go
+++ b/internal/formats/group/merge_cran_test.go
@@ -170,6 +170,13 @@ func TestGroupMerge_CranNeverRelaysProxyRDS(t *testing.T) {
 	rds := get(r, "/repository/rj/src/contrib/PACKAGES.rds")
 	assert.NotContains(t, rds.Body.String(), rdsMarker,
 		"the group must never answer with the proxy's real upstream .rds — R would parse it successfully and never fall back to the merged PACKAGES.gz")
+	// #436: relaying a member's document here also meant transferring it for
+	// nothing (a real proxy's plain PACKAGES can be tens of MB) before R even
+	// discards it — cran.Handler implements GroupIndexStrictMerger so this
+	// answers a short 502 instead of the proxy's document.
+	assert.Equal(t, http.StatusBadGateway, rds.Code, "the refusal must fail the group honestly, not degrade to a member's document")
+	assert.NotContains(t, rds.Body.String(), "upstreamonly", "the 502 body must be an error, not the proxy member's own document")
+	assert.NotContains(t, rds.Body.String(), "onlyhosted", "the 502 body must be an error, not the hosted member's own document")
 
 	// The properly mergeable flavors are unaffected: both members still show up.
 	plain := get(r, "/repository/rj/src/contrib/PACKAGES")


### PR DESCRIPTION
## What happens today

`MergeGroupIndex` already refuses to produce `PACKAGES.rds` — there's no way to
merge text stanzas into R's binary serialization format. That refusal degrades
to the first member's plain `PACKAGES` document with a `200`, which is enough
to make R's own `readRDS`/`available.packages` fallback retry `PACKAGES.gz`
(verified live on #430), but not free: against a real proxy member that
document is upstream's whole index — tens of MB a client downloads and
discards before the retry it was always going to make anyway.

## Fix

`cran.Handler` now also implements `formats.GroupIndexStrictMerger`, with
`GroupIndexMemberFailureIsFatal` always `false` — member-skipping stays
exactly as it is today. Implementing the interface at all is what routes the
`PACKAGES.rds` refusal through the group layer's `isStrict` branch instead: a
short `502` naming the reason, rather than a member's document. R treats a
failed download the same as a failed `readRDS`, so the retry to
`PACKAGES.gz` is unchanged.

## Testing

- `TestGroupMerge_CranNeverRelaysProxyRDS` tightened to assert the `502` and
  that the body contains neither member's document (confirmed it fails
  against the pre-fix code, passes with the fix).
- New `TestCRAN_ImplementsGroupIndexStrictMerger`.
- `go build`/`go vet`/`go test ./...` green (the one pre-existing failure,
  `TestWebhookHandler_Test_200`, is a sandbox-network artifact unrelated to
  this change).

Verified live against a real `docker compose` stack with a real
`cran.r-project.org` proxy member and a hosted-only package:

- `PACKAGES.rds` via the group: `200`/7.17 MB → `502`/206 bytes.
- A real R client (`r-base`) still finds and installs the hosted-only
  package end to end — server log confirms the same
  `PACKAGES.rds → PACKAGES.gz → tarball` request sequence as before, just
  with a cheap first step.
- The package still renders in Browse over a real Chrome session.
- Re-checked what this change does *not* touch: a direct (non-group) hosted
  or proxy repository, and a hosted-only group's `PACKAGES`/`PACKAGES.gz` —
  all unaffected.

Fixes #436.