### PR TITLE
docs(readme): list every format, and stop calling tracing planned

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## What is Nexspence?
 
-Nexspence is a self-hosted artifact repository manager that supports **15 package formats**, three repository types (hosted, proxy, group), fine-grained RBAC, SSO via OIDC/LDAP, audit logging, S3-compatible storage, and a modern dark-theme web UI — all in a single binary backed by PostgreSQL. It exposes the full **Sonatype Nexus v1 REST API** at `/service/rest/v1/` for drop-in compatibility with existing CI/CD pipelines and package manager configs.
+Nexspence is a self-hosted artifact repository manager that supports **17 package formats**, three repository types (hosted, proxy, group), fine-grained RBAC, SSO via OIDC/LDAP, audit logging, S3-compatible storage, and a modern dark-theme web UI — all in a single binary backed by PostgreSQL. It exposes the full **Sonatype Nexus v1 REST API** at `/service/rest/v1/` for drop-in compatibility with existing CI/CD pipelines and package manager configs.
 
 ---
 
@@ -262,11 +262,13 @@ Published on the [Terraform Registry](https://registry.terraform.io/providers/ne
 | Helm charts | ✓ | ✓ | ✓ |
 | Cargo (Rust) | ✓ | ✓ | ✓ |
 | Raw files | ✓ | ✓ | ✓ |
-| APT (Debian/Ubuntu) | ✓ | ✓ | — |
-| Yum / RPM | ✓ | ✓ | — |
-| Conan (C/C++) | ✓ | ✓ | — |
-| Conda | ✓ | ✓ | — |
-| Terraform Registry | ✓ | ✓ | — |
+| APT (Debian/Ubuntu) | ✓ | ✓ | ✓ |
+| Yum / RPM | ✓ | ✓ | ✓ |
+| Conan (C/C++) | ✓ | ✓ | ✓ |
+| Conda | ✓ | ✓ | ✓ |
+| Terraform Registry | ✓ | ✓ | ✓ |
+| RubyGems | ✓ | ✓ | — |
+| R / CRAN | ✓ | ✓ | ✓ |
 
 ---
 
@@ -331,9 +333,9 @@ The Helm chart reference ships with the chart itself: [`deploy/helm/nexspence/RE
 | 64–67 | Landing page, in-app docs, security hardening | ✓ complete |
 | 68 | Extended monitoring — Prometheus endpoint, Grafana dashboard, UI Charts tab | ✓ complete |
 | 69 | Blob GC — age-gated orphan collection, global cron scheduler, UI panel | ✓ complete |
+| 70 | OpenTelemetry tracing — spans across API, proxy and background jobs, trace_id in structured logs | ✓ complete |
 | CLI | [`nxs` CLI](https://github.com/nexspence/nxs) — terminal & CI/CD client, v0.1.0 | ✓ complete |
 | next | SBOM generation, cosign image signing | planned |
-| next | OpenTelemetry traces | planned |
 
 ---
 

--- a/internal/domain/readme_formats_test.go
+++ b/internal/domain/readme_formats_test.go
@@ -1,0 +1,118 @@
+package domain_test
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/nexspence-oss/nexspence/internal/domain"
+)
+
+// The README states a format count and lists the formats in a table, and both
+// drifted three formats behind the code before anyone noticed (#438) — the
+// claim is only ever read by humans, and a new format's PR touches the docs
+// site (which is tested, see site_formats_test.go) but not this file. Same
+// guard, applied to the README.
+
+const readmePath = "../../README.md"
+
+func readmeText(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile(readmePath)
+	if err != nil {
+		t.Fatalf("read README: %v", err)
+	}
+	return string(b)
+}
+
+// readmeFormatTable returns the rows of the "Supported Package Formats" table,
+// each as its display name (the first cell).
+func readmeFormatTable(t *testing.T) []string {
+	t.Helper()
+	text := readmeText(t)
+	start := strings.Index(text, "## Supported Package Formats")
+	if start < 0 {
+		t.Fatal("README has no \"Supported Package Formats\" section")
+	}
+	section := text[start:]
+	if end := strings.Index(section, "\n---"); end > 0 {
+		section = section[:end]
+	}
+
+	var names []string
+	for _, line := range strings.Split(section, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "|") {
+			continue
+		}
+		cells := strings.Split(strings.Trim(line, "|"), "|")
+		name := strings.TrimSpace(cells[0])
+		if name == "Format" || strings.HasPrefix(name, "---") || strings.HasPrefix(name, ":--") {
+			continue // header and separator rows
+		}
+		names = append(names, name)
+	}
+	return names
+}
+
+func TestREADMEFormatCountMatchesCode(t *testing.T) {
+	m := regexp.MustCompile(`\*\*(\d+) package formats\*\*`).FindStringSubmatch(readmeText(t))
+	if m == nil {
+		t.Fatal("README states no package format count")
+	}
+	got, err := strconv.Atoi(m[1])
+	if err != nil {
+		t.Fatalf("unparsable count %q", m[1])
+	}
+	if want := len(domain.AllFormats); got != want {
+		t.Errorf("README claims %d package formats, code supports %d", got, want)
+	}
+}
+
+func TestREADMEFormatTableListsEveryFormat(t *testing.T) {
+	rows := readmeFormatTable(t)
+	if len(rows) != len(domain.AllFormats) {
+		t.Errorf("README formats table has %d rows, code supports %d formats", len(rows), len(domain.AllFormats))
+	}
+
+	// The table uses display names, so each format is matched on a substring
+	// its row is expected to carry — same approach as the docs site's own test.
+	labels := map[domain.RepoFormat]string{
+		domain.FormatMaven2:    "Maven",
+		domain.FormatNPM:       "npm",
+		domain.FormatPyPI:      "PyPI",
+		domain.FormatDocker:    "Docker",
+		domain.FormatOCI:       "OCI",
+		domain.FormatGo:        "Go modules",
+		domain.FormatNuGet:     "NuGet",
+		domain.FormatHelm:      "Helm",
+		domain.FormatCargo:     "Cargo",
+		domain.FormatApt:       "APT",
+		domain.FormatYum:       "Yum",
+		domain.FormatConan:     "Conan",
+		domain.FormatRaw:       "Raw",
+		domain.FormatConda:     "Conda",
+		domain.FormatTerraform: "Terraform",
+		domain.FormatRubyGems:  "RubyGems",
+		domain.FormatCRAN:      "CRAN",
+	}
+	for _, f := range domain.AllFormats {
+		label, ok := labels[f]
+		if !ok {
+			t.Errorf("format %q has no expected README table label — add one when adding the format", f)
+			continue
+		}
+		found := false
+		for _, name := range rows {
+			if strings.Contains(name, label) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("format %q (%s) is missing from the README formats table", f, label)
+		}
+	}
+}


### PR DESCRIPTION
## What

The README's "Supported Package Formats" table stopped at 15 formats — RubyGems and R/CRAN (#430) were never added — and its Group column still said "—" for APT, Yum, Conan, Conda and Terraform, all of which have merged group indexes today. The intro's "**15 package formats**" said the same. The Roadmap still listed OpenTelemetry tracing as planned, though it shipped in #320/#321; of the two rows marked planned only SBOM generation / cosign signing is genuinely still open.

## Why it drifted

Both are claims only a human ever reads, in a file a new format's PR does not touch. The docs site has exactly this problem already solved: `internal/domain/site_formats_test.go` holds the page's count and table to `domain.AllFormats`. This adds the same guard for the README, so the next format that lands fails CI instead of quietly making the table wrong again.

## Testing

`go test ./internal/domain/` green. The guard was checked against the pre-fix README, where it reports the real drift rather than passing vacuously:

```
README claims 15 package formats, code supports 17
README formats table has 15 rows, code supports 17 formats
format "rubygems" (RubyGems) is missing from the README formats table
format "cran" (CRAN) is missing from the README formats table
```

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm2ywv9KRRQAFbTZ2kDV1G