### PR TITLE
fix(ui): let an admin reset another user's password from the Users tab

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -260,11 +260,14 @@ export const nexusApi = {
     apiClient.put(`/service/rest/v1/security/users/${userId}`, data),
   deleteUser: (userId: string) =>
     apiClient.delete(`/service/rest/v1/security/users/${userId}`),
-  changePassword: (userId: string, password: string) =>
+  // The backend binds {oldPassword, newPassword} as JSON. oldPassword is
+  // omitted on the admin path (resetting another user's password), where the
+  // handler does not ask for it; the self path (/api/v1/me/change-password)
+  // requires it.
+  changePassword: (userId: string, newPassword: string, oldPassword?: string) =>
     apiClient.put(
-      `/service/rest/v1/security/users/${userId}/change-password`,
-      password,
-      { headers: { 'Content-Type': 'text/plain' } },
+      `/service/rest/v1/security/users/${encodeURIComponent(userId)}/change-password`,
+      { oldPassword, newPassword },
     ),
 
   // Roles

--- a/frontend/src/pages/UsersPage.test.tsx
+++ b/frontend/src/pages/UsersPage.test.tsx
@@ -388,4 +388,88 @@ describe('UsersPage', () => {
     await user.click(screen.getByRole('button', { name: 'Roles' }))
     expect(await screen.findByText('No roles defined')).toBeInTheDocument()
   })
+
+  it("resets a user's password from the row action, sending JSON the backend binds", async () => {
+    const user = userEvent.setup()
+    let putUrl = ''
+    let body: Record<string, unknown> | null = null
+    let contentType = ''
+    server.use(
+      http.put('/service/rest/v1/security/users/:userId/change-password', async ({ request, params }) => {
+        putUrl = String(params.userId)
+        contentType = request.headers.get('content-type') ?? ''
+        body = (await request.json()) as Record<string, unknown>
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('alice')
+    await user.click(screen.getAllByTitle('Reset password')[0])
+
+    const heading = await screen.findByRole('heading', { name: /Reset Password — alice/ })
+    const form = heading.parentElement!.querySelector('form')!
+    await user.type(within(form).getByLabelText('New password *'), 'n3wp4ss')
+    await user.type(within(form).getByLabelText('Confirm new password *'), 'n3wp4ss')
+    await user.click(form.querySelector('button[type="submit"]') as HTMLButtonElement)
+
+    await waitFor(() => expect(body).toBeTruthy())
+    expect(putUrl).toBe('alice')
+    // The old shape was a raw string with Content-Type: text/plain, which the
+    // handler's ShouldBindJSON answered with a 400.
+    expect(contentType).toContain('application/json')
+    expect(body).toEqual({ newPassword: 'n3wp4ss' })
+    await waitFor(() => expect(screen.queryByRole('heading', { name: /Reset Password/ })).not.toBeInTheDocument())
+  })
+
+  it('refuses a mismatched confirmation without calling the API', async () => {
+    const user = userEvent.setup()
+    let called = false
+    server.use(
+      http.put('/service/rest/v1/security/users/:userId/change-password', () => {
+        called = true
+        return new HttpResponse(null, { status: 204 })
+      }),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('alice')
+    await user.click(screen.getAllByTitle('Reset password')[0])
+    const form = (await screen.findByRole('heading', { name: /Reset Password/ })).parentElement!.querySelector('form')!
+    await user.type(within(form).getByLabelText('New password *'), 'one')
+    await user.type(within(form).getByLabelText('Confirm new password *'), 'two')
+    await user.click(form.querySelector('button[type="submit"]') as HTMLButtonElement)
+    expect(await screen.findByRole('alert')).toHaveTextContent('The two passwords do not match')
+    expect(called).toBe(false)
+  })
+
+  it('surfaces a failed reset instead of closing the modal', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.put('/service/rest/v1/security/users/:userId/change-password', () =>
+        HttpResponse.json({ error: 'password too short' }, { status: 500 }),
+      ),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('alice')
+    await user.click(screen.getAllByTitle('Reset password')[0])
+    const form = (await screen.findByRole('heading', { name: /Reset Password/ })).parentElement!.querySelector('form')!
+    await user.type(within(form).getByLabelText('New password *'), 'short')
+    await user.type(within(form).getByLabelText('Confirm new password *'), 'short')
+    await user.click(form.querySelector('button[type="submit"]') as HTMLButtonElement)
+    expect(await screen.findByRole('alert')).toHaveTextContent('password too short')
+    expect(screen.getByRole('heading', { name: /Reset Password/ })).toBeInTheDocument()
+  })
+
+  it('disables the reset action for an LDAP-sourced user', async () => {
+    server.use(
+      http.get('/service/rest/v1/security/users', () =>
+        HttpResponse.json([userItem({ userId: 'ldapuser', source: 'ldap' })]),
+      ),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('ldapuser')
+    // A local password is never checked for a user the directory authenticates,
+    // so offering the action would be a dead end.
+    const btn = screen.getByTitle(/LDAP users authenticate against the directory/)
+    expect(btn).toBeDisabled()
+  })
 })

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserPlus, Trash2, RefreshCw, Shield, User, AlertTriangle, Plus, Edit2 } from 'lucide-react'
+import { UserPlus, Trash2, RefreshCw, Shield, User, AlertTriangle, Plus, Edit2, KeyRound } from 'lucide-react'
 import { nexusApi, apiClient, apiErrorMessage } from '@/api/client'
 import styles from './UsersPage.module.css'
 import { Select } from '../components/Select'
@@ -173,12 +173,61 @@ export function AssignRolesModal({ user, roles, onClose, onSaved }: {
   )
 }
 
+/* ─── Reset password modal ──────────────────────────────────── */
+// An admin resetting somebody else's password does not send a current one:
+// the backend's ChangePassword takes the SetPassword branch for a caller with
+// nx-admin, and only asks for oldPassword when a user changes their own.
+export function ResetPasswordModal({ user, onClose, onSaved }: {
+  user: UserItem
+  onClose: () => void
+  onSaved: () => void
+}) {
+  const [password, setPassword] = useState('')
+  const [confirmation, setConfirmation] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState('')
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (password !== confirmation) { setErr('The two passwords do not match'); return }
+    setSaving(true); setErr('')
+    try {
+      await nexusApi.changePassword(user.userId, password)
+      onSaved()
+    } catch (e) {
+      setErr(apiErrorMessage(e, 'Failed to reset password'))
+    } finally { setSaving(false) }
+  }
+
+  return (
+    <HoloModal open={true} onClose={onClose}>
+      <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: 'var(--holo-text)' }}>Reset Password — {user.userId}</h2>
+      <form onSubmit={submit} className={styles.form}>
+        <div className={styles.formRow}>
+          <label className={styles.label} htmlFor="reset-password">New password *</label>
+          <HoloInput id="reset-password" type="password" value={password} onChange={e => setPassword(e.target.value)} required />
+        </div>
+        <div className={styles.formRow}>
+          <label className={styles.label} htmlFor="reset-password-confirm">Confirm new password *</label>
+          <HoloInput id="reset-password-confirm" type="password" value={confirmation} onChange={e => setConfirmation(e.target.value)} required />
+        </div>
+        {err && <div role="alert" className={styles.error}>{err}</div>}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 8 }}>
+          <HoloButton type="button" onClick={onClose}>Cancel</HoloButton>
+          <HoloButton variant="primary" type="submit" disabled={saving}>{saving ? 'Saving…' : 'Reset Password'}</HoloButton>
+        </div>
+      </form>
+    </HoloModal>
+  )
+}
+
 /* ─── Users tab ──────────────────────────────────────────────── */
 export function UsersTab() {
   const qc = useQueryClient()
   const [filter, setFilter] = useState('')
   const [showCreate, setShowCreate] = useState(false)
   const [assignUser, setAssignUser] = useState<UserItem | null>(null)
+  const [resetUser, setResetUser] = useState<UserItem | null>(null)
 
   const { data: users = [], isLoading, isError, error, refetch } = useQuery<UserItem[]>({
     queryKey: ['users'],
@@ -238,7 +287,7 @@ export function UsersTab() {
             const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ')
             return (
               <div key={user.userId} style={{
-                display: 'grid', gridTemplateColumns: '8px 1fr auto auto auto',
+                display: 'grid', gridTemplateColumns: '8px 1fr auto auto auto auto',
                 alignItems: 'center', gap: 12, padding: '11px 16px',
                 background: 'rgba(10,8,28,0.97)', border: '1px solid rgba(124,92,255,0.2)',
                 borderRadius: 10, transition: 'border-color 0.15s, background 0.15s',
@@ -264,6 +313,10 @@ export function UsersTab() {
                   </HoloButton>
                 </div>
                 <HoloPill style={{ fontSize: 11 }}>{user.source}</HoloPill>
+                <HoloButton style={{ padding: 5 }} disabled={user.source === 'ldap'} onClick={() => setResetUser(user)}
+                  title={user.source === 'ldap'
+                    ? 'LDAP users authenticate against the directory — a local password is never checked'
+                    : 'Reset password'}><KeyRound size={14} /></HoloButton>
                 <HoloButton variant="danger" style={{ padding: 5 }} disabled={user.userId === 'admin'} onClick={() => {
                   if (confirm(`Delete user "${user.userId}"?`)) deleteMutation.mutate(user.userId)
                 }} title="Delete user"><Trash2 size={14} /></HoloButton>
@@ -285,6 +338,10 @@ export function UsersTab() {
           setAssignUser(null)
           qc.invalidateQueries({ queryKey: ['users'] })
         }} />
+      )}
+
+      {resetUser && (
+        <ResetPasswordModal user={resetUser} onClose={() => setResetUser(null)} onSaved={() => setResetUser(null)} />
       )}
     </>
   )


### PR DESCRIPTION
## What

An administrator had no way to help a locked-out user from the UI. The backend has supported this all along — `ChangePassword` takes the `SetPassword` branch for an `nx-admin` caller and never asks for a current password — but nothing reached it: a user row offered only "Assign roles" and "Delete".

The one client helper that pointed at the endpoint, `nexusApi.changePassword`, had no caller anywhere, and wired up as-is it would have failed: it sent the new password as a raw string with `Content-Type: text/plain`, while the handler binds `{oldPassword, newPassword}` through `ShouldBindJSON` — a 400.

## Changes

- `changePassword` sends the JSON the handler binds, takes an optional `oldPassword` for the self path (`/api/v1/me/change-password`, still uncalled — that's the separate gap #441 notes), and escapes the username in the path.
- A `KeyRound` action on each user row opens a modal with a new-password field and a confirmation of it. No current-password field: the admin path does not ask for one.

## One judgment call worth flagging

The action is **disabled for a user whose `source` is `ldap`**. `Login` routes `source=ldap` to the directory before it ever looks at a password hash, so a locally set password is never checked for such a user — the action would be a dead end, the same reasoning #442 applies to profile edits.

`oidc` and `saml` users **keep** the action: unlike LDAP, those sources fall through to the local password branch in `Login`, so a password set for them does work. That is existing backend behavior, and this PR does not change it.

## Testing

`npx vitest run src/pages/UsersPage.test.tsx` — 25 passed. New cases cover the request shape (JSON content type, `{newPassword}` with no `oldPassword`, the username in the path), the mismatched-confirmation guard not calling the API, a failed reset keeping the modal open with the server's message, and the disabled LDAP row.

The shape test was checked against the old `changePassword`, where it fails rather than passing vacuously. `tsc --noEmit` and `eslint` clean.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm2ywv9KRRQAFbTZ2kDV1G