### PR TITLE
feat(ui): let an admin edit a local user, and stop dropping their email

### DIFF
--- a/frontend/src/pages/UsersPage.test.tsx
+++ b/frontend/src/pages/UsersPage.test.tsx
@@ -472,4 +472,91 @@ describe('UsersPage', () => {
     const btn = screen.getByTitle(/LDAP users authenticate against the directory/)
     expect(btn).toBeDisabled()
   })
+
+  it('edits a local user and sends the fields the API binds', async () => {
+    const user = userEvent.setup()
+    let putUser = ''
+    let body: Record<string, unknown> | null = null
+    server.use(
+      http.put('/service/rest/v1/security/users/:userId', async ({ request, params }) => {
+        putUser = String(params.userId)
+        body = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(userItem())
+      }),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('alice')
+    await user.click(screen.getAllByTitle('Edit user')[0])
+
+    const heading = await screen.findByRole('heading', { name: /Edit User — alice/ })
+    const form = heading.parentElement!.querySelector('form')!
+    // Pre-filled from the row, so an edit of one field keeps the rest.
+    expect(within(form).getByLabelText('Email')).toHaveValue('alice@test.com')
+    await user.clear(within(form).getByLabelText('Email'))
+    await user.type(within(form).getByLabelText('Email'), 'alice@fixed.com')
+    await user.click(form.querySelector('button[type="submit"]') as HTMLButtonElement)
+
+    await waitFor(() => expect(body).toBeTruthy())
+    expect(putUser).toBe('alice')
+    // emailAddress, not email: that is the tag domain.User binds.
+    expect(body).toEqual({
+      firstName: 'Alice',
+      lastName: 'Smith',
+      emailAddress: 'alice@fixed.com',
+      status: 'active',
+    })
+  })
+
+  it('surfaces a failed edit instead of closing the modal', async () => {
+    const user = userEvent.setup()
+    server.use(
+      http.put('/service/rest/v1/security/users/:userId', () =>
+        HttpResponse.json({ error: 'user with this email' }, { status: 409 }),
+      ),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('alice')
+    await user.click(screen.getAllByTitle('Edit user')[0])
+    const form = (await screen.findByRole('heading', { name: /Edit User/ })).parentElement!.querySelector('form')!
+    await user.click(form.querySelector('button[type="submit"]') as HTMLButtonElement)
+    expect(await screen.findByRole('alert')).toHaveTextContent('user with this email')
+    expect(screen.getByRole('heading', { name: /Edit User/ })).toBeInTheDocument()
+  })
+
+  it('disables the edit action for a user provisioned by an identity provider', async () => {
+    server.use(
+      http.get('/service/rest/v1/security/users', () =>
+        HttpResponse.json([userItem({ userId: 'sso', source: 'oidc' })]),
+      ),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('sso')
+    // The IdP overwrites the profile on every login, so an edit here is a dead end.
+    expect(screen.getByTitle(/re-provisioned from the identity provider/)).toBeDisabled()
+  })
+
+  it('sends the email address the create modal collected', async () => {
+    const user = userEvent.setup()
+    let posted: Record<string, unknown> | null = null
+    server.use(
+      http.post('/service/rest/v1/security/users', async ({ request }) => {
+        posted = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(userItem(), { status: 201 })
+      }),
+    )
+    renderWithProviders(<UsersPage />)
+    await screen.findByText('alice')
+    await user.click(screen.getByRole('button', { name: /Add User/ }))
+    const heading = await screen.findByRole('heading', { name: 'Add User' })
+    const form = heading.parentElement!.querySelector('form')!
+    await user.type(within(form).getByText('Username *').parentElement!.querySelector('input') as HTMLInputElement, 'charlie')
+    await user.type(form.querySelector('input[type="password"]') as HTMLInputElement, 's3cret')
+    await user.type(form.querySelector('input[type="email"]') as HTMLInputElement, 'charlie@test.com')
+    await user.click(form.querySelector('button[type="submit"]') as HTMLButtonElement)
+
+    await waitFor(() => expect(posted).toBeTruthy())
+    // The key used to be "email", which the handler's domain.User bind ignored,
+    // so every user created from the UI lost their address (#446).
+    expect(posted).toMatchObject({ userId: 'charlie', emailAddress: 'charlie@test.com' })
+  })
 })

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { UserPlus, Trash2, RefreshCw, Shield, User, AlertTriangle, Plus, Edit2, KeyRound } from 'lucide-react'
+import { UserPlus, Trash2, RefreshCw, Shield, User, AlertTriangle, Plus, Edit2, KeyRound, Pencil } from 'lucide-react'
 import { nexusApi, apiClient, apiErrorMessage } from '@/api/client'
 import styles from './UsersPage.module.css'
 import { Select } from '../components/Select'
@@ -173,6 +173,78 @@ export function AssignRolesModal({ user, roles, onClose, onSaved }: {
   )
 }
 
+/* ─── Edit user modal ───────────────────────────────────────── */
+// UserService.Update applies its fields partially: an empty string means "keep
+// what is there", not "clear it". So a field left blank here stays as it was —
+// said out loud in the modal, because an admin blanking an email and getting
+// the old one back has no other way to find out why.
+export function EditUserModal({ user, onClose, onSaved }: {
+  user: UserItem
+  onClose: () => void
+  onSaved: () => void
+}) {
+  const [form, setForm] = useState({
+    firstName: user.firstName ?? '',
+    lastName: user.lastName ?? '',
+    emailAddress: user.emailAddress ?? '',
+    status: user.status ?? 'active',
+  })
+  const [saving, setSaving] = useState(false)
+  const [err, setErr] = useState('')
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSaving(true); setErr('')
+    try {
+      await nexusApi.updateUser(user.userId, form)
+      onSaved()
+    } catch (e) {
+      setErr(apiErrorMessage(e, 'Failed to update user'))
+    } finally { setSaving(false) }
+  }
+
+  return (
+    <HoloModal open={true} onClose={onClose}>
+      <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700, color: 'var(--holo-text)' }}>Edit User — {user.userId}</h2>
+      <form onSubmit={submit} className={styles.form}>
+        <div className={styles.formGrid}>
+          <div className={styles.formRow}>
+            <label className={styles.label} htmlFor="edit-first-name">First name</label>
+            <HoloInput id="edit-first-name" value={form.firstName} onChange={e => setForm(f => ({ ...f, firstName: e.target.value }))} />
+          </div>
+          <div className={styles.formRow}>
+            <label className={styles.label} htmlFor="edit-last-name">Last name</label>
+            <HoloInput id="edit-last-name" value={form.lastName} onChange={e => setForm(f => ({ ...f, lastName: e.target.value }))} />
+          </div>
+        </div>
+        <div className={styles.formRow}>
+          <label className={styles.label} htmlFor="edit-email">Email</label>
+          <HoloInput id="edit-email" type="email" value={form.emailAddress} onChange={e => setForm(f => ({ ...f, emailAddress: e.target.value }))} />
+        </div>
+        <div className={styles.formRow}>
+          <label className={styles.label}>Status</label>
+          <Select
+            options={[
+              { value: 'active',   label: 'Active' },
+              { value: 'disabled', label: 'Disabled' },
+            ]}
+            value={form.status}
+            onChange={v => setForm(f => ({ ...f, status: v }))}
+          />
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--holo-text-faint)' }}>
+          Emptying a field leaves it unchanged — the API applies these fields partially.
+        </div>
+        {err && <div role="alert" className={styles.error}>{err}</div>}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 8 }}>
+          <HoloButton type="button" onClick={onClose}>Cancel</HoloButton>
+          <HoloButton variant="primary" type="submit" disabled={saving}>{saving ? 'Saving…' : 'Save'}</HoloButton>
+        </div>
+      </form>
+    </HoloModal>
+  )
+}
+
 /* ─── Reset password modal ──────────────────────────────────── */
 // An admin resetting somebody else's password does not send a current one:
 // the backend's ChangePassword takes the SetPassword branch for a caller with
@@ -228,6 +300,7 @@ export function UsersTab() {
   const [showCreate, setShowCreate] = useState(false)
   const [assignUser, setAssignUser] = useState<UserItem | null>(null)
   const [resetUser, setResetUser] = useState<UserItem | null>(null)
+  const [editUser, setEditUser] = useState<UserItem | null>(null)
 
   const { data: users = [], isLoading, isError, error, refetch } = useQuery<UserItem[]>({
     queryKey: ['users'],
@@ -287,7 +360,7 @@ export function UsersTab() {
             const fullName = [user.firstName, user.lastName].filter(Boolean).join(' ')
             return (
               <div key={user.userId} style={{
-                display: 'grid', gridTemplateColumns: '8px 1fr auto auto auto auto',
+                display: 'grid', gridTemplateColumns: '8px 1fr auto auto auto auto auto',
                 alignItems: 'center', gap: 12, padding: '11px 16px',
                 background: 'rgba(10,8,28,0.97)', border: '1px solid rgba(124,92,255,0.2)',
                 borderRadius: 10, transition: 'border-color 0.15s, background 0.15s',
@@ -313,6 +386,10 @@ export function UsersTab() {
                   </HoloButton>
                 </div>
                 <HoloPill style={{ fontSize: 11 }}>{user.source}</HoloPill>
+                <HoloButton style={{ padding: 5 }} disabled={user.source !== 'local'} onClick={() => setEditUser(user)}
+                  title={user.source !== 'local'
+                    ? `A ${user.source} account's profile is re-provisioned from the identity provider on every login`
+                    : 'Edit user'}><Pencil size={14} /></HoloButton>
                 <HoloButton style={{ padding: 5 }} disabled={user.source === 'ldap'} onClick={() => setResetUser(user)}
                   title={user.source === 'ldap'
                     ? 'LDAP users authenticate against the directory — a local password is never checked'
@@ -342,6 +419,13 @@ export function UsersTab() {
 
       {resetUser && (
         <ResetPasswordModal user={resetUser} onClose={() => setResetUser(null)} onSaved={() => setResetUser(null)} />
+      )}
+
+      {editUser && (
+        <EditUserModal user={editUser} onClose={() => setEditUser(null)} onSaved={() => {
+          setEditUser(null)
+          qc.invalidateQueries({ queryKey: ['users'] })
+        }} />
       )}
     </>
   )
@@ -469,7 +553,7 @@ export default function UsersPage() {
 
 /* ─── Create user modal ──────────────────────────────────────── */
 export function CreateUserModal({ onClose, onCreated }: { onClose: () => void; onCreated: () => void }) {
-  const [form, setForm] = useState({ userId: '', email: '', firstName: '', lastName: '', password: '', status: 'active' })
+  const [form, setForm] = useState({ userId: '', emailAddress: '', firstName: '', lastName: '', password: '', status: 'active' })
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -507,7 +591,7 @@ export function CreateUserModal({ onClose, onCreated }: { onClose: () => void; o
         </div>
         <div className={styles.formRow}>
           <label className={styles.label}>Email</label>
-          <HoloInput type="email" value={form.email} onChange={e => setForm(f => ({ ...f, email: e.target.value }))} />
+          <HoloInput type="email" value={form.emailAddress} onChange={e => setForm(f => ({ ...f, emailAddress: e.target.value }))} />
         </div>
         <div className={styles.formRow}>
           <label className={styles.label}>Status</label>


### PR DESCRIPTION
> Stacked on #445 (same file). Base retargets to `main` once that merges; review the second commit.

## What

`UserService.Update` has always applied partial updates to email, first/last name and status, the route is wired and RBAC-gated like every other admin user action, and `nexusApi.updateUser` was already written — but nothing called it. A user row offered only "Assign roles" and "Delete", so correcting a typo'd email or renaming someone meant a direct API call or a database update.

A `Pencil` action on each row now opens a modal over those four fields.

## Two judgment calls

**Disabled for `ldap`/`oidc`/`saml` accounts.** All three re-provision `Email`/`FirstName`/`LastName` from the IdP on every login, so the edit would be undone at the user's next SSO login — the dead end #442 describes. `Update` itself still does not gate on `Source`; this changes only what the UI offers.

**Emptying a field is a no-op**, because `Update` reads an empty string as "keep what is there". Rather than let an admin clear an email and silently get the old one back, the modal says so.

## Also fixes #446 — the reason a wrong email is easy to end up with

`CreateUserModal` posted its address under the key `email`, while `Create` binds an embedded `domain.User`, whose tag is `emailAddress`. Gin drops the unknown key, so **every user created through the UI was created with no email at all** — a `201`, no warning, a blank address in the list afterwards. The handler tests all post `emailAddress`, and the create-modal test only asserted the `userId` it posted, so nothing covered the mismatch.

## Testing

`npx vitest run src/pages/UsersPage.test.tsx` — 29 passed. New cases: the edit request shape (pre-filled from the row, `emailAddress` not `email`, the username in the path), a `409` keeping the modal open with the server's message, the disabled IdP row, and the created user's address.

Both new assertions were checked against the pre-fix code, where they fail rather than passing vacuously. `tsc --noEmit` and `eslint` clean.

Closes #442
Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm2ywv9KRRQAFbTZ2kDV1G